### PR TITLE
Export low level interface API for MSVC

### DIFF
--- a/include/LightGBM/boosting.h
+++ b/include/LightGBM/boosting.h
@@ -17,7 +17,7 @@ class Metric;
 /*!
 * \brief The interface for Boosting
 */
-class Boosting {
+class LIGHTGBM_EXPORT Boosting {
 public:
   /*! \brief virtual destructor */
   virtual ~Boosting() {}

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -14,17 +14,7 @@
 * The reason is because they are called frequently, the type-conversion on them maybe time cost.
 */
 
-#ifdef __cplusplus
-#define DLL_EXTERN_C extern "C"
-#else
-#define DLL_EXTERN_C
-#endif
-
-#ifdef _MSC_VER
-#define DllExport DLL_EXTERN_C __declspec(dllexport)
-#else
-#define DllExport DLL_EXTERN_C
-#endif
+#include <LightGBM/export.h>
 
 typedef void* DatasetHandle;
 typedef void* BoosterHandle;
@@ -44,7 +34,7 @@ typedef void* BoosterHandle;
 *  and -1 when an error occured,
 * \return const char* error inforomation
 */
-DllExport const char* LGBM_GetLastError();
+LIGHTGBM_C_EXPORT const char* LGBM_GetLastError();
 
 
 // --- start Dataset interface
@@ -57,7 +47,7 @@ DllExport const char* LGBM_GetLastError();
 * \param out a loaded dataset
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetCreateFromFile(const char* filename,
+LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromFile(const char* filename,
   const char* parameters,
   const DatasetHandle reference,
   DatasetHandle* out);
@@ -77,7 +67,7 @@ DllExport int LGBM_DatasetCreateFromFile(const char* filename,
 * \param out created dataset
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetCreateFromCSR(const void* indptr,
+LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromCSR(const void* indptr,
   int indptr_type,
   const int32_t* indices,
   const void* data,
@@ -104,7 +94,7 @@ DllExport int LGBM_DatasetCreateFromCSR(const void* indptr,
 * \param out created dataset
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetCreateFromCSC(const void* col_ptr,
+LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromCSC(const void* col_ptr,
   int col_ptr_type,
   const int32_t* indices,
   const void* data,
@@ -128,7 +118,7 @@ DllExport int LGBM_DatasetCreateFromCSC(const void* col_ptr,
 * \param out created dataset
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetCreateFromMat(const void* data,
+LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromMat(const void* data,
   int data_type,
   int32_t nrow,
   int32_t ncol,
@@ -146,7 +136,7 @@ DllExport int LGBM_DatasetCreateFromMat(const void* data,
 * \param out subset of data
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetGetSubset(
+LIGHTGBM_C_EXPORT int LGBM_DatasetGetSubset(
   const DatasetHandle handle,
   const int32_t* used_row_indices,
   int32_t num_used_row_indices,
@@ -160,7 +150,7 @@ DllExport int LGBM_DatasetGetSubset(
 * \param num_feature_names number of feature names
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetSetFeatureNames(
+LIGHTGBM_C_EXPORT int LGBM_DatasetSetFeatureNames(
   DatasetHandle handle,
   const char** feature_names,
   int num_feature_names);
@@ -173,7 +163,7 @@ DllExport int LGBM_DatasetSetFeatureNames(
 * \param num_feature_names number of feature names
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetGetFeatureNames(
+LIGHTGBM_C_EXPORT int LGBM_DatasetGetFeatureNames(
   DatasetHandle handle,
   char** feature_names,
   int* num_feature_names);
@@ -183,7 +173,7 @@ DllExport int LGBM_DatasetGetFeatureNames(
 * \brief free space for dataset
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetFree(DatasetHandle handle);
+LIGHTGBM_C_EXPORT int LGBM_DatasetFree(DatasetHandle handle);
 
 /*!
 * \brief save dateset to binary file
@@ -191,7 +181,7 @@ DllExport int LGBM_DatasetFree(DatasetHandle handle);
 * \param filename file name
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetSaveBinary(DatasetHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_DatasetSaveBinary(DatasetHandle handle,
   const char* filename);
 
 /*!
@@ -205,7 +195,7 @@ DllExport int LGBM_DatasetSaveBinary(DatasetHandle handle,
 * \param type C_API_DTYPE_FLOAT32 or C_API_DTYPE_INT32
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetSetField(DatasetHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_DatasetSetField(DatasetHandle handle,
   const char* field_name,
   const void* field_data,
   int num_element,
@@ -220,7 +210,7 @@ DllExport int LGBM_DatasetSetField(DatasetHandle handle,
 * \param out_type  C_API_DTYPE_FLOAT32 or C_API_DTYPE_INT32
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetGetField(DatasetHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_DatasetGetField(DatasetHandle handle,
   const char* field_name,
   int* out_len,
   const void** out_ptr,
@@ -232,7 +222,7 @@ DllExport int LGBM_DatasetGetField(DatasetHandle handle,
 * \param out The address to hold number of data
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetGetNumData(DatasetHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_DatasetGetNumData(DatasetHandle handle,
   int* out);
 
 /*!
@@ -241,7 +231,7 @@ DllExport int LGBM_DatasetGetNumData(DatasetHandle handle,
 * \param out The output of number of features
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_DatasetGetNumFeature(DatasetHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_DatasetGetNumFeature(DatasetHandle handle,
   int* out);
 
 // --- start Booster interfaces
@@ -253,7 +243,7 @@ DllExport int LGBM_DatasetGetNumFeature(DatasetHandle handle,
 * \prama out handle of created Booster
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterCreate(const DatasetHandle train_data,
+LIGHTGBM_C_EXPORT int LGBM_BoosterCreate(const DatasetHandle train_data,
   const char* parameters,
   BoosterHandle* out);
 
@@ -264,7 +254,7 @@ DllExport int LGBM_BoosterCreate(const DatasetHandle train_data,
 * \param out handle of created Booster
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterCreateFromModelfile(
+LIGHTGBM_C_EXPORT int LGBM_BoosterCreateFromModelfile(
   const char* filename,
   int* out_num_iterations,
   BoosterHandle* out);
@@ -275,7 +265,7 @@ DllExport int LGBM_BoosterCreateFromModelfile(
 * \param handle handle to be freed
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterFree(BoosterHandle handle);
+LIGHTGBM_C_EXPORT int LGBM_BoosterFree(BoosterHandle handle);
 
 /*!
 * \brief Merge model in two booster to first handle
@@ -283,7 +273,7 @@ DllExport int LGBM_BoosterFree(BoosterHandle handle);
 * \param other_handle
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterMerge(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterMerge(BoosterHandle handle,
   BoosterHandle other_handle);
 
 /*!
@@ -292,7 +282,7 @@ DllExport int LGBM_BoosterMerge(BoosterHandle handle,
 * \param valid_data validation data set
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterAddValidData(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterAddValidData(BoosterHandle handle,
   const DatasetHandle valid_data);
 
 /*!
@@ -301,7 +291,7 @@ DllExport int LGBM_BoosterAddValidData(BoosterHandle handle,
 * \param train_data training data set
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterResetTrainingData(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterResetTrainingData(BoosterHandle handle,
   const DatasetHandle train_data);
 
 /*!
@@ -310,7 +300,7 @@ DllExport int LGBM_BoosterResetTrainingData(BoosterHandle handle,
 * \param parameters format: 'key1=value1 key2=value2'
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterResetParameter(BoosterHandle handle, const char* parameters);
+LIGHTGBM_C_EXPORT int LGBM_BoosterResetParameter(BoosterHandle handle, const char* parameters);
 
 /*!
 * \brief Get number of class
@@ -318,7 +308,7 @@ DllExport int LGBM_BoosterResetParameter(BoosterHandle handle, const char* param
 * \param out_len number of class
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterGetNumClasses(BoosterHandle handle, int* out_len);
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetNumClasses(BoosterHandle handle, int* out_len);
 
 /*!
 * \brief update the model in one round
@@ -326,7 +316,7 @@ DllExport int LGBM_BoosterGetNumClasses(BoosterHandle handle, int* out_len);
 * \param is_finished 1 means finised(cannot split any more)
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterUpdateOneIter(BoosterHandle handle, int* is_finished);
+LIGHTGBM_C_EXPORT int LGBM_BoosterUpdateOneIter(BoosterHandle handle, int* is_finished);
 
 /*!
 * \brief update the model, by directly specify gradient and second order gradient,
@@ -337,7 +327,7 @@ DllExport int LGBM_BoosterUpdateOneIter(BoosterHandle handle, int* is_finished);
 * \param is_finished 1 means finised(cannot split any more)
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterUpdateOneIterCustom(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterUpdateOneIterCustom(BoosterHandle handle,
   const float* grad,
   const float* hess,
   int* is_finished);
@@ -347,21 +337,21 @@ DllExport int LGBM_BoosterUpdateOneIterCustom(BoosterHandle handle,
 * \param handle handle
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterRollbackOneIter(BoosterHandle handle);
+LIGHTGBM_C_EXPORT int LGBM_BoosterRollbackOneIter(BoosterHandle handle);
 
 /*!
 * \brief Get iteration of current boosting rounds
 * \param out_iteration iteration of boosting rounds
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterGetCurrentIteration(BoosterHandle handle, int* out_iteration);
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetCurrentIteration(BoosterHandle handle, int* out_iteration);
 
 /*!
 * \brief Get number of eval
 * \param out_len total number of eval results
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterGetEvalCounts(BoosterHandle handle, int* out_len);
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetEvalCounts(BoosterHandle handle, int* out_len);
 
 /*!
 * \brief Get Name of eval
@@ -369,7 +359,7 @@ DllExport int LGBM_BoosterGetEvalCounts(BoosterHandle handle, int* out_len);
 * \param out_strs names of eval result, need to pre-allocate memory before call this
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterGetEvalNames(BoosterHandle handle, int* out_len, char** out_strs);
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetEvalNames(BoosterHandle handle, int* out_len, char** out_strs);
 
 /*!
 * \brief get evaluation for training data and validation data
@@ -381,7 +371,7 @@ Note: 1. you should call LGBM_BoosterGetEvalNames first to get the name of evalu
 * \param out_result float arrary contains result
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterGetEval(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetEval(BoosterHandle handle,
   int data_idx,
   int* out_len,
   double* out_results);
@@ -395,7 +385,7 @@ Note:  should pre-allocate memory for out_result, its length is equal to num_cla
 * \param out_len len of output result
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterGetNumPredict(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetNumPredict(BoosterHandle handle,
   int data_idx,
   int64_t* out_len);
 
@@ -409,7 +399,7 @@ Note:  should pre-allocate memory for out_result, its length is equal to num_cla
 * \param out_result used to set a pointer to array, should allocate memory before call this function
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterGetPredict(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetPredict(BoosterHandle handle,
   int data_idx,
   int64_t* out_len,
   double* out_result);
@@ -427,7 +417,7 @@ DllExport int LGBM_BoosterGetPredict(BoosterHandle handle,
 * \param result_filename filename of result file
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterPredictForFile(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForFile(BoosterHandle handle,
   const char* data_filename,
   int data_has_header,
   int predict_type,
@@ -446,7 +436,7 @@ DllExport int LGBM_BoosterPredictForFile(BoosterHandle handle,
 * \param out_len lenght of prediction
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterCalcNumPredict(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterCalcNumPredict(BoosterHandle handle,
   int num_row,
   int predict_type,
   int num_iteration,
@@ -475,7 +465,7 @@ DllExport int LGBM_BoosterCalcNumPredict(BoosterHandle handle,
 * \param out_result used to set a pointer to array, should allocate memory before call this function
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterPredictForCSR(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSR(BoosterHandle handle,
   const void* indptr,
   int indptr_type,
   const int32_t* indices,
@@ -512,7 +502,7 @@ DllExport int LGBM_BoosterPredictForCSR(BoosterHandle handle,
 * \param out_result used to set a pointer to array, should allocate memory before call this function
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterPredictForCSC(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSC(BoosterHandle handle,
   const void* col_ptr,
   int col_ptr_type,
   const int32_t* indices,
@@ -546,7 +536,7 @@ DllExport int LGBM_BoosterPredictForCSC(BoosterHandle handle,
 * \param out_result used to set a pointer to array, should allocate memory before call this function
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterPredictForMat(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForMat(BoosterHandle handle,
   const void* data,
   int data_type,
   int32_t nrow,
@@ -564,7 +554,7 @@ DllExport int LGBM_BoosterPredictForMat(BoosterHandle handle,
 * \param filename file name
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterSaveModel(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterSaveModel(BoosterHandle handle,
   int num_iteration,
   const char* filename);
 
@@ -577,7 +567,7 @@ DllExport int LGBM_BoosterSaveModel(BoosterHandle handle,
 * \param out_str json format string of model, need to pre-allocate memory before call this
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterDumpModel(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterDumpModel(BoosterHandle handle,
   int num_iteration,
   int buffer_len,
   int* out_len,
@@ -591,7 +581,7 @@ DllExport int LGBM_BoosterDumpModel(BoosterHandle handle,
 * \param out_val out result
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterGetLeafValue(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetLeafValue(BoosterHandle handle,
   int tree_idx,
   int leaf_idx,
   double* out_val);
@@ -604,7 +594,7 @@ DllExport int LGBM_BoosterGetLeafValue(BoosterHandle handle,
 * \param val leaf value
 * \return 0 when succeed, -1 when failure happens
 */
-DllExport int LGBM_BoosterSetLeafValue(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterSetLeafValue(BoosterHandle handle,
   int tree_idx,
   int leaf_idx,
   double val);

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -5,6 +5,7 @@
 #include <LightGBM/utils/log.h>
 
 #include <LightGBM/meta.h>
+#include <LightGBM/export.h>
 
 #include <vector>
 #include <string>
@@ -123,7 +124,7 @@ public:
   * And add an prefix "name:" while using column name
   * Note: when using Index, it dosen't count the label index */
   std::string categorical_column = "";
-  void Set(const std::unordered_map<std::string, std::string>& params) override;
+  LIGHTGBM_EXPORT void Set(const std::unordered_map<std::string, std::string>& params) override;
 };
 
 /*! \brief Config for objective function */
@@ -145,7 +146,7 @@ public:
   int num_class = 1;
   // Balancing of positive and negative weights
   double scale_pos_weight = 1.0f;
-  void Set(const std::unordered_map<std::string, std::string>& params) override;
+  LIGHTGBM_EXPORT void Set(const std::unordered_map<std::string, std::string>& params) override;
 };
 
 /*! \brief Config for metrics interface*/
@@ -158,7 +159,7 @@ public:
   double fair_c = 1.0f;
   std::vector<double> label_gain;
   std::vector<int> eval_at;
-  void Set(const std::unordered_map<std::string, std::string>& params) override;
+  LIGHTGBM_EXPORT void Set(const std::unordered_map<std::string, std::string>& params) override;
 };
 
 
@@ -182,7 +183,7 @@ public:
   // max_depth < 0 means not limit
   int max_depth = -1;
   int top_k = 20;
-  void Set(const std::unordered_map<std::string, std::string>& params) override;
+  LIGHTGBM_EXPORT void Set(const std::unordered_map<std::string, std::string>& params) override;
 };
 
 /*! \brief Config for Boosting */
@@ -207,7 +208,7 @@ public:
   int drop_seed = 4;
   std::string tree_learner_type = "serial";
   TreeConfig tree_config;
-  void Set(const std::unordered_map<std::string, std::string>& params) override;
+  LIGHTGBM_EXPORT void Set(const std::unordered_map<std::string, std::string>& params) override;
 private:
   void GetTreeLearnerType(const std::unordered_map<std::string,
     std::string>& params);
@@ -220,7 +221,7 @@ public:
   int local_listen_port = 12400;
   int time_out = 120;  // in minutes
   std::string machine_list_filename = "";
-  void Set(const std::unordered_map<std::string, std::string>& params) override;
+  LIGHTGBM_EXPORT void Set(const std::unordered_map<std::string, std::string>& params) override;
 };
 
 
@@ -241,7 +242,7 @@ public:
   std::vector<std::string> metric_types;
   MetricConfig metric_config;
 
-  void Set(const std::unordered_map<std::string, std::string>& params) override;
+  LIGHTGBM_EXPORT void Set(const std::unordered_map<std::string, std::string>& params) override;
 
 private:
   void GetBoostingType(const std::unordered_map<std::string, std::string>& params);

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -280,14 +280,14 @@ class Dataset {
 public:
   friend DatasetLoader;
 
-  Dataset();
+  LIGHTGBM_EXPORT Dataset();
 
-  Dataset(data_size_t num_data);
+  LIGHTGBM_EXPORT Dataset(data_size_t num_data);
 
   /*! \brief Destructor */
-  ~Dataset();
+  LIGHTGBM_EXPORT ~Dataset();
 
-  bool CheckAlign(const Dataset& other) const {
+  LIGHTGBM_EXPORT bool CheckAlign(const Dataset& other) const {
     if (num_features_ != other.num_features_) {
       return false;
     }
@@ -330,26 +330,26 @@ public:
 
   Dataset* Subset(const data_size_t* used_indices, data_size_t num_used_indices, bool is_enable_sparse) const;
 
-  void FinishLoad();
+  LIGHTGBM_EXPORT void FinishLoad();
 
-  bool SetFloatField(const char* field_name, const float* field_data, data_size_t num_element);
+  LIGHTGBM_EXPORT bool SetFloatField(const char* field_name, const float* field_data, data_size_t num_element);
 
-  bool SetDoubleField(const char* field_name, const double* field_data, data_size_t num_element);
+  LIGHTGBM_EXPORT bool SetDoubleField(const char* field_name, const double* field_data, data_size_t num_element);
 
-  bool SetIntField(const char* field_name, const int* field_data, data_size_t num_element);
+  LIGHTGBM_EXPORT bool SetIntField(const char* field_name, const int* field_data, data_size_t num_element);
 
-  bool GetFloatField(const char* field_name, data_size_t* out_len, const float** out_ptr);
+  LIGHTGBM_EXPORT bool GetFloatField(const char* field_name, data_size_t* out_len, const float** out_ptr);
 
-  bool GetDoubleField(const char* field_name, data_size_t* out_len, const double** out_ptr);
+  LIGHTGBM_EXPORT bool GetDoubleField(const char* field_name, data_size_t* out_len, const double** out_ptr);
 
-  bool GetIntField(const char* field_name, data_size_t* out_len, const int** out_ptr);
+  LIGHTGBM_EXPORT bool GetIntField(const char* field_name, data_size_t* out_len, const int** out_ptr);
 
   /*!
   * \brief Save current dataset into binary file, will save to "filename.bin"
   */
-  void SaveBinaryFile(const char* bin_filename);
+  LIGHTGBM_EXPORT void SaveBinaryFile(const char* bin_filename);
 
-  void CopyFeatureMapperFrom(const Dataset* dataset, bool is_enable_sparse);
+  LIGHTGBM_EXPORT void CopyFeatureMapperFrom(const Dataset* dataset, bool is_enable_sparse);
 
   /*!
   * \brief Get a feature pointer for specific index

--- a/include/LightGBM/dataset_loader.h
+++ b/include/LightGBM/dataset_loader.h
@@ -8,21 +8,21 @@ namespace LightGBM {
 class DatasetLoader {
 public:
 
-  DatasetLoader(const IOConfig& io_config, const PredictFunction& predict_fun, int num_class, const char* filename);
+  LIGHTGBM_EXPORT DatasetLoader(const IOConfig& io_config, const PredictFunction& predict_fun, int num_class, const char* filename);
 
-  ~DatasetLoader();
+  LIGHTGBM_EXPORT ~DatasetLoader();
 
-  Dataset* LoadFromFile(const char* filename, int rank, int num_machines);
+  LIGHTGBM_EXPORT Dataset* LoadFromFile(const char* filename, int rank, int num_machines);
 
-  Dataset* LoadFromFile(const char* filename) {
+  LIGHTGBM_EXPORT Dataset* LoadFromFile(const char* filename) {
     return LoadFromFile(filename, 0, 1);
   }
 
-  Dataset* LoadFromFileAlignWithOtherDataset(const char* filename, const Dataset* train_data);
+  LIGHTGBM_EXPORT Dataset* LoadFromFileAlignWithOtherDataset(const char* filename, const Dataset* train_data);
 
-  Dataset* LoadFromBinFile(const char* data_filename, const char* bin_filename, int rank, int num_machines);
+  LIGHTGBM_EXPORT Dataset* LoadFromBinFile(const char* data_filename, const char* bin_filename, int rank, int num_machines);
 
-  Dataset* CostructFromSampleData(std::vector<std::vector<double>>& sample_values, size_t total_sample_size, data_size_t num_data);
+  LIGHTGBM_EXPORT Dataset* CostructFromSampleData(std::vector<std::vector<double>>& sample_values, size_t total_sample_size, data_size_t num_data);
 
   /*! \brief Disable copy */
   DatasetLoader& operator=(const DatasetLoader&) = delete;

--- a/include/LightGBM/export.h
+++ b/include/LightGBM/export.h
@@ -1,0 +1,21 @@
+#ifndef LIGHTGBM_EXPORT_H_
+#define LIGHTGBM_EXPORT_H_
+
+/** Macros for exporting symbols in MSVC/GCC/CLANG **/
+
+#ifdef __cplusplus
+#define LIGHTGBM_EXTERN_C extern "C"
+#else
+#define LIGHTGBM_EXTERN_C
+#endif
+
+
+#ifdef _MSC_VER
+#define LIGHTGBM_EXPORT __declspec(dllexport)
+#define LIGHTGBM_C_EXPORT LIGHTGBM_EXTERN_C __declspec(dllexport)
+#else
+#define LIGHTGBM_EXPORT 
+#define LIGHTGBM_C_EXPORT LIGHTGBM_EXTERN_C
+#endif
+
+#endif /** LIGHTGBM_EXPORT_H_ **/

--- a/include/LightGBM/metric.h
+++ b/include/LightGBM/metric.h
@@ -46,7 +46,7 @@ public:
   * \param type Specific type of metric
   * \param config Config for metric
   */
-  static Metric* CreateMetric(const std::string& type, const MetricConfig& config);
+  LIGHTGBM_EXPORT static Metric* CreateMetric(const std::string& type, const MetricConfig& config);
 
 };
 

--- a/include/LightGBM/objective_function.h
+++ b/include/LightGBM/objective_function.h
@@ -44,7 +44,7 @@ public:
   * \param type Specific type of objective function
   * \param config Config for objective function
   */
-  static ObjectiveFunction* CreateObjectiveFunction(const std::string& type,
+  LIGHTGBM_EXPORT static ObjectiveFunction* CreateObjectiveFunction(const std::string& type,
     const ObjectiveConfig& config);
 };
 

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -267,11 +267,11 @@ private:
 
 // start of c_api functions
 
-DllExport const char* LGBM_GetLastError() {
+LIGHTGBM_C_EXPORT const char* LGBM_GetLastError() {
   return LastErrorMsg();
 }
 
-DllExport int LGBM_DatasetCreateFromFile(const char* filename,
+LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromFile(const char* filename,
   const char* parameters,
   const DatasetHandle reference,
   DatasetHandle* out) {
@@ -289,7 +289,7 @@ DllExport int LGBM_DatasetCreateFromFile(const char* filename,
   API_END();
 }
 
-DllExport int LGBM_DatasetCreateFromMat(const void* data,
+LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromMat(const void* data,
   int data_type,
   int32_t nrow,
   int32_t ncol,
@@ -338,7 +338,7 @@ DllExport int LGBM_DatasetCreateFromMat(const void* data,
   API_END();
 }
 
-DllExport int LGBM_DatasetCreateFromCSR(const void* indptr,
+LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromCSR(const void* indptr,
   int indptr_type,
   const int32_t* indices,
   const void* data,
@@ -400,7 +400,7 @@ DllExport int LGBM_DatasetCreateFromCSR(const void* indptr,
   API_END();
 }
 
-DllExport int LGBM_DatasetCreateFromCSC(const void* col_ptr,
+LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromCSC(const void* col_ptr,
   int col_ptr_type,
   const int32_t* indices,
   const void* data,
@@ -462,7 +462,7 @@ DllExport int LGBM_DatasetCreateFromCSC(const void* col_ptr,
   API_END();
 }
 
-DllExport int LGBM_DatasetGetSubset(
+LIGHTGBM_C_EXPORT int LGBM_DatasetGetSubset(
   const DatasetHandle handle,
   const int32_t* used_row_indices,
   int32_t num_used_row_indices,
@@ -482,7 +482,7 @@ DllExport int LGBM_DatasetGetSubset(
   API_END();
 }
 
-DllExport int LGBM_DatasetSetFeatureNames(
+LIGHTGBM_C_EXPORT int LGBM_DatasetSetFeatureNames(
   DatasetHandle handle,
   const char** feature_names,
   int num_feature_names) {
@@ -496,7 +496,7 @@ DllExport int LGBM_DatasetSetFeatureNames(
   API_END();
 }
 
-DllExport int LGBM_DatasetGetFeatureNames(
+LIGHTGBM_C_EXPORT int LGBM_DatasetGetFeatureNames(
   DatasetHandle handle,
   char** feature_names,
   int* num_feature_names) {
@@ -510,13 +510,13 @@ DllExport int LGBM_DatasetGetFeatureNames(
   API_END();
 }
 
-DllExport int LGBM_DatasetFree(DatasetHandle handle) {
+LIGHTGBM_C_EXPORT int LGBM_DatasetFree(DatasetHandle handle) {
   API_BEGIN();
   delete reinterpret_cast<Dataset*>(handle);
   API_END();
 }
 
-DllExport int LGBM_DatasetSaveBinary(DatasetHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_DatasetSaveBinary(DatasetHandle handle,
   const char* filename) {
   API_BEGIN();
   auto dataset = reinterpret_cast<Dataset*>(handle);
@@ -524,7 +524,7 @@ DllExport int LGBM_DatasetSaveBinary(DatasetHandle handle,
   API_END();
 }
 
-DllExport int LGBM_DatasetSetField(DatasetHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_DatasetSetField(DatasetHandle handle,
   const char* field_name,
   const void* field_data,
   int num_element,
@@ -543,7 +543,7 @@ DllExport int LGBM_DatasetSetField(DatasetHandle handle,
   API_END();
 }
 
-DllExport int LGBM_DatasetGetField(DatasetHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_DatasetGetField(DatasetHandle handle,
   const char* field_name,
   int* out_len,
   const void** out_ptr,
@@ -566,7 +566,7 @@ DllExport int LGBM_DatasetGetField(DatasetHandle handle,
   API_END();
 }
 
-DllExport int LGBM_DatasetGetNumData(DatasetHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_DatasetGetNumData(DatasetHandle handle,
   int* out) {
   API_BEGIN();
   auto dataset = reinterpret_cast<Dataset*>(handle);
@@ -574,7 +574,7 @@ DllExport int LGBM_DatasetGetNumData(DatasetHandle handle,
   API_END();
 }
 
-DllExport int LGBM_DatasetGetNumFeature(DatasetHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_DatasetGetNumFeature(DatasetHandle handle,
   int* out) {
   API_BEGIN();
   auto dataset = reinterpret_cast<Dataset*>(handle);
@@ -584,7 +584,7 @@ DllExport int LGBM_DatasetGetNumFeature(DatasetHandle handle,
 
 // ---- start of booster
 
-DllExport int LGBM_BoosterCreate(const DatasetHandle train_data,
+LIGHTGBM_C_EXPORT int LGBM_BoosterCreate(const DatasetHandle train_data,
   const char* parameters,
   BoosterHandle* out) {
   API_BEGIN();
@@ -594,7 +594,7 @@ DllExport int LGBM_BoosterCreate(const DatasetHandle train_data,
   API_END();
 }
 
-DllExport int LGBM_BoosterCreateFromModelfile(
+LIGHTGBM_C_EXPORT int LGBM_BoosterCreateFromModelfile(
   const char* filename,
   int* out_num_iterations,
   BoosterHandle* out) {
@@ -605,13 +605,13 @@ DllExport int LGBM_BoosterCreateFromModelfile(
   API_END();
 }
 
-DllExport int LGBM_BoosterFree(BoosterHandle handle) {
+LIGHTGBM_C_EXPORT int LGBM_BoosterFree(BoosterHandle handle) {
   API_BEGIN();
   delete reinterpret_cast<Booster*>(handle);
   API_END();
 }
 
-DllExport int LGBM_BoosterMerge(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterMerge(BoosterHandle handle,
   BoosterHandle other_handle) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
@@ -620,7 +620,7 @@ DllExport int LGBM_BoosterMerge(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterAddValidData(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterAddValidData(BoosterHandle handle,
   const DatasetHandle valid_data) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
@@ -629,7 +629,7 @@ DllExport int LGBM_BoosterAddValidData(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterResetTrainingData(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterResetTrainingData(BoosterHandle handle,
   const DatasetHandle train_data) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
@@ -638,21 +638,21 @@ DllExport int LGBM_BoosterResetTrainingData(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterResetParameter(BoosterHandle handle, const char* parameters) {
+LIGHTGBM_C_EXPORT int LGBM_BoosterResetParameter(BoosterHandle handle, const char* parameters) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
   ref_booster->ResetConfig(parameters);
   API_END();
 }
 
-DllExport int LGBM_BoosterGetNumClasses(BoosterHandle handle, int* out_len) {
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetNumClasses(BoosterHandle handle, int* out_len) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
   *out_len = ref_booster->GetBoosting()->NumberOfClasses();
   API_END();
 }
 
-DllExport int LGBM_BoosterUpdateOneIter(BoosterHandle handle, int* is_finished) {
+LIGHTGBM_C_EXPORT int LGBM_BoosterUpdateOneIter(BoosterHandle handle, int* is_finished) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
   if (ref_booster->TrainOneIter()) {
@@ -663,7 +663,7 @@ DllExport int LGBM_BoosterUpdateOneIter(BoosterHandle handle, int* is_finished) 
   API_END();
 }
 
-DllExport int LGBM_BoosterUpdateOneIterCustom(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterUpdateOneIterCustom(BoosterHandle handle,
   const float* grad,
   const float* hess,
   int* is_finished) {
@@ -677,35 +677,35 @@ DllExport int LGBM_BoosterUpdateOneIterCustom(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterRollbackOneIter(BoosterHandle handle) {
+LIGHTGBM_C_EXPORT int LGBM_BoosterRollbackOneIter(BoosterHandle handle) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
   ref_booster->RollbackOneIter();
   API_END();
 }
 
-DllExport int LGBM_BoosterGetCurrentIteration(BoosterHandle handle, int* out_iteration) {
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetCurrentIteration(BoosterHandle handle, int* out_iteration) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
   *out_iteration = ref_booster->GetBoosting()->GetCurrentIteration();
   API_END();
 }
 
-DllExport int LGBM_BoosterGetEvalCounts(BoosterHandle handle, int* out_len) {
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetEvalCounts(BoosterHandle handle, int* out_len) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
   *out_len = ref_booster->GetEvalCounts();
   API_END();
 }
 
-DllExport int LGBM_BoosterGetEvalNames(BoosterHandle handle, int* out_len, char** out_strs) {
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetEvalNames(BoosterHandle handle, int* out_len, char** out_strs) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
   *out_len = ref_booster->GetEvalNames(out_strs);
   API_END();
 }
 
-DllExport int LGBM_BoosterGetEval(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetEval(BoosterHandle handle,
   int data_idx,
   int* out_len,
   double* out_results) {
@@ -720,7 +720,7 @@ DllExport int LGBM_BoosterGetEval(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterGetNumPredict(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetNumPredict(BoosterHandle handle,
   int data_idx,
   int64_t* out_len) {
   API_BEGIN();
@@ -729,7 +729,7 @@ DllExport int LGBM_BoosterGetNumPredict(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterGetPredict(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetPredict(BoosterHandle handle,
   int data_idx,
   int64_t* out_len,
   double* out_result) {
@@ -739,7 +739,7 @@ DllExport int LGBM_BoosterGetPredict(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterPredictForFile(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForFile(BoosterHandle handle,
   const char* data_filename,
   int data_has_header,
   int predict_type,
@@ -766,7 +766,7 @@ int64_t GetNumPredOneRow(const Booster* ref_booster, int predict_type, int64_t n
   return num_preb_in_one_row;
 }
 
-DllExport int LGBM_BoosterCalcNumPredict(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterCalcNumPredict(BoosterHandle handle,
   int num_row,
   int predict_type,
   int num_iteration,
@@ -777,7 +777,7 @@ DllExport int LGBM_BoosterCalcNumPredict(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterPredictForCSR(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSR(BoosterHandle handle,
   const void* indptr,
   int indptr_type,
   const int32_t* indices,
@@ -808,7 +808,7 @@ DllExport int LGBM_BoosterPredictForCSR(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterPredictForCSC(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSC(BoosterHandle handle,
   const void* col_ptr,
   int col_ptr_type,
   const int32_t* indices,
@@ -853,7 +853,7 @@ DllExport int LGBM_BoosterPredictForCSC(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterPredictForMat(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForMat(BoosterHandle handle,
   const void* data,
   int data_type,
   int32_t nrow,
@@ -880,7 +880,7 @@ DllExport int LGBM_BoosterPredictForMat(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterSaveModel(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterSaveModel(BoosterHandle handle,
   int num_iteration,
   const char* filename) {
   API_BEGIN();
@@ -889,7 +889,7 @@ DllExport int LGBM_BoosterSaveModel(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterDumpModel(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterDumpModel(BoosterHandle handle,
   int num_iteration,
   int buffer_len,
   int* out_len,
@@ -904,7 +904,7 @@ DllExport int LGBM_BoosterDumpModel(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterGetLeafValue(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetLeafValue(BoosterHandle handle,
   int tree_idx,
   int leaf_idx,
   double* out_val) {
@@ -914,7 +914,7 @@ DllExport int LGBM_BoosterGetLeafValue(BoosterHandle handle,
   API_END();
 }
 
-DllExport int LGBM_BoosterSetLeafValue(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterSetLeafValue(BoosterHandle handle,
   int tree_idx,
   int leaf_idx,
   double val) {


### PR DESCRIPTION
Added more exported symbols to have access to the low-level LightGBM API.

A new file `LightGBM/export.h` was created to define the  `LIGHTGBM_EXPORT` and `LIGHTGBM_C_EXPORT` macros, according to the compiler.