### PR TITLE
Add Intel OpenCL warning

### DIFF
--- a/docs/GPU-Windows.md
+++ b/docs/GPU-Windows.md
@@ -57,11 +57,13 @@ Does not apply to you if you do not use a third-party antivirus nor the default 
 
 Installing the appropriate OpenCL SDK requires you to download the correct vendor source SDK. You need to know on what you are going to use LightGBM!:
 
-* For running on Intel, get Intel SDK for OpenCL: https://software.intel.com/en-us/articles/opencl-drivers
+* For running on Intel, get Intel SDK for OpenCL: https://software.intel.com/en-us/articles/opencl-drivers (NOT RECOMMENDED)
 * For running on AMD, get AMD APP SDK: http://developer.amd.com/tools-and-sdks/opencl-zone/amd-accelerated-parallel-processing-app-sdk/
 * For running on NVIDIA, get CUDA Toolkit: https://developer.nvidia.com/cuda-downloads
 
 Further reading and correspondnce table (especially if you intend to use cross-platform devices, like Intel CPU with AMD APP SDK): [GPU SDK Correspondence and Device Targeting Table](./GPU-Targets.md).
+
+Warning: using Intel OpenCL is not recommended and may crash your machine due to being non compliant to OpenCL standards. If your objective is to use LightGBM + OpenCL on CPU, please use AMD APP SDK instead (it can run also on Intel CPUs without any issues).
 
 ---
 

--- a/docs/GPU-Windows.md
+++ b/docs/GPU-Windows.md
@@ -158,6 +158,13 @@ This is what you should (approximately) get at the end of Boost compilation:
 
 ![Boost compiled](https://cloud.githubusercontent.com/assets/9083669/24918623/5152a3c0-1ee1-11e7-9d59-d75fb1193241.png)
 
+If you are getting an error:
+
+* Wipe your boost directory
+* Close the command prompt
+* Make sure you added `C:\boost\boost-build\bin;C:\boost\boost-build\include\boost` to your PATH (adjust accordingly if you use another folder)
+* Do the boost compilation steps again (extract => command prompt => `cd` => `bootstrap` => `b2` => `cd` => `b2`
+
 ---
 
 ## Git Installation

--- a/docs/Parameters.md
+++ b/docs/Parameters.md
@@ -65,6 +65,8 @@ The parameter format is `key1=value1 key2=value2 ... ` . And parameters can be s
 * `num_threads`, default=OpenMP_default, type=int, alias=`num_thread`,`nthread`
   * Number of threads for LightGBM. 
   * For the best speed, set this to the number of **real CPU cores**, not the number of threads (most CPU using [hyper-threading](https://en.wikipedia.org/wiki/Hyper-threading) to generate 2 threads per CPU core).
+  * Do not set it too large if your dataset is small (do not use 64 threads for a dataset with 10,000 for instance).
+  * Be aware a task manager or any similar CPU monitoring tool might report cores not being fully utilized. This is normal.
   * For parallel learning, should not use full CPU cores since this will cause poor performance for the network.
 * `device`, default=`cpu`, options=`cpu`,`gpu`
   * Choose device for the tree learning, can use gpu to achieve the faster learning.


### PR DESCRIPTION
Using Intel OpenCL is not recommended and may crash the machine due to being non compliant to OpenCL standards. If the objective is to use LightGBM + OpenCL on CPU, one should use AMD APP SDK instead (it can run also on Intel CPUs without any issues).

@guolinke update wiki to reflect the warning?

Fixes:

* #89: LightGBM installs fine on Sierra, but doesn't seem to be running in parallel
* #446: Installation of CMake&MinGW is slow than Visual Studio
* #447: OpenCL Intel Crash + Windows
* #484: R + Multithreading
* #503: cannot compile Boost properly (Windows 10; R)

About #89, tested with different Macbooks under Mac 10.9, 10.10, 10.11, 10.12, with LightGBM v1, v2, and master: no issue detected for performance compared to Windows / Linux.