### PR TITLE
R-package: Provide more verbose error for categorical_feature

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -80,12 +80,12 @@ Dataset <- R6Class(
       if (!is.null(private$categorical_feature)) {
         if (typeof(private$categorical_feature) == "character") {
             cate_indices <- as.list(match(private$categorical_feature, private$colnames) - 1)
-            if (length(cate_indices) != length(private$categorical_feature)) {
-              stop("lgb.self.get.handle: cannot find feature name ", sQuote(private$categorical_feature[!private$categorical_feature %in% private$colnames]))
+            if (sum(is.na(cate_indices)) > 0) {
+              stop("lgb.self.get.handle: supplied an unknown feature in categorical_feature: ", sQuote(private$categorical_feature[is.na(cate_indices)]))
             }
           } else {
             if (max(private$categorical_feature) > length(private$colnames)) {
-              stop("lgb.self.get.handle: supplied a too large value in categorical_feature")
+              stop("lgb.self.get.handle: supplied a too large value in categorical_feature: ", max(private$categorical_feature), " but only ", length(private$colnames), " features")
             }
             cate_indices <- as.list(private$categorical_feature - 1)
           }


### PR DESCRIPTION
When the user input unknown categorical_feature values, error is more verbose for troubleshooting.

Follows #228.

Example frame:

| job | month |
| --- | --- |
| values | values |

Verified not breaking what we have previously:

```r
> model <- lgb.train(params, temp_train, 2, learning_rate=1, min_data = 1, min_hessian = 1, num_leaves = 1024)
[LightGBM] [Info] Number of postive: 521, number of negative: 4000
[LightGBM] [Info] Number of data: 4521, number of features: 2
[LightGBM] [Info] No further splits with positive gain, best gain: 0.000000, leaves: 126
[LightGBM] [Info] No further splits with positive gain, best gain: 0.000000, leaves: 116
> model <- lgb.train(params, temp_train, 2, learning_rate=1, min_data = 1, min_hessian = 1, num_leaves = 1024,
+ categorical_feature = c(1, 2))
[LightGBM] [Info] Number of postive: 521, number of negative: 4000
[LightGBM] [Info] Number of data: 4521, number of features: 2
[LightGBM] [Info] No further splits with positive gain, best gain: 0.000000, leaves: 103
[LightGBM] [Info] No further splits with positive gain, best gain: -inf, leaves: 102
> model <- lgb.train(params, temp_train, 2, learning_rate=1, min_data = 1, min_hessian = 1, num_leaves = 1024,
+ categorical_feature = c("job", "month"))
[LightGBM] [Info] Number of postive: 521, number of negative: 4000
[LightGBM] [Info] Number of data: 4521, number of features: 2
[LightGBM] [Info] No further splits with positive gain, best gain: 0.000000, leaves: 103
[LightGBM] [Info] No further splits with positive gain, best gain: -inf, leaves: 102
> model <- lgb.train(params, temp_train, 2, learning_rate=1, min_data = 1, min_hessian = 1, num_leaves = 1024,
+ categorical_feature = c(1))
[LightGBM] [Info] Number of postive: 521, number of negative: 4000
[LightGBM] [Info] Number of data: 4521, number of features: 2
[LightGBM] [Info] No further splits with positive gain, best gain: 0.000000, leaves: 112
[LightGBM] [Info] No further splits with positive gain, best gain: 0.000000, leaves: 104
> model <- lgb.train(params, temp_train, 2, learning_rate=1, min_data = 1, min_hessian = 1, num_leaves = 1024,
+ categorical_feature = c("job"))
[LightGBM] [Info] Number of postive: 521, number of negative: 4000
[LightGBM] [Info] Number of data: 4521, number of features: 2
[LightGBM] [Info] No further splits with positive gain, best gain: 0.000000, leaves: 112
[LightGBM] [Info] No further splits with positive gain, best gain: 0.000000, leaves: 104

```

Now, the errors are explicit and obvious:

```r
> model <- lgb.train(params, temp_train, 2, learning_rate=1, min_data = 1, min_hessian = 1, num_leaves = 1024,
+ categorical_feature = c("job", "woo"))
Error in data$construct() : 
  lgb.self.get.handle: supplied an unknown feature in categorical_feature: ‘woo’
> model <- lgb.train(params, temp_train, 2, learning_rate=1, min_data = 1, min_hessian = 1, num_leaves = 1024,
+ categorical_feature = c(1, 2, 3))
Error in data$construct() : 
  lgb.self.get.handle: supplied a too large value in categorical_feature: 3 but only 2 features
```