### PR TITLE
python-package: set attributes with kwargs

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -240,7 +240,8 @@ class LGBMModel(LGBMModelBase):
             self.fobj = _objective_function_wrapper(self.objective)
         else:
             self.fobj = None
-        self.other_params = kwargs
+        self.other_params = {}
+        self.set_params(**kwargs)
 
     def get_params(self, deep=True):
         params = super(LGBMModel, self).get_params(deep=deep)


### PR DESCRIPTION
This commit will regain backward compatibility that has been broken after e465f92aa389b42da3cd596a2df4a59ae5032de7.

For example, before e465f92aa389b42da3cd596a2df4a59ae5032de7, we could get some attributes:

```python
gbm = LGBMClassifier(use_missing=False)
print(gbm.use_missing)
``` 

but currently we have to change the code like this:

```python
gbm = LGBMClassifier(use_missing=False)
print(gbm.other_params['use_missing'])
```