### PR TITLE
eliminate all VS2017 warnings

### DIFF
--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -271,6 +271,20 @@ inline static std::string ArrayToString(const std::vector<T>& arr, size_t n, cha
   return str_buf.str();
 }
 
+template<typename T, bool is_float>
+struct __StringToTHelper {
+  T operator()(const std::string& str) const {
+    return static_cast<T>(std::stol(str));
+  }
+};
+
+template<typename T>
+struct __StringToTHelper<T, true> {
+  T operator()(const std::string& str) const {
+    return static_cast<T>(std::stod(str));
+  }
+};
+
 template<typename T>
 inline static std::vector<T> StringToArray(const std::string& str, char delimiter, size_t n) {
   if (n == 0) {
@@ -281,14 +295,9 @@ inline static std::vector<T> StringToArray(const std::string& str, char delimite
     Log::Fatal("StringToArray error, size doesn't match.");
   }
   std::vector<T> ret(n);
-  if (std::is_same<T, float>::value || std::is_same<T, double>::value) {
-    for (size_t i = 0; i < n; ++i) {
-      ret[i] = static_cast<T>(std::stod(strs[i]));
-    }
-  } else {
-    for (size_t i = 0; i < n; ++i) {
-      ret[i] = static_cast<T>(std::stol(strs[i]));
-    }
+  __StringToTHelper<T, std::is_floating_point<T>::value> helper;
+  for (size_t i = 0; i < n; ++i) {
+    ret[i] = helper(strs[i]);
   }
   return ret;
 }
@@ -297,14 +306,10 @@ template<typename T>
 inline static std::vector<T> StringToArray(const std::string& str, char delimiter) {
   std::vector<std::string> strs = Split(str.c_str(), delimiter);
   std::vector<T> ret;
-  if (std::is_same<T, float>::value || std::is_same<T, double>::value) {
-    for (const auto& s : strs) {
-      ret.push_back(static_cast<T>(std::stod(s)));
-    }
-  } else {
-    for (const auto& s : strs) {
-      ret.push_back(static_cast<T>(std::stol(s)));
-    }
+  ret.reserve(strs.size());
+  __StringToTHelper<T, std::is_floating_point<T>::value> helper;
+  for (const auto& s : strs) {
+    ret.push_back(helper(s));
   }
   return ret;
 }

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -968,7 +968,7 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSC(BoosterHandle handle,
   int64_t num_preb_in_one_row = GetNumPredOneRow(ref_booster, predict_type, num_iteration);
   int ncol = static_cast<int>(ncol_ptr - 1);
 
-  Threading::For<int64_t>(0, num_row,
+  Threading::For<data_size_t>(0, static_cast<data_size_t>(num_row),
                           [&predictor, &out_result, num_preb_in_one_row, ncol, col_ptr, col_ptr_type, indices, data, data_type, ncol_ptr, nelem]
   (int, data_size_t start, data_size_t end) {
     std::vector<CSC_RowIterator> iterators;

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -83,7 +83,7 @@ void SerialTreeLearner::Init(const Dataset* train_data) {
   // if has ordered bin, need to allocate a buffer to fast split
   if (has_ordered_bin_) {
     is_data_in_leaf_.resize(num_data_);
-    std::fill(is_data_in_leaf_.begin(), is_data_in_leaf_.end(), 0);
+    std::fill(is_data_in_leaf_.begin(), is_data_in_leaf_.end(), static_cast<char>(0));
     ordered_bin_indices_.clear();
     for (int i = 0; i < static_cast<int>(ordered_bins_.size()); i++) {
       if (ordered_bins_[i] != nullptr) {
@@ -125,7 +125,7 @@ void SerialTreeLearner::ResetTrainingData(const Dataset* train_data) {
   // if has ordered bin, need to allocate a buffer to fast split
   if (has_ordered_bin_) {
     is_data_in_leaf_.resize(num_data_);
-    std::fill(is_data_in_leaf_.begin(), is_data_in_leaf_.end(), 0);
+    std::fill(is_data_in_leaf_.begin(), is_data_in_leaf_.end(), static_cast<char>(0));
     ordered_bin_indices_.clear();
     for (int i = 0; i < static_cast<int>(ordered_bins_.size()); i++) {
       if (ordered_bins_[i] != nullptr) {


### PR DESCRIPTION
Hi.

You didn't use type traits with c++ template in a best practice way, so that there are some warnings in VS2017. And some other warnings are about integral type mismatch.

I fixed them all.