### PR TITLE
Fix __func__ is not defined in MSVS2013

### DIFF
--- a/include/LightGBM/meta.h
+++ b/include/LightGBM/meta.h
@@ -28,6 +28,10 @@ std::function<void(const std::vector<std::pair<int, double>>&, double* output)>;
 
 #define NO_SPECIFIC (-1)
 
+#if (_MSC_VER <= 1800)
+#define __func__ __FUNCTION__
+#endif
+
 }  // namespace LightGBM
 
 #endif   // LightGBM_META_H_

--- a/src/metric/xentropy_metric.hpp
+++ b/src/metric/xentropy_metric.hpp
@@ -1,6 +1,8 @@
 #ifndef LIGHTGBM_METRIC_XENTROPY_METRIC_HPP_
 #define LIGHTGBM_METRIC_XENTROPY_METRIC_HPP_
 
+#include <LightGBM/meta.h>
+
 #include <LightGBM/utils/log.h>
 #include <LightGBM/utils/common.h>
 

--- a/src/objective/xentropy_objective.hpp
+++ b/src/objective/xentropy_objective.hpp
@@ -1,6 +1,8 @@
 #ifndef LIGHTGBM_OBJECTIVE_XENTROPY_OBJECTIVE_HPP_
 #define LIGHTGBM_OBJECTIVE_XENTROPY_OBJECTIVE_HPP_
 
+#include <LightGBM/meta.h>
+
 #include <LightGBM/utils/common.h>
 
 #include <LightGBM/objective_function.h>


### PR DESCRIPTION
Fixes ability to build with MSVS2013 by defining `__func__` keyword.
Discussed in #817.