### PR TITLE
[WIP][ci][python] updated pep8 to pycodestyle

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ install:
   - ps: $env:LGB_VER = (Get-Content VERSION.txt).trim()
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda create -q -n test-env python=%PYTHON_VERSION% numpy nose scipy scikit-learn pandas matplotlib pep8 pytest
+  - conda create -q -n test-env python=%PYTHON_VERSION% numpy nose scipy scikit-learn pandas matplotlib pytest
   - activate test-env
 
 build_script:

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -50,8 +50,8 @@ if [[ ${TASK} == "check-docs" ]]; then
 fi
 
 if [[ ${TASK} == "pylint" ]]; then
-    conda install pep8
-    pep8 --ignore=E501 --exclude=./compute,./docs . || exit -1
+    conda install pycodestyle
+    pycodestyle --ignore=E501 --exclude=./compute,./docs . || exit -1
     exit 0
 fi
 


### PR DESCRIPTION
pep8 is now pycodestyle.
Refer to https://github.com/PyCQA/pycodestyle/issues/466 .

This PR removes the following warning:
![image](https://user-images.githubusercontent.com/25141164/39657573-c40baefe-5011-11e8-817e-7fb78b3dad60.png)

New version finds some warnings, which should be fixed.