### PR TITLE
[R-package] Fallback to MinGW when VS build fails

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -20,7 +20,7 @@ The default compiler is Visual Studio (or [MS Build](https://www.visualstudio.co
 
 To force the usage of Rtools / MinGW, you can set `use_mingw` to `TRUE` in `R-package/src/install.libs.R`.
 
-For users who wants to install online with GPU, please check the end of this document for installation using a helper package ([Laurae2/lgbdl](https://github.com/Laurae2/lgbdl/)).
+For users who wants to install online with GPU or want to choose a specific compiler, please check the end of this document for installation using a helper package ([Laurae2/lgbdl](https://github.com/Laurae2/lgbdl/)).
 
 It is recommended to use *Visual Studio* for its better multi-threading efficency in Windows for many core systems. For very simple systems (dual core computers or worse), MinGW64 is recommended for maximum performance. If you do not know what to choose, it is recommended to use [Visual Studio](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017), the default compiler.
 
@@ -113,10 +113,11 @@ lgb.dl(commit = "master",
        repo = "https://github.com/Microsoft/LightGBM")
 ```
 
-You may also install online using a LightGBM with proper GPU support using the following from R:
+You may also install online using a LightGBM with proper GPU support using Visual Studio (as an example here) using the following from R:
 
 ```r
 lgb.dl(commit = "master",
+       compiler = "vs", # Remove this for MinGW + GPU installation
        repo = "https://github.com/Microsoft/LightGBM",
        use_gpu = TRUE)
 ```

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -16,11 +16,13 @@ Installing [Rtools](https://cran.r-project.org/bin/windows/Rtools/) is mandatory
 
 [cmake](https://cmake.org/) must be version 3.8 or higher.
 
-The default compiler is Rtools or any [MinGW64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/) (x86_64-posix-seh) to compile by setting `use_mingw` to `TRUE` in `R-package/src/install.libs.R`. You also can use Visual Studio (or [MS Build](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017)) in Windows.
+The default compiler is Visual Studio (or [MS Build](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017)) in Windows, with an automatic fallback to Rtools or any [MinGW64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/) (x86_64-posix-seh) available (this means if you have only Rtools and cmake, it will compile fine).
 
-For Visual Studio users who wants to install online, please check the end of this document for installation using a helper package ([Laurae2/lgbdl](https://github.com/Laurae2/lgbdl/)).
+To force the usage of Rtools / MinGW, you can set `use_mingw` to `TRUE` in `R-package/src/install.libs.R`.
 
-It is recommended to use *Visual Studio* for its better multi-threading efficency in Windows for many core systems. For very simple systems (dual core computers or worse), MinGW64 is recommended for maximum performance. If you do not know what to choose, it is recommended to use [Visual Studio](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017).
+For users who wants to install online with GPU, please check the end of this document for installation using a helper package ([Laurae2/lgbdl](https://github.com/Laurae2/lgbdl/)).
+
+It is recommended to use *Visual Studio* for its better multi-threading efficency in Windows for many core systems. For very simple systems (dual core computers or worse), MinGW64 is recommended for maximum performance. If you do not know what to choose, it is recommended to use [Visual Studio](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017), the default compiler.
 
 #### Mac OS X Preparation
 
@@ -109,6 +111,14 @@ You may also install using a precompiled dll/lib using the following from R:
 lgb.dl(commit = "master",
        libdll = "C:\\LightGBM\\windows\\x64\\DLL\\lib_lightgbm.dll", # YOUR PRECOMPILED DLL
        repo = "https://github.com/Microsoft/LightGBM")
+```
+
+You may also install online using a LightGBM with proper GPU support using the following from R:
+
+```r
+lgb.dl(commit = "master",
+       repo = "https://github.com/Microsoft/LightGBM",
+       use_gpu = TRUE)
 ```
 
 For more details about options, please check [Laurae2/lgbdl](https://github.com/Laurae2/lgbdl/) R-package.

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -7,11 +7,11 @@ Installation
 ### Preparation
 You need to install git and [cmake](https://cmake.org/) first.
 
-The default compiler is Visual Studio (or [MS Build](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017)) in Windows. You also can use Rtools (default) or [MinGW64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/) (x86_64-posix-seh) to compile by setting `use_mingw` to `TRUE` in `R-package/src/install.libs.R`. For MinGW users who wants to install online, please check the end of this document for installation using a helper package ([Laurae2/lgbdl](https://github.com/Laurae2/lgbdl/)).
+The default compiler is gcc (Linux) or Rtools' MinGW (Windows). You may also compile with Visual Studio (or [MS Build](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017)) by setting `use_mingw` to `TRUE` in `R-package/src/install.libs.R`. It is also possible to compile with [MinGW64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/) (x86_64-posix-seh) in Windows. For Visual Studio users who wants to install online, please check the end of this document for installation using a helper package ([Laurae2/lgbdl](https://github.com/Laurae2/lgbdl/)).
 
 It is recommended to use *Visual Studio* for its better multi-threading efficency in Windows for many core systems. For very simple systems (dual core computers or worse), MinGW64 is recommended for maximum performance. If you do not know what to choose, it is recommended to use [Visual Studio](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017).
 
-For Windows users, installing [Rtools](https://cran.r-project.org/bin/windows/Rtools/) is mandatory.
+For Windows users, installing [Rtools](https://cran.r-project.org/bin/windows/Rtools/) is mandatory even when using Visual Studio compilation.
 
 For Mac OS X users, gcc with OpenMP support must be installed first. Refer to [wiki](https://github.com/Microsoft/LightGBM/wiki/Installation-Guide#osx) for installing gcc with OpenMP support.
 
@@ -81,13 +81,12 @@ In addition, if you are using a Visual Studio precompiled DLL, assuming you do n
 
 Once you have all this setup, you can use `lgb.dl` from `lgbdl` package to install LightGBM from repository.
 
-For instance, you can install the R package from LightGBM master commit of GitHub using the following from R:
+For instance, you can install the R package from LightGBM master commit of GitHub with Visual Studio using the following from R:
 
 ```r
 lgb.dl(commit = "master",
-       compiler = "gcc",
-       repo = "https://github.com/Microsoft/LightGBM",
-       cores = 4)
+       compiler = "vs",
+       repo = "https://github.com/Microsoft/LightGBM")
 ```
 
 You may also install using a precompiled dll/lib using the following from R:

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -33,7 +33,7 @@ Install LightGBM R-package with the following command:
 ```sh
 git clone --recursive https://github.com/Microsoft/LightGBM
 cd LightGBM/R-package
-R CMD INSTALL --build .
+R CMD INSTALL --build . --no-multiarch
 ```
 
 Or build a self-contained R package which can be installed afterwards:
@@ -42,7 +42,7 @@ Or build a self-contained R package which can be installed afterwards:
 git clone --recursive https://github.com/Microsoft/LightGBM
 cd LightGBM/R-package
 Rscript build_package.R
-R CMD INSTALL lightgbm_2.0.2.tar.gz
+R CMD INSTALL lightgbm_2.0.2.tar.gz --no-multiarch
 ``` 
 
 Note: for the build with Visual Studio/MSBuild in Windows, you should use the Windows CMD or Powershell.
@@ -54,7 +54,9 @@ Set `use_gpu` to `TRUE` in `R-package/src/install.libs.R` to enable the build wi
 You can also install directly from R using the repository with `devtools`:
 
 ```r
-devtools::install_github("Microsoft/LightGBM", subdir = "R-package")
+library(devtools)
+options(devtools.install.args = "--no-multiarch") # if you have 64-bit R only, you can skip this
+install_github("Microsoft/LightGBM", subdir = "R-package")
 ```
 
 If you are using a precompiled dll/lib locally, you can move the dll/lib into LightGBM root folder, modify `LightGBM/R-package/src/install.libs.R`'s 2nd line (change `use_precompile <- FALSE` to `use_precompile <- TRUE`), and install R-package as usual.

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -1,7 +1,7 @@
 # User options
 use_precompile <- FALSE
 use_gpu <- FALSE
-use_mingw <- FALSE
+use_mingw <- TRUE
 
 if (.Machine$sizeof.pointer != 8){
   stop("Only support 64-bit R, please check your the version of your R and Rtools.")

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -50,7 +50,8 @@ if (!use_precompile) {
   if (WINDOWS) {
     if (use_mingw) {
       cmake_cmd <- paste0(cmake_cmd, " -G \"MinGW Makefiles\" ")
-      build_cmd <- "mingw32-make.exe _lightgbm -j4"
+      build_cmd <- "mingw32-make.exe _lightgbm -j"
+      system(build_cmd) # Must build twice for Windows due sh.exe in Rtools
     } else {
       cmake_cmd <- paste0(cmake_cmd, " -DCMAKE_GENERATOR_PLATFORM=x64 ")
       build_cmd <- "cmake --build . --target _lightgbm  --config Release"
@@ -64,9 +65,6 @@ if (!use_precompile) {
   
   # Install
   system(paste0(cmake_cmd, " .."))
-  if (WINDOWS && use_mingw) {
-    system(build_cmd) # Must build twice for Windows due sh.exe in Rtools
-  }
   system(build_cmd)
   src <- file.path(lib_folder, paste0("lib_lightgbm", SHLIB_EXT), fsep = "/")
   

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -56,7 +56,7 @@ if (!use_precompile) {
       cmake_cmd <- paste0(cmake_base, " -DCMAKE_GENERATOR_PLATFORM=x64 ")
       tryVS <- system(paste0(cmake_cmd, " .."))
       if (tryVS == 1) {
-        system("rm -rf .")
+        unlink("./*", recursive = TRUE) # Clean up build directory
         cmake_cmd <- paste0(cmake_base, " -G \"MinGW Makefiles\" ") # Switch to MinGW on failure, try build once
         system(paste0(cmake_cmd, " ..")) # Must build twice for Windows due sh.exe in Rtools
       }

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -56,6 +56,7 @@ if (!use_precompile) {
       cmake_cmd <- paste0(cmake_base, " -DCMAKE_GENERATOR_PLATFORM=x64 ")
       tryVS <- system(paste0(cmake_cmd, " .."))
       if (tryVS == 1) {
+        system("rm -rf .")
         cmake_cmd <- paste0(cmake_base, " -G \"MinGW Makefiles\" ") # Switch to MinGW on failure, try build once
         system(paste0(cmake_cmd, " ..")) # Must build twice for Windows due sh.exe in Rtools
       }

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -51,7 +51,7 @@ if (!use_precompile) {
     if (use_mingw) {
       cmake_cmd <- paste0(cmake_cmd, " -G \"MinGW Makefiles\" ")
       build_cmd <- "mingw32-make.exe _lightgbm -j"
-      system(build_cmd) # Must build twice for Windows due sh.exe in Rtools
+      system(paste0(cmake_cmd, " ..")) # Must build twice for Windows due sh.exe in Rtools
     } else {
       cmake_cmd <- paste0(cmake_cmd, " -DCMAKE_GENERATOR_PLATFORM=x64 ")
       build_cmd <- "cmake --build . --target _lightgbm  --config Release"

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -43,7 +43,7 @@ if (!use_precompile) {
   
   # Prepare installation steps
   cmake_cmd <- "cmake "
-  build_cmd <- "make _lightgbm -j4"
+  build_cmd <- "make _lightgbm -j"
   lib_folder <- file.path(R_PACKAGE_SOURCE, "src", fsep = "/")
   
   # Check if Windows installation (for gcc vs Visual Studio)
@@ -64,6 +64,9 @@ if (!use_precompile) {
   
   # Install
   system(paste0(cmake_cmd, " .."))
+  if (WINDOWS && use_mingw) {
+    system(build_cmd) # Must build twice for Windows due sh.exe in Rtools
+  }
   system(build_cmd)
   src <- file.path(lib_folder, paste0("lib_lightgbm", SHLIB_EXT), fsep = "/")
   

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -59,9 +59,11 @@ if (!use_precompile) {
         unlink("./*", recursive = TRUE) # Clean up build directory
         cmake_cmd <- paste0(cmake_base, " -G \"MinGW Makefiles\" ") # Switch to MinGW on failure, try build once
         system(paste0(cmake_cmd, " ..")) # Must build twice for Windows due sh.exe in Rtools
+        build_cmd <- "mingw32-make.exe _lightgbm -j"
+      } else {
+        build_cmd <- "cmake --build . --target _lightgbm  --config Release"
+        lib_folder <- file.path(R_PACKAGE_SOURCE, "src/Release", fsep = "/")
       }
-      build_cmd <- "cmake --build . --target _lightgbm  --config Release"
-      lib_folder <- file.path(R_PACKAGE_SOURCE, "src/Release", fsep = "/")
     }
   }
   

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -54,9 +54,8 @@ if (!use_precompile) {
       system(paste0(cmake_cmd, " ..")) # Must build twice for Windows due sh.exe in Rtools
     } else {
       cmake_cmd <- paste0(cmake_base, " -DCMAKE_GENERATOR_PLATFORM=x64 ")
-      tryVS <- system(paste0(cmake_cmd, " .."), intern = TRUE)
-      cat(tryVS, "\n", sep = "") # try building with Visual Studio
-      if (regexpr("(does not support platform specification, but platform)", tryVS) != -1) {
+      tryVS <- system(paste0(cmake_cmd, " .."))
+      if (tryVS == 1) {
         cmake_cmd <- paste0(cmake_base, " -G \"MinGW Makefiles\" ") # Switch to MinGW on failure, try build once
         system(paste0(cmake_cmd, " ..")) # Must build twice for Windows due sh.exe in Rtools
       }


### PR DESCRIPTION
This PR is to help the release of CRAN package of LightGBM.

It removes Visual Studio requirement on Windows. User may still install LightGBM with Visual Studio from GitHub using [Laurae2/lgbdl](https://github.com/Laurae2/lgbdl/).

MinGW should be the default for the following reasons in Windows:

* R expects MinGW compilation
* Rtools, mandatory to start compiling packages, uses MinGW / gcc
* Rtools is most likely installed than Visual Studio
* CRAN does not use Visual Studio
* Precompiled DLLs for CRAN are last resort only

Updates:

* MinGW instead of Visual Studio by default
* R README.md documentation to reflect changes

See issue #629.