### PR TITLE
[R-package] Fix version number in README

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -44,7 +44,7 @@ git clone --recursive https://github.com/Microsoft/LightGBM
 cd LightGBM/R-package
 Rscript build_package.R
 # export CXX=g++-7 CC=gcc-7 # for macOS
-R CMD INSTALL lightgbm_2.0.4.tar.gz --no-multiarch
+R CMD INSTALL lightgbm_2.1.0.tar.gz --no-multiarch
 ``` 
 
 Note: for the build with Visual Studio/MSBuild in Windows, you should use the Windows CMD or Powershell.


### PR DESCRIPTION
Right now the build instructions for R reference 2.0.4, but currently the R package is at 2.1.0. Updating it so instructions can be copy-paste.