### PR TITLE
add DLL name and path

### DIFF
--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -20,7 +20,8 @@ def find_lib_path():
         dll_path.append(os.path.join(curr_path, '../../windows/x64/Dll/'))
         dll_path.append(os.path.join(curr_path, './windows/x64/Dll/'))
         dll_path.append(os.path.join(curr_path, '../../Release/'))
-        dll_path = [os.path.join(p, 'lib_lightgbm.dll') for p in dll_path]
+        dll_path.append(os.path.join(curr_path, '../../windows/x64/Release/')) 
+        dll_path = [os.path.join(p, 'lightgbm.dll') for p in dll_path]
     else:
         dll_path = [os.path.join(p, 'lib_lightgbm.so') for p in dll_path]
     lib_path = [p for p in dll_path if os.path.exists(p) and os.path.isfile(p)]


### PR DESCRIPTION
Following this guide
：https://github.com/Microsoft/LightGBM/wiki/Installation-Guide

When installing python-package, the default DLL path on my system
(Windows 7,Visual Studio 2013,x64 with MPI), is
"../../windows/x64/Release/lightgbm.dll".

Using default setting may cause an error of not founding any dlls.