### PR TITLE
Move Boost.Compute include path to the beginning of compiler search paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ else()
 endif(USE_OPENMP)
 
 if(USE_GPU)
+    SET(BOOST_COMPUTE_HEADER_DIR ${PROJECT_SOURCE_DIR}/compute/include)
+    include_directories (${BOOST_COMPUTE_HEADER_DIR})
     find_package(OpenCL REQUIRED)
     include_directories(${OpenCL_INCLUDE_DIRS})
     MESSAGE(STATUS "OpenCL include directory:" ${OpenCL_INCLUDE_DIRS})
@@ -75,13 +77,11 @@ endif()
 
 
 SET(LightGBM_HEADER_DIR ${PROJECT_SOURCE_DIR}/include)
-SET(BOOST_COMPUTE_HEADER_DIR ${PROJECT_SOURCE_DIR}/compute/include)
 
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 SET(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 
 include_directories (${LightGBM_HEADER_DIR})
-include_directories (${BOOST_COMPUTE_HEADER_DIR})
 
 if(APPLE)
   if (APPLE_OUTPUT_DYLIB)

--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -167,7 +167,7 @@ void GBDT::ResetTrainingData(const BoostingConfig* config, const Dataset* train_
       CHECK(num_tree_per_iteration_ == num_class_);
       // + 1 here for the binary classification
       class_default_output_ = std::vector<double>(num_tree_per_iteration_ + 1, 0.0f);
-      std::vector<data_size_t> cnt_per_class(num_tree_per_iteration_, 0);
+      std::vector<data_size_t> cnt_per_class(num_tree_per_iteration_ + 1, 0);
       auto label = train_data_->metadata().label();
       for (int i = 0; i < num_data_; ++i) {
         ++cnt_per_class[static_cast<int>(label[i])];


### PR DESCRIPTION
We want to put the submodule Boost.Compute at the beginning of compiler search paths, because the submodule usually contains upstream bug fixes that have not been included into the stable Boost releases installed on the host OS.
