### PR TITLE
[R-package] Prevent R6 and jsonlite downloads

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -28,11 +28,11 @@ Suggests:
     stringi (>= 0.5.2)
 Depends:
     R (>= 3.0),
-    R6
+    R6 (>= 2.0)
 Imports:
     methods,
     Matrix (>= 1.1-0),
     data.table (>= 1.9.6),
     magrittr (>= 1.5),
-    jsonlite
+    jsonlite (>= 1.0)
 RoxygenNote: 6.0.1


### PR DESCRIPTION
Attempts to prevent R6 and jsonlite downloads when installing LightGBM by specifying in description file their versions.

Sometimes R wants to update these packages while installing LightGBM, and in the case of an Intranet with fake Internet it will always fail the installation no matter what (just because it can talk with R servers but not download from, as it is not allowed in some scenarii).