### PR TITLE
Fix compilation warning and linkage error with MSVC due to struct mismatch

### DIFF
--- a/include/LightGBM/boosting.h
+++ b/include/LightGBM/boosting.h
@@ -13,7 +13,7 @@ namespace LightGBM {
 class Dataset;
 class ObjectiveFunction;
 class Metric;
-class PredictionEarlyStopInstance;
+struct PredictionEarlyStopInstance;
 
 /*!
 * \brief The interface for Boosting

--- a/include/LightGBM/prediction_early_stop.h
+++ b/include/LightGBM/prediction_early_stop.h
@@ -8,7 +8,6 @@
 
 namespace LightGBM {
 
-#pragma warning(disable : 4099)
 struct PredictionEarlyStopInstance {
   /// Callback function type for early stopping.
   /// Takes current prediction and number of elements in prediction
@@ -19,7 +18,6 @@ struct PredictionEarlyStopInstance {
   int          round_period;       // call callback_function every `runPeriod` iterations
 };
 
-#pragma warning(disable : 4099)
 struct PredictionEarlyStopConfig {
   int round_period;
   double margin_threshold;


### PR DESCRIPTION
Hi @guolinke , I noticed there was an issue with MSVC when linking against the .so file. This was because I was declaring PredictionEarlyStopInstance to be a class when it is a struct. It's fixed now.