### PR TITLE
fixed a segfault in tree -> JSON export

### DIFF
--- a/src/io/tree.cpp
+++ b/src/io/tree.cpp
@@ -394,10 +394,16 @@ std::string Tree::NodeToJSON(int index) {
     // leaf
     index = ~index;
     str_buf << "{" << std::endl;
-    str_buf << "\"leaf_index\":" << index << "," << std::endl;
-    str_buf << "\"leaf_parent\":" << leaf_parent_[index] << "," << std::endl;
-    str_buf << "\"leaf_value\":" << leaf_value_[index] << "," << std::endl;
-    str_buf << "\"leaf_count\":" << leaf_count_[index] << std::endl;
+    str_buf << "\"leaf_index\":" << index;
+    if (leaf_value_.size() > 0) {
+      str_buf << "," << std::endl;
+      str_buf << "\"leaf_parent\":" << leaf_parent_[index] << "," << std::endl;
+      str_buf << "\"leaf_value\":" << leaf_value_[index] << "," << std::endl;
+      str_buf << "\"leaf_count\":" << leaf_count_[index] << std::endl;
+    }
+    else {
+      str_buf << std::endl;
+    }
     str_buf << "}";
   }
 

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -158,4 +158,3 @@ class TestSklearn(unittest.TestCase):
         clf.fit(data.data, data.target)
         importances = clf.feature_importances_
         self.assertEqual(len(importances), 4)
-

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -8,7 +8,7 @@ import lightgbm as lgb
 import numpy as np
 from sklearn.base import clone
 from sklearn.datasets import (load_boston, load_breast_cancer, load_digits,
-                              load_svmlight_file)
+                              load_iris, load_svmlight_file)
 from sklearn.externals import joblib
 from sklearn.metrics import log_loss, mean_squared_error
 from sklearn.model_selection import GridSearchCV, train_test_split
@@ -151,3 +151,11 @@ class TestSklearn(unittest.TestCase):
         self.assertEqual(len(pred_origin), len(pred_pickle))
         for preds in zip(pred_origin, pred_pickle):
             self.assertAlmostEqual(*preds, places=5)
+
+    def test_feature_importances_single_leaf(self):
+        clf = lgb.LGBMClassifier(n_estimators=100)
+        data = load_iris()
+        clf.fit(data.data, data.target)
+        importances = clf.feature_importances_
+        self.assertEqual(len(importances), 4)
+


### PR DESCRIPTION
Hey, 

LighGBM Python wrapper segfaults when `feature_importances_` attribute is accessed, and there are trees with a single leaf in ensemble. It is a problem in LightGBM 2.0.5, but not in 2.0.4. 

git bisect shows that the problem started after https://github.com/Microsoft/LightGBM/pull/673; it seems `booster._load_model_from_string(booster._save_model_to_string())` doesn't reset booster properly, and so `booster.dump_model()` doesn't work (segfault) after resetting.

If I'm not mistaken, segfault happens here, when accessing `leaf_parent_`: https://github.com/Microsoft/LightGBM/blob/c62dcf7319300a82d1ca8d1df720e359fdb658ff/src/io/tree.cpp#L398

I'm sending a pull request with a test, in case it is helpful.

Cheers!