### PR TITLE
[ci] fix macOS builds on Travis

### DIFF
--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+    rm '/usr/local/include/c++'
+#    brew cask uninstall oclint  #  Reserve variant to deal with conflict link
     if [[ ${TASK} == "mpi" ]]; then
         brew install open-mpi
     else
         brew install gcc
     fi
-    brew link --overwrite gcc
+#    brew link --overwrite gcc  # Previous variant to deal with conflict link
     wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION:0:1}-latest-MacOSX-x86_64.sh
 else
     if [[ ${TASK} != "pylint" ]] && [[ ${TASK} != "check-docs" ]]; then

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -15,8 +15,8 @@ if [[ ${TASK} == "gpu" ]]; then
 fi
 
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-    export CXX=g++-7
-    export CC=gcc-7
+    export CXX=g++-8
+    export CC=gcc-8
 fi
 
 LGB_VER=$(head -n 1 VERSION.txt)


### PR DESCRIPTION
This PR introduces new way to overwrite link to gcc (previous one `brew link --overwrite gcc` don't work now, maybe temporary). Also gcc's version has been incremented, now Travis image comes with gcc-8.

Fixed #1356.

@guolinke Could you please turn on Rolling builds option for Appveyor? This will bring significant speedup. This option is located here: Settings -> General -> Rolling builds.
https://www.appveyor.com/docs/build-configuration/#rolling-builds

![image](https://user-images.githubusercontent.com/25141164/39656546-628cad48-5009-11e8-83e0-b16a9d5521de.png)
