### PR TITLE
Do not map NaN in pandas categorical columns to -1

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -251,7 +251,7 @@ def _data_from_pandas(data, feature_name, categorical_feature, pandas_categorica
                     data[col] = data[col].cat.set_categories(category)
         if len(cat_cols):  # cat_cols is pandas Index object
             data = data.copy()  # not alter origin DataFrame
-            data[cat_cols] = data[cat_cols].apply(lambda x: x.cat.codes)
+            data[cat_cols] = data[cat_cols].apply(lambda x: x.cat.codes).replace({-1: np.nan})
         if categorical_feature is not None:
             if feature_name is None:
                 feature_name = list(data.columns)


### PR DESCRIPTION
In `_data_from_pandas`, the categorical columns are replaced with `x.cat.codes`. This step converts NaN values in the columns into -1, and the following warning is printed:

```
[LightGBM] [Warning] Met negative value in categorical features, will convert it to NaN
```

So the NaN values are being converted into -1 by `_data_from_pandas` and then converted back to NaN later.

For example, it can be reproduced with the following lines (with pandas 0.22.0):
```python
category = pd.Series(['first', 'second', 'first', 'first', np.nan])
category_type = pd.api.types.CategoricalDtype(categories=['first', 'second'])
X = pd.DataFrame(category.astype(category_type))
y = np.array([1, 0, 1, 1, 1])
clf = lgb.LGBMClassifier(verbose=-1)
clf.fit(X, y)
# [LightGBM] [Warning] Met negative value in categorical features, will convert it to NaN
```

This PR avoids the warning by mapping `-1` in the categorical columns back to `np.nan` before the data is returned.