### PR TITLE
Add boost_from_average to docs

### DIFF
--- a/docs/Parameters.md
+++ b/docs/Parameters.md
@@ -183,6 +183,8 @@ The parameter format is ```key1=value1 key2=value2 ... ``` . And parameters can 
   * parameter used to safeguard optimization
 * ```scale_pos_weight```, default=```1.0```, type=double
   * weight of positive class in binary classification task
+* ```boost_from_average```, default=```true```, type=bool
+  * adjust initial score of each observation to the mean of each class for faster convergence
 * ```is_unbalance```, default=```false```, type=bool
   * used in binary classification. Set this to ```true``` if training data are unbalance.
 * ```max_position```, default=```20```, type=int


### PR DESCRIPTION
Adds `boost_from_average` to docs to keep consistency with current master branch (issue #352, commit e179c7c).

![image](https://cloud.githubusercontent.com/assets/9083669/24296170/3e62aacc-109e-11e7-96c4-5a8b2fd04285.png)
