### PR TITLE
better log for "Check max_depth and num_leaves"

### DIFF
--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -242,7 +242,7 @@ void OverallConfig::CheckParamConflict() {
     int full_num_leaves = static_cast<int>(std::pow(2, boosting_config.tree_config.max_depth));
     if (full_num_leaves > boosting_config.tree_config.num_leaves 
         && boosting_config.tree_config.num_leaves == kDefaultNumLeaves) {
-      Log::Warning("Accuracy may be bad since you didn't set num_leaves or max_depth² > num_leaves.");
+      Log::Warning("Accuracy may be bad since you didn't set num_leaves and max_depth² > num_leaves.");
     }
   }
 }

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -242,7 +242,7 @@ void OverallConfig::CheckParamConflict() {
     int full_num_leaves = static_cast<int>(std::pow(2, boosting_config.tree_config.max_depth));
     if (full_num_leaves > boosting_config.tree_config.num_leaves 
         && boosting_config.tree_config.num_leaves == kDefaultNumLeaves) {
-      Log::Warning("Accuarcy may be bad since you didn't set num_leaves.");
+      Log::Warning("Accuracy may be bad since you didn't set num_leaves or max_depth² > num_leaves.");
     }
   }
 }


### PR DESCRIPTION
The default log said "[LightGBM] [Warning] Accuarcy may be bad since you didn't set num_leaves." but the case max_depth²>num_leaves could also trigger this log.
Correction of a typo too : Accuarcy > Accuracy