### PR TITLE
Remove wheel from Python requirement

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -155,7 +155,6 @@ if __name__ == "__main__":
           version=version,
           description='LightGBM Python Package',
           install_requires=[
-              'wheel',
               'numpy',
               'scipy',
               'scikit-learn'


### PR DESCRIPTION
The wheel package is only used in the Python wheel release process, and it is not being actually imported anywhere in the lightgbm code. 

There is no need to require user installing wheel in the pip install process.