### PR TITLE
[python package] added get_ref_chain function to Dataset object, used it in train() to…

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1187,8 +1187,8 @@ class Dataset(object):
         head = self
         ref_chain = []
         while len(ref_chain) < ref_limit:
-            if isinstance(head, Dataset) and head.handle is not None:
-                ref_chain += ([head] if isinstance(head, Dataset) else [])
+            if isinstance(head, Dataset):
+                ref_chain += [head]
                 if (head.reference is not None) and (head.reference not in ref_chain):
                     head = head.reference
                 else:

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1004,7 +1004,8 @@ class Dataset(object):
         self.set_categorical_feature(reference.categorical_feature)
         self.set_feature_name(reference.feature_name)
         self._set_predictor(reference._predictor)
-        if self.reference is reference:
+        # we're done if self and reference share a common upstrem reference
+        if self.get_ref_chain().intersection(reference.get_ref_chain()):
             return
         if self.data is not None:
             self.reference = reference

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1174,6 +1174,25 @@ class Dataset(object):
         else:
             raise LightGBMError("Cannot get num_feature before construct dataset")
 
+    def get_ref_chain(self, ref_limit = 100):
+        '''
+        Gets a chain of Dataset objects, starting with r, then going to r.reference if exists, 
+            then to r.reference.reference, etc. until we hit ref_limit or a reference loop
+
+        Returns
+        -------
+        chain of references of self : set of Dataset objects
+        '''
+        head = self
+        ref_chain=[]
+        while len(ref_chain)<ref_limit:
+            ref_chain += ([head] if isinstance(head, Dataset) else [])
+            if isinstance(head, Dataset) and (head.reference is not None) and (head.reference not in ref_chain):
+                head = head.reference
+            else:
+                break
+        return(set(ref_chain))
+
 
 class Booster(object):
     """"Booster in LightGBM."""

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -128,8 +128,7 @@ def train(params, train_set, num_boost_round=100,
                 continue
             if not isinstance(valid_data, Dataset):
                 raise TypeError("Traninig only accepts Dataset object")
-            if not train_set.get_ref_chain().intersection(valid_data.get_ref_chain()):
-                valid_data.set_reference(train_set)
+            valid_data.set_reference(train_set)
             reduced_valid_sets.append(valid_data)
             if valid_names is not None and len(valid_names) > i:
                 name_valid_sets.append(valid_names[i])

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -128,7 +128,8 @@ def train(params, train_set, num_boost_round=100,
                 continue
             if not isinstance(valid_data, Dataset):
                 raise TypeError("Traninig only accepts Dataset object")
-            valid_data.set_reference(train_set)
+            if not train_set.get_ref_chain().intersection(valid_data.get_ref_chain()):
+                valid_data.set_reference(train_set)
             reduced_valid_sets.append(valid_data)
             if valid_names is not None and len(valid_names) > i:
                 name_valid_sets.append(valid_names[i])


### PR DESCRIPTION
… compare if training and validation have common reference ancestors.

Basically, in engine.py, the train() function no longer directly sets the reference of valid_data to be train_set, but rather checks to see if valid_data and train_set are both derived from the same 'ancestor', and only does does the reference setting if not.   In order to do this check I implemented a method for the Dataset object which returns the dataset itself, its reference, the reference of its reference, etc.

This should resolve #714 

I built lightgbm with the changes and ran the example code in #714 which showed an error, and with the modifications there were no more errors.  Let me know if there are other checks I should do.