### PR TITLE
[R-package] Custom evaluation metric gets values as non-raw

### DIFF
--- a/R-package/demo/early_stopping.R
+++ b/R-package/demo/early_stopping.R
@@ -34,7 +34,7 @@ logregobj <- function(preds, dtrain) {
 # Take this in mind when you use the customization, and maybe you need write customized evaluation function
 evalerror <- function(preds, dtrain) {
   labels <- getinfo(dtrain, "label")
-  err <- as.numeric(sum(labels != (preds > 0))) / length(labels)
+  err <- as.numeric(sum(labels != (preds > 0.5))) / length(labels)
   return(list(name = "error", value = err, higher_better = FALSE))
 }
 print("Start training with early Stopping setting")


### PR DESCRIPTION
When using custom evaluation metric, values are passed as not raw values. (fix example)

See example below:

```r
library(lightgbm)

# Load in the agaricus dataset
data(agaricus.train, package = "lightgbm")
data(agaricus.test, package = "lightgbm")

dtrain <- lgb.Dataset(agaricus.train$data, label = agaricus.train$label)
dtest <- lgb.Dataset(agaricus.test$data, label = agaricus.test$label)

param <- list(num_leaves = 4,
              learning_rate = 1)
valids <- list(eval = dtest)
num_round <- 1

evalerror <- function(preds, dtrain) {
  labels <- getinfo(dtrain, "label")
  print(preds)
  err <- as.numeric(sum(labels != (preds >= 0.5))) / length(labels)
  return(list(name = "error", value = err, higher_better = FALSE))
}

bst <- lgb.train(param,
                 dtrain,
                 num_round,
                 valids,
                 objective = "binary",
                 eval = evalerror)

predict(bst, agaricus.test$data)
```

Example:

```r
> bst <- lgb.train(param,
+                  dtrain,
+                  num_round,
+                  valids,
+                  objective = "binary",
+                  eval = evalerror,
+                  # scale_pos_weight = 1000,
+                  is_unbalance = FALSE)
[LightGBM] [Info] Number of positive: 3140, number of negative: 3373
[LightGBM] [Info] Total Bins 128
[LightGBM] [Info] Number of data: 6513, number of used features: 107
[LightGBM] [Info] Trained a tree with leaves=4 and max_depth=3
   [1] 0.1524445 0.8703669 0.1524445 0.1524445 0.1336260 0.8703669 0.8703669 0.1524445 0.8703669 0.1192029 0.8703669 0.1524445 0.1336260 0.1524445 0.1336260 (...)

(...)

> predict(bst, agaricus.test$data)
   [1] 0.1524445 0.8703669 0.1524445 0.1524445 0.1336260 0.8703669 0.8703669 0.1524445 0.8703669 0.1192029 0.8703669 0.1524445 0.1336260 0.1524445 0.1336260 (...)
```