### PR TITLE
Add a Dockerfile for the command-line interface

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,7 @@ Follow the general installation instructions
 * [OSX](https://docs.docker.com/installation/mac/): [docker toolbox](https://www.docker.com/toolbox)
 * [Ubuntu](https://docs.docker.com/installation/ubuntulinux/)
 
-## Running the Container
+## Running the Python package container
 
 Build the container, for python users:
 
@@ -19,3 +19,40 @@ Build the container, for python users:
 After build finished, run the container:
 
     docker run --rm -it lightgbm
+
+## Using CLI via Docker
+
+Build a Docker image with LightGBM CLI:
+
+    docker build -t lightgbm-cli -f dockerfile-cli .
+
+where `lightgbm-cli` is the image name.
+
+Run the CLI from the container:
+
+    docker run --rm -it \
+    --volume $HOME/lgbm.conf:/lgbm.conf \
+    --volume $HOME/model.txt:/model.txt \
+    --volume $HOME/tmp:/out \
+    lightgbm-cli \
+    config=lgbm.conf
+
+In the above example, three volumes are [mounted](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v-read-only)
+from the host machine to the Docker container:
+
+* `lgbm.conf` - task config, for example
+
+    ```
+    app=multiclass
+    num_class=3
+    task=convert_model
+    input_model=model.txt
+    convert_model=/out/predict.cpp
+    convert_model_language=cpp
+    ```
+
+* `model.txt` - an input file for the task, could be training data or, in this case, a pre-trained model.
+* `out` - a directory to store the output of the task, notice that `convert_model` in the task config is using it.
+
+`config=lgbm.conf` is a command-line argument passed to the `lightgbm` executable, more arguments can
+be passed if required.

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,32 +10,29 @@ Follow the general installation instructions
 * [OSX](https://docs.docker.com/installation/mac/): [docker toolbox](https://www.docker.com/toolbox)
 * [Ubuntu](https://docs.docker.com/installation/ubuntulinux/)
 
-## Running the Python package container
-
-Build the container, for python users:
-
-    docker build -t lightgbm -f dockerfile-python .
-
-After build finished, run the container:
-
-    docker run --rm -it lightgbm
-
-## Using CLI via Docker
+## Using CLI Version of LightGBM via Docker
 
 Build a Docker image with LightGBM CLI:
 
+    ```
+    mkdir lightgbm-docker
+    cd lightgbm-docker
+    wget https://raw.githubusercontent.com/Microsoft/LightGBM/master/docker/dockerfile-cli
     docker build -t lightgbm-cli -f dockerfile-cli .
+    ```
 
-where `lightgbm-cli` is the image name.
+where `lightgbm-cli` is the desired Docker image name.
 
 Run the CLI from the container:
 
+    ```
     docker run --rm -it \
     --volume $HOME/lgbm.conf:/lgbm.conf \
     --volume $HOME/model.txt:/model.txt \
     --volume $HOME/tmp:/out \
     lightgbm-cli \
     config=lgbm.conf
+    ```
 
 In the above example, three volumes are [mounted](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v-read-only)
 from the host machine to the Docker container:
@@ -56,3 +53,20 @@ from the host machine to the Docker container:
 
 `config=lgbm.conf` is a command-line argument passed to the `lightgbm` executable, more arguments can
 be passed if required.
+
+## Running the Python-package Сontainer
+
+Build the container, for python users:
+
+    ```
+    mkdir lightgbm-docker
+    cd lightgbm-docker
+    wget https://raw.githubusercontent.com/Microsoft/LightGBM/master/docker/dockerfile-python
+    docker build -t lightgbm -f dockerfile-python .
+    ```
+
+After build finished, run the container:
+
+    ```
+    docker run --rm -it lightgbm
+    ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,39 +14,39 @@ Follow the general installation instructions
 
 Build a Docker image with LightGBM CLI:
 
-    ```
-    mkdir lightgbm-docker
-    cd lightgbm-docker
-    wget https://raw.githubusercontent.com/Microsoft/LightGBM/master/docker/dockerfile-cli
-    docker build -t lightgbm-cli -f dockerfile-cli .
-    ```
+```
+mkdir lightgbm-docker
+cd lightgbm-docker
+wget https://raw.githubusercontent.com/Microsoft/LightGBM/master/docker/dockerfile-cli
+docker build -t lightgbm-cli -f dockerfile-cli .
+```
 
 where `lightgbm-cli` is the desired Docker image name.
 
 Run the CLI from the container:
 
-    ```
-    docker run --rm -it \
-    --volume $HOME/lgbm.conf:/lgbm.conf \
-    --volume $HOME/model.txt:/model.txt \
-    --volume $HOME/tmp:/out \
-    lightgbm-cli \
-    config=lgbm.conf
-    ```
+```
+docker run --rm -it \
+--volume $HOME/lgbm.conf:/lgbm.conf \
+--volume $HOME/model.txt:/model.txt \
+--volume $HOME/tmp:/out \
+lightgbm-cli \
+config=lgbm.conf
+```
 
 In the above example, three volumes are [mounted](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v-read-only)
 from the host machine to the Docker container:
 
 * `lgbm.conf` - task config, for example
 
-    ```
-    app=multiclass
-    num_class=3
-    task=convert_model
-    input_model=model.txt
-    convert_model=/out/predict.cpp
-    convert_model_language=cpp
-    ```
+```
+app=multiclass
+num_class=3
+task=convert_model
+input_model=model.txt
+convert_model=/out/predict.cpp
+convert_model_language=cpp
+```
 
 * `model.txt` - an input file for the task, could be training data or, in this case, a pre-trained model.
 * `out` - a directory to store the output of the task, notice that `convert_model` in the task config is using it.
@@ -58,15 +58,15 @@ be passed if required.
 
 Build the container, for Python users:
 
-    ```
-    mkdir lightgbm-docker
-    cd lightgbm-docker
-    wget https://raw.githubusercontent.com/Microsoft/LightGBM/master/docker/dockerfile-python
-    docker build -t lightgbm -f dockerfile-python .
-    ```
+```
+mkdir lightgbm-docker
+cd lightgbm-docker
+wget https://raw.githubusercontent.com/Microsoft/LightGBM/master/docker/dockerfile-python
+docker build -t lightgbm -f dockerfile-python .
+```
 
 After build finished, run the container:
 
-    ```
-    docker run --rm -it lightgbm
-    ```
+```
+docker run --rm -it lightgbm
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -56,7 +56,7 @@ be passed if required.
 
 ## Running the Python-package Сontainer
 
-Build the container, for python users:
+Build the container, for Python users:
 
     ```
     mkdir lightgbm-docker

--- a/docker/dockerfile-cli
+++ b/docker/dockerfile-cli
@@ -1,0 +1,16 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+    apt-get install -y cmake build-essential gcc g++ git && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone --recursive https://github.com/Microsoft/LightGBM && \
+    mkdir LightGBM/build && \
+    cd LightGBM/build && \
+    cmake .. && \
+    make -j4 && \
+    make install && \
+    cd ../.. && \
+    rm -rf LightGBM 
+
+ENTRYPOINT ["lightgbm"]

--- a/docker/dockerfile-cli
+++ b/docker/dockerfile-cli
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install -y cmake build-essential gcc g++ git && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone --recursive https://github.com/Microsoft/LightGBM && \
+RUN git clone --recursive --branch stable https://github.com/Microsoft/LightGBM && \
     mkdir LightGBM/build && \
     cd LightGBM/build && \
     cmake .. && \


### PR DESCRIPTION
Hello! Not sure if you'd find it useful, but I wrote a small `Dockerfile` to run LightGBM CLI. I used it because `convert_model` is not available via Python API yet.