### PR TITLE
Better debugging info when OpenCL compilation fails

### DIFF
--- a/src/treelearner/gpu_tree_learner.h
+++ b/src/treelearner/gpu_tree_learner.h
@@ -98,6 +98,13 @@ private:
   * \brief Compile OpenCL GPU source code to kernel binaries
   */
   void BuildGPUKernels();
+  
+  /*!
+   * \brief Returns OpenCL kernel build log when compiled with option opts
+   * \param opts OpenCL build options 
+   * \return OpenCL build log
+  */
+  std::string GetBuildLog(const std::string &opts);
 
   /*!
   * \brief Setup GPU kernel arguments, preparing for launching


### PR DESCRIPTION
On some OpenCL platforms the GPU code may fail to compile. This patch fixes the previously non-working exception handler under this failure case and prints a nice build log. It will be very helpful when reporting issues.