### PR TITLE
OpenCL GPU fails for NVIDIA

### DIFF
--- a/docs/GPU-Targets.rst
+++ b/docs/GPU-Targets.rst
@@ -14,9 +14,9 @@ You can find below a table of correspondence:
 +===========================+=================+=================+=================+==============+
 | `Intel SDK for OpenCL`_   | Supported       | Supported \*    | Supported       | Untested     |
 +---------------------------+-----------------+-----------------+-----------------+--------------+
-| `AMD APP SDK`_            | Supported       | Untested \*     | Supported       | Untested     |
+| `AMD APP SDK`_            | Supported       | Untested \*     | Supported       | Fails        |
 +---------------------------+-----------------+-----------------+-----------------+--------------+
-| `NVIDIA CUDA Toolkit`_    | Untested \*\*   | Untested \*\*   | Untested \*\*   | Supported    |
+| `NVIDIA CUDA Toolkit`_    | Fails    \*\*   | Fails    \*\*   | Fails    \*\*   | Supported    |
 +---------------------------+-----------------+-----------------+-----------------+--------------+
 
 Legend:


### PR DESCRIPTION
Add failures for NVIDIA OpenCL inter-operability with other non-NVIDIA vendor platforms.