### PR TITLE
Fix undefined behavior

### DIFF
--- a/include/LightGBM/utils/random.h
+++ b/include/LightGBM/utils/random.h
@@ -103,7 +103,7 @@ private:
     return x & 0x7FFFFFF;
   }
 
-  int x = 123456789;
+  unsigned int x = 123456789;
 };
 
 


### PR DESCRIPTION
The result of a right-shift of a signed negative number is
implementation-dependent.
cf. https://msdn.microsoft.com/en-us//library/336xbhcz.aspx

Fix #519
Fix #521