### PR TITLE
Fix AMD APP SDK download link

### DIFF
--- a/.travis/amd_sdk.sh
+++ b/.travis/amd_sdk.sh
@@ -3,8 +3,8 @@
 # Original script from https://github.com/gregvw/amd_sdk/
 
 # Location from which get nonce and file name from
-URL="http://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/"
-URLDOWN="http://developer.amd.com/amd-license-agreement-appsdk/"
+URL="https://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/"
+URLDOWN="https://developer.amd.com/amd-license-agreement-appsdk/"
 
 NONCE1_STRING='name="amd_developer_central_downloads_page_nonce"'
 FILE_STRING='name="f"'
@@ -35,4 +35,4 @@ NONCE2=`echo $FORM | awk -F ${NONCE2_STRING} '{print $2}'`
 NONCE2=`echo $NONCE2 | awk -F'"' '{print $2}'`
 echo $NONCE2
 
-wget --content-disposition --trust-server-names $URLDOWN --post-data "amd_developer_central_nonce=${NONCE2}&f=${FILE}" -O AMD-SDK.tar.bz2;
+wget --no-check-certificate --content-disposition --trust-server-names $URLDOWN --post-data "amd_developer_central_nonce=${NONCE2}&f=${FILE}" -O AMD-SDK.tar.bz2;


### PR DESCRIPTION
AMD website recently Switched to HTTPS, which makes the previous downloading script failure. This PR fix this issue and all GPU tests pass now.
