### PR TITLE
Enable boost_from_average as default for binary objective

### DIFF
--- a/src/objective/binary_objective.hpp
+++ b/src/objective/binary_objective.hpp
@@ -114,6 +114,29 @@ public:
       }
     }
   }
+  
+  // implement custom average to boost from (if enabled among options)
+  double BoostFromScore() const override {
+    double suml = 0.0f;
+    double sumw = 0.0f;
+    if (weights_ != nullptr) {
+      #pragma omp parallel for schedule(static) reduction(+:suml,sumw)
+      for (data_size_t i = 0; i < num_data_; ++i) {
+        suml += label_[i] * weights_[i];
+        sumw += weights_[i];
+      }
+    } else {
+      sumw = static_cast<double>(num_data_);
+      #pragma omp parallel for schedule(static) reduction(+:suml)
+      for (data_size_t i = 0; i < num_data_; ++i) {
+        suml += label_[i];
+      }
+    }
+    double pavg = suml / sumw;
+    double initscore = std::log(pavg / (1.0f - pavg));
+    Log::Info("[%s:%s]: pavg=%f -> initscore=%f",  GetName(), __func__, pavg, initscore);
+    return initscore;
+  }
 
   const char* GetName() const override {
     return "binary";

--- a/src/objective/binary_objective.hpp
+++ b/src/objective/binary_objective.hpp
@@ -133,7 +133,7 @@ public:
       }
     }
     double pavg = suml / sumw;
-    double initscore = std::log(pavg / (1.0f - pavg));
+    double initscore = std::log(pavg / (1.0f - pavg)) / sigmoid_;
     Log::Info("[%s:%s]: pavg=%f -> initscore=%f",  GetName(), __func__, pavg, initscore);
     return initscore;
   }


### PR DESCRIPTION
This appears to fix issue #1336, leading to greater default boosting efficiency particularly for small unbalanced binary regression problems.

The change is simple; I copied verbatim the BoostFromScore method in the xentropy objective:

https://github.com/Microsoft/LightGBM/blob/5392c9eaf616b10028170346db898a598739a1a7/src/objective/xentropy_objective.hpp#L107-L128

To the future: There is much in common between `xentropy` and `binary` objectives; it's not clear to me yet whether one should subsume the other.  I.e., if `xentropy` ends up doing essentially the same thing as `binary`, maybe `xentropy` should become simply an alias for `binary`.