### PR TITLE
docs: fix build error by mocking LGBMDeprecated

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,11 @@ from recommonmark.transform import AutoStructify
 
 # -- mock out modules
 from unittest.mock import Mock
-MOCK_MODULES = ['numpy', 'scipy', 'scipy.sparse', 'sklearn', 'matplotlib', 'pandas', 'graphviz']
+MOCK_MODULES = [
+    'numpy', 'scipy', 'scipy.sparse',
+    'sklearn', 'matplotlib', 'pandas', 'graphviz',
+    'lightgbm.compat.LGBMDeprecated'
+]
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()
 


### PR DESCRIPTION
If scikit-learn isn't installed (and Read the Docs doesn't have it),
LGBMDeprecated aren't created and can't be imported.

cf. https://github.com/Microsoft/LightGBM/blob/master/python-package/lightgbm/compat.py#L76

#485 