### PR TITLE
Fix [R-package] Prevent remembering parameters

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -1,10 +1,7 @@
 Dataset <- R6Class(
   classname = "lgb.Dataset",
-  cloneable = TRUE,
+  cloneable = FALSE,
   public = list(
-    
-    # Logical to check whether a dataset can be used re-modeled in-memory as another Dataset or not
-    remodel = TRUE,
     
     # Finalize will free up the handles
     finalize = function() {
@@ -278,9 +275,6 @@ Dataset <- R6Class(
       if (is.null(self$getinfo("label"))) {
         stop("lgb.Dataset.construct: label should be set")
       }
-      
-      # Forcefully block construction
-      self$remodel <- FALSE
       
       # Return self
       return(invisible(self))

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -71,7 +71,7 @@ lgb.train <- function(params = list(),
                       categorical_feature = NULL,
                       early_stopping_rounds = NULL,
                       callbacks = list(),
-                      reset_data = FALSE
+                      reset_data = FALSE,
                       ...) {
   
   # Setup temporary variables

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -153,10 +153,7 @@ lgb.train <- function(params = list(),
   }
   
   # Construct datasets, if needed
-  if (data$remodel == TRUE) {
-    data <- data$clone(deep = FALSE)
-    data$construct()
-  }
+  data$construct()
   vaild_contain_train <- FALSE
   train_data_name <- "train"
   reduced_valid_sets <- list()

--- a/R-package/man/lgb.train.Rd
+++ b/R-package/man/lgb.train.Rd
@@ -15,7 +15,8 @@ lgb.cv(params = list(), data, nrounds = 10, nfold = 3, label = NULL,
 lgb.train(params = list(), data, nrounds = 10, valids = list(),
   obj = NULL, eval = NULL, verbose = 1, record = TRUE, eval_freq = 1L,
   init_model = NULL, colnames = NULL, categorical_feature = NULL,
-  early_stopping_rounds = NULL, callbacks = list(), ...)
+  early_stopping_rounds = NULL, callbacks = list(), reset_data = FALSE,
+  ...)
 
 lightgbm(data, label = NULL, weight = NULL, params = list(),
   nrounds = 10, verbose = 1, eval_freq = 1L,
@@ -77,6 +78,8 @@ List of callback functions that are applied at each iteration.}
 \item{...}{other parameters, see parameters.md for more informations}
 
 \item{valids}{a list of \code{lgb.Dataset} objects, used for validation}
+
+\item{reset_data}{Boolean, setting it to TRUE (not the default value) will transform the booster model into a predictor model which frees up memory and the original datasets}
 
 \item{boosting}{boosting type. \code{gbdt}, \code{dart}}
 

--- a/R-package/man/predict.lgb.Booster.Rd
+++ b/R-package/man/predict.lgb.Booster.Rd
@@ -5,7 +5,8 @@
 \title{Predict method for LightGBM model}
 \usage{
 \method{predict}{lgb.Booster}(object, data, num_iteration = NULL,
-  rawscore = FALSE, predleaf = FALSE, header = FALSE, reshape = FALSE)
+  rawscore = FALSE, predleaf = FALSE, header = FALSE, reshape = FALSE,
+  ...)
 }
 \arguments{
 \item{object}{Object of class \code{lgb.Booster}}


### PR DESCRIPTION
Reverts Microsoft/LightGBM#796 and fixes it correctly.

STILL TODO

- [x] Use model save/load trick
- [x] Check model save/load trick
- [x] Update doc

```r
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label, weight = inverse.rle(list(lengths = c(rep(500, 12), 513), values = 1:13)), init_score = inverse.rle(list(lengths = c(rep(500, 12), 513), values = (1:13) * 2)))
params <- list(objective = "regression", metric = "l2")

# Works with/without
dtrain$construct()

model <- lgb.train(params,
                   dtrain,
                   10,
                   list(train = dtrain),
                   min_data = 1,
                   learning_rate = 1,
                   early_stopping_rounds = 10,
                   reset_data = TRUE)

# Check whether data is copied deeply or not
dtrain$setinfo("weight", inverse.rle(list(lengths = c(rep(500, 12), 513), values = 13:1)))

# Info (weight as example) on data are NOT identical // CORRECT
dtrain$getinfo("weight")

# Not identical training! // CORRECT
model <- lgb.train(params,
                   dtrain,
                   10,
                   list(train = dtrain),
                   min_data = 1,
                   learning_rate = 1,
                   early_stopping_rounds = 10)
```