### PR TITLE
Fixed compilation without OpenMP

### DIFF
--- a/src/metric/map_metric.hpp
+++ b/src/metric/map_metric.hpp
@@ -6,7 +6,7 @@
 
 #include <LightGBM/metric.h>
 
-#include <omp.h>
+#include <LightGBM/utils/openmp_wrapper.h>
 
 #include <sstream>
 #include <vector>


### PR DESCRIPTION
To be able to compile without OpenMP, all the includes `<omp.h>` should be replaced by `<LightGBM/utils/openmp_wrapper.h>`. I just fixed this for map_metric.cpp