### PR TITLE
fixed a bug in BinMapper: division by zero

### DIFF
--- a/src/io/bin.cpp
+++ b/src/io/bin.cpp
@@ -126,15 +126,16 @@ void BinMapper::FindBin(double* values, int num_sample_values, size_t total_samp
       bin_upper_bound_.push_back(std::numeric_limits<double>::infinity());
       num_bin_ = static_cast<int>(bin_upper_bound_.size());
     } else {
+      double mean_bin_size = static_cast<double>(total_sample_cnt) / max_bin;
       if (min_data_in_bin > 0) {
         max_bin = std::min(max_bin, static_cast<int>(total_sample_cnt / min_data_in_bin));
         max_bin = std::max(max_bin, 1);
-      }
-      double mean_bin_size = static_cast<double>(total_sample_cnt) / max_bin;
-      if (zero_cnt > mean_bin_size) {
-        int non_zero_cnt = num_sample_values;
-        max_bin = std::min(max_bin, 1 + static_cast<int>(non_zero_cnt / min_data_in_bin));
-      }
+		mean_bin_size = static_cast<double>(total_sample_cnt) / max_bin;
+		if (zero_cnt > mean_bin_size) {
+			int non_zero_cnt = num_sample_values;
+			max_bin = std::min(max_bin, 1 + static_cast<int>(non_zero_cnt / min_data_in_bin));
+		}
+	  }
       // mean size for one bin
       int rest_bin_cnt = max_bin;
       int rest_sample_cnt = static_cast<int>(total_sample_cnt);

--- a/src/io/bin.cpp
+++ b/src/io/bin.cpp
@@ -126,16 +126,15 @@ void BinMapper::FindBin(double* values, int num_sample_values, size_t total_samp
       bin_upper_bound_.push_back(std::numeric_limits<double>::infinity());
       num_bin_ = static_cast<int>(bin_upper_bound_.size());
     } else {
-      double mean_bin_size = static_cast<double>(total_sample_cnt) / max_bin;
       if (min_data_in_bin > 0) {
         max_bin = std::min(max_bin, static_cast<int>(total_sample_cnt / min_data_in_bin));
         max_bin = std::max(max_bin, 1);
-		mean_bin_size = static_cast<double>(total_sample_cnt) / max_bin;
-		if (zero_cnt > mean_bin_size) {
-			int non_zero_cnt = num_sample_values;
-			max_bin = std::min(max_bin, 1 + static_cast<int>(non_zero_cnt / min_data_in_bin));
-		}
-	  }
+      }
+      double mean_bin_size = static_cast<double>(total_sample_cnt) / max_bin;
+      if (zero_cnt > mean_bin_size) {
+        int non_zero_cnt = num_sample_values;
+        max_bin = std::min(max_bin, 1 + static_cast<int>(non_zero_cnt / min_data_in_bin));
+      }
       // mean size for one bin
       int rest_bin_cnt = max_bin;
       int rest_sample_cnt = static_cast<int>(total_sample_cnt);

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -221,7 +221,8 @@ void IOConfig::Set(const std::unordered_map<std::string, std::string>& params) {
   GetString(params, "ignore_column", &ignore_column);
   GetString(params, "categorical_column", &categorical_column);
   GetInt(params, "min_data_in_leaf", &min_data_in_leaf);
-  GetInt(params, "min_dato_in_bin", &min_data_in_bin);
+  GetInt(params, "min_data_in_bin", &min_data_in_bin);
+  CHECK(min_data_in_bin > 0);
   GetDouble(params, "max_conflict_rate", &max_conflict_rate);
   GetBool(params, "enable_bundle", &enable_bundle);
   GetBool(params, "adjacent_bundle", &adjacent_bundle);


### PR DESCRIPTION
The division expression in line 136 may encounter runtime division-by-zero error if min_data_in_bin is set to 0. Modified the control flow to avoid this problem.