### PR TITLE
Fix num_class parameter. Now it takes the value set. It allows multiclass tasks.

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -49,7 +49,11 @@ Booster <- R6Class(
       }
       class(handle)     <- "lgb.Booster.handle"
       private$handle    <- handle
-      private$num_class <- 1L
+      if ("num_class" %in% names(params)){
+	private$num_class <- params$num_class
+      } else{
+	private$num_class <- 1L
+      }
       private$num_class <-
         lgb.call("LGBM_BoosterGetNumClasses_R", ret = private$num_class, private$handle)
     },


### PR DESCRIPTION
Hi,

I was trying to make a multiclass model using the R API and I found that it didn't detect when I indicated the correct number of classes using the parameter "num_class". I digged into the code and I found that the num_class parameter was harcoded so that I fixed it.

Hope it helps!
