### PR TITLE
Switch RMSE to MSE (true L2 loss)

### DIFF
--- a/docs/Parameters.md
+++ b/docs/Parameters.md
@@ -203,9 +203,10 @@ The parameter format is ```key1=value1 key2=value2 ... ``` . And parameters can 
 
 ## Metric parameters
 
-* ```metric```, default={```l2``` for regression}, {```binary_logloss``` for binary classification},{```ndcg``` for lambdarank}, type=multi-enum, options=```l1```,```l2```,```ndcg```,```auc```,```binary_logloss```,```binary_error```
+* ```metric```, default={```l2``` for regression}, {```binary_logloss``` for binary classification},{```ndcg``` for lambdarank}, type=multi-enum, options=```l1```,```l2```,```ndcg```,```auc```,```binary_logloss```,```binary_error```...
   * ```l1```, absolute loss, alias=```mean_absolute_error```, ```mae```
   * ```l2```, square loss, alias=```mean_squared_error```, ```mse```
+  * ```l2_root```, root square loss, alias=```root_mean_squared_error```, ```rmse```
   * ```huber```, [Huber loss](https://en.wikipedia.org/wiki/Huber_loss "Huber loss - Wikipedia")
   * ```fair```, [Fair loss](https://www.kaggle.com/c/allstate-claims-severity/discussion/24520)
   * ```poisson```, [Poisson regression](https://en.wikipedia.org/wiki/Poisson_regression "Poisson regression")

--- a/src/metric/metric.cpp
+++ b/src/metric/metric.cpp
@@ -10,6 +10,8 @@ namespace LightGBM {
 Metric* Metric::CreateMetric(const std::string& type, const MetricConfig& config) {
   if (type == std::string("l2") || type == std::string("mean_squared_error") || type == std::string("mse")) {
     return new L2Metric(config);
+  } else if (type == std::string("l2_root") || type == std::string("root_mean_squared_error") || type == std::string("rmse")) {
+    return new RMSEMetric(config);
   } else if (type == std::string("l1") || type == std::string("mean_absolute_error") || type == std::string("mae")) {
     return new L1Metric(config);
   } else if (type == std::string("huber")) {

--- a/src/metric/regression_metric.hpp
+++ b/src/metric/regression_metric.hpp
@@ -111,6 +111,25 @@ private:
   std::vector<std::string> name_;
 };
 
+/*! \brief RMSE loss for regression task */
+class RMSEMetric: public RegressionMetric<RMSEMetric> {
+public:
+  explicit RMSEMetric(const MetricConfig& config) :RegressionMetric<RMSEMetric>(config) {}
+
+  inline static double LossOnPoint(float label, double score, double, double) {
+    return (score - label)*(score - label);
+  }
+
+  inline static double AverageLoss(double sum_loss, double sum_weights) {
+    // need sqrt the result for RMSE loss
+    return std::sqrt(sum_loss / sum_weights);
+  }
+
+  inline static const char* Name() {
+    return "rmse";
+  }
+};
+
 /*! \brief L2 loss for regression task */
 class L2Metric: public RegressionMetric<L2Metric> {
 public:

--- a/src/metric/regression_metric.hpp
+++ b/src/metric/regression_metric.hpp
@@ -122,7 +122,7 @@ public:
 
   inline static double AverageLoss(double sum_loss, double sum_weights) {
     // need sqrt the result for L2 loss
-    return std::sqrt(sum_loss / sum_weights);
+    return sum_loss / sum_weights;
   }
 
   inline static const char* Name() {

--- a/src/metric/regression_metric.hpp
+++ b/src/metric/regression_metric.hpp
@@ -121,7 +121,7 @@ public:
   }
 
   inline static double AverageLoss(double sum_loss, double sum_weights) {
-    // need sqrt the result for L2 loss
+    // need mean of the result for L2 loss
     return sum_loss / sum_weights;
   }
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -72,7 +72,7 @@ class TestEngine(unittest.TestCase):
     def test_regreesion(self):
         evals_result, ret = template.test_template()
         ret **= 0.5
-        self.assertLess(ret, 4)
+        self.assertLess(ret, 16)
         self.assertAlmostEqual(min(evals_result['eval']['l2']), ret, places=5)
 
     def test_multiclass(self):

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -71,7 +71,6 @@ class TestEngine(unittest.TestCase):
 
     def test_regreesion(self):
         evals_result, ret = template.test_template()
-        ret **= 0.5
         self.assertLess(ret, 16)
         self.assertAlmostEqual(min(evals_result['eval']['l2']), ret, places=5)
 


### PR DESCRIPTION
To keep consistency with the name "Mean Squared Error" as it is not RMSE.

We may add RMSE back under a better name in another PR, because L2 = MSE being RMSE is causing confusion for users.