### PR TITLE
refine early stopping and add a test case

### DIFF
--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -201,7 +201,6 @@ def early_stopping(stopping_rounds, verbose=True):
                             env.iteration + 1, '\t'.join([_format_eval_result(x) for x in env.evaluation_result_list]))
                     best_msg[i] = best_msg_buffer
             elif env.iteration - best_iter[i] >= stopping_rounds:
-                env.model.set_attr(best_iteration=str(best_iter[i]))
                 if verbose:
                     print('Early stopping, best iteration is:\n' + best_msg[i])
                 raise EarlyStopException(best_iter[i])

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -86,6 +86,32 @@ class TestEngine(unittest.TestCase):
         self.assertLess(ret, 0.2)
         self.assertAlmostEqual(min(evals_result['eval']['multi_logloss']), ret, places=5)
 
+    def test_early_stopping(self):
+        X_y = load_breast_cancer(True)
+        params = {
+            'objective': 'binary',
+            'metric': 'binary_logloss',
+            'verbose': -1,
+            'seed': 42
+        }
+        X_train, X_test, y_train, y_test = train_test_split(*X_y, test_size=0.1, random_state=42)
+        lgb_train = lgb.Dataset(X_train, y_train)
+        lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train)
+        # no early stopping
+        gbm = lgb.train(params, lgb_train,
+                        num_boost_round=10,
+                        valid_sets=lgb_eval,
+                        verbose_eval=False,
+                        early_stopping_rounds=5)
+        self.assertEqual(gbm.best_iteration, -1)
+        # early stopping occurs
+        gbm = lgb.train(params, lgb_train,
+                        num_boost_round=100,
+                        valid_sets=lgb_eval,
+                        verbose_eval=False,
+                        early_stopping_rounds=5)
+        self.assertLessEqual(gbm.best_iteration, 100)
+
     def test_continue_train_and_other(self):
         params = {
             'objective': 'regression',


### PR DESCRIPTION
is there a reason to use attr() to pass best_iteration? I think direct use EarlyStopException object is enough, and it avoids data type casting.