### PR TITLE
python: always assign best_score after train

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -452,7 +452,8 @@ class LGBMModel(_LGBMModelBase):
 
         if early_stopping_rounds is not None:
             self._best_iteration = self._Booster.best_iteration
-            self._best_score = self._Booster.best_score
+
+        self._best_score = self._Booster.best_score
 
         # free dataset
         self.booster_.free_dataset()


### PR DESCRIPTION
This commit will regain backward compatibility that has been broken
after 015c8fff7203b7266ce187938327bc7b478a7218.
When not using early_stopping, `best_score` has scores calculated with all trees.

I'm sorry that I overlooked https://github.com/Microsoft/LightGBM/pull/870#discussion_r135602296.