### PR TITLE
Follow up for #216 tip: no negative features.

### DIFF
--- a/docs/Parameters.md
+++ b/docs/Parameters.md
@@ -116,6 +116,8 @@ The parameter format is ```key1=value1 key2=value2 ... ``` . And parameters can 
   * ```true``` if training data are pre-partitioned, and different machines using different partition.
 * ```is_sparse```, default=```true```, type=bool, alias=```is_enable_sparse```
   * used to enable/disable sparse optimization. Set to ```false``` to disable sparse optimization.
+* ```sparse_aware```, default=```false```, type=bool
+  * used to enable/disable very specific sparse optimization routines. Do not set to ```true``` when you have features with negative values.
 * ```two_round```, default=```false```, type=bool, alias=```two_round_loading```,```use_two_round_loading```
   * by default, LightGBM will map data file to memory and load features from memory. This will provide faster data loading speed. But it may out of memory when the data file is very big.
   * set this to ```true``` if data file is too big to fit in memory.


### PR DESCRIPTION
This should follow #216 .

The user should not provide negative values to LightGBM when using `sparse_aware = true`. This kills the speed when negative values are provided and not corrected manually to be (at least) 0.

Example on Bosch numeric dataset (take note as all negative values are clamped to 0, it is not comparable to other benchmarks on Bosch):

| Threads | Negatives? | 1 |  6 |
| --- | ---: | ---: | ---: |
| master branch | no | 85.02 | 42.02 |
| sparse_aware = false | no | 60.53 | 27.34 |
| sparse_aware = true | no | 56.41 | 26.27 |
| sparse_aware = true | many | cancelled | 351.25 |

edit: add master branch benchmark.