### PR TITLE
Update links to Development Guide in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ LightGBM has been developed and used by many active community members. Your help
 - Contribute to the [tests](https://github.com/Microsoft/LightGBM/tree/master/tests) to make it more reliable. 
 - Contribute to the [documents](https://github.com/Microsoft/LightGBM/tree/master/docs) to make it clearer for everyone.
 - Contribute to the [examples](https://github.com/Microsoft/LightGBM/tree/master/examples) to share your experience with other users.
-- Check out [Development Guide](./docs/development.md).
+- Check out [Development Guide](./docs/development.rst).
 - Open issue if you met problems during development.
 
 Microsoft Open Source Code of Conduct

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,4 +33,4 @@ make html
 * [Parallel Learning Guide](https://github.com/Microsoft/LightGBM/wiki/Parallel-Learning-Guide)
 * [GPU Tutorial](./GPU-Tutorial.md)
 * [FAQ](./FAQ.md)
-* [Development Guide](./development.md)
+* [Development Guide](./development.rst)


### PR DESCRIPTION
Links to docs/development.md updated to docs/development.rst after https://github.com/Microsoft/LightGBM/pull/776