### PR TITLE
Fix GPU compilation folder structure

### DIFF
--- a/docs/GPU-Windows.md
+++ b/docs/GPU-Windows.md
@@ -145,8 +145,8 @@ Your folder should look like this at the end (not fully detailed):
   |--------- bin
   |--------- include
   |------------ boost
-  |------ lib
-  |------ share
+  |--------- lib
+  |--------- share
 ```
 
 This is what you should (approximately) get at the end of Boost compilation:


### PR DESCRIPTION
Just one small bug found from here: https://github.com/Microsoft/LightGBM/issues/503

Does not cause any issue, but just for readability.