### PR TITLE
Added complexity regularization parameters (L1, L2, min_gain_to_split)

### DIFF
--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -151,6 +151,8 @@ struct TreeConfig: public ConfigBase {
 public:
   int min_data_in_leaf = 100;
   double min_sum_hessian_in_leaf = 10.0f;
+  double reg_lambda = 0.0f;
+  double reg_gamma = 0.0f;
   // should > 1, only one leaf means not need to learning
   int num_leaves = 127;
   int feature_fraction_seed = 2;

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -151,8 +151,8 @@ struct TreeConfig: public ConfigBase {
 public:
   int min_data_in_leaf = 100;
   double min_sum_hessian_in_leaf = 10.0f;
-  double reg_lambda = 0.0f;
-  double reg_gamma = 0.0f;
+  double lambda_l2 = 0.0f;
+  double min_gain_to_split = 0.0f;
   // should > 1, only one leaf means not need to learning
   int num_leaves = 127;
   int feature_fraction_seed = 2;

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -151,6 +151,7 @@ struct TreeConfig: public ConfigBase {
 public:
   int min_data_in_leaf = 100;
   double min_sum_hessian_in_leaf = 10.0f;
+  double lambda_l1 = 0.0f;
   double lambda_l2 = 0.0f;
   double min_gain_to_split = 0.0f;
   // should > 1, only one leaf means not need to learning

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -267,6 +267,8 @@ void TreeConfig::Set(const std::unordered_map<std::string, std::string>& params)
   GetInt(params, "min_data_in_leaf", &min_data_in_leaf);
   GetDouble(params, "min_sum_hessian_in_leaf", &min_sum_hessian_in_leaf);
   CHECK(min_sum_hessian_in_leaf > 1.0f || min_data_in_leaf > 0);
+  GetDouble(params, "lambda_l1", &lambda_l1);
+  CHECK(lambda_l1 >= 0.0f)
   GetDouble(params, "lambda_l2", &lambda_l2);
   CHECK(lambda_l2 >= 0.0f)
   GetDouble(params, "min_gain_to_split", &min_gain_to_split);

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -267,10 +267,10 @@ void TreeConfig::Set(const std::unordered_map<std::string, std::string>& params)
   GetInt(params, "min_data_in_leaf", &min_data_in_leaf);
   GetDouble(params, "min_sum_hessian_in_leaf", &min_sum_hessian_in_leaf);
   CHECK(min_sum_hessian_in_leaf > 1.0f || min_data_in_leaf > 0);
-  GetDouble(params, "reg_lambda", &reg_lambda);
-  CHECK(reg_lambda >= 0.0f)
-  GetDouble(params, "reg_gamma", &reg_gamma);
-  CHECK(reg_gamma >= 0.0f)
+  GetDouble(params, "lambda_l2", &lambda_l2);
+  CHECK(lambda_l2 >= 0.0f)
+  GetDouble(params, "min_gain_to_split", &min_gain_to_split);
+  CHECK(min_gain_to_split >= 0.0f)
   GetInt(params, "num_leaves", &num_leaves);
   CHECK(num_leaves > 1);
   GetInt(params, "feature_fraction_seed", &feature_fraction_seed);

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -267,6 +267,10 @@ void TreeConfig::Set(const std::unordered_map<std::string, std::string>& params)
   GetInt(params, "min_data_in_leaf", &min_data_in_leaf);
   GetDouble(params, "min_sum_hessian_in_leaf", &min_sum_hessian_in_leaf);
   CHECK(min_sum_hessian_in_leaf > 1.0f || min_data_in_leaf > 0);
+  GetDouble(params, "reg_lambda", &reg_lambda);
+  CHECK(reg_lambda >= 0.0f)
+  GetDouble(params, "reg_gamma", &reg_gamma);
+  CHECK(reg_gamma >= 0.0f)
   GetInt(params, "num_leaves", &num_leaves);
   CHECK(num_leaves > 1);
   GetInt(params, "feature_fraction_seed", &feature_fraction_seed);

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -199,7 +199,7 @@ void Dataset::LoadDataToMemory(int rank, int num_machines, bool is_pre_partition
         [this, rank, num_machines, &qid, &query_boundaries, &is_query_used, num_queries]
       (data_size_t line_idx) {
         if (qid >= num_queries) {
-          Log::Fatal("Current query exceed the range of query file, \
+          Log::Fatal("Current query exceeds the range of query file, \
                       please ensure your query file is correct");
         }
         if (line_idx >= query_boundaries[qid + 1]) {
@@ -373,7 +373,7 @@ void Dataset::ConstructBinMappers(int rank, int num_machines, const std::vector<
     len[num_machines - 1] = total_num_feature - start[num_machines - 1];
     // get size of bin mapper with max_bin_ size
     int type_size = BinMapper::SizeForSpecificBin(max_bin_);
-    // since sizes of different feature may not be same, we expand all bin mapper to type_size 
+    // since sizes of different feature may not be same, we expand all bin mapper to type_size
     int buffer_size = type_size * total_num_feature;
     char* input_buffer = new char[buffer_size];
     char* output_buffer = new char[buffer_size];
@@ -660,7 +660,7 @@ void Dataset::ExtractFeaturesFromFile() {
 }
 
 void Dataset::SaveBinaryFile() {
-  // if is loaded from binary file, not need to save 
+  // if is loaded from binary file, not need to save
   if (!is_loading_from_binfile_) {
     std::string bin_filename(data_filename_);
     bin_filename.append(".bin");
@@ -782,7 +782,7 @@ void Dataset::LoadDataFromBinFile(int rank, int num_machines, bool is_pre_partit
   if (read_cnt != size_of_head) {
     Log::Fatal("Binary file error: header is incorrect");
   }
-  // get header 
+  // get header
   const char* mem_ptr = buffer;
   global_num_data_ = *(reinterpret_cast<const size_t*>(mem_ptr));
   mem_ptr += sizeof(global_num_data_);
@@ -853,7 +853,7 @@ void Dataset::LoadDataFromBinFile(int rank, int num_machines, bool is_pre_partit
       for (data_size_t i = 0; i < num_data_; ++i) {
         if (random_.NextInt(0, num_machines) == rank) {
           used_data_indices_.push_back(i);
-        } 
+        }
       }
     } else {
       // if contain query file, minimal sample unit is one query

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -219,12 +219,10 @@ private:
   * \return split gain
   */
   double GetLeafSplitGain(double sum_gradients, double sum_hessians) const {
-    if (sum_gradients < -lambda_l1_) {
-      double reg_sum_gradients = sum_gradients + lambda_l1_;
-      return (reg_sum_gradients * reg_sum_gradients) / (sum_hessians + lambda_l2_);
-    } else if (sum_gradients > lambda_l1_) {
-      double reg_sum_gradients = sum_gradients - lambda_l1_;
-      return (reg_sum_gradients * reg_sum_gradients) / (sum_hessians + lambda_l2_);
+    double abs_sum_gradients = fabs(sum_gradients);
+    if (abs_sum_gradients > lambda_l1_) {
+      double reg_abs_sum_gradients = abs_sum_gradients - lambda_l1_;
+      return (reg_abs_sum_gradients * reg_abs_sum_gradients) / (sum_hessians + lambda_l2_);
     }
     return 0.0f;
   }
@@ -235,11 +233,10 @@ private:
   * \param sum_hessians
   * \return leaf output
   */
-  double CalculateSplittedLeafOutput(double sum_gradients, double sum_hessians) const {
-    if (sum_gradients < -lambda_l1_) {
-      return -(sum_gradients + lambda_l1_) / (sum_hessians + lambda_l2_);
-    } else if (sum_gradients > lambda_l1_) {
-      return -(sum_gradients - lambda_l1_) / (sum_hessians + lambda_l2_);
+  double CalculateSplittedLeafOutput_alt(double sum_gradients, double sum_hessians) const {
+    double abs_sum_gradients = fabs(sum_gradients);
+    if (abs_sum_gradients > lambda_l1_) {
+      return -copysign(abs_sum_gradients - lambda_l1_, sum_gradients) / (sum_hessians + lambda_l2_);
     }
     return 0.0f;
   }

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -233,7 +233,7 @@ private:
   * \param sum_hessians
   * \return leaf output
   */
-  double CalculateSplittedLeafOutput_alt(double sum_gradients, double sum_hessians) const {
+  double CalculateSplittedLeafOutput(double sum_gradients, double sum_hessians) const {
     double abs_sum_gradients = fabs(sum_gradients);
     if (abs_sum_gradients > lambda_l1_) {
       return -copysign(abs_sum_gradients - lambda_l1_, sum_gradients) / (sum_hessians + lambda_l2_);

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -213,41 +213,35 @@ public:
 
 private:
   /*!
-  * \brief Return the L1 regularized sum_gradients
-  * \param sum_gradients
-  * \return regularized sum_gradients
-  */
-  double L1RegularizedGradients(double sum_gradients) const {
-  if (sum_gradients > lambda_l1_) return sum_gradients - lambda_l1_;
-  if (sum_gradients < -lambda_l1_) return sum_gradients + lambda_l1_;
-  return 0.0f;
-  }
-
-  /*!
-  * \brief Calculate the split gain based on sum_gradients and sum_hessians
+  * \brief Calculate the split gain based on regularized sum_gradients and sum_hessians
   * \param sum_gradients
   * \param sum_hessians
   * \return split gain
   */
   double GetLeafSplitGain(double sum_gradients, double sum_hessians) const {
-    if (lambda_l1_ != 0.0f) {
-      double reg_sum_gradients = L1RegularizedGradients(sum_gradients);
+    if (sum_gradients < -lambda_l1_) {
+      double reg_sum_gradients = sum_gradients + lambda_l1_;
+      return (reg_sum_gradients * reg_sum_gradients) / (sum_hessians + lambda_l2_);
+    } else if (sum_gradients > lambda_l1_) {
+      double reg_sum_gradients = sum_gradients - lambda_l1_;
       return (reg_sum_gradients * reg_sum_gradients) / (sum_hessians + lambda_l2_);
     }
-    return (sum_gradients * sum_gradients) / (sum_hessians + lambda_l2_);
+    return 0.0f;
   }
 
   /*!
-  * \brief Calculate the output of a leaf based on sum_gradients and sum_hessians
+  * \brief Calculate the output of a leaf based on regularized sum_gradients and sum_hessians
   * \param sum_gradients
   * \param sum_hessians
   * \return leaf output
   */
   double CalculateSplittedLeafOutput(double sum_gradients, double sum_hessians) const {
-    if (lambda_l1_ != 0.0f) {
-      return -(L1RegularizedGradients(sum_gradients)) / (sum_hessians + lambda_l2_);
+    if (sum_gradients < -lambda_l1_) {
+      return -(sum_gradients + lambda_l1_) / (sum_hessians + lambda_l2_);
+    } else if (sum_gradients > lambda_l1_) {
+      return -(sum_gradients - lambda_l1_) / (sum_hessians + lambda_l2_);
     }
-    return -(sum_gradients) / (sum_hessians + lambda_l2_);
+    return 0.0f;
   }
 
   int feature_idx_;

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -26,10 +26,11 @@ public:
   * \param min_num_data_one_leaf minimal number of data in one leaf
   */
   void Init(const Feature* feature, int feature_idx, data_size_t min_num_data_one_leaf,
-    double min_sum_hessian_one_leaf, double lambda_l2, double min_gain_to_split) {
+    double min_sum_hessian_one_leaf, double lambda_l1, double lambda_l2, double min_gain_to_split) {
     feature_idx_ = feature_idx;
     min_num_data_one_leaf_ = min_num_data_one_leaf;
     min_sum_hessian_one_leaf_ = min_sum_hessian_one_leaf;
+    lambda_l1_ = lambda_l1;
     lambda_l2_ = lambda_l2;
     min_gain_to_split_ = min_gain_to_split;
     bin_data_ = feature->bin_data();
@@ -115,6 +116,7 @@ public:
     double sum_right_hessian = kEpsilon;
     data_size_t right_count = 0;
     double gain_shift = GetLeafSplitGain(sum_gradients_, sum_hessians_);
+    double min_gain_shift = gain_shift + min_gain_to_split_;
     is_splittable_ = false;
     // from right to left, and we don't need data in bin0
     for (unsigned int t = num_bins_ - 1; t > 0; --t) {
@@ -129,16 +131,14 @@ public:
 
       double sum_left_hessian = sum_hessians_ - sum_right_hessian;
       // if sum hessian too small
-      if (sum_left_hessian < min_sum_hessian_one_leaf_) {
-        break;
-      }
+      if (sum_left_hessian < min_sum_hessian_one_leaf_) break;
+
       double sum_left_gradient = sum_gradients_ - sum_right_gradient;
       // current split gain
       double current_gain = GetLeafSplitGain(sum_left_gradient, sum_left_hessian) + GetLeafSplitGain(sum_right_gradient, sum_right_hessian);
       // gain with split is worse than without split
-      if (current_gain < gain_shift + 2 * min_gain_to_split_) {
-        continue;
-      }
+      if (current_gain < min_gain_shift) continue;
+
       // mark to is splittable
       is_splittable_ = true;
       // better split point
@@ -213,12 +213,27 @@ public:
 
 private:
   /*!
+  * \brief Return the L1 regularized sum_gradients
+  * \param sum_gradients
+  * \return regularized sum_gradients
+  */
+  double L1RegularizedGradients(double sum_gradients) const {
+  if (sum_gradients > lambda_l1_) return sum_gradients - lambda_l1_;
+  if (sum_gradients < -lambda_l1_) return sum_gradients + lambda_l1_;
+  return 0.0f;
+  }
+
+  /*!
   * \brief Calculate the split gain based on sum_gradients and sum_hessians
   * \param sum_gradients
   * \param sum_hessians
   * \return split gain
   */
   double GetLeafSplitGain(double sum_gradients, double sum_hessians) const {
+    if (lambda_l1_ != 0.0f) {
+      double reg_sum_gradients = L1RegularizedGradients(sum_gradients);
+      return (reg_sum_gradients * reg_sum_gradients) / (sum_hessians + lambda_l2_);
+    }
     return (sum_gradients * sum_gradients) / (sum_hessians + lambda_l2_);
   }
 
@@ -229,6 +244,9 @@ private:
   * \return leaf output
   */
   double CalculateSplittedLeafOutput(double sum_gradients, double sum_hessians) const {
+    if (lambda_l1_ != 0.0f) {
+      return -(L1RegularizedGradients(sum_gradients)) / (sum_hessians + lambda_l2_);
+    }
     return -(sum_gradients) / (sum_hessians + lambda_l2_);
   }
 
@@ -237,6 +255,8 @@ private:
   data_size_t min_num_data_one_leaf_;
   /*! \brief minimal sum hessian of data in one leaf */
   double min_sum_hessian_one_leaf_;
+  /*! \brief lambda of the L1 weights regularization */
+  double lambda_l1_;
   /*! \brief lambda of the L2 weights regularization */
   double lambda_l2_;
   /*! \brief minimal gain (loss reduction) to split */

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -26,10 +26,12 @@ public:
   * \param min_num_data_one_leaf minimal number of data in one leaf
   */
   void Init(const Feature* feature, int feature_idx, data_size_t min_num_data_one_leaf,
-    double min_sum_hessian_one_leaf) {
+    double min_sum_hessian_one_leaf, double reg_lambda, double reg_gamma) {
     feature_idx_ = feature_idx;
     min_num_data_one_leaf_ = min_num_data_one_leaf;
     min_sum_hessian_one_leaf_ = min_sum_hessian_one_leaf;
+    reg_lambda_ = reg_lambda;
+    reg_gamma_ = reg_gamma;
     bin_data_ = feature->bin_data();
     num_bins_ = feature->num_bin();
     data_ = new HistogramBinEntry[num_bins_];
@@ -133,8 +135,8 @@ public:
       double sum_left_gradient = sum_gradients_ - sum_right_gradient;
       // current split gain
       double current_gain = GetLeafSplitGain(sum_left_gradient, sum_left_hessian) + GetLeafSplitGain(sum_right_gradient, sum_right_hessian);
-      // gain is worst than no perform split
-      if (current_gain < gain_shift) {
+      // gain with split is worse than without split
+      if (current_gain < gain_shift + 2 * reg_gamma_) {
         continue;
       }
       // mark to is splittable
@@ -217,7 +219,7 @@ private:
   * \return split gain
   */
   double GetLeafSplitGain(double sum_gradients, double sum_hessians) const {
-    return (sum_gradients * sum_gradients) / (sum_hessians);
+    return (sum_gradients * sum_gradients) / (sum_hessians + reg_lambda_);
   }
 
   /*!
@@ -227,7 +229,7 @@ private:
   * \return leaf output
   */
   double CalculateSplittedLeafOutput(double sum_gradients, double sum_hessians) const {
-    return -(sum_gradients) / (sum_hessians);
+    return -(sum_gradients) / (sum_hessians + reg_lambda_);
   }
 
   int feature_idx_;
@@ -235,6 +237,10 @@ private:
   data_size_t min_num_data_one_leaf_;
   /*! \brief minimal sum hessian of data in one leaf */
   double min_sum_hessian_one_leaf_;
+  /*! \brief lambda L2 weights regularization */
+  double reg_lambda_;
+  /*! \brief minimal loss reduction to split */
+  double reg_gamma_;
   /*! \brief the bin data of current feature */
   const Bin* bin_data_;
   /*! \brief number of bin of histogram */

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -26,12 +26,12 @@ public:
   * \param min_num_data_one_leaf minimal number of data in one leaf
   */
   void Init(const Feature* feature, int feature_idx, data_size_t min_num_data_one_leaf,
-    double min_sum_hessian_one_leaf, double reg_lambda, double reg_gamma) {
+    double min_sum_hessian_one_leaf, double lambda_l2, double min_gain_to_split) {
     feature_idx_ = feature_idx;
     min_num_data_one_leaf_ = min_num_data_one_leaf;
     min_sum_hessian_one_leaf_ = min_sum_hessian_one_leaf;
-    reg_lambda_ = reg_lambda;
-    reg_gamma_ = reg_gamma;
+    lambda_l2_ = lambda_l2;
+    min_gain_to_split_ = min_gain_to_split;
     bin_data_ = feature->bin_data();
     num_bins_ = feature->num_bin();
     data_ = new HistogramBinEntry[num_bins_];
@@ -136,7 +136,7 @@ public:
       // current split gain
       double current_gain = GetLeafSplitGain(sum_left_gradient, sum_left_hessian) + GetLeafSplitGain(sum_right_gradient, sum_right_hessian);
       // gain with split is worse than without split
-      if (current_gain < gain_shift + 2 * reg_gamma_) {
+      if (current_gain < gain_shift + 2 * min_gain_to_split_) {
         continue;
       }
       // mark to is splittable
@@ -219,7 +219,7 @@ private:
   * \return split gain
   */
   double GetLeafSplitGain(double sum_gradients, double sum_hessians) const {
-    return (sum_gradients * sum_gradients) / (sum_hessians + reg_lambda_);
+    return (sum_gradients * sum_gradients) / (sum_hessians + lambda_l2_);
   }
 
   /*!
@@ -229,7 +229,7 @@ private:
   * \return leaf output
   */
   double CalculateSplittedLeafOutput(double sum_gradients, double sum_hessians) const {
-    return -(sum_gradients) / (sum_hessians + reg_lambda_);
+    return -(sum_gradients) / (sum_hessians + lambda_l2_);
   }
 
   int feature_idx_;
@@ -237,10 +237,10 @@ private:
   data_size_t min_num_data_one_leaf_;
   /*! \brief minimal sum hessian of data in one leaf */
   double min_sum_hessian_one_leaf_;
-  /*! \brief lambda L2 weights regularization */
-  double reg_lambda_;
-  /*! \brief minimal loss reduction to split */
-  double reg_gamma_;
+  /*! \brief lambda of the L2 weights regularization */
+  double lambda_l2_;
+  /*! \brief minimal gain (loss reduction) to split */
+  double min_gain_to_split_;
   /*! \brief the bin data of current feature */
   const Bin* bin_data_;
   /*! \brief number of bin of histogram */

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -219,7 +219,7 @@ private:
   * \return split gain
   */
   double GetLeafSplitGain(double sum_gradients, double sum_hessians) const {
-    double abs_sum_gradients = fabs(sum_gradients);
+    double abs_sum_gradients = std::fabs(sum_gradients);
     if (abs_sum_gradients > lambda_l1_) {
       double reg_abs_sum_gradients = abs_sum_gradients - lambda_l1_;
       return (reg_abs_sum_gradients * reg_abs_sum_gradients) / (sum_hessians + lambda_l2_);
@@ -234,9 +234,9 @@ private:
   * \return leaf output
   */
   double CalculateSplittedLeafOutput(double sum_gradients, double sum_hessians) const {
-    double abs_sum_gradients = fabs(sum_gradients);
+    double abs_sum_gradients = std::fabs(sum_gradients);
     if (abs_sum_gradients > lambda_l1_) {
-      return -copysign(abs_sum_gradients - lambda_l1_, sum_gradients) / (sum_hessians + lambda_l2_);
+      return -std::copysign(abs_sum_gradients - lambda_l1_, sum_gradients) / (sum_hessians + lambda_l2_);
     }
     return 0.0f;
   }

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -16,6 +16,8 @@ SerialTreeLearner::SerialTreeLearner(const TreeConfig& tree_config)
   num_leaves_ = tree_config.num_leaves;
   min_num_data_one_leaf_ = static_cast<data_size_t>(tree_config.min_data_in_leaf);
   min_sum_hessian_one_leaf_ = static_cast<double>(tree_config.min_sum_hessian_in_leaf);
+  reg_lambda_ = tree_config.reg_lambda;
+  reg_gamma_ = tree_config.reg_gamma;
   feature_fraction_ = tree_config.feature_fraction;
   random_ = Random(tree_config.feature_fraction_seed);
   histogram_pool_size_ = tree_config.histogram_pool_size;
@@ -68,7 +70,9 @@ void SerialTreeLearner::Init(const Dataset* train_data) {
     for (int j = 0; j < train_data_->num_features(); ++j) {
       tmp_histogram_array[j].Init(train_data_->FeatureAt(j),
         j, min_num_data_one_leaf_,
-        min_sum_hessian_one_leaf_);
+        min_sum_hessian_one_leaf_,
+        reg_lambda_,
+        reg_gamma_);
     }
     return tmp_histogram_array;
   };

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -16,6 +16,7 @@ SerialTreeLearner::SerialTreeLearner(const TreeConfig& tree_config)
   num_leaves_ = tree_config.num_leaves;
   min_num_data_one_leaf_ = static_cast<data_size_t>(tree_config.min_data_in_leaf);
   min_sum_hessian_one_leaf_ = static_cast<double>(tree_config.min_sum_hessian_in_leaf);
+  lambda_l1_ = tree_config.lambda_l1;
   lambda_l2_ = tree_config.lambda_l2;
   min_gain_to_split_ = tree_config.min_gain_to_split;
   feature_fraction_ = tree_config.feature_fraction;
@@ -71,6 +72,7 @@ void SerialTreeLearner::Init(const Dataset* train_data) {
       tmp_histogram_array[j].Init(train_data_->FeatureAt(j),
         j, min_num_data_one_leaf_,
         min_sum_hessian_one_leaf_,
+        lambda_l1_,
         lambda_l2_,
         min_gain_to_split_);
     }

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -16,8 +16,8 @@ SerialTreeLearner::SerialTreeLearner(const TreeConfig& tree_config)
   num_leaves_ = tree_config.num_leaves;
   min_num_data_one_leaf_ = static_cast<data_size_t>(tree_config.min_data_in_leaf);
   min_sum_hessian_one_leaf_ = static_cast<double>(tree_config.min_sum_hessian_in_leaf);
-  reg_lambda_ = tree_config.reg_lambda;
-  reg_gamma_ = tree_config.reg_gamma;
+  lambda_l2_ = tree_config.lambda_l2;
+  min_gain_to_split_ = tree_config.min_gain_to_split;
   feature_fraction_ = tree_config.feature_fraction;
   random_ = Random(tree_config.feature_fraction_seed);
   histogram_pool_size_ = tree_config.histogram_pool_size;
@@ -71,8 +71,8 @@ void SerialTreeLearner::Init(const Dataset* train_data) {
       tmp_histogram_array[j].Init(train_data_->FeatureAt(j),
         j, min_num_data_one_leaf_,
         min_sum_hessian_one_leaf_,
-        reg_lambda_,
-        reg_gamma_);
+        lambda_l2_,
+        min_gain_to_split_);
     }
     return tmp_histogram_array;
   };

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -115,6 +115,8 @@ protected:
   data_size_t min_num_data_one_leaf_;
   /*! \brief minimal sum hessian on one leaf */
   double min_sum_hessian_one_leaf_;
+  /*! \brief lambda of the L1 weights regularization */
+  double lambda_l1_;
   /*! \brief lambda of the L2 weights regularization */
   double lambda_l2_;
   /*! \brief minimal gain (loss reduction) to split */

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -111,10 +111,14 @@ protected:
   const score_t* hessians_;
   /*! \brief number of total leaves */
   int num_leaves_;
-  /*! \brief mininal data on one leaf */
+  /*! \brief minimal data on one leaf */
   data_size_t min_num_data_one_leaf_;
-  /*! \brief mininal sum hessian on one leaf */
+  /*! \brief minimal sum hessian on one leaf */
   double min_sum_hessian_one_leaf_;
+  /*! \brief lambda L2 weights regularization */
+  double reg_lambda_;
+  /*! \brief minimal loss reduction to split */
+  double reg_gamma_;
   /*! \brief sub-feature fraction rate */
   double feature_fraction_;
   /*! \brief training data partition on leaves */

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -115,10 +115,10 @@ protected:
   data_size_t min_num_data_one_leaf_;
   /*! \brief minimal sum hessian on one leaf */
   double min_sum_hessian_one_leaf_;
-  /*! \brief lambda L2 weights regularization */
-  double reg_lambda_;
-  /*! \brief minimal loss reduction to split */
-  double reg_gamma_;
+  /*! \brief lambda of the L2 weights regularization */
+  double lambda_l2_;
+  /*! \brief minimal gain (loss reduction) to split */
+  double min_gain_to_split_;
   /*! \brief sub-feature fraction rate */
   double feature_fraction_;
   /*! \brief training data partition on leaves */


### PR DESCRIPTION
These commits add three regularization parameters that discourage or constrain the complexity of the boosting trees. The parameters can reduce the degree of overfitting and have the added benefit of speeding up training because they limits the number of leaves. The parameters follow (as closely as possible) the implementation of XGBoost's regularization parameters (`alpha`, `lambda`, and `gamma`) to fit with users' expectations about appropriate values.

1. `lambda_l1 (default = 0.0f)` controls the L1 weights regularization by setting the strength of an L1 regularization term in the objective function (i.e. `lambda_l1 * |weights|`). This term is implemented by pushing `sum_gradients` towards zero in the weights calculations.
2. `lambda_l2 (default = 0.0f)` controls the L2 weights regularization by setting the strength of an L2 regularization term in the objective function (i.e. `0.5 * lambda_l2 * weights^2`, with the factor 0.5 mirroring XGBoost's implementation). This term is implemented by increasing `sum_hessians` in the weights calculations.
3. `min_gain_to_split (default = 0.0f)` sets the minimal gain / loss reduction required to split a leaf.

When used to train a binary classifier on a sizable (> 1 million data points) database, even somewhat naive and unoptimized values for these parameters improve performance beyond what could be realized with the current regularization parameters.

Nevertheless, I would appreciate it if you could check whether the current implementation seems performant and complete (i.e. was all code that calculates gain/loss reduction and output weights adjusted).

*Note that I did not yet update the example models with these parameters. It would be trivial to do this after we've settled on the appropriate parameter names and implementation.