### PR TITLE
Fix error in R package where parameter is converted to scientific notation

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -110,7 +110,7 @@ lgb.params2str <- function(params, ...) {
   for (key in names(params)) {
     
     # Join multi value first
-    val <- paste0(params[[key]], collapse = ",")
+    val <- paste0(format(params[[key]], scientific = FALSE), collapse = ",")
     if (nchar(val) <= 0) next # Skip join
     
     # Join key value


### PR DESCRIPTION
Fixes an error when a large number is used in a lightgbm parameter.  R will by default convert to scientific notation, which raises the error below.

Code:
```r
library(lightgbm)
data(agaricus.train, package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(train$data, label = train$label)
model <- lgb.train(
  data = dtrain
  ,nrounds = 10
  ,min_data = 1
  ,num_leaves = 3
  ,objective = "regression"
  ,bin_construct_sample_cnt = 2000000
)
```

Result:
```
Error in lgb.call("LGBM_DatasetCreateFromCSC_R", ret = handle, private$raw_data@p,  : 
  api error: Parameter bin_construct_sample_cnt should be of type int, got "2e+06"
```