### PR TITLE
Fix objective functions with zero hessian

### DIFF
--- a/docs/Features.rst
+++ b/docs/Features.rst
@@ -205,9 +205,21 @@ Support following metrics:
 
 -  NDCG
 
+-  MAP
+
 -  Multi class log loss
 
 -  Multi class error rate
+
+-  Fair
+
+-  Huber
+
+-  Poisson
+
+-  Quantile
+
+-  kullback Leibler
 
 For more details, please refer to `Parameters <./Parameters.rst#metric-parameters>`__.
 

--- a/docs/Features.rst
+++ b/docs/Features.rst
@@ -219,6 +219,8 @@ Support following metrics:
 
 -  Quantile
 
+-  MAPE
+
 -  kullback Leibler
 
 For more details, please refer to `Parameters <./Parameters.rst#metric-parameters>`__.

--- a/docs/Features.rst
+++ b/docs/Features.rst
@@ -283,7 +283,7 @@ References
 
 .. _LightGBM\: A Highly Efficient Gradient Boosting Decision Tree: https://papers.nips.cc/paper/6907-lightgbm-a-highly-efficient-gradient-boosting-decision-tree.pdf
 
-.. _On Grouping for Maximum Homogeneity: http://amstat.tandfonline.com/doi/abs/10.1080/01621459.1958.10501479
+.. _On Grouping for Maximum Homogeneity: http://www.csiss.org/SPACE/workshops/2004/SAC/files/fisher.pdf
 
 .. _Optimization of collective communication operations in MPICH: http://wwwi10.lrr.in.tum.de/~gerndt/home/Teaching/HPCSeminar/mpich_multi_coll.pdf
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -54,7 +54,7 @@ Core Parameters
    - **Note**: Only can be used in CLI version.
 
 -  ``application``, default=\ ``regression``, type=enum,
-   options=\ ``regression``, ``regression_l1``, ``huber``, ``fair``, ``poisson``, ``quantile``,
+   options=\ ``regression``, ``regression_l1``, ``huber``, ``fair``, ``poisson``, ``quantile``, ``mape``,
    ``binary``, ``multiclass``, ``multiclassova``, ``xentropy``, ``xentlambda``, ``lambdarank``,
    alias=\ ``objective``, ``app``
 
@@ -71,6 +71,8 @@ Core Parameters
       -  ``poisson``, `Poisson regression`_
 
       -  ``quantile``, `Quantile regression`_
+
+      -  ``mape``, `MAPE loss`_
 
    -  ``binary``, binary `log loss`_ classification application
 
@@ -511,10 +513,6 @@ Objective Parameters
 
    -  parameter for `Fair loss`_. Will be used in ``regression`` task
 
--  ``gaussian_eta``, default=\ ``1.0``, type=double
-
-   -  parameter to control the width of Gaussian function. Will be used in ``regression_l1`` and ``huber`` losses
-
 -  ``poisson_max_delta_step``, default=\ ``0.7``, type=double
 
    -  parameter for `Poisson regression`_ to safeguard optimization
@@ -571,6 +569,8 @@ Metric Parameters
    -  ``l2_root``, root square loss, alias=\ ``root_mean_squared_error``, ``rmse``
 
    -  ``quantile``, `Quantile regression`_
+   
+   -  ``mape``, `MAPE loss`_
 
    -  ``huber``, `Huber loss`_
 
@@ -741,6 +741,8 @@ You can specific query/group id in data file now. Please refer to parameter ``gr
 .. _Huber loss: https://en.wikipedia.org/wiki/Huber_loss
 
 .. _Quantile regression: https://en.wikipedia.org/wiki/Quantile_regression
+
+.. _MAPE loss: https://en.wikipedia.org/wiki/Mean_absolute_percentage_error
 
 .. _Fair loss: https://www.kaggle.com/c/allstate-claims-severity/discussion/24520
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -54,7 +54,7 @@ Core Parameters
    - **Note**: Only can be used in CLI version.
 
 -  ``application``, default=\ ``regression``, type=enum,
-   options=\ ``regression``, ``regression_l1``, ``huber``, ``fair``, ``poisson``, ``quantile``, ``quantile_l2``,
+   options=\ ``regression``, ``regression_l1``, ``huber``, ``fair``, ``poisson``, ``quantile``,
    ``binary``, ``multiclass``, ``multiclassova``, ``xentropy``, ``xentlambda``, ``lambdarank``,
    alias=\ ``objective``, ``app``
 
@@ -71,8 +71,6 @@ Core Parameters
       -  ``poisson``, `Poisson regression`_
 
       -  ``quantile``, `Quantile regression`_
-
-      -  ``quantile_l2``, like the ``quantile``, but L2 loss is used instead
 
    -  ``binary``, binary `log loss`_ classification application
 

--- a/docs/Quick-Start.rst
+++ b/docs/Quick-Start.rst
@@ -234,6 +234,8 @@ Examples
 
 .. _Quantile regression: https://en.wikipedia.org/wiki/Quantile_regression
 
+.. _MAPE loss: https://en.wikipedia.org/wiki/Mean_absolute_percentage_error
+
 .. _log loss: https://en.wikipedia.org/wiki/Cross_entropy
 
 .. _softmax: https://en.wikipedia.org/wiki/Softmax_function

--- a/docs/Quick-Start.rst
+++ b/docs/Quick-Start.rst
@@ -68,7 +68,7 @@ Some important parameters:
    -  ``convert_model``, for converting model file into if-else format, see more information in `Convert model parameters <./Parameters.rst#convert-model-parameters>`__
 
 -  ``application``, default=\ ``regression``, type=enum,
-   options=\ ``regression``, ``regression_l1``, ``huber``, ``fair``, ``poisson``, ``quantile``,
+   options=\ ``regression``, ``regression_l1``, ``huber``, ``fair``, ``poisson``, ``quantile``, ``mape``,
    ``binary``, ``multiclass``, ``multiclassova``, ``xentropy``, ``xentlambda``, ``lambdarank``,
    alias=\ ``objective``, ``app``
 
@@ -85,6 +85,8 @@ Some important parameters:
       -  ``poisson``, `Poisson regression`_
 
       -  ``quantile``, `Quantile regression`_
+
+      -  ``mape``, `MAPE loss`_
 
    -  ``binary``, binary `log loss`_ classification application
 

--- a/docs/Quick-Start.rst
+++ b/docs/Quick-Start.rst
@@ -68,7 +68,7 @@ Some important parameters:
    -  ``convert_model``, for converting model file into if-else format, see more information in `Convert model parameters <./Parameters.rst#convert-model-parameters>`__
 
 -  ``application``, default=\ ``regression``, type=enum,
-   options=\ ``regression``, ``regression_l1``, ``huber``, ``fair``, ``poisson``, ``quantile``, ``quantile_l2``,
+   options=\ ``regression``, ``regression_l1``, ``huber``, ``fair``, ``poisson``, ``quantile``,
    ``binary``, ``multiclass``, ``multiclassova``, ``xentropy``, ``xentlambda``, ``lambdarank``,
    alias=\ ``objective``, ``app``
 
@@ -85,8 +85,6 @@ Some important parameters:
       -  ``poisson``, `Poisson regression`_
 
       -  ``quantile``, `Quantile regression`_
-
-      -  ``quantile_l2``, like the ``quantile``, but L2 loss is used instead
 
    -  ``binary``, binary `log loss`_ classification application
 

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -164,8 +164,6 @@ public:
   virtual ~ObjectiveConfig() {}
   double sigmoid = 1.0f;
   double fair_c = 1.0f;
-  // for Approximate Hessian With Gaussian
-  double gaussian_eta = 1.0f;
   double poisson_max_delta_step = 0.7f;
   // for lambdarank
   std::vector<double> label_gain;
@@ -473,7 +471,7 @@ struct ParameterAlias {
       "convert_model", "convert_model_language",
       "feature_fraction_seed", "enable_bundle", "data_filename", "valid_data_filenames",
       "snapshot_freq", "verbosity", "sparse_threshold", "enable_load_from_binary_file",
-      "max_conflict_rate", "poisson_max_delta_step", "gaussian_eta",
+      "max_conflict_rate", "poisson_max_delta_step",
       "histogram_pool_size", "is_provide_training_metric", "machine_list_filename", "machines",
       "zero_as_missing", "init_score_file", "valid_init_score_file", "is_predict_contrib",
       "max_cat_threshold",  "cat_smooth", "min_data_per_group", "cat_l2", "max_cat_to_onehot",

--- a/include/LightGBM/network.h
+++ b/include/LightGBM/network.h
@@ -210,6 +210,28 @@ public:
     return global;
   }
 
+  template<class T>
+  static T GlobalSyncUpByMean(T& local) {
+    T global = local;
+    Allreduce(reinterpret_cast<char*>(&local),
+              sizeof(local), sizeof(local),
+              reinterpret_cast<char*>(&global),
+              [](const char* src, char* dst, int type_size, comm_size_t len) {
+      comm_size_t used_size = 0;
+      const T *p1;
+      T *p2;
+      while (used_size < len) {
+        p1 = reinterpret_cast<const T *>(src);
+        p2 = reinterpret_cast<T *>(dst);
+        *p2 += *p1;
+        src += type_size;
+        dst += type_size;
+        used_size += type_size;
+      }
+    });
+    return static_cast<T>(global / num_machines_);
+  }
+
 private:
 
   static void AllgatherBruck(char* input, const comm_size_t* block_start, const comm_size_t* block_len, char* output, comm_size_t all_size);

--- a/include/LightGBM/network.h
+++ b/include/LightGBM/network.h
@@ -212,7 +212,7 @@ public:
 
   template<class T>
   static T GlobalSyncUpByMean(T& local) {
-    T global = local;
+    T global = (T)0;
     Allreduce(reinterpret_cast<char*>(&local),
               sizeof(local), sizeof(local),
               reinterpret_cast<char*>(&global),

--- a/include/LightGBM/objective_function.h
+++ b/include/LightGBM/objective_function.h
@@ -38,7 +38,9 @@ public:
   virtual bool IsRenewTreeOutput() const { return false; }
 
   virtual double RenewTreeOutput(double ori_output, const double*,
-                                 const std::function<data_size_t(data_size_t)>&, data_size_t) const { return ori_output; }
+                                 const data_size_t*,
+                                 const data_size_t*,
+                                 data_size_t) const { return ori_output; }
 
   virtual double BoostFromScore() const { return 0.0f; }
 

--- a/include/LightGBM/objective_function.h
+++ b/include/LightGBM/objective_function.h
@@ -35,9 +35,12 @@ public:
 
   virtual bool IsConstantHessian() const { return false; }
 
-  virtual bool BoostFromAverage() const { return false; }
+  virtual bool IsRenewTreeOutput() const { return false; }
 
-  virtual bool GetCustomAverage(double *) const { return false; }
+  virtual double RenewTreeOutput(double ori_output, const double*,
+                                 const std::function<data_size_t(data_size_t)>&, data_size_t) const { return ori_output; }
+
+  virtual double BoostFromScore() const { return 0.0f; }
 
   virtual bool SkipEmptyClass() const { return false; }
 

--- a/include/LightGBM/tree_learner.h
+++ b/include/LightGBM/tree_learner.h
@@ -12,6 +12,7 @@ namespace LightGBM {
 /*! \brief forward declaration */
 class Tree;
 class Dataset;
+class ObjectiveFunction;
 
 /*!
 * \brief Interface for tree learner
@@ -66,6 +67,9 @@ public:
   * \param out_score output score
   */
   virtual void AddPredictionToScore(const Tree* tree, double* out_score) const = 0;
+
+  virtual void RenewTreeOutput(Tree* tree, const ObjectiveFunction* obj, const double* prediction,
+                               data_size_t total_num_data, const data_size_t* bag_indices, data_size_t bag_cnt) const = 0;
 
   TreeLearner() = default;
   /*! \brief Disable copy */

--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -907,14 +907,14 @@ static T WeightedPercentile(const std::function<T(int)>& data, const std::functi
     weighted_cdf[i] = weighted_cdf[i - 1] + weight(sorted_idx[i]);
   }
   double threshold = weighted_cdf[data_size - 1] * alpha;
-  size_t pos = std::lower_bound(weighted_cdf.begin(), weighted_cdf.end(), threshold) - weighted_cdf.begin();
-  CHECK(threshold >= weighted_cdf[pos]);
-  if (pos == data_size - 1) {
-    return data(sorted_idx[data_size - 1]);
+  size_t pos = std::upper_bound(weighted_cdf.begin(), weighted_cdf.end(), threshold) - weighted_cdf.begin();
+  if (pos == 0) {
+    return data(sorted_idx[0]);
   }
-  CHECK(threshold < weighted_cdf[pos + 1]);
-  T v1 = data(sorted_idx[pos]);
-  T v2 = data(sorted_idx[pos + 1]);
+  CHECK(threshold >= weighted_cdf[pos - 1]);
+  CHECK(threshold < weighted_cdf[pos]);
+  T v1 = data(sorted_idx[pos - 1]);
+  T v2 = data(sorted_idx[pos]);
   return static_cast<T>((threshold - weighted_cdf[pos]) / (weighted_cdf[pos + 1] - weighted_cdf[pos]) * (v2 - v1) + v1);
 }
 

--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -871,9 +871,9 @@ static int Sign(T x) {
 template <typename T>
 static T Percentile(std::vector<T>* data, double alpha) {
   std::vector<T>& ref_data = *data;
-  int data_size = static_cast<int>(ref_data.size());
+  const int data_size = static_cast<int>(ref_data.size());
   const double float_pos = (1.0f - alpha) * data_size;
-  int pos = static_cast<int>(float_pos);
+  const int pos = static_cast<int>(float_pos);
   if (pos < 1) {
     return ref_data[ArrayArgs<T>::ArgMax(ref_data)];
   } else if (pos >= data_size) {

--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -640,27 +640,6 @@ inline static void SortForPair(std::vector<T1>& keys, std::vector<T2>& values, s
 
 }
 
-/*
-* approximate hessians of absolute loss with Gaussian function
-* cf. https://en.wikipedia.org/wiki/Gaussian_function
-*
-* y is a prediction.
-* t means true target.
-* g means gradient.
-* eta is a parameter to control the width of Gaussian function.
-* w means weights.
-*/
-inline static double ApproximateHessianWithGaussian(const double y, const double t, const double g,
-                                                    const double eta, const double w=1.0f) {
-  const double diff = y - t;
-  const double pi = 4.0 * std::atan(1.0);
-  const double x = std::fabs(diff);
-  const double a = 2.0 * std::fabs(g) * w;  // difference of two first derivatives, (zero to inf) and (zero to -inf).
-  const double b = 0.0;
-  const double c = std::max((std::fabs(y) + std::fabs(t)) * eta, 1.0e-10);
-  return w * std::exp(-(x - b) * (x - b) / (2.0 * c * c)) * a / (c * std::sqrt(2 * pi));
-}
-
 template <typename T>
 inline static std::vector<T*> Vector2Ptr(std::vector<std::vector<T>>& data) {
   std::vector<T*> ptr(data.size());
@@ -880,6 +859,11 @@ inline static const char* SkipNewLine(const char* str) {
     ++str;
   }
   return str;
+}
+
+template <typename T>
+static int Sign(T x) {
+  return (x > T(0)) - (x < T(0));
 }
 
 }  // namespace Common

--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -868,9 +868,12 @@ static int Sign(T x) {
 }
 
 template <typename T>
-static T Percentile(std::vector<T>* data, double alpha) {
-  std::vector<T>& ref_data = *data;
-  const int data_size = static_cast<int>(ref_data.size());
+static T Percentile(const std::function<T(int)>& data, int data_size, double alpha) {
+  // To-Do: speed up.
+  std::vector<T> ref_data(data_size);
+  for (int i = 0; i < data_size; ++i) {
+    ref_data[i] = data(i);
+  }
   const double float_pos = (1.0f - alpha) * data_size;
   const int pos = static_cast<int>(float_pos);
   if (pos < 1) {
@@ -896,6 +899,7 @@ static T Percentile(std::vector<T>* data, double alpha) {
 template <typename T, typename T2>
 static T WeightedPercentile(const std::function<T(int)>& data, const std::function<T2(int)>& weight,
                             int data_size, double alpha) {
+  // To-Do: speed up.
   std::vector<int> sorted_idx(data_size);
   for (int i = 0; i < data_size; ++i) {
     sorted_idx[i] = i;

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1956,7 +1956,7 @@ class Booster(object):
                 self.__name_inner_eval = \
                     [string_buffers[i].value.decode() for i in range_(self.__num_inner_eval)]
                 self.__higher_better_inner_eval = \
-                    [name.startswith(('auc', 'ndcg', 'map')) for name in self.__name_inner_eval]
+                    [name.startswith(('auc', 'ndcg@', 'map@')) for name in self.__name_inner_eval]
 
     def attr(self, key):
         """Get attribute string from the Booster.

--- a/src/boosting/goss.hpp
+++ b/src/boosting/goss.hpp
@@ -206,11 +206,6 @@ public:
     }
   }
 
-  /*!
-  * \brief Get Type name of this boosting object
-  */
-  const char* SubModelName() const override { return "tree"; }
-
 private:
   std::vector<data_size_t> tmp_indice_right_;
 };

--- a/src/boosting/score_updater.hpp
+++ b/src/boosting/score_updater.hpp
@@ -73,7 +73,8 @@ public:
   * \param cur_tree_id Current tree for multiclass training
   */
   inline void AddScore(const Tree* tree, int cur_tree_id) {
-    tree->AddPredictionToScore(data_, num_data_, score_.data() + cur_tree_id * num_data_);
+    const size_t offset = static_cast<size_t>(num_data_) * cur_tree_id;
+    tree->AddPredictionToScore(data_, num_data_, score_.data() + offset);
   }
   /*!
   * \brief Adding prediction score, only used for training data.
@@ -83,7 +84,8 @@ public:
   * \param cur_tree_id Current tree for multiclass training
   */
   inline void AddScore(const TreeLearner* tree_learner, const Tree* tree, int cur_tree_id) {
-    tree_learner->AddPredictionToScore(tree, score_.data() + cur_tree_id * num_data_);
+    const size_t offset = static_cast<size_t>(num_data_) * cur_tree_id;
+    tree_learner->AddPredictionToScore(tree, score_.data() + offset);
   }
   /*!
   * \brief Using tree model to get prediction number, then adding to scores for parts of data
@@ -95,10 +97,12 @@ public:
   */
   inline void AddScore(const Tree* tree, const data_size_t* data_indices,
                        data_size_t data_cnt, int cur_tree_id) {
-    tree->AddPredictionToScore(data_, data_indices, data_cnt, score_.data() + cur_tree_id * num_data_);
+    const size_t offset = static_cast<size_t>(num_data_) * cur_tree_id;
+    tree->AddPredictionToScore(data_, data_indices, data_cnt, score_.data() + offset);
   }
   /*! \brief Pointer of score */
   inline const double* score() const { return score_.data(); }
+
   inline data_size_t num_data() const { return num_data_; }
 
   /*! \brief Disable copy */

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -310,8 +310,6 @@ void ObjectiveConfig::Set(const std::unordered_map<std::string, std::string>& pa
   CHECK(sigmoid > 0);
   GetDouble(params, "fair_c", &fair_c);
   CHECK(fair_c > 0);
-  GetDouble(params, "gaussian_eta", &gaussian_eta);
-  CHECK(gaussian_eta > 0);
   GetDouble(params, "poisson_max_delta_step", &poisson_max_delta_step);
   CHECK(poisson_max_delta_step > 0);
   GetInt(params, "max_position", &max_position);

--- a/src/metric/metric.cpp
+++ b/src/metric/metric.cpp
@@ -43,6 +43,8 @@ Metric* Metric::CreateMetric(const std::string& type, const MetricConfig& config
     return new CrossEntropyLambdaMetric(config);
   } else if (type == std::string("kldiv") || type == std::string("kullback_leibler")) {
     return new KullbackLeiblerDivergence(config);
+  } else if (type == std::string("mean_absolute_percentage_error") || type == std::string("mape")) {
+    return new MAPEMetric(config);
   }
   return nullptr;
 }

--- a/src/metric/rank_metric.hpp
+++ b/src/metric/rank_metric.hpp
@@ -57,9 +57,11 @@ public:
         sum_query_weights_ += query_weights_[i];
       }
     }
+    inverse_max_dcgs_.resize(num_queries_);
     // cache the inverse max DCG for all querys, used to calculate NDCG
+    #pragma omp parallel for schedule(static)
     for (data_size_t i = 0; i < num_queries_; ++i) {
-      inverse_max_dcgs_.emplace_back(eval_at_.size(), 0.0f);
+      inverse_max_dcgs_[i].resize(eval_at_.size(), 0.0f);
       DCGCalculator::CalMaxDCG(eval_at_, label_ + query_boundaries_[i],
                                query_boundaries_[i + 1] - query_boundaries_[i],
                                &inverse_max_dcgs_[i]);

--- a/src/metric/regression_metric.hpp
+++ b/src/metric/regression_metric.hpp
@@ -235,12 +235,7 @@ public:
   }
 
   inline static double LossOnPoint(label_t label, double score, const MetricConfig&) {
-    if (std::fabs(label) <= 1) {
-      // directly use score for zero label
-      return std::fabs(score);
-    } else {
-      return std::fabs((label - score) / label);
-    }
+    return std::fabs((label - score)) / std::max(1.0f, std::fabs(label));
   }
   inline static const char* Name() {
     return "mape";

--- a/src/metric/regression_metric.hpp
+++ b/src/metric/regression_metric.hpp
@@ -227,5 +227,25 @@ public:
   }
 };
 
+
+/*! \brief Mape regression loss for regression task */
+class MAPEMetric : public RegressionMetric<MAPEMetric> {
+public:
+  explicit MAPEMetric(const MetricConfig& config) :RegressionMetric<MAPEMetric>(config) {
+  }
+
+  inline static double LossOnPoint(label_t label, double score, const MetricConfig&) {
+    if (std::fabs(label) <= 1) {
+      // directly use score for zero label
+      return std::fabs(score);
+    } else {
+      return std::fabs((label - score) / label);
+    }
+  }
+  inline static const char* Name() {
+    return "mape";
+  }
+};
+
 }  // namespace LightGBM
 #endif   // LightGBM_METRIC_REGRESSION_METRIC_HPP_

--- a/src/objective/objective_function.cpp
+++ b/src/objective/objective_function.cpp
@@ -33,6 +33,8 @@ ObjectiveFunction* ObjectiveFunction::CreateObjectiveFunction(const std::string&
     return new CrossEntropy(config);
   } else if (type == std::string("xentlambda") || type == std::string("cross_entropy_lambda")) {
     return new CrossEntropyLambda(config);
+  } else if (type == std::string("mean_absolute_percentage_error") || type == std::string("mape")) {
+    return new RegressionMAPELOSS(config);
   }
   return nullptr;
 }

--- a/src/objective/objective_function.cpp
+++ b/src/objective/objective_function.cpp
@@ -15,8 +15,6 @@ ObjectiveFunction* ObjectiveFunction::CreateObjectiveFunction(const std::string&
     return new RegressionL1loss(config);
   } else if (type == std::string("quantile")) {
     return new RegressionQuantileloss(config);
-  } else if (type == std::string("quantile_l2")) {
-    return new RegressionQuantileL2loss(config);
   } else if (type == std::string("huber")) {
     return new RegressionHuberLoss(config);
   } else if (type == std::string("fair")) {
@@ -48,8 +46,6 @@ ObjectiveFunction* ObjectiveFunction::CreateObjectiveFunction(const std::string&
     return new RegressionL1loss(strs);
   } else if (type == std::string("quantile")) {
     return new RegressionQuantileloss(strs);
-  } else if (type == std::string("quantile_l2")) {
-    return new RegressionQuantileL2loss(strs);
   } else if (type == std::string("huber")) {
     return new RegressionHuberLoss(strs);
   } else if (type == std::string("fair")) {

--- a/src/objective/regression_objective.hpp
+++ b/src/objective/regression_objective.hpp
@@ -26,7 +26,7 @@ public:
       }
     }
   }
-
+  
   ~RegressionL2loss() {
   }
 
@@ -161,11 +161,11 @@ public:
       for (data_size_t i = 0; i < num_data_; ++i) {
         deltas[i] = label_[i] * weights_[i];
       }
-      ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_, pos);
+      ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_, pos - 1);
       return deltas[pos - 1];
     } else {
       std::vector<label_t> deltas(label_, label_ + num_data_);
-      ArrayArgs<label_t>::ArgMaxAtK(&deltas, 0, num_data_, pos);
+      ArrayArgs<label_t>::ArgMaxAtK(&deltas, 0, num_data_, pos - 1);
       return deltas[pos - 1];
     }
   }
@@ -186,7 +186,7 @@ public:
       }
     }
     const int pos = std::max(1, static_cast<int>(0.5 * num_data_in_leaf));
-    ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_in_leaf, pos);
+    ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_in_leaf, pos - 1);
     return deltas[pos - 1];
   }
 
@@ -438,11 +438,11 @@ public:
       for (data_size_t i = 0; i < num_data_; ++i) {
         deltas[i] = label_[i] * weights_[i];
       }
-      ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_, pos);
+      ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_, pos - 1);
       return deltas[pos - 1];
     } else {
       std::vector<label_t> deltas(label_, label_ + num_data_);
-      ArrayArgs<label_t>::ArgMaxAtK(&deltas, 0, num_data_, pos);
+      ArrayArgs<label_t>::ArgMaxAtK(&deltas, 0, num_data_, pos - 1);
       return deltas[pos - 1];
     }
   }
@@ -463,7 +463,7 @@ public:
       }
     }
     const int pos = std::max(1, static_cast<int>((1.0f - alpha_) * num_data_in_leaf));
-    ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_in_leaf, pos);
+    ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_in_leaf, pos - 1);
     return deltas[pos - 1];
   }
 

--- a/src/objective/regression_objective.hpp
+++ b/src/objective/regression_objective.hpp
@@ -5,7 +5,6 @@
 
 #include <LightGBM/objective_function.h>
 #include <LightGBM/utils/common.h>
-#include <LightGBM/utils/array_args.h>
 
 namespace LightGBM {
 
@@ -161,12 +160,10 @@ public:
       for (data_size_t i = 0; i < num_data_; ++i) {
         deltas[i] = label_[i] * weights_[i];
       }
-      ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_, pos - 1);
-      return deltas[pos - 1];
+      return Common::Percentile(&deltas, 0.5);
     } else {
       std::vector<label_t> deltas(label_, label_ + num_data_);
-      ArrayArgs<label_t>::ArgMaxAtK(&deltas, 0, num_data_, pos - 1);
-      return deltas[pos - 1];
+      return Common::Percentile(&deltas, 0.5);
     }
   }
 
@@ -185,9 +182,7 @@ public:
         deltas[i] = delta;
       }
     }
-    const int pos = std::max(1, static_cast<int>(0.5 * num_data_in_leaf));
-    ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_in_leaf, pos - 1);
-    return deltas[pos - 1];
+    return Common::Percentile(&deltas, 0.5);
   }
 
   const char* GetName() const override {
@@ -431,19 +426,16 @@ public:
   }
 
   double BoostFromScore() const override {
-    const int pos = std::max(1, static_cast<int>((1.0f - alpha_) * num_data_));
     if (weights_ != nullptr) {
       // To-Do: Weighted CDF solution.
       std::vector<double> deltas(num_data_);
       for (data_size_t i = 0; i < num_data_; ++i) {
         deltas[i] = label_[i] * weights_[i];
       }
-      ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_, pos - 1);
-      return deltas[pos - 1];
+      return Common::Percentile(&deltas, alpha_);
     } else {
       std::vector<label_t> deltas(label_, label_ + num_data_);
-      ArrayArgs<label_t>::ArgMaxAtK(&deltas, 0, num_data_, pos - 1);
-      return deltas[pos - 1];
+      return Common::Percentile(&deltas, alpha_);
     }
   }
 
@@ -462,9 +454,7 @@ public:
         deltas[i] = delta;
       }
     }
-    const int pos = std::max(1, static_cast<int>((1.0f - alpha_) * num_data_in_leaf));
-    ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_in_leaf, pos - 1);
-    return deltas[pos - 1];
+    return Common::Percentile(&deltas, alpha_);
   }
 
 private:

--- a/src/objective/regression_objective.hpp
+++ b/src/objective/regression_objective.hpp
@@ -431,7 +431,7 @@ public:
   }
 
   double BoostFromScore() const override {
-    const int pos = std::max(1, static_cast<int>(alpha_ * num_data_));
+    const int pos = std::max(1, static_cast<int>((1.0f - alpha_) * num_data_));
     if (weights_ != nullptr) {
       // To-Do: Weighted CDF solution.
       std::vector<double> deltas(num_data_);
@@ -462,7 +462,7 @@ public:
         deltas[i] = delta;
       }
     }
-    const int pos = std::max(1, static_cast<int>(alpha_ * num_data_in_leaf));
+    const int pos = std::max(1, static_cast<int>((1.0f - alpha_) * num_data_in_leaf));
     ArrayArgs<double>::ArgMaxAtK(&deltas, 0, num_data_in_leaf, pos);
     return deltas[pos - 1];
   }

--- a/src/objective/regression_objective.hpp
+++ b/src/objective/regression_objective.hpp
@@ -124,11 +124,9 @@ protected:
 class RegressionL1loss: public RegressionL2loss {
 public:
   explicit RegressionL1loss(const ObjectiveConfig& config): RegressionL2loss(config) {
-    eta_ = static_cast<double>(config.gaussian_eta);
   }
 
   explicit RegressionL1loss(const std::vector<std::string>& strs): RegressionL2loss(strs) {
-
   }
 
   ~RegressionL1loss() {}
@@ -188,13 +186,6 @@ public:
   const char* GetName() const override {
     return "regression_l1";
   }
-
-  bool IsConstantHessian() const override {
-    return false;
-  }
-
-private:
-  double eta_;
 };
 
 /*!
@@ -204,7 +195,6 @@ class RegressionHuberLoss: public RegressionL2loss {
 public:
   explicit RegressionHuberLoss(const ObjectiveConfig& config): RegressionL2loss(config) {
     alpha_ = static_cast<double>(config.alpha);
-    eta_ = static_cast<double>(config.gaussian_eta);
   }
 
   explicit RegressionHuberLoss(const std::vector<std::string>& strs): RegressionL2loss(strs) {
@@ -252,8 +242,6 @@ public:
 private:
   /*! \brief delta for Huber loss */
   double alpha_;
-  /*! \brief a parameter to control the width of Gaussian function to approximate hessian */
-  double eta_;
 };
 
 

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -303,10 +303,8 @@ public:
   * \return leaf output
   */
   static double CalculateSplittedLeafOutput(double sum_gradients, double sum_hessians, double l1, double l2) {
-    double abs_sum_gradients = std::fabs(sum_gradients);
-    double reg_abs_sum_gradients = std::max(0.0, abs_sum_gradients - l1);
-    return -std::copysign(reg_abs_sum_gradients, sum_gradients)
-      / (sum_hessians + l2);
+    const double reg_abs_sum_gradients = std::max(0.0, std::fabs(sum_gradients) - l1);
+    return -(Common::Sign(sum_gradients) * reg_abs_sum_gradients) / (sum_hessians + l2);
   }
 
 private:

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -1,6 +1,8 @@
 #include "serial_tree_learner.h"
 
 #include <LightGBM/utils/array_args.h>
+#include <LightGBM/network.h>
+#include <LightGBM/objective_function.h>
 
 #include <algorithm>
 #include <vector>
@@ -584,6 +586,70 @@ void SerialTreeLearner::Split(Tree* tree, int best_leaf, int* left_leaf, int* ri
   } else {
     smaller_leaf_splits_->Init(*right_leaf, data_partition_.get(), best_split_info.right_sum_gradient, best_split_info.right_sum_hessian);
     larger_leaf_splits_->Init(*left_leaf, data_partition_.get(), best_split_info.left_sum_gradient, best_split_info.left_sum_hessian);
+  }
+}
+
+void SerialTreeLearner::RenewTreeOutput(Tree* tree, const ObjectiveFunction* obj, const double* prediction,
+                     data_size_t total_num_data, const data_size_t* bag_indices, data_size_t bag_cnt) const {
+  if (obj != nullptr && obj->IsRenewTreeOutput()) {
+    CHECK(tree->num_leaves() <= data_partition_->num_leaves());
+    if (Network::num_machines() <= 1) {
+      // Didn't use subset
+      if (total_num_data == num_data_) {
+        #pragma omp parallel for schedule(static)
+        for (int i = 0; i < tree->num_leaves(); ++i) {
+          const double output = static_cast<double>(tree->LeafOutput(i));
+          data_size_t cnt_leaf_data = 0;
+          auto tmp_idx = data_partition_->GetIndexOnLeaf(i, &cnt_leaf_data);
+          if (cnt_leaf_data <= 0) { continue; }
+          auto get_delta_fun = [tmp_idx](data_size_t i) {
+            return tmp_idx[i];
+          };
+          const double new_output = obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
+          tree->SetLeafOutput(i, new_output);
+        }
+      } else {
+        CHECK(bag_cnt == num_data_);
+        #pragma omp parallel for schedule(static)
+        for (int i = 0; i < tree->num_leaves(); ++i) {
+          const double output = static_cast<double>(tree->LeafOutput(i));
+          data_size_t cnt_leaf_data = 0;
+          auto tmp_idx = data_partition_->GetIndexOnLeaf(i, &cnt_leaf_data);
+          if (cnt_leaf_data <= 0) { continue; }
+          auto get_delta_fun = [tmp_idx, bag_indices](data_size_t i) {
+            return bag_indices[tmp_idx[i]];
+          };
+          const double new_output = obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
+          tree->SetLeafOutput(i, new_output);
+        }
+      }
+    } else {
+      const bool use_subset = (total_num_data == num_data_);
+      if (use_subset) {
+        CHECK(bag_cnt == num_data_);
+      }
+      for (int i = 0; i < tree->num_leaves(); ++i) {
+        const double output = static_cast<double>(tree->LeafOutput(i));
+        data_size_t cnt_leaf_data = 0;
+        auto tmp_idx = data_partition_->GetIndexOnLeaf(i, &cnt_leaf_data);
+        CHECK(cnt_leaf_data > 0);
+        double new_output = output;
+        if (!use_subset) {
+          auto get_delta_fun = [tmp_idx](data_size_t i) {
+            return tmp_idx[i];
+          };
+          obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
+        } else {
+          auto get_delta_fun = [tmp_idx, bag_indices](data_size_t i) {
+            return bag_indices[tmp_idx[i]];
+          };
+          obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
+        }
+        // sync global mean
+        new_output = Network::GlobalSyncUpByMean(new_output);
+        tree->SetLeafOutput(i, new_output);
+      }
+    }
   }
 }
 

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -601,9 +601,9 @@ void SerialTreeLearner::RenewTreeOutput(Tree* tree, const ObjectiveFunction* obj
           const double output = static_cast<double>(tree->LeafOutput(i));
           data_size_t cnt_leaf_data = 0;
           auto tmp_idx = data_partition_->GetIndexOnLeaf(i, &cnt_leaf_data);
-          if (cnt_leaf_data <= 0) { continue; }
-          auto get_delta_fun = [tmp_idx](data_size_t i) {
-            return tmp_idx[i];
+          CHECK(cnt_leaf_data > 0);
+          auto get_delta_fun = [tmp_idx](data_size_t j) {
+            return tmp_idx[j];
           };
           const double new_output = obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
           tree->SetLeafOutput(i, new_output);
@@ -615,16 +615,16 @@ void SerialTreeLearner::RenewTreeOutput(Tree* tree, const ObjectiveFunction* obj
           const double output = static_cast<double>(tree->LeafOutput(i));
           data_size_t cnt_leaf_data = 0;
           auto tmp_idx = data_partition_->GetIndexOnLeaf(i, &cnt_leaf_data);
-          if (cnt_leaf_data <= 0) { continue; }
-          auto get_delta_fun = [tmp_idx, bag_indices](data_size_t i) {
-            return bag_indices[tmp_idx[i]];
+          CHECK(cnt_leaf_data > 0);
+          auto get_delta_fun = [tmp_idx, bag_indices](data_size_t j) {
+            return bag_indices[tmp_idx[j]];
           };
           const double new_output = obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
           tree->SetLeafOutput(i, new_output);
         }
       }
     } else {
-      const bool use_subset = (total_num_data == num_data_);
+      const bool use_subset = (total_num_data != num_data_);
       if (use_subset) {
         CHECK(bag_cnt == num_data_);
       }
@@ -640,8 +640,8 @@ void SerialTreeLearner::RenewTreeOutput(Tree* tree, const ObjectiveFunction* obj
           };
           obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
         } else {
-          auto get_delta_fun = [tmp_idx, bag_indices](data_size_t i) {
-            return bag_indices[tmp_idx[i]];
+          auto get_delta_fun = [tmp_idx, bag_indices](data_size_t j) {
+            return bag_indices[tmp_idx[j]];
           };
           obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
         }

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -590,7 +590,7 @@ void SerialTreeLearner::Split(Tree* tree, int best_leaf, int* left_leaf, int* ri
 }
 
 void SerialTreeLearner::RenewTreeOutput(Tree* tree, const ObjectiveFunction* obj, const double* prediction,
-                     data_size_t total_num_data, const data_size_t* bag_indices, data_size_t bag_cnt) const {
+                                        data_size_t total_num_data, const data_size_t* bag_indices, data_size_t bag_cnt) const {
   if (obj != nullptr && obj->IsRenewTreeOutput()) {
     CHECK(tree->num_leaves() <= data_partition_->num_leaves());
     if (Network::num_machines() <= 1) {

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -7,6 +7,7 @@
 #include <LightGBM/tree_learner.h>
 #include <LightGBM/dataset.h>
 #include <LightGBM/tree.h>
+#include <LightGBM/objective_function.h>
 
 #include "feature_histogram.hpp"
 #include "split_info.hpp"
@@ -62,6 +63,42 @@ public:
       auto tmp_idx = data_partition_->GetIndexOnLeaf(i, &cnt_leaf_data);
       for (data_size_t j = 0; j < cnt_leaf_data; ++j) {
         out_score[tmp_idx[j]] += output;
+      }
+    }
+  }
+
+  void RenewTreeOutput(Tree* tree, const ObjectiveFunction* obj, const double* prediction,
+                       data_size_t total_num_data, const data_size_t* bag_indices, data_size_t bag_cnt) const {
+    if (obj != nullptr && obj->IsRenewTreeOutput()) {
+      CHECK(tree->num_leaves() <= data_partition_->num_leaves());
+      // Didn't use subset
+      if (total_num_data == num_data_) {
+        #pragma omp parallel for schedule(static)
+        for (int i = 0; i < tree->num_leaves(); ++i) {
+          double output = static_cast<double>(tree->LeafOutput(i));
+          data_size_t cnt_leaf_data = 0;
+          auto tmp_idx = data_partition_->GetIndexOnLeaf(i, &cnt_leaf_data);
+          if (cnt_leaf_data <= 0) { continue; }
+          auto get_delta_fun = [tmp_idx](data_size_t i) {
+            return tmp_idx[i];
+          };
+          double new_output = obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
+          tree->SetLeafOutput(i, new_output);
+        }
+      } else {
+        CHECK(bag_cnt == num_data_);
+        #pragma omp parallel for schedule(static)
+        for (int i = 0; i < tree->num_leaves(); ++i) {
+          double output = static_cast<double>(tree->LeafOutput(i));
+          data_size_t cnt_leaf_data = 0;
+          auto tmp_idx = data_partition_->GetIndexOnLeaf(i, &cnt_leaf_data);
+          if (cnt_leaf_data <= 0) { continue; }
+          auto get_delta_fun = [tmp_idx, bag_indices](data_size_t i) {
+            return bag_indices[tmp_idx[i]];
+          };
+          double new_output = obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
+          tree->SetLeafOutput(i, new_output);
+        }
       }
     }
   }

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -7,6 +7,7 @@
 #include <LightGBM/tree_learner.h>
 #include <LightGBM/dataset.h>
 #include <LightGBM/tree.h>
+#include <LightGBM/network.h>
 #include <LightGBM/objective_function.h>
 
 #include "feature_histogram.hpp"
@@ -71,32 +72,60 @@ public:
                        data_size_t total_num_data, const data_size_t* bag_indices, data_size_t bag_cnt) const {
     if (obj != nullptr && obj->IsRenewTreeOutput()) {
       CHECK(tree->num_leaves() <= data_partition_->num_leaves());
-      // Didn't use subset
-      if (total_num_data == num_data_) {
-        #pragma omp parallel for schedule(static)
-        for (int i = 0; i < tree->num_leaves(); ++i) {
-          double output = static_cast<double>(tree->LeafOutput(i));
-          data_size_t cnt_leaf_data = 0;
-          auto tmp_idx = data_partition_->GetIndexOnLeaf(i, &cnt_leaf_data);
-          if (cnt_leaf_data <= 0) { continue; }
-          auto get_delta_fun = [tmp_idx](data_size_t i) {
-            return tmp_idx[i];
-          };
-          double new_output = obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
-          tree->SetLeafOutput(i, new_output);
+      if (Network::num_machines() <= 1) {
+        // Didn't use subset
+        if (total_num_data == num_data_) {
+          #pragma omp parallel for schedule(static)
+          for (int i = 0; i < tree->num_leaves(); ++i) {
+            const double output = static_cast<double>(tree->LeafOutput(i));
+            data_size_t cnt_leaf_data = 0;
+            auto tmp_idx = data_partition_->GetIndexOnLeaf(i, &cnt_leaf_data);
+            if (cnt_leaf_data <= 0) { continue; }
+            auto get_delta_fun = [tmp_idx](data_size_t i) {
+              return tmp_idx[i];
+            };
+            const double new_output = obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
+            tree->SetLeafOutput(i, new_output);
+          }
+        } else {
+          CHECK(bag_cnt == num_data_);
+          #pragma omp parallel for schedule(static)
+          for (int i = 0; i < tree->num_leaves(); ++i) {
+            const double output = static_cast<double>(tree->LeafOutput(i));
+            data_size_t cnt_leaf_data = 0;
+            auto tmp_idx = data_partition_->GetIndexOnLeaf(i, &cnt_leaf_data);
+            if (cnt_leaf_data <= 0) { continue; }
+            auto get_delta_fun = [tmp_idx, bag_indices](data_size_t i) {
+              return bag_indices[tmp_idx[i]];
+            };
+            const double new_output = obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
+            tree->SetLeafOutput(i, new_output);
+          }
         }
       } else {
-        CHECK(bag_cnt == num_data_);
-        #pragma omp parallel for schedule(static)
+        const bool use_subset = (total_num_data == num_data_);
+        if (use_subset) {
+          CHECK(bag_cnt == num_data_);
+        }
         for (int i = 0; i < tree->num_leaves(); ++i) {
-          double output = static_cast<double>(tree->LeafOutput(i));
+          const double output = static_cast<double>(tree->LeafOutput(i));
           data_size_t cnt_leaf_data = 0;
           auto tmp_idx = data_partition_->GetIndexOnLeaf(i, &cnt_leaf_data);
-          if (cnt_leaf_data <= 0) { continue; }
-          auto get_delta_fun = [tmp_idx, bag_indices](data_size_t i) {
-            return bag_indices[tmp_idx[i]];
-          };
-          double new_output = obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
+          CHECK(cnt_leaf_data > 0);
+          double new_output = output;
+          if (!use_subset) {
+            auto get_delta_fun = [tmp_idx](data_size_t i) {
+              return tmp_idx[i];
+            };
+            obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
+          } else {
+            auto get_delta_fun = [tmp_idx, bag_indices](data_size_t i) {
+              return bag_indices[tmp_idx[i]];
+            };
+            obj->RenewTreeOutput(output, prediction, get_delta_fun, cnt_leaf_data);
+          }
+          // sync global mean
+          new_output = Network::GlobalSyncUpByMean(new_output);
           tree->SetLeafOutput(i, new_output);
         }
       }


### PR DESCRIPTION
Use sklearn's solution for the objective function with zero heassian:
1. only use first-order gradients to construct, 
2. then fix the tree's output according to objective function.

Some benchmarks on L1 objective function:

dataset: https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/regression.html#YearPredictionMSD

Result:
![image](https://user-images.githubusercontent.com/16040950/34907052-938c2f8e-f8b3-11e7-987f-3c49d5b2d366.png)
