### PR TITLE
[MRG] expose feature importance to c_api

### DIFF
--- a/examples/python-guide/simple_example.py
+++ b/examples/python-guide/simple_example.py
@@ -52,16 +52,7 @@ y_pred = gbm.predict(X_test, num_iteration=gbm.best_iteration)
 # eval
 print('The rmse of prediction is:', mean_squared_error(y_test, y_pred) ** 0.5)
 
-print('Dump model to JSON...')
-# dump model to json (and save to file)
-model_json = gbm.dump_model()
-
-with open('model.json', 'w+') as f:
-    json.dump(model_json, f, indent=4)
-
-
 print('Feature names:', gbm.feature_name())
 
-print('Calculate feature importances...')
 # feature importances
 print('Feature importances:', list(gbm.feature_importance()))

--- a/examples/python-guide/sklearn_example.py
+++ b/examples/python-guide/sklearn_example.py
@@ -32,7 +32,6 @@ y_pred = gbm.predict(X_test, num_iteration=gbm.best_iteration)
 # eval
 print('The rmse of prediction is:', mean_squared_error(y_test, y_pred) ** 0.5)
 
-print('Calculate feature importances...')
 # feature importances
 print('Feature importances:', list(gbm.feature_importances_))
 

--- a/include/LightGBM/boosting.h
+++ b/include/LightGBM/boosting.h
@@ -197,7 +197,7 @@ public:
   * \param importance_type: 0 for split, 1 for gain
   * \return vector of feature_importance
   */
-  virtual std::vector<float> FeatureImportance(int num_iteration, int importance_type) const = 0;
+  virtual std::vector<double> FeatureImportance(int num_iteration, int importance_type) const = 0;
 
   /*!
   * \brief Get max feature index of this model

--- a/include/LightGBM/boosting.h
+++ b/include/LightGBM/boosting.h
@@ -192,6 +192,13 @@ public:
   virtual bool LoadModelFromString(const std::string& model_str) = 0;
 
   /*!
+  * \brief Calculate feature importances
+  * \param num_iteration Number of model that want to use for feature importance, -1 means use all
+  * \return vector of feature_importance
+  */
+  virtual std::vector<size_t> FeatureImportance(int num_iteration) const = 0;
+
+  /*!
   * \brief Get max feature index of this model
   * \return Max feature index of this model
   */

--- a/include/LightGBM/boosting.h
+++ b/include/LightGBM/boosting.h
@@ -194,9 +194,10 @@ public:
   /*!
   * \brief Calculate feature importances
   * \param num_iteration Number of model that want to use for feature importance, -1 means use all
+  * \param importance_type: 0 for split, 1 for gain
   * \return vector of feature_importance
   */
-  virtual std::vector<size_t> FeatureImportance(int num_iteration) const = 0;
+  virtual std::vector<float> FeatureImportance(int num_iteration, int importance_type) const = 0;
 
   /*!
   * \brief Get max feature index of this model

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -722,6 +722,17 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterSetLeafValue(BoosterHandle handle,
                                                int leaf_idx,
                                                double val);
 
+/*!
+* \brief get model feature importance
+* \param handle handle
+* \param num_iteration, <= 0 means use all
+* \param out_results output value array
+* \return 0 when succeed, -1 when failure happens
+*/
+LIGHTGBM_C_EXPORT int LGBM_BoosterFeatureImportance(BoosterHandle handle,
+                                                    int num_iteration,
+                                                    int* out_results);
+
 #if defined(_MSC_VER)
 // exception handle and error msg
 static char* LastErrorMsg() { static __declspec(thread) char err_msg[512] = "Everything is fine"; return err_msg; }

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -726,12 +726,14 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterSetLeafValue(BoosterHandle handle,
 * \brief get model feature importance
 * \param handle handle
 * \param num_iteration, <= 0 means use all
+* \param importance_type: 0 for split, 1 for gain
 * \param out_results output value array
 * \return 0 when succeed, -1 when failure happens
 */
 LIGHTGBM_C_EXPORT int LGBM_BoosterFeatureImportance(BoosterHandle handle,
                                                     int num_iteration,
-                                                    int* out_results);
+                                                    int importance_type,
+                                                    double* out_results);
 
 #if defined(_MSC_VER)
 // exception handle and error msg

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1726,13 +1726,23 @@ class Booster(object):
         result : array
             Array of feature importances.
         """
+        if importance_type == "split":
+            importance_type_int = 0
+        elif importance_type == "gain":
+            importance_type_int = 1
+        else:
+            importance_type_int = -1
         num_feature = self.num_feature()
-        result = np.array([0 for _ in range_(num_feature)], dtype=np.int32)
+        result = np.array([0 for _ in range_(num_feature)], dtype=np.float64)
         _safe_call(_LIB.LGBM_BoosterFeatureImportance(
             self.handle,
             ctypes.c_int(iteration),
-            result.ctypes.data_as(ctypes.POINTER(ctypes.c_int))))
-        return result
+            ctypes.c_int(importance_type_int),
+            result.ctypes.data_as(ctypes.POINTER(ctypes.c_double))))
+        if importance_type_int == 0:
+            return result.astype(int)
+        else:
+            return result
 
     def __inner_eval(self, data_name, data_idx, feval=None):
         """

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1680,6 +1680,14 @@ class Booster(object):
         predictor.pandas_categorical = self.pandas_categorical
         return predictor
 
+    def num_feature(self):
+        """Get num of features"""
+        out_num_feature = ctypes.c_int(0)
+        _safe_call(_LIB.LGBM_BoosterGetNumFeature(
+            self.handle,
+            ctypes.byref(out_num_feature)))
+        return out_num_feature.value
+
     def feature_name(self):
         """
         Get feature names.
@@ -1689,12 +1697,7 @@ class Booster(object):
         result : array
             Array of feature names.
         """
-        out_num_feature = ctypes.c_int(0)
-        """Get num of features"""
-        _safe_call(_LIB.LGBM_BoosterGetNumFeature(
-            self.handle,
-            ctypes.byref(out_num_feature)))
-        num_feature = out_num_feature.value
+        num_feature = self.num_feature()
         """Get name of features"""
         tmp_out_len = ctypes.c_int(0)
         string_buffers = [ctypes.create_string_buffer(255) for i in range_(num_feature)]
@@ -1707,7 +1710,7 @@ class Booster(object):
             raise ValueError("Length of feature names doesn't equal with num_feature")
         return [string_buffers[i].value.decode() for i in range_(num_feature)]
 
-    def feature_importance(self, importance_type='split'):
+    def feature_importance(self, importance_type='split', iteration=-1):
         """
         Get feature importances
 
@@ -1723,23 +1726,13 @@ class Booster(object):
         result : array
             Array of feature importances.
         """
-        if importance_type not in ["split", "gain"]:
-            raise KeyError("importance_type must be split or gain")
-        dump_model = self.dump_model()
-        ret = [0] * (dump_model["max_feature_idx"] + 1)
-
-        def dfs(root):
-            if "split_feature" in root:
-                if root['split_gain'] > 0:
-                    if importance_type == 'split':
-                        ret[root["split_feature"]] += 1
-                    elif importance_type == 'gain':
-                        ret[root["split_feature"]] += root["split_gain"]
-                dfs(root["left_child"])
-                dfs(root["right_child"])
-        for tree in dump_model["tree_info"]:
-            dfs(tree["tree_structure"])
-        return np.array(ret)
+        num_feature = self.num_feature()
+        result = np.array([0 for _ in range_(num_feature)], dtype=np.int32)
+        _safe_call(_LIB.LGBM_BoosterFeatureImportance(
+            self.handle,
+            ctypes.c_int(iteration),
+            result.ctypes.data_as(ctypes.POINTER(ctypes.c_int))))
+        return result
 
     def __inner_eval(self, data_name, data_idx, feval=None):
         """

--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -994,6 +994,8 @@ std::string GBDT::SaveModelToString(int num_iteration) const {
 
   ss << "feature_infos=" << Common::Join(feature_infos_, " ") << std::endl;
 
+  std::vector<size_t> feature_importances = FeatureImportance(num_iteration);
+
   ss << std::endl;
   int num_used_model = static_cast<int>(models_.size());
   if (num_iteration > 0) {
@@ -1006,7 +1008,19 @@ std::string GBDT::SaveModelToString(int num_iteration) const {
     ss << models_[i]->ToString() << std::endl;
   }
 
-  std::vector<std::pair<size_t, std::string>> pairs = FeatureImportance(num_used_model);
+  // store the importance first
+  std::vector<std::pair<size_t, std::string>> pairs;
+  for (size_t i = 0; i < feature_importances.size(); ++i) {
+    if (feature_importances[i] > 0) {
+      pairs.emplace_back(feature_importances[i], feature_names_[i]);
+    }
+  }
+  // sort the importance
+  std::sort(pairs.begin(), pairs.end(),
+            [] (const std::pair<size_t, std::string>& lhs,
+                const std::pair<size_t, std::string>& rhs) {
+    return lhs.first > rhs.first;
+  });
   ss << std::endl << "feature importances:" << std::endl;
   for (size_t i = 0; i < pairs.size(); ++i) {
     ss << pairs[i].second << "=" << std::to_string(pairs[i].first) << std::endl;
@@ -1130,30 +1144,23 @@ bool GBDT::LoadModelFromString(const std::string& model_str) {
   return true;
 }
 
-std::vector<std::pair<size_t, std::string>> GBDT::FeatureImportance(int num_used_model) const {
+std::vector<size_t> GBDT::FeatureImportance(int num_iteration) const {
+
+  int num_used_model = static_cast<int>(models_.size());
+  if (num_iteration > 0) {
+    num_iteration += boost_from_average_ ? 1 : 0;
+    num_used_model = std::min(num_iteration * num_tree_per_iteration_, num_used_model);
+  }
 
   std::vector<size_t> feature_importances(max_feature_idx_ + 1, 0);
-  for (int iter = 0; iter < num_used_model; ++iter) {
+  for (int iter = boost_from_average_ ? 1 : 0; iter < num_used_model; ++iter) {
     for (int split_idx = 0; split_idx < models_[iter]->num_leaves() - 1; ++split_idx) {
       if (models_[iter]->split_gain(split_idx) > 0) {
         ++feature_importances[models_[iter]->split_feature(split_idx)];
       }
     }
   }
-  // store the importance first
-  std::vector<std::pair<size_t, std::string>> pairs;
-  for (size_t i = 0; i < feature_importances.size(); ++i) {
-    if (feature_importances[i] > 0) {
-      pairs.emplace_back(feature_importances[i], feature_names_[i]);
-    }
-  }
-  // sort the importance
-  std::sort(pairs.begin(), pairs.end(),
-            [] (const std::pair<size_t, std::string>& lhs,
-                const std::pair<size_t, std::string>& rhs) {
-    return lhs.first > rhs.first;
-  });
-  return pairs;
+  return feature_importances;
 }
 
 }  // namespace LightGBM

--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -994,7 +994,7 @@ std::string GBDT::SaveModelToString(int num_iteration) const {
 
   ss << "feature_infos=" << Common::Join(feature_infos_, " ") << std::endl;
 
-  std::vector<float> feature_importances = FeatureImportance(num_iteration, 0);
+  std::vector<double> feature_importances = FeatureImportance(num_iteration, 0);
 
   ss << std::endl;
   int num_used_model = static_cast<int>(models_.size());
@@ -1145,7 +1145,7 @@ bool GBDT::LoadModelFromString(const std::string& model_str) {
   return true;
 }
 
-std::vector<float> GBDT::FeatureImportance(int num_iteration, int importance_type) const {
+std::vector<double> GBDT::FeatureImportance(int num_iteration, int importance_type) const {
 
   int num_used_model = static_cast<int>(models_.size());
   if (num_iteration > 0) {
@@ -1153,12 +1153,12 @@ std::vector<float> GBDT::FeatureImportance(int num_iteration, int importance_typ
     num_used_model = std::min(num_iteration * num_tree_per_iteration_, num_used_model);
   }
 
-  std::vector<float> feature_importances(max_feature_idx_ + 1, 0.0f);
+  std::vector<double> feature_importances(max_feature_idx_ + 1, 0.0);
   if (importance_type == 0) {
     for (int iter = boost_from_average_ ? 1 : 0; iter < num_used_model; ++iter) {
       for (int split_idx = 0; split_idx < models_[iter]->num_leaves() - 1; ++split_idx) {
         if (models_[iter]->split_gain(split_idx) > 0) {
-          feature_importances[models_[iter]->split_feature(split_idx)] += 1.0f;
+          feature_importances[models_[iter]->split_feature(split_idx)] += 1.0;
         }
       }
     }

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -204,9 +204,10 @@ public:
   /*!
   * \brief Calculate feature importances
   * \param num_iteration Number of model that want to use for feature importance, -1 means use all
+  * \param importance_type: 0 for split, 1 for gain
   * \return vector of feature_importance
   */
-  std::vector<size_t> FeatureImportance(int num_iteration) const override;
+  std::vector<float> FeatureImportance(int num_iteration, int importance_type) const override;
 
   /*!
   * \brief Get max feature index of this model

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -202,6 +202,13 @@ public:
   bool LoadModelFromString(const std::string& model_str) override;
 
   /*!
+  * \brief Calculate feature importances
+  * \param num_iteration Number of model that want to use for feature importance, -1 means use all
+  * \return vector of feature_importance
+  */
+  std::vector<size_t> FeatureImportance(int num_iteration) const override;
+
+  /*!
   * \brief Get max feature index of this model
   * \return Max feature index of this model
   */
@@ -302,12 +309,6 @@ protected:
   * \return best_msg if met early_stopping
   */
   std::string OutputMetric(int iter);
-  /*!
-  * \brief Calculate feature importances
-  * \param num_used_model Number of model that want to use for feature importance, -1 means use all
-  * \return sorted pairs of (feature_importance, feature_name)
-  */
-  std::vector<std::pair<size_t, std::string>> FeatureImportance(int num_used_model) const;
 
   /*! \brief current iteration */
   int iter_;

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -207,7 +207,7 @@ public:
   * \param importance_type: 0 for split, 1 for gain
   * \return vector of feature_importance
   */
-  std::vector<float> FeatureImportance(int num_iteration, int importance_type) const override;
+  std::vector<double> FeatureImportance(int num_iteration, int importance_type) const override;
 
   /*!
   * \brief Get max feature index of this model

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -248,7 +248,7 @@ public:
     return boosting_->DumpModel(num_iteration);
   }
 
-  std::vector<float> FeatureImportance(int num_iteration, int importance_type) {
+  std::vector<double> FeatureImportance(int num_iteration, int importance_type) {
     return boosting_->FeatureImportance(num_iteration, importance_type);
   }
 
@@ -1185,7 +1185,7 @@ int LGBM_BoosterFeatureImportance(BoosterHandle handle,
                                   double* out_results) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
-  std::vector<float> feature_importances = ref_booster->FeatureImportance(num_iteration, importance_type);
+  std::vector<double> feature_importances = ref_booster->FeatureImportance(num_iteration, importance_type);
   for (size_t i = 0; i < feature_importances.size(); ++i) {
     (out_results)[i] = feature_importances[i];
   }

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -248,8 +248,8 @@ public:
     return boosting_->DumpModel(num_iteration);
   }
 
-  std::vector<size_t> FeatureImportance(int num_iteration) {
-    return boosting_->FeatureImportance(num_iteration);
+  std::vector<float> FeatureImportance(int num_iteration, int importance_type) {
+    return boosting_->FeatureImportance(num_iteration, importance_type);
   }
 
   double GetLeafValue(int tree_idx, int leaf_idx) const {
@@ -1181,12 +1181,13 @@ int LGBM_BoosterSetLeafValue(BoosterHandle handle,
 
 int LGBM_BoosterFeatureImportance(BoosterHandle handle,
                                   int num_iteration,
-                                  int* out_results) {
+                                  int importance_type,
+                                  double* out_results) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
-  std::vector<size_t> pairs = ref_booster->FeatureImportance(num_iteration);
-  for (size_t i = 0; i < pairs.size(); ++i) {
-    (out_results)[i] = pairs[i];
+  std::vector<float> feature_importances = ref_booster->FeatureImportance(num_iteration, importance_type);
+  for (size_t i = 0; i < feature_importances.size(); ++i) {
+    (out_results)[i] = feature_importances[i];
   }
   API_END();
 }

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -248,6 +248,10 @@ public:
     return boosting_->DumpModel(num_iteration);
   }
 
+  std::vector<size_t> FeatureImportance(int num_iteration) {
+    return boosting_->FeatureImportance(num_iteration);
+  }
+
   double GetLeafValue(int tree_idx, int leaf_idx) const {
     return dynamic_cast<GBDT*>(boosting_.get())->GetLeafValue(tree_idx, leaf_idx);
   }
@@ -1172,6 +1176,18 @@ int LGBM_BoosterSetLeafValue(BoosterHandle handle,
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
   ref_booster->SetLeafValue(tree_idx, leaf_idx, val);
+  API_END();
+}
+
+int LGBM_BoosterFeatureImportance(BoosterHandle handle,
+                                  int num_iteration,
+                                  int* out_results) {
+  API_BEGIN();
+  Booster* ref_booster = reinterpret_cast<Booster*>(handle);
+  std::vector<size_t> pairs = ref_booster->FeatureImportance(num_iteration);
+  for (size_t i = 0; i < pairs.size(); ++i) {
+    (out_results)[i] = pairs[i];
+  }
   API_END();
 }
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -290,7 +290,7 @@ class TestEngine(unittest.TestCase):
         self.assertIn(valid_set_name, gbm.best_score)
         self.assertIn('binary_logloss', gbm.best_score[valid_set_name])
 
-    def test_continue_train_and_dump_model(self):
+    def test_continue_train(self):
         X, y = load_boston(True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
@@ -317,9 +317,6 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['l1'][-1], ret, places=5)
         for l1, mae in zip(evals_result['valid_0']['l1'], evals_result['valid_0']['mae']):
             self.assertAlmostEqual(l1, mae, places=5)
-        # test dump model
-        self.assertIn('tree_info', gbm.dump_model())
-        self.assertIsInstance(gbm.feature_importance(), np.ndarray)
         os.remove(model_name)
 
     def test_continue_train_multiclass(self):


### PR DESCRIPTION
not let python feature importance rely on dumped json model

@guolinke there are two feature importance types in python now, they are different return types (split - int, gain - float), what do you think it's a better way to deal with it, should I make them all return float?