### PR TITLE
remove a gcc warning

### DIFF
--- a/include/LightGBM/utils/array_args.h
+++ b/include/LightGBM/utils/array_args.h
@@ -142,7 +142,7 @@ public:
     }
   }
 
-  inline static void MaxK(const std::vector<VAL_T>& array, int k, std::vector<VAL_T>* out) {
+  inline static void MaxK(const std::vector<VAL_T>& array, size_t k, std::vector<VAL_T>* out) {
     out->clear();
     if (k <= 0) {
       return;


### PR DESCRIPTION
The warning is like this:

In file included from /home/kimi/LightGBM/src/treelearner/parallel_tree_learner.h:4:0,
                 from /home/kimi/LightGBM/src/treelearner/voting_parallel_tree_learner.cpp:1:
/home/kimi/LightGBM/include/LightGBM/utils/array_args.h: In instantiation of ‘static void LightGBM::ArrayArgs<VAL_T>::MaxK(const std::vector<_RealType>&, int, std::vector<_RealType>*) [with VAL_T = LightGBM::SplitInfo]’:
/home/kimi/LightGBM/src/treelearner/voting_parallel_tree_learner.cpp:183:25:   required from here
/home/kimi/LightGBM/include/LightGBM/utils/array_args.h:153:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (k >= array.size()) {
           ^