### PR TITLE
Fix Subdirectory demo contains invalid file names

### DIFF
--- a/R-package/demo/README.md
+++ b/R-package/demo/README.md
@@ -1,9 +1,0 @@
-LightGBM R examples
-====
-* [Basic walkthrough of wrappers](basic_walkthrough.R)
-* [Boosting from existing prediction](boost_from_prediction.R)
-* [Early Stopping](early_stopping.R)
-* [Cross Validation](cross_validation.R)
-* [Multiclass Training/Prediction](multiclass.R)
-* [Leaf (in)Stability](leaf_stability.R)
-* [Weight-Parameter Adjustment Relationship](weight_param.R)


### PR DESCRIPTION
This PR fixes package building error for strict environments where a warning becomes an error:

```r
Subdirectory 'demo' contains invalid file names:
  'README.md'
```