### PR TITLE
Temporarily removing architecture optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(USE_GPU)
 endif(USE_GPU)
 
 if(UNIX OR MINGW OR CYGWIN)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -O3 -Wall -std=c++11 -Wno-ignored-attributes -march=core2 -mtune=native")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -O3 -Wall -std=c++11 -Wno-ignored-attributes")
 endif()
 
 if(MSVC)


### PR DESCRIPTION
Removes `-march=core2 -mtune=native`.

Fix to fix cmake inconsistency and allow proper debug: https://github.com/Microsoft/LightGBM/issues/436 (they show up even in Debug but they were supposed to be only for Release in cmake?)

Temporary fix but not permanent fix: https://github.com/Microsoft/LightGBM/issues/431#issuecomment-296198423

Performance impact: approximately between -1% and 1%, depends on the task but it will be unnoticeable by most except by benchmarkers.

To follow later: more details on 6-7 May about when one should add the optimizations for the CPU architecture. I will put it in a separate doc. + a website about Gradient Boosted Trees and optimization flag comparisons.