### PR TITLE
Make openmp optional, allow for dylib mac library output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8)
 PROJECT(lightgbm)
 
 OPTION(USE_MPI "MPI based parallel learning" OFF)
+OPTION(USE_OPENMP "Enable OpenMP" ON)
 
 if(USE_MPI)
     find_package(MPI REQUIRED)
@@ -13,9 +14,18 @@ else()
     ADD_DEFINITIONS(-DUSE_SOCKET)
 endif(USE_MPI)
 
-find_package(OpenMP REQUIRED)
+if(USE_OPENMP)
+    find_package(OpenMP REQUIRED)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+else()
+    # Ignore unknown #pragma warning
+    if( (CMAKE_CXX_COMPILER_ID MATCHES "[cC][lL][aA][nN][gG]")
+      OR (CMAKE_CXX_COMPILER_ID MATCHES "[gG][nN][uU]"))
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+    endif()
+endif(USE_OPENMP)
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+
 
 if(UNIX OR MINGW OR CYGWIN)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -O3 -Wall -std=c++11")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ PROJECT(lightgbm)
 OPTION(USE_MPI "MPI based parallel learning" OFF)
 OPTION(USE_OPENMP "Enable OpenMP" ON)
 
+if(APPLE)
+    OPTION(APPLE_OUTPUT_DYLIB "Output dylib shared library" OFF)
+endif()
+
 if(USE_MPI)
     find_package(MPI REQUIRED)
     ADD_DEFINITIONS(-DUSE_MPI)
@@ -65,7 +69,11 @@ SET(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 include_directories (${LightGBM_HEADER_DIR})
 
 if(APPLE)
-  SET(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+  if (APPLE_OUTPUT_DYLIB)
+    SET(CMAKE_SHARED_LIBRARY_SUFFIX ".dylib")
+  else()
+    SET(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+  endif()
 endif(APPLE)
 
 if(USE_MPI)

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -4,7 +4,7 @@
 #include <cstring>
 #include <cstdio>
 #include <sstream>
-#include <omp.h>
+#include <LightGBM/utils/openmp_wrapper.h>
 #include <cstdint>
 #include <memory>
 

--- a/include/LightGBM/utils/openmp_wrapper.h
+++ b/include/LightGBM/utils/openmp_wrapper.h
@@ -1,0 +1,27 @@
+#ifndef LIGHTGBM_OPENMP_WRAPPER_H_
+#define LIGHTGBM_OPENMP_WRAPPER_H_
+
+#ifdef _OPENMP
+  #include <omp.h>
+#else
+  #ifdef _MSC_VER
+    #pragma warning( disable : 4068 ) // disable unknown pragma warning
+  #endif
+
+  #ifdef __cplusplus
+    extern "C" {
+  #endif
+    /** Fall here if no OPENMP support, so just
+        simulate a single thread running.
+        All #pragma omp should be ignored by the compiler **/
+    inline void omp_set_num_threads(int) {}
+    inline int omp_get_num_threads() {return 1;}
+    inline int omp_get_thread_num() {return 0;}
+  #ifdef __cplusplus
+  }; // extern "C"
+  #endif
+#endif
+
+
+
+#endif /* LIGHTGBM_OPENMP_WRAPPER_H_ */

--- a/include/LightGBM/utils/threading.h
+++ b/include/LightGBM/utils/threading.h
@@ -1,7 +1,7 @@
 #ifndef LIGHTGBM_UTILS_THREADING_H_
 #define LIGHTGBM_UTILS_THREADING_H_
 
-#include <omp.h>
+#include <LightGBM/utils/openmp_wrapper.h>
 
 #include <vector>
 #include <functional>

--- a/src/application/application.cpp
+++ b/src/application/application.cpp
@@ -12,7 +12,7 @@
 
 #include "predictor.hpp"
 
-#include <omp.h>
+#include <LightGBM/utils/openmp_wrapper.h>
 
 #include <cstdio>
 #include <ctime>

--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -6,7 +6,7 @@
 #include <LightGBM/utils/text_reader.h>
 #include <LightGBM/dataset.h>
 
-#include <omp.h>
+#include <LightGBM/utils/openmp_wrapper.h>
 
 #include <cstring>
 #include <cstdio>

--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -1,6 +1,6 @@
 #include "gbdt.h"
 
-#include <omp.h>
+#include <LightGBM/utils/openmp_wrapper.h>
 
 #include <LightGBM/utils/common.h>
 

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1,4 +1,4 @@
-#include <omp.h>
+#include <LightGBM/utils/openmp_wrapper.h>
 
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/random.h>

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -2,7 +2,7 @@
 
 #include <LightGBM/feature.h>
 
-#include <omp.h>
+#include <LightGBM/utils/openmp_wrapper.h>
 
 #include <cstdio>
 #include <unordered_map>

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -1,4 +1,4 @@
-#include <omp.h>
+#include <LightGBM/utils/openmp_wrapper.h>
 
 #include <LightGBM/utils/log.h>
 #include <LightGBM/dataset_loader.h>

--- a/src/io/sparse_bin.hpp
+++ b/src/io/sparse_bin.hpp
@@ -5,7 +5,7 @@
 
 #include <LightGBM/bin.h>
 
-#include <omp.h>
+#include <LightGBM/utils/openmp_wrapper.h>
 
 #include <cstring>
 #include <cstdint>

--- a/src/metric/rank_metric.hpp
+++ b/src/metric/rank_metric.hpp
@@ -6,7 +6,7 @@
 
 #include <LightGBM/metric.h>
 
-#include <omp.h>
+#include <LightGBM/utils/openmp_wrapper.h>
 
 #include <sstream>
 #include <vector>

--- a/src/treelearner/data_partition.hpp
+++ b/src/treelearner/data_partition.hpp
@@ -4,7 +4,7 @@
 #include <LightGBM/meta.h>
 #include <LightGBM/feature.h>
 
-#include <omp.h>
+#include <LightGBM/utils/openmp_wrapper.h>
 
 #include <cstring>
 


### PR DESCRIPTION
This PR allows compiling LightGBM with a compiler that doesn't support OpenMP, which is the case of some clang versions shipped with MacOS. It also adds the CMAKE option to create a dylib library instead of a .so one.

The main change in the C Code is the new header file `utils/openmp_wrapper.h`