### PR TITLE
[R-package] Prevent remembering parameters

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -4,7 +4,7 @@ Dataset <- R6Class(
   public = list(
     
     # Logical to check whether a dataset can be used re-modeled in-memory as another Dataset or not
-    remodel <- TRUE
+    remodel <- TRUE,
     
     # Finalize will free up the handles
     finalize = function() {

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -4,7 +4,7 @@ Dataset <- R6Class(
   public = list(
     
     # Logical to check whether a dataset can be used re-modeled in-memory as another Dataset or not
-    remodel <- TRUE,
+    remodel = TRUE,
     
     # Finalize will free up the handles
     finalize = function() {

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -3,6 +3,9 @@ Dataset <- R6Class(
   cloneable = TRUE,
   public = list(
     
+    # Logical to check whether a dataset can be used re-modeled in-memory as another Dataset or not
+    remodel <- TRUE
+    
     # Finalize will free up the handles
     finalize = function() {
       
@@ -275,6 +278,9 @@ Dataset <- R6Class(
       if (is.null(self$getinfo("label"))) {
         stop("lgb.Dataset.construct: label should be set")
       }
+      
+      # Forcefully block construction
+      self$remodel <- FALSE
       
       # Return self
       return(invisible(self))

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -1,6 +1,6 @@
 Dataset <- R6Class(
   classname = "lgb.Dataset",
-  cloneable = FALSE,
+  cloneable = TRUE,
   public = list(
     
     # Finalize will free up the handles

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -153,7 +153,10 @@ lgb.train <- function(params = list(),
   }
   
   # Construct datasets, if needed
-  data$construct()
+  if (data$remodel == TRUE) {
+    data <- data$clone(deep = TRUE)
+    data$construct()
+  }
   vaild_contain_train <- FALSE
   train_data_name <- "train"
   reduced_valid_sets <- list()

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -154,7 +154,7 @@ lgb.train <- function(params = list(),
   
   # Construct datasets, if needed
   if (data$remodel == TRUE) {
-    data <- data$clone(deep = TRUE)
+    data <- data$clone(deep = FALSE)
     data$construct()
   }
   vaild_contain_train <- FALSE


### PR DESCRIPTION
When the user does not construct the dataset explicitly, the user is free to train as much as it wants as the original dataset is never erased.

Fixes https://github.com/Microsoft/LightGBM/issues/775

Test cases, check test 3 vs test 4 to see it in action:

```r
# TEST 1: CV is not affected by default
lgb.unloader(wipe = TRUE)
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label, weight = inverse.rle(list(lengths = c(rep(500, 12), 513), values = 1:13)), init_score = inverse.rle(list(lengths = c(rep(500, 12), 513), values = (1:13) * 2)))
params <- list(objective = "regression", metric = "l2")
set.seed(1)
model <- lgb.cv(params,
                dtrain,
                10,
                nfold = 4,
                min_data = 1,
                learning_rate = 0.01,
                early_stopping_rounds = 10)

# Clone dataset
dtest <- dtrain$clone(deep = FALSE)

# Check whether data is copied deeply or not
dtrain$setinfo("weight", inverse.rle(list(lengths = c(rep(500, 12), 513), values = 13:1)))

# Info (weight as example) on data are NOT identical
dtest$getinfo("weight")
dtrain$getinfo("weight")

# NOT identical
set.seed(1)
model <- lgb.cv(params,
                dtest,
                10,
                nfold = 4,
                min_data = 1,
                learning_rate = 0.01,
                early_stopping_rounds = 10)
set.seed(1)
model <- lgb.cv(params,
                dtrain,
                10,
                nfold = 4,
                min_data = 1,
                learning_rate = 0.01,
                early_stopping_rounds = 10)


# TEST 2: fails with explicit construct
lgb.unloader(wipe = TRUE)
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label, weight = inverse.rle(list(lengths = c(rep(500, 12), 513), values = 1:13)), init_score = inverse.rle(list(lengths = c(rep(500, 12), 513), values = (1:13) * 2)))
dtrain$construct()
params <- list(objective = "regression", metric = "l2")
model <- lgb.train(params,
                   dtrain,
                   10,
                   list(train = dtrain),
                   min_data = 1,
                   learning_rate = 1,
                   early_stopping_rounds = 10)

# Clone dataset
dtest <- dtrain$clone(deep = FALSE)

# Check whether data is copied deeply or not
dtrain$setinfo("weight", inverse.rle(list(lengths = c(rep(500, 12), 513), values = 13:1)))

# Info (weight as example) on data are NOT identical
dtest$getinfo("weight")
dtrain$getinfo("weight")

# BUT TRAINING IS IDENTICAL...
model <- lgb.train(params,
                   dtest,
                   10,
                   list(train = dtest),
                   min_data = 1,
                   learning_rate = 1,
                   early_stopping_rounds = 10)
model <- lgb.train(params,
                   dtrain,
                   10,
                   list(train = dtrain),
                   min_data = 1,
                   learning_rate = 1,
                   early_stopping_rounds = 10)


# TEST 3: success without explicit prior construct
lgb.unloader(wipe = TRUE)
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label, weight = inverse.rle(list(lengths = c(rep(500, 12), 513), values = 1:13)), init_score = inverse.rle(list(lengths = c(rep(500, 12), 513), values = (1:13) * 2)))

# Clone dataset
dtest <- dtrain$clone(deep = FALSE)

# Check whether data is copied deeply or not
dtrain$setinfo("weight", inverse.rle(list(lengths = c(rep(500, 12), 513), values = 13:1)))

# Info (weight as example) on data are NOT identical
dtest$getinfo("weight")
dtrain$getinfo("weight")

params <- list(objective = "regression", metric = "l2")

# NOT identical
model <- lgb.train(params,
                   dtest,
                   10,
                   list(train = dtest),
                   min_data = 1,
                   learning_rate = 1,
                   early_stopping_rounds = 10)
model <- lgb.train(params,
                   dtrain,
                   10,
                   list(train = dtrain),
                   min_data = 1,
                   learning_rate = 1,
                   early_stopping_rounds = 10)


# TEST 4: fails without explicit prior construct when not using dataset cloner
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label, weight = inverse.rle(list(lengths = c(rep(500, 12), 513), values = 1:13)), init_score = inverse.rle(list(lengths = c(rep(500, 12), 513), values = (1:13) * 2)))

# Copy dataset
dtest <- dtrain

# Check whether data is copied deeply or not
dtrain$setinfo("weight", inverse.rle(list(lengths = c(rep(500, 12), 513), values = 13:1)))

# Info (weight as example) on data are IDENTICAL
dtest$getinfo("weight")
dtrain$getinfo("weight")

params <- list(objective = "regression", metric = "l2")

# IDENTICAL RESULTS even though different weights
model <- lgb.train(params,
                   dtest,
                   10,
                   list(train = dtest),
                   min_data = 1,
                   learning_rate = 1,
                   early_stopping_rounds = 10)
model <- lgb.train(params,
                   dtrain,
                   10,
                   list(train = dtrain),
                   min_data = 1,
                   learning_rate = 1,
                   early_stopping_rounds = 10)
```