### PR TITLE
Fix a memory allocation bug of cnt_per_class in GBDT::ResetTrainingData()

### DIFF
--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -167,7 +167,7 @@ void GBDT::ResetTrainingData(const BoostingConfig* config, const Dataset* train_
       CHECK(num_tree_per_iteration_ == num_class_);
       // + 1 here for the binary classification
       class_default_output_ = std::vector<double>(num_tree_per_iteration_ + 1, 0.0f);
-      std::vector<data_size_t> cnt_per_class(num_tree_per_iteration_, 0);
+      std::vector<data_size_t> cnt_per_class(num_tree_per_iteration_ + 1, 0);
       auto label = train_data_->metadata().label();
       for (int i = 0; i < num_data_; ++i) {
         ++cnt_per_class[static_cast<int>(label[i])];


### PR DESCRIPTION
In `GBDT::ResetTrainingData()` we have a vector `cnt_per_class` to count the number of examples of each label. This vector is initialized with `num_tree_per_iteration_` elements, which seems to be n-1 when there are n classes? So `cnt_per_class` is missing one element; for example, in binary classification case `num_tree_per_iteration_ = 1` but we need `cnt_per_class` to hold counters for two classes. So I allocate `num_tree_per_iteration_ + 1` elements for `cnt_per_class`. I hope this is the correct fix.
