### PR TITLE
Fixed bug where text_reader could attempt reads beyond `read_cnt`

### DIFF
--- a/include/LightGBM/utils/text_reader.h
+++ b/include/LightGBM/utils/text_reader.h
@@ -112,7 +112,7 @@ public:
           ++i;
           ++total_cnt;
           // skip end of line
-          while (buffer_process[i] == '\n' || buffer_process[i] == '\r') { ++i; }
+          while ((buffer_process[i] == '\n' || buffer_process[i] == '\r') && i < read_cnt) { ++i; }
           last_i = i;
         }
         else {
@@ -247,7 +247,7 @@ public:
           ++i;
           ++total_cnt;
           // skip end of line
-          while (buffer_process[i] == '\n' || buffer_process[i] == '\r') { ++i; }
+          while ((buffer_process[i] == '\n' || buffer_process[i] == '\r') && i < read_cnt) { ++i; }
           last_i = i;
         }
         else {
@@ -281,7 +281,7 @@ public:
   }
 
   INDEX_T ReadPartAndProcessParallel(const std::vector<INDEX_T>& used_data_indices, const std::function<void(INDEX_T, const std::vector<std::string>&)>& process_fun) {
-    return ReadAllAndProcessParallelWithFilter(process_fun, 
+    return ReadAllAndProcessParallelWithFilter(process_fun,
       [&used_data_indices](INDEX_T used_cnt ,INDEX_T total_cnt) {
       if (used_cnt < used_data_indices.size() && total_cnt == used_data_indices[used_cnt]) {
         return true;


### PR DESCRIPTION
This error was a bit difficult to figure out: `terminate called after throwing an instance of 'std::length_error' what():  basic_string::_M_create`. It sometimes occurs when loading data because of the following bug:

At the end of a file, `fread` (in [pipeline_reader.h](https://github.com/Microsoft/LightGBM/blob/b23a2c31040131bb63dcff228d427b43bca5570e/include/LightGBM/utils/pipeline_reader.h)) often only partially fills `buffer_process` with new data because it reaches the end of the file. This leaves old data in the part of the buffer that extends beyond the size of the file. When the data file ends with a `\n` or a `\r`, the last index of `buffer_process` that was filled with new data will also contain a `\n` or a `\r`.
In rare cases, the next index (that contains old data from a previous call of the function), will also contains a `\n` or a `\r`. When this happens, `while (buffer_process[i] == '\n' || buffer_process[i] == '\r') { ++i; }` (at [text_reader.h#L115](https://github.com/Microsoft/LightGBM/blob/5d0228985865201d442536eca6ec454da5a347fa/include/LightGBM/utils/text_reader.h#L115)) moves `last_i` beyond the boundaries of the file, resulting in an error when calling `last_line_ = std::string(buffer_process + last_i, read_cnt - last_i)` (at [text_reader.h#L123](https://github.com/Microsoft/LightGBM/blob/5d0228985865201d442536eca6ec454da5a347fa/include/LightGBM/utils/text_reader.h#L123)).