### PR TITLE
Fixed compilation error on OSX with GNU 6.2.0

### DIFF
--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <cstdint>
 #include <algorithm>
+#include <cmath>
 
 namespace LightGBM {
 
@@ -165,7 +166,7 @@ inline static const char* Atof(const char* p, float* out) {
     *out = sign * (frac ? (value / scale) : (value * scale));
   } else {
     size_t cnt = 0;
-    while (*(p + cnt) != '\0' && *(p + cnt) != ' ' 
+    while (*(p + cnt) != '\0' && *(p + cnt) != ' '
       && *(p + cnt) != '\t' && *(p + cnt) != ','
       && *(p + cnt) != '\n' && *(p + cnt) != '\r'
       && *(p + cnt) != ':')  {


### PR DESCRIPTION
Travis didn't catch this, but on OSX (using GNU 6.2.0) I get the following compilation error:
`error: 'exp' is not a member of 'std'
     rec[i] = std::exp(rec[i] - wmax);`

Indeed, `exp` is in `<cmath>`.