### PR TITLE
[installation] MinGW fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,10 @@ if(UNIX OR MINGW OR CYGWIN)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -O3 -Wextra -Wall -Wno-ignored-attributes -Wno-unknown-pragmas")
 endif()
 
+if(WIN32 AND MINGW)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++")
+endif()
+
 if(MSVC)
     if(MSVC_VERSION LESS 1800)
         message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a newer msvc.")


### PR DESCRIPTION
I've discovered that LightGBM suffers from the same [problem](https://github.com/dmlc/xgboost/issues/977) as xgboost does, but the name a little bit differs:
```
_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13find_first_ofEPKcyy
```

The [solution](https://github.com/dmlc/xgboost/issues/977#issuecomment-320521225) which solved the problem for me with xgboost doesn't work here, but `CMAKE_CXX_FLAGS` solves it.