### PR TITLE
Use gcc-7 on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 
 if(APPLE)
-    SET(CMAKE_CXX_COMPILER "g++-6")
-    SET(CMAKE_C_COMPILER "gcc-6")
+    SET(CMAKE_CXX_COMPILER "g++-7")
+    SET(CMAKE_C_COMPILER "gcc-7")
 endif()
 
 PROJECT(lightgbm)


### PR DESCRIPTION
Homebrew updated gcc to 7.1.
https://github.com/Homebrew/homebrew-core/commit/0387fe46e9ce9fe4a14dbce9d31d70f5824ff830
https://github.com/Homebrew/homebrew-core/commit/0ab90d39e3ca786c9f0b2fb44c2fd29880336cd2