### PR TITLE
[R-package] Merge iterations and early stopping with params

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -137,7 +137,12 @@ lgb.cv <- function(params = list(),
   if (!is.null(predictor)) {
     begin_iteration <- predictor$current_iter() + 1
   }
-  end_iteration <- begin_iteration + nrounds - 1
+  # Check for number of rounds passed as parameter - in case there are multiple ones, take only the first one
+  if (sum(names(params) %in% c("num_iterations", "num_iteration", "num_tree", "num_trees", "num_round", "num_rounds")) > 0) {
+    end_iteration <- begin_iteration + params[which(names(params) %in% c("num_iterations", "num_iteration", "num_tree", "num_trees", "num_round", "num_rounds"))[1]] - 1
+  } else {
+    end_iteration <- begin_iteration + nrounds - 1
+  }
   
   # Check for training dataset type correctness
   if (!lgb.is.Dataset(data)) {
@@ -146,7 +151,7 @@ lgb.cv <- function(params = list(),
     }
     data <- lgb.Dataset(data, label = label)
   }
-
+  
   # Check for weights
   if (!is.null(weight)) {
     data$set_info("weight", weight)
@@ -209,10 +214,16 @@ lgb.cv <- function(params = list(),
     callbacks <- add.cb(callbacks, cb.record.evaluation())
   }
   
-  # Add early stopping callback
-  if (!is.null(early_stopping_rounds)) {
-    if (early_stopping_rounds > 0) {
-      callbacks <- add.cb(callbacks, cb.early.stop(early_stopping_rounds, verbose = verbose))
+  # Check for early stopping passed as parameter when adding early stopping callback
+  if (sum(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping")) > 0) {
+    if (params[which(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping"))[1]] > 0) {
+      callbacks <- add.cb(callbacks, cb.early.stop(params[which(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping"))[1]], verbose = verbose))
+    }
+  } else {
+    if (!is.null(early_stopping_rounds)) {
+      if (early_stopping_rounds > 0) {
+        callbacks <- add.cb(callbacks, cb.early.stop(early_stopping_rounds, verbose = verbose))
+      }
     }
   }
   

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -139,7 +139,7 @@ lgb.cv <- function(params = list(),
   }
   # Check for number of rounds passed as parameter - in case there are multiple ones, take only the first one
   if (sum(names(params) %in% c("num_iterations", "num_iteration", "num_tree", "num_trees", "num_round", "num_rounds")) > 0) {
-    end_iteration <- begin_iteration + params[which(names(params) %in% c("num_iterations", "num_iteration", "num_tree", "num_trees", "num_round", "num_rounds"))[1]] - 1
+    end_iteration <- begin_iteration + params[[which(names(params) %in% c("num_iterations", "num_iteration", "num_tree", "num_trees", "num_round", "num_rounds"))[1]]] - 1
   } else {
     end_iteration <- begin_iteration + nrounds - 1
   }
@@ -216,8 +216,8 @@ lgb.cv <- function(params = list(),
   
   # Check for early stopping passed as parameter when adding early stopping callback
   if (sum(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping")) > 0) {
-    if (params[which(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping"))[1]] > 0) {
-      callbacks <- add.cb(callbacks, cb.early.stop(params[which(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping"))[1]], verbose = verbose))
+    if (params[[which(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping"))[1]]] > 0) {
+      callbacks <- add.cb(callbacks, cb.early.stop(params[[which(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping"))[1]]], verbose = verbose))
     }
   } else {
     if (!is.null(early_stopping_rounds)) {

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -97,6 +97,10 @@ lgb.train <- function(params = list(),
   # Check for parameters
   lgb.check.params(params)
   
+  # Check for early stopping passed as parameter
+  
+  # Check for number of rounds passed as parameter
+  
   # Init predictor to empty
   predictor <- NULL
   

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -97,10 +97,6 @@ lgb.train <- function(params = list(),
   # Check for parameters
   lgb.check.params(params)
   
-  # Check for early stopping passed as parameter
-  
-  # Check for number of rounds passed as parameter
-  
   # Init predictor to empty
   predictor <- NULL
   
@@ -116,7 +112,13 @@ lgb.train <- function(params = list(),
   if (!is.null(predictor)) {
     begin_iteration <- predictor$current_iter() + 1
   }
-  end_iteration <- begin_iteration + nrounds - 1
+  # Check for number of rounds passed as parameter - in case there are multiple ones, take only the first one
+  if (sum(names(params) %in% c("num_iterations", "num_iteration", "num_tree", "num_trees", "num_round", "num_rounds")) > 0) {
+    end_iteration <- begin_iteration + params[which(names(params) %in% c("num_iterations", "num_iteration", "num_tree", "num_trees", "num_round", "num_rounds"))[1]] - 1
+  } else {
+    end_iteration <- begin_iteration + nrounds - 1
+  }
+  
   
   # Check for training dataset type correctness
   if (!lgb.is.Dataset(data)) {
@@ -199,10 +201,16 @@ lgb.train <- function(params = list(),
     callbacks <- add.cb(callbacks, cb.record.evaluation())
   }
   
-  # Add early stopping callback
-  if (!is.null(early_stopping_rounds)) {
-    if (early_stopping_rounds > 0) {
-      callbacks <- add.cb(callbacks, cb.early.stop(early_stopping_rounds, verbose = verbose))
+  # Check for early stopping passed as parameter when adding early stopping callback
+  if (sum(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping")) > 0) {
+    if (params[which(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping"))[1]] > 0) {
+      callbacks <- add.cb(callbacks, cb.early.stop(params[which(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping"))[1]], verbose = verbose))
+    }
+  } else {
+    if (!is.null(early_stopping_rounds)) {
+      if (early_stopping_rounds > 0) {
+        callbacks <- add.cb(callbacks, cb.early.stop(early_stopping_rounds, verbose = verbose))
+      }
     }
   }
   

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -114,7 +114,7 @@ lgb.train <- function(params = list(),
   }
   # Check for number of rounds passed as parameter - in case there are multiple ones, take only the first one
   if (sum(names(params) %in% c("num_iterations", "num_iteration", "num_tree", "num_trees", "num_round", "num_rounds")) > 0) {
-    end_iteration <- begin_iteration + params[which(names(params) %in% c("num_iterations", "num_iteration", "num_tree", "num_trees", "num_round", "num_rounds"))[1]] - 1
+    end_iteration <- begin_iteration + params[[which(names(params) %in% c("num_iterations", "num_iteration", "num_tree", "num_trees", "num_round", "num_rounds"))[1]]] - 1
   } else {
     end_iteration <- begin_iteration + nrounds - 1
   }
@@ -203,8 +203,8 @@ lgb.train <- function(params = list(),
   
   # Check for early stopping passed as parameter when adding early stopping callback
   if (sum(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping")) > 0) {
-    if (params[which(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping"))[1]] > 0) {
-      callbacks <- add.cb(callbacks, cb.early.stop(params[which(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping"))[1]], verbose = verbose))
+    if (params[[which(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping"))[1]]] > 0) {
+      callbacks <- add.cb(callbacks, cb.early.stop(params[[which(names(params) %in% c("early_stopping_round", "early_stopping_rounds", "early_stopping"))[1]]], verbose = verbose))
     }
   } else {
     if (!is.null(early_stopping_rounds)) {


### PR DESCRIPTION
This PR forces the R-package to use the number of iterations and the early stopping from `params` if they are passed. They have priority over the default parameters `nrounds` and `early_stopping_rounds`.

See https://github.com/Microsoft/LightGBM/pull/806

Test cases:

```r
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label)
data(agaricus.test, package = "lightgbm")
test <- agaricus.test
dtest <- lgb.Dataset.create.valid(dtrain, test$data, label = test$label)
params <- list(objective = "regression", metric = "l2", num_iterations = 5)
valids <- list(test = dtest)
model <- lgb.train(params,
                   dtrain,
                   100,
                   valids,
                   min_data = 1,
                   learning_rate = 1,
                   early_stopping_rounds = 10)
```

```r
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label)
data(agaricus.test, package = "lightgbm")
test <- agaricus.test
dtest <- lgb.Dataset.create.valid(dtrain, test$data, label = test$label)
params <- list(objective = "regression", metric = "l2", num_iterations = 5, early_stopping_rounds = 1)
valids <- list(test = dtest)
model <- lgb.train(params,
                   dtrain,
                   100,
                   valids,
                   min_data = 1,
                   learning_rate = 1,
                   early_stopping_rounds = 10)
```

```r
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label)
params <- list(objective = "regression", metric = "l2", num_rounds = 5)
model <- lgb.cv(params,
                dtrain,
                10,
                nfold = 5,
                min_data = 1,
                learning_rate = 1,
                early_stopping_rounds = 10)
```

```r
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label)
params <- list(objective = "regression", metric = "l2", num_rounds = 5, early_stopping_rounds = 1)
model <- lgb.cv(params,
                dtrain,
                10,
                nfold = 5,
                min_data = 1,
                learning_rate = 1,
                early_stopping_rounds = 10)
```