### PR TITLE
Reorganize documentation references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ LightGBM, Light Gradient Boosting Machine
 [![GitHub
 Issues](https://img.shields.io/github/issues/Microsoft/LightGBM.svg)](https://github.com/Microsoft/LightGBM/issues)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/1ys5ot401m0fep6l/branch/master?svg=true)](https://ci.appveyor.com/project/guolinke/lightgbm/branch/master)
-[![Documentation Status](https://readthedocs.org/projects/lightgbm/badge/?version=latest)](http://lightgbm.readthedocs.io/)
+[![Documentation Status](https://readthedocs.org/projects/lightgbm/badge/?version=latest)](https://lightgbm.readthedocs.io/)
 [![PyPI version](https://badge.fury.io/py/lightgbm.svg)](https://badge.fury.io/py/lightgbm)
 
 LightGBM is a gradient boosting framework that uses tree based learning algorithms. It is designed to be distributed and efficient with the following advantages:
@@ -39,7 +39,7 @@ News
 
 01/08/2017 : Release [**R-package**](https://github.com/Microsoft/LightGBM/tree/master/R-package) beta version, welcome to have a try and provide feedback.
 
-12/05/2016 : **Categorical Features as input directly**(without one-hot coding). Experiment on [Expo data](http://stat-computing.org/dataexpo/2009/) shows about 8x speed-up with same accuracy compared with one-hot coding.
+12/05/2016 : **Categorical Features as input directly** (without one-hot coding). Experiment on [Expo data](http://stat-computing.org/dataexpo/2009/) shows about 8x speed-up with same accuracy compared with one-hot coding.
 
 12/02/2016 : Release [**python-package**](https://github.com/Microsoft/LightGBM/tree/master/python-package) beta version, welcome to have a try and provide feedback.
 
@@ -52,37 +52,31 @@ Julia Package: https://github.com/Allardvm/LightGBM.jl
 JPMML: https://github.com/jpmml/jpmml-lightgbm
 
 
-Get Started And Documents
+Get Started And Documentation
 -------------------------
-To get started, please follow the [Installation Guide](https://github.com/Microsoft/LightGBM/wiki/Installation-Guide) and [Quick Start](https://github.com/Microsoft/LightGBM/wiki/Quick-Start).
+Install by following the guide for the [command line program](https://github.com/Microsoft/LightGBM/wiki/Installation-Guide), [Python package](https://github.com/Microsoft/LightGBM/tree/master/python-package) or [R-package](https://github.com/Microsoft/LightGBM/tree/master/R-package). Then please see the [Quick Start](https://github.com/Microsoft/LightGBM/wiki/Quick-Start) guide.
 
-* [**Wiki**](https://github.com/Microsoft/LightGBM/wiki)
-* [**Installation Guide**](https://github.com/Microsoft/LightGBM/wiki/Installation-Guide)
-* [**Quick Start**](https://github.com/Microsoft/LightGBM/wiki/Quick-Start)
-* [**Examples**](https://github.com/Microsoft/LightGBM/tree/master/examples)
-* [**Features**](https://github.com/Microsoft/LightGBM/wiki/Features)
-* [**Parallel Learning Guide**](https://github.com/Microsoft/LightGBM/wiki/Parallel-Learning-Guide)
-* [**GPU Learning Tutorial**](https://github.com/Microsoft/LightGBM/blob/master/docs/GPU-Tutorial.md)
-* [**Configuration**](https://github.com/Microsoft/LightGBM/wiki/Configuration)
-* [**Document Indexer**](https://github.com/Microsoft/LightGBM/blob/master/docs/README.md)
+Our primary documentation is at https://lightgbm.readthedocs.io/ and is generated from this repository.
 
-External Links
---------------
-Useful if you are looking for details:
+Next you will want to read:
 
-* [**Read The Docs**](http://lightgbm.readthedocs.io/en/latest/) for an all in one documentation from this repository in a browsable fashion
-* [**Laurae++ interactive documentation**](https://sites.google.com/view/lauraepp/parameters) for an interactive and detailed documentation on hyperparameters
+* [**Examples**](https://github.com/Microsoft/LightGBM/tree/master/examples) showing command line usage of common tasks
+* [**Features**](https://github.com/Microsoft/LightGBM/wiki/Features) and algorithms supported by LightGBM
+* [**Parameters**](https://github.com/Microsoft/LightGBM/blob/master/docs/Parameters.md) is an exhaustive list of customization you can make
+* [**Parallel Learning**](https://github.com/Microsoft/LightGBM/wiki/Parallel-Learning-Guide) and [**GPU Learning**](https://github.com/Microsoft/LightGBM/blob/master/docs/GPU-Tutorial.md) can speed up computation
+* [**Laurae++ interactive documentation**](https://sites.google.com/view/lauraepp/parameters) is a detailed guide for hyperparameters
+
+Documentation for contributors:
+
+* [**How we Update readthedocs.io**](https://github.com/Microsoft/LightGBM/blob/master/docs/README.md)
+* Check out the [Development Guide](https://github.com/Microsoft/LightGBM/blob/master/docs/development.rst).
 
 Support
 -------
 
-You can ask questions and join the development discussion on:
-
-* [LightGBM Gitter](https://gitter.im/Microsoft/LightGBM).
-* [Stack Overflow](https://stackoverflow.com/questions/tagged/lightgbm).
-
-
-You can also create **bug reports and feature requests** (not including questions) in [Github issues](https://github.com/Microsoft/LightGBM/issues).
+* Ask a question [on Stack Overflow with the `lightgbm` tag ](https://stackoverflow.com/questions/ask?tags=lightgbm), we monitor this for new questions.
+* Discuss on the [LightGBM Gitter](https://gitter.im/Microsoft/LightGBM).
+* Open **bug reports** and **feature requests** (not questions) on [Github issues](https://github.com/Microsoft/LightGBM/issues).
 
 How to Contribute
 -----------------
@@ -90,10 +84,9 @@ How to Contribute
 LightGBM has been developed and used by many active community members. Your help is very valuable to make it better for everyone.
 
 - Check out [call for contributions](https://github.com/Microsoft/LightGBM/issues?q=is%3Aissue+is%3Aopen+label%3Acall-for-contribution) to see what can be improved, or open an issue if you want something.
-- Contribute to the [tests](https://github.com/Microsoft/LightGBM/tree/master/tests) to make it more reliable. 
+- Contribute to the [tests](https://github.com/Microsoft/LightGBM/tree/master/tests) to make it more reliable.
 - Contribute to the [documents](https://github.com/Microsoft/LightGBM/tree/master/docs) to make it clearer for everyone.
 - Contribute to the [examples](https://github.com/Microsoft/LightGBM/tree/master/examples) to share your experience with other users.
-- Check out [Development Guide](https://github.com/Microsoft/LightGBM/blob/master/docs/development.rst).
 - Open issue if you met problems during development.
 
 Microsoft Open Source Code of Conduct

--- a/docs/Parameters.md
+++ b/docs/Parameters.md
@@ -1,6 +1,6 @@
 # Parameters
 
-This is a page contains all parameters in LightGBM.
+This is a page contains all parameters in LightGBM command line program.
 
 ***List of other Helpful Links***
 * [Python API Reference](./Python-API.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,8 @@
-# Documents
+# Documentation
 
-The documentation of LightGBM is generated with Sphinx and recommonmark, and hosted on Read the Docs.
+Documentation for LightGBM is generated using [Sphinx](http://www.sphinx-doc.org/) and [recommonmark](https://recommonmark.readthedocs.io/).
 
-For detail, see:
-
-* [Read the Docs](https://readthedocs.org/)
-  * [Welcome to Read The Docs](http://docs.readthedocs.io/)
-* [Sphinx](http://www.sphinx-doc.org/)
-* [recommonmark](https://recommonmark.readthedocs.io/)
+After each commit on `master`, documentation is updated and published to https://lightgbm.readthedocs.io/
 
 ## Build
 
@@ -18,17 +13,6 @@ pip install -r requirements.txt
 make html
 ```
 
-## Links
+## Wiki
 
-* [Installation Guide](https://github.com/Microsoft/LightGBM/wiki/Installation-Guide)
-* [Quick Start](./Quick-Start.md)
-* [Python Quick Start](./Python-intro.md)
-* [Features](https://github.com/Microsoft/LightGBM/wiki/Features)
-* [Experiments](https://github.com/Microsoft/LightGBM/wiki/Experiments)
-* [Parameters](./Parameters.md)
-* [Parameters Tuning](./Parameters-tuning.md)
-* [Python API Reference](./Python-API.md)
-* [Parallel Learning Guide](https://github.com/Microsoft/LightGBM/wiki/Parallel-Learning-Guide)
-* [GPU Tutorial](./GPU-Tutorial.md)
-* [FAQ](./FAQ.md)
-* [Development Guide](./development.rst)
+In addition to our documentation hosted on Read the Docs, some additional topics are explained at https://github.com/Microsoft/LightGBM/wiki.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -4,7 +4,7 @@ Development Guide
 Algorithms
 ----------
 
-Refer to `Features <https://github.com/Microsoft/LightGBM/wiki/Features>`__ to get important algorithms used in LightGBM.
+Refer to `Features <https://github.com/Microsoft/LightGBM/wiki/Features>`__ to understand important algorithms used in LightGBM.
 
 Classes and Code Structure
 --------------------------
@@ -78,7 +78,7 @@ Refere to the comments in `c\_api.h <https://github.com/Microsoft/LightGBM/blob/
 High Level Language Package
 ---------------------------
 
-Follow the implementation of `python-package <https://github.com/Microsoft/LightGBM/tree/master/python-package/lightgbm>`__.
+See the implementations at `python-package <https://github.com/Microsoft/LightGBM/tree/master/python-package/lightgbm>`__ and `python-package <https://github.com/Microsoft/LightGBM/tree/master/R-package>`__.
 
 Ask Questions
 -------------

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -78,7 +78,7 @@ Refere to the comments in `c\_api.h <https://github.com/Microsoft/LightGBM/blob/
 High Level Language Package
 ---------------------------
 
-See the implementations at `python-package <https://github.com/Microsoft/LightGBM/tree/master/python-package/lightgbm>`__ and `python-package <https://github.com/Microsoft/LightGBM/tree/master/R-package>`__.
+See the implementations at `python-package <https://github.com/Microsoft/LightGBM/tree/master/python-package/lightgbm>`__ and `R-package <https://github.com/Microsoft/LightGBM/tree/master/R-package>`__.
 
 Ask Questions
 -------------


### PR DESCRIPTION
This PR is a light refactoring of how documentation is organized. The intention is to **get users more quickly to the documentation they are seeking**.

Notes:

* This now refers to Read the Docs as the "primary" documentation website.
* Links are fixed or improved
* Context is added for links to documentation

Next steps:

After this PR, we can consider to move all documentation from the Wiki to the `docs/` folder. If the LightGBM project owners think this is valuable then I can lead this task and complete it.