### PR TITLE
Update dataset.cpp

### DIFF
--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -586,7 +586,7 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
                                   bool is_constant_hessian,
                                   HistogramBinEntry* hist_data) const {
 
-  if (leaf_idx < 0 || num_data <= 0 || hist_data == nullptr) {
+  if (leaf_idx < 0 || num_data < 0 || hist_data == nullptr) {
     return;
   }
 


### PR DESCRIPTION
While in parallel training, when one worker have 0 data, then it will not execute ConstructHistogram.
if so, ptr_smaller_leaf_hist_data will not be 0 but the old data. that will get the wrong Histogram, and the wrong split info.