### PR TITLE
[R-package] Testing R6 object fix (do NOT merge)

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -446,8 +446,7 @@ Dataset <- R6Class(
       }
       
       # return(self) goes NUTS in R6 object + memory displacement
-      self$finalize()
-      return(self)
+      return(NULL)
       
     },
     

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -274,8 +274,8 @@ Dataset <- R6Class(
         stop("lgb.Dataset.construct: label should be set")
       }
       
-      # Return oneself
-      return(self)
+      # return(self) goes NUTS in R6 object + memory displacement
+      return(NULL)
       
     },
     

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -274,8 +274,8 @@ Dataset <- R6Class(
         stop("lgb.Dataset.construct: label should be set")
       }
       
-      # return(self) goes NUTS in R6 object + memory displacement
-      return(NULL)
+      # return oneself
+      return(self)
       
     },
     
@@ -445,8 +445,8 @@ Dataset <- R6Class(
         
       }
       
-      # Return self
-      return(self)
+      # return(self) goes NUTS in R6 object + memory displacement
+      return(NULL)
       
     },
     

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -446,7 +446,8 @@ Dataset <- R6Class(
       }
       
       # return(self) goes NUTS in R6 object + memory displacement
-      return(NULL)
+      self$finalize()
+      return(self)
       
     },
     


### PR DESCRIPTION
DO NOT MERGE

Temporary fix for #539, but this only delays the issue...

```r
> require(lightgbm)
Loading required package: lightgbm
Loading required package: R6
Warning message:
package ‘R6’ was built under R version 3.3.3 
> data <- matrix(1, 4000000, 20)
> label <- rep(1, 4000000)
> tic = proc.time()[3]
> label <- as.numeric(label)
> cat(proc.time()[3] - tic, 'secs', '\n')
0.02 secs 
> print(typeof(label))
[1] "double"
> print(head(label))
[1] 1 1 1 1 1 1
> train <- lgb.Dataset(data = data)
> tic = proc.time()[3]
> train$setinfo("label", label)
NULL
> cat(proc.time()[3] - tic, 'secs', '\n')
0 secs 
> str(train$getinfo("label"))
 num [1:4000000] 1 1 1 1 1 1 1 1 1 1 ...
```

```r
lgb.unloader(wipe = TRUE)
require(lightgbm)
data <- matrix(1, 4000000, 20)
label <- rep(1, 4000000)
tic = proc.time()[3]
label <- as.numeric(label)
cat(proc.time()[3] - tic, 'secs', '\n')
print(typeof(label))
print(head(label))
train <- lgb.Dataset(data = data)
tic = proc.time()[3]
train$setinfo("label", label)
cat(proc.time()[3] - tic, 'secs', '\n')
str(train$getinfo("label"))
train # issue 539 is deferred at printing of train. Just don't print train...
```
