### PR TITLE
Fixed gcc non virtual destructor warning (bin.h) plus minor const fix

### DIFF
--- a/include/LightGBM/bin.h
+++ b/include/LightGBM/bin.h
@@ -242,6 +242,7 @@ public:
   * \return Bin data
   */
   virtual uint32_t Get(data_size_t idx) = 0;
+  virtual ~BinIterator() = default;
 };
 
 /*!

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -173,7 +173,7 @@ public:
   * \brief Get Number of queries
   * \return Number of queries
   */
-  inline const data_size_t num_queries() const { return num_queries_; }
+  inline data_size_t num_queries() const { return num_queries_; }
 
   /*!
   * \brief Get weights for queries, if not exists, will return nullptr


### PR DESCRIPTION
Added virtual destructor to BinIterator class. Let's see if using C++11's `default` works on Travis and MSVC.