### PR TITLE
[ci] updated Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ install:
   - ps: >-
       switch ($env:PYTHON_VERSION) {
           "2.7" {$env:MINICONDA = """C:\Miniconda-x64"""}
-          "3.4" {$env:MINICONDA = """C:\Miniconda3-x64"""}
+          "3.4" {$env:MINICONDA = """C:\Miniconda34-x64"""}
           "3.5" {$env:MINICONDA = """C:\Miniconda35-x64"""}
           "3.6" {$env:MINICONDA = """C:\Miniconda36-x64"""}
           default {$env:MINICONDA = """C:\Miniconda36-x64"""}


### PR DESCRIPTION
Updated path to Miniconda with Python 3.4 on Appveyor.

Refer to https://github.com/appveyor/website/commit/ccbf2c87ad7a17f2979e3697cc787073543679ea.