### PR TITLE
Simple CV fix for R-package best score

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -3,6 +3,7 @@ CVBooster <- R6Class(
   cloneable = FALSE,
   public = list(
     best_iter = -1,
+    best_score = -1,
     record_evals = list(),
     boosters = list(),
     initialize = function(x) {


### PR DESCRIPTION
Fix a bug from a comment on issue 760 (workaround: not linked to avoid auto-closing of the issue).

Install with:

```r
devtools::install_github("Laurae2/LightGBM/R-package@patch-1")
```

Try this:

```r
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label)
params <- list(objective = "regression", metric = "l2")
model <- lgb.cv(params,
                dtrain,
                20,
                nfold = 5,
                min_data = 1,
                learning_rate = 0.3,
                early_stopping_rounds = 10)
```