### PR TITLE
[Python-package]: Fix RandomState issue #376

### DIFF
--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -236,7 +236,7 @@ def _make_n_folds(full_data, data_splitter, nfold, params, seed, fpreproc=None, 
         folds = sfk.split(X=np.zeros(num_data), y=full_data.get_label())
     else:
         if shuffle:
-            randidx = np.RandomState(seed).random.permutation(num_data)
+            randidx = np.random.RandomState(seed).permutation(num_data)
         else:
             randidx = np.arange(num_data)
         kstep = int(num_data / nfold)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -149,6 +149,9 @@ class TestEngine(unittest.TestCase):
         lgb.cv({'verbose': -1}, lgb_train, num_boost_round=20, nfold=5, shuffle=False,
                metrics='l1', verbose_eval=False,
                callbacks=[lgb.reset_parameter(learning_rate=lambda i: 0.1 - 0.001 * i)])
+        lgb.cv({'verbose': -1}, lgb_train, num_boost_round=20, nfold=5, shuffle=True,
+               metrics='l1', verbose_eval=False,
+               callbacks=[lgb.reset_parameter(learning_rate=lambda i: 0.1 - 0.001 * i)])
         tss = TimeSeriesSplit(3)
         lgb.cv({'verbose': -1}, lgb_train, num_boost_round=20, data_splitter=tss, nfold=5,  # test if wrong nfold is ignored
                metrics='l2', verbose_eval=False)


### PR DESCRIPTION
Refer to issue #376 for the solution.

Explanation: https://docs.scipy.org/doc/numpy/reference/generated/numpy.random.RandomState.html

Demo Python code:

```python
import numpy as np

np.random.RandomState(1).permutation(10)
Out: array([2, 9, 6, 4, 0, 3, 1, 7, 8, 5])

np.RandomState(1).random.permutation(10)
Traceback (most recent call last):

  File "<ipython-input-5-d2d1cb7145c9>", line 1, in <module>
    np.RandomState(1).random.permutation(10)

AttributeError: module 'numpy' has no attribute 'RandomState'
```