### PR TITLE
[R-package] Classification requirement for CV balanced strata

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -323,7 +323,7 @@ generate.cv.folds <- function(nfold, nrows, stratified, label, group, params) {
     rnd_idx <- sample(seq_len(nrows))
     
     # Request stratified folds
-    if (isTRUE(stratified) && length(label) == length(rnd_idx)) {
+    if (isTRUE(stratified) && params$objective %in% c("binary", "multiclass") && length(label) == length(rnd_idx)) {
       
       y <- label[rnd_idx]
       y <- factor(y)
@@ -400,6 +400,7 @@ lgb.stratified.folds <- function(y, k = 10) {
   }
   
   if (k < length(y)) {
+    
     ## Reset levels so that the possible levels and
     ## the levels in the vector are the same
     y <- factor(as.character(y))


### PR DESCRIPTION
Force requirement of binary objective or multiclass objective for stratified cross-validation in R-package.

Fixes https://github.com/Microsoft/LightGBM/issues/896

Reproducible working code:

```r
lgb.unloader(wipe = TRUE)
library(lightgbm)
data(agaricus.train, package='lightgbm')
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label=runif(6513,0,100))
params <- list(objective="regression", metric="l2")
model <- lgb.cv(params,
                dtrain,
                10,
                nfold = 5,
                min_data = 1,
                learning_rate = 1,
                early_stopping_rounds = 10,
                stratified = TRUE)

lgb.unloader(wipe = TRUE)
library(lightgbm)
data(agaricus.train, package='lightgbm')
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label=runif(6513,0,100))
params <- list(objective="regression", metric="l2")
model <- lgb.cv(params,
                dtrain,
                10,
                nfold = 5,
                min_data = 1,
                learning_rate = 1,
                early_stopping_rounds = 10,
                stratified = FALSE)

lgb.unloader(wipe = TRUE)
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label)
params <- list(objective = "regression", metric = "l2")
model <- lgb.cv(params,
                dtrain,
                10,
                nfold = 5,
                min_data = 1,
                learning_rate = 1,
                early_stopping_rounds = 10,
                stratified = TRUE)

lgb.unloader(wipe = TRUE)
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label)
params <- list(objective = "regression", metric = "l2")
model <- lgb.cv(params,
                dtrain,
                10,
                nfold = 5,
                min_data = 1,
                learning_rate = 1,
                early_stopping_rounds = 10,
                stratified = FALSE)
```