### PR TITLE
[python][docs] add info on adaptive learning rate in the sklearn API

### DIFF
--- a/docs/Python-Intro.rst
+++ b/docs/Python-Intro.rst
@@ -196,8 +196,7 @@ The model will train until the validation score stops improving.
 Validation error needs to improve at least every ``early_stopping_rounds`` to continue training.
 
 If early stopping occurs, the model will have an additional field: ``bst.best_iteration``.
-Note that ``train()`` will return a model from the last iteration, not the best one.
-And you can set ``num_iteration=bst.best_iteration`` when saving model.
+Note that ``train()`` will return a model from the best iteration.
 
 This works with both metrics to minimize (L2, log loss, etc.) and to maximize (NDCG, AUC).
 Note that if you specify more than one evaluation metric, all of them will be used for early stopping.

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -149,12 +149,9 @@ class LGBMModel(_LGBMModelBase):
             Maximum tree depth for base learners, -1 means no limit.
         learning_rate : float, optional (default=0.1)
             Boosting learning rate.
-            The user can set up shrinkage of the learning rate `a la` ``learning_rates`` argument of
-            the ``lightgbm.engine.train()`` API by registration of a dedicated callback function 
-            in the ``LGBMModel.fit()`` call:
-            ``model.fit(X, y,  callbacks = [lgb.reset_parameter(learning_rate=func(iter)])``,
-            where ``func(iter)`` is a custom function that defines dependence of the learning rate
-            on the iteration. Note, that this will ignore the ``learning_rate`` argument in training.
+            You can use ``callbacks`` parameter of ``fit`` method to shrink/adapt learning rate 
+            using ``reset_parameter`` callback. 
+            Note, that this will ignore the ``learning_rate`` argument in training.
         n_estimators : int, optional (default=100)
             Number of boosted trees to fit.
         subsample_for_bin : int, optional (default=50000)

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -149,8 +149,8 @@ class LGBMModel(_LGBMModelBase):
             Maximum tree depth for base learners, -1 means no limit.
         learning_rate : float, optional (default=0.1)
             Boosting learning rate.
-            You can use ``callbacks`` parameter of ``fit`` method to shrink/adapt learning rate 
-            in training using ``reset_parameter`` callback. 
+            You can use ``callbacks`` parameter of ``fit`` method to shrink/adapt learning rate
+            in training using ``reset_parameter`` callback.
             Note, that this will ignore the ``learning_rate`` argument in training.
         n_estimators : int, optional (default=100)
             Number of boosted trees to fit.

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -150,7 +150,7 @@ class LGBMModel(_LGBMModelBase):
         learning_rate : float, optional (default=0.1)
             Boosting learning rate.
             You can use ``callbacks`` parameter of ``fit`` method to shrink/adapt learning rate 
-            using ``reset_parameter`` callback. 
+            in training using ``reset_parameter`` callback. 
             Note, that this will ignore the ``learning_rate`` argument in training.
         n_estimators : int, optional (default=100)
             Number of boosted trees to fit.

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -149,6 +149,12 @@ class LGBMModel(_LGBMModelBase):
             Maximum tree depth for base learners, -1 means no limit.
         learning_rate : float, optional (default=0.1)
             Boosting learning rate.
+            The user can set up shrinkage of the learning rate `a la` ``learning_rates`` argument of
+            the ``lightgbm.engine.train()`` API by registration of a dedicated callback function 
+            in the ``LGBMModel.fit()`` call:
+            ``model.fit(X, y,  callbacks = [lgb.reset_parameter(learning_rate=func(iter)])``,
+            where ``func(iter)`` is a custom function that defines dependence of the learning rate
+            on the iteration. Note, that this will ignore the ``learning_rate`` argument in training.
         n_estimators : int, optional (default=100)
             Number of boosted trees to fit.
         subsample_for_bin : int, optional (default=50000)


### PR DESCRIPTION
A small add-on to the docs to clarify how users of the sklearn API can implement shrinkage of the learning rate via a callback
The PR follows the discussion in #1317 