### PR TITLE
Attempt to fix categorical issue in R package

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -79,7 +79,7 @@ Dataset <- R6Class(
       # Get categorical feature index
       if (!is.null(private$categorical_feature)) {
         if (typeof(private$categorical_feature) == "character") {
-            cate_indices <- as.list(match(private$categorical_feature, private$colnames))
+            cate_indices <- as.list(match(private$categorical_feature, private$colnames) - 1)
           } else {
             cate_indices <- as.list(private$categorical_feature - 1)
           }

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -80,7 +80,13 @@ Dataset <- R6Class(
       if (!is.null(private$categorical_feature)) {
         if (typeof(private$categorical_feature) == "character") {
             cate_indices <- as.list(match(private$categorical_feature, private$colnames) - 1)
+            if (length(cate_indices) != length(private$categorical_feature)) {
+              stop("lgb.self.get.handle: cannot find feature name ", sQuote(private$categorical_feature[!private$categorical_feature %in% private$colnames]))
+            }
           } else {
+            if (max(private$categorical_feature) > length(private$colnames)) {
+              stop("lgb.self.get.handle: supplied a too large value in categorical_feature")
+            }
             cate_indices <- as.list(private$categorical_feature - 1)
           }
         private$params$categorical_feature <- cate_indices

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -78,27 +78,11 @@ Dataset <- R6Class(
       }
       # Get categorical feature index
       if (!is.null(private$categorical_feature)) {
-        fname_dict <- list()
-        if (!is.null(private$colnames)) {
-          fname_dict <- `names<-`(
-              list((seq_along(private$colnames) - 1)),
-              private$colnames
-            )
-        }
-        cate_indices <- list()
-        for (key in private$categorical_feature) {
-          if (is.character(key)) {
-            idx <- fname_dict[[key]]
-            if (is.null(idx)) {
-              stop("lgb.self.get.handle: cannot find feature name ", sQuote(key))
-            }
-            cate_indices <- c(cate_indices, idx)
+        if (typeof(private$categorical_feature) == "character") {
+            cate_indices <- as.list(match(private$categorical_feature, private$colnames))
           } else {
-            # one-based indices to zero-based
-            idx <- as.integer(key - 1)
-            cate_indices <- c(cate_indices, idx)
+            cate_indices <- as.list(private$categorical_feature - 1)
           }
-        }
         private$params$categorical_feature <- cate_indices
       }
       # Check has header or not


### PR DESCRIPTION
Fix for categorical issue #219 and major performance increase when categorical feature count is huge (we talk about 1mil or more).

Users will get the following error (or a very similar one, depending on the initial type of data: dense/sparse) when trying to use an illegal number/column name:

```
Error in lgb.call("LGBM_DatasetCreateFromCSC_R", ret = handle, private$raw_data@p,  : 
  api error: categorical_column is not a number,                         if you want to use a column name,                         please add the prefix "name:" to the column name
```

Test with: `devtools::install_github("Laurae2/LightGBM", ref = "patch-5", subdir = "R-package")`

Dataset example: http://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank.zip

Reproducible example:

```r
library(data.table)
library(sparsity)
library(lightgbm)
library(Matrix)

bank <- fread("D:/bank.csv")

numericd <- bank
numericd$job <- as.numeric(as.factor(numericd$job)) - 1
numericd$marital <- as.numeric(as.factor(numericd$marital)) - 1
numericd$education <- as.numeric(as.factor(numericd$education)) - 1
numericd$default <- as.numeric(as.factor(numericd$default)) - 1
numericd$housing <- as.numeric(as.factor(numericd$housing)) - 1
numericd$loan <- as.numeric(as.factor(numericd$loan)) - 1
numericd$contact <- as.numeric(as.factor(numericd$contact)) - 1
numericd$month <- as.numeric(as.factor(numericd$month)) - 1
numericd$poutcome <- as.numeric(as.factor(numericd$poutcome)) - 1
numericd$y <- as.numeric(as.factor(numericd$y)) - 1

temp_train <- lgb.Dataset(Laurae::DT2mat(numericd[, 1:16, with=FALSE]), label=numericd$y, free_raw_data = FALSE, colnames = colnames(numericd)[1:16], categorical_feature = c(1, 2, 3, 4, 6, 7, 8, 10, 15))

params <- list(objective="binary", metric="l2")

model <- lgb.cv(params, temp_train, 20, folds = Laurae::kfold(numericd$y, 5), min_data=1, learning_rate=0.1, early_stopping_rounds=10, min_data = 0, min_hessian = 1)
model <- lgb.train(params, temp_train, 1, min_data=1, learning_rate=0.1, min_data = 0, min_hessian = 1)
lgb.dump(model, num_iteration = 1)

mini_num <- Matrix(Laurae::DT2mat(numericd[, c(2, 11), with = FALSE]), sparse = TRUE)
params <- list(objective="binary", metric="l2")

temp_train <- lgb.Dataset(mini_num, label=numericd$y, free_raw_data = FALSE, colnames = colnames(numericd)[c(2, 11)])
model <- lgb.train(params, temp_train, 2, learning_rate=1, min_data = 1, min_hessian = 1, num_leaves = 1024, categorical_feature = c(1, 2))

temp_train <- lgb.Dataset(mini_num, label=numericd$y, free_raw_data = FALSE)
lgb.Dataset.set.categorical(temp_train, c(1, 2))
temp_train$set_colnames(colnames(numericd)[c(2, 11)])
model <- lgb.train(params, temp_train, 2, learning_rate=1, min_data = 1, min_hessian = 1, num_leaves = 1024, categorical_feature = c(1, 2))

temp_train <- lgb.Dataset(mini_num, label=numericd$y, free_raw_data = FALSE)
temp_train$set_colnames(colnames(numericd)[c(2, 11)])
model <- lgb.train(params, temp_train, 2, learning_rate=1, min_data = 1, min_hessian = 1, num_leaves = 1024, categorical_feature = c("job", "month"))
```

First call (full non-categorical) must return:

```
> model <- lgb.train(params, temp_train, 2, learning_rate=1, min_data = 1, min_hessian = 1, num_leaves = 1024)
[LightGBM] [Info] Number of postive: 521, number of negative: 4000
[LightGBM] [Info] Number of data: 4521, number of features: 2
[LightGBM] [Info] No further splits with positive gain, best gain: 0.000000, leaves: 126
[LightGBM] [Info] No further splits with positive gain, best gain: 0.000000, leaves: 116
```

Second and subsequent calls (categorical by ID, categorical by names) must return:

```
[LightGBM] [Info] Number of postive: 521, number of negative: 4000
[LightGBM] [Info] Number of data: 4521, number of features: 2
[LightGBM] [Info] No further splits with positive gain, best gain: 0.000000, leaves: 103
[LightGBM] [Info] No further splits with positive gain, best gain: -inf, leaves: 102
```
