### PR TITLE
fix the reshape and predleaf arguments

### DIFF
--- a/R-package/R/lgb.Predictor.R
+++ b/R-package/R/lgb.Predictor.R
@@ -85,7 +85,11 @@ Predictor <- R6Class(
         stop("predict: prediction length ", sQuote(length(preds))," is not a multiple of nrows(data): ", sQuote(num_row))
       }
       npred_per_case <- length(preds) / num_row
-      if (reshape && npred_per_case > 1) { preds <- matrix(preds, ncol = npred_per_case) }
+      if (predleaf) {
+        preds <- matrix(preds, ncol = npred_per_case, byrow = TRUE)
+      } else if (reshape && npred_per_case > 1) {
+        preds <- matrix(preds, ncol = npred_per_case, byrow = TRUE)
+      }
       preds
     }
   ),


### PR DESCRIPTION
This PR should fix the issue #243 
- the prediction output will be a (nrow, ntree) matrix when predleaf = TRUE
- the prediction output will be a (nrow, nclass) matrix when reshape = TRUE