### PR TITLE
Added dump_model() to simple_example.py

### DIFF
--- a/examples/python-guide/simple_example.py
+++ b/examples/python-guide/simple_example.py
@@ -46,6 +46,10 @@ print('Save model...')
 # save model to file
 gbm.save_model('model.txt')
 
+# dump model to json format
+with open('model.json', 'w') as model:
+    model.write(gbm.dump_model(num_iteration=gbm.best_iteration))
+
 print('Start predicting...')
 # predict
 y_pred = gbm.predict(X_test, num_iteration=gbm.best_iteration)


### PR DESCRIPTION
The example pages have the following description for "simple_example.py"

simple_example.py:
* Construct Dataset
* Basic train and predict
* Eval during training
* Early stopping
* Save model to file
* **Dump model to json format**
* Feature importances

But the dump part was missing from the file