### PR TITLE
python-package: fix creating eval_set in LGBMClassifier

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -589,18 +589,17 @@ class LGBMClassifier(LGBMModel, LGBMClassifierBase):
             elif eval_metric == 'error' or eval_metric == 'multi_error':
                 eval_metric = 'binary_error'
 
-        _eval_set = []
         if eval_set is not None:
             if isinstance(eval_set, tuple):
                 eval_set = [eval_set]
-            for valid_x, valid_y in eval_set:
+            for i, (valid_x, valid_y) in enumerate(eval_set):
                 if valid_x is X and valid_y is y:
-                    _eval_set.append((valid_x, _y))
+                    eval_set[i] = (valid_x, _y)
                 else:
-                    _eval_set.append((valid_x, self._le.transform(valid_y)))
+                    eval_set[i] = (valid_x, self._le.transform(valid_y))
 
         super(LGBMClassifier, self).fit(X, _y, sample_weight=sample_weight,
-                                        init_score=init_score, eval_set=_eval_set,
+                                        init_score=init_score, eval_set=eval_set,
                                         eval_names=eval_names,
                                         eval_sample_weight=eval_sample_weight,
                                         eval_init_score=eval_init_score,

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -572,7 +572,7 @@ class LGBMClassifier(LGBMModel, LGBMClassifierBase):
             feature_name='auto', categorical_feature='auto',
             callbacks=None):
         self._le = LGBMLabelEncoder().fit(y)
-        y = self._le.transform(y)
+        _y = self._le.transform(y)
 
         self.classes = self._le.classes_
         self.n_classes = len(self.classes_)
@@ -589,11 +589,18 @@ class LGBMClassifier(LGBMModel, LGBMClassifierBase):
             elif eval_metric == 'error' or eval_metric == 'multi_error':
                 eval_metric = 'binary_error'
 
+        _eval_set = []
         if eval_set is not None:
-            eval_set = [(x[0], self._le.transform(x[1])) for x in eval_set]
+            if isinstance(eval_set, tuple):
+                eval_set = [eval_set]
+            for valid_x, valid_y in eval_set:
+                if valid_x is X and valid_y is y:
+                    _eval_set.append((valid_x, _y))
+                else:
+                    _eval_set.append((valid_x, self._le.transform(valid_y)))
 
-        super(LGBMClassifier, self).fit(X, y, sample_weight=sample_weight,
-                                        init_score=init_score, eval_set=eval_set,
+        super(LGBMClassifier, self).fit(X, _y, sample_weight=sample_weight,
+                                        init_score=init_score, eval_set=_eval_set,
                                         eval_names=eval_names,
                                         eval_sample_weight=eval_sample_weight,
                                         eval_init_score=eval_init_score,


### PR DESCRIPTION
This PR fixes creating eval_set in LGBMClassifier.
The current master (0eb9921991d21f7a61f5404494bad810811b1209) treats traing set as valid set even when valid set is traing set.  

### Sample script

```python
import numpy
numpy.random.seed(42)
import lightgbm

train_x = numpy.random.rand(100, 10)
train_y = numpy.random.randint(2, size=100)
valid_x = numpy.random.rand(100, 10)
valid_y = numpy.random.randint(2, size=100)

gbm = lightgbm.LGBMClassifier()
gbm.fit(train_x, train_y, eval_set=[(train_x, train_y), (valid_x, valid_y)])
```

### Before

```
❯ python test.py
[1]	valid_0's binary_logloss: 0.680061	valid_1's binary_logloss: 0.693353
[2]	valid_0's binary_logloss: 0.6688	valid_1's binary_logloss: 0.698276
[3]	valid_0's binary_logloss: 0.659384	valid_1's binary_logloss: 0.701111
[4]	valid_0's binary_logloss: 0.651245	valid_1's binary_logloss: 0.706889
[5]	valid_0's binary_logloss: 0.643804	valid_1's binary_logloss: 0.707129
[6]	valid_0's binary_logloss: 0.637556	valid_1's binary_logloss: 0.713327
[7]	valid_0's binary_logloss: 0.630633	valid_1's binary_logloss: 0.711053
[8]	valid_0's binary_logloss: 0.626307	valid_1's binary_logloss: 0.711603
[9]	valid_0's binary_logloss: 0.621181	valid_1's binary_logloss: 0.712893
[10]	valid_0's binary_logloss: 0.616207	valid_1's binary_logloss: 0.712305
```

### After

```
❯ python test.py
[1]	training's binary_logloss: 0.680061	valid_1's binary_logloss: 0.693353
[2]	training's binary_logloss: 0.6688	valid_1's binary_logloss: 0.698276
[3]	training's binary_logloss: 0.659384	valid_1's binary_logloss: 0.701111
[4]	training's binary_logloss: 0.651245	valid_1's binary_logloss: 0.706889
[5]	training's binary_logloss: 0.643804	valid_1's binary_logloss: 0.707129
[6]	training's binary_logloss: 0.637556	valid_1's binary_logloss: 0.713327
[7]	training's binary_logloss: 0.630633	valid_1's binary_logloss: 0.711053
[8]	training's binary_logloss: 0.626307	valid_1's binary_logloss: 0.711603
[9]	training's binary_logloss: 0.621181	valid_1's binary_logloss: 0.712893
[10]	training's binary_logloss: 0.616207	valid_1's binary_logloss: 0.712305
```