### PR TITLE
[R] fix weight and init_score assignment in lgb.cv

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -236,7 +236,7 @@ lgb.cv <- function(params = list(),
   if (!is.list(folds[[1]])) {
     bst_folds <- lapply(seq_along(folds), function(k) {
       dtest <- slice(data, folds[[k]])
-      dtrain <- slice(data, unlist(folds[-k]))
+      dtrain <- slice(data, seq_len(nrow(data))[-folds[[k]]])
       setinfo(dtrain, "weight", getinfo(data, "weight")[-folds[[k]]])
       setinfo(dtrain, "init_score", getinfo(data, "init_score")[-folds[[k]]])
       setinfo(dtest, "weight", getinfo(data, "weight")[folds[[k]]])


### PR DESCRIPTION
In the R package lgb.cv function, I think weight and init_score are being assigned to the wrong row indices.  This is because in lines 239-241 the indices in 'folds' are in random order , but getinfo returns the training weight and init_score in the order of the original data. 

In my work, this was causing some strange results when using init_score with lgb.cv.  This change makes results look more reasonable.