### PR TITLE
Shut up warnings

### DIFF
--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -658,9 +658,7 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
         // feature is not used
         auto data_ptr = hist_data + group_bin_boundaries_[group];
         const int num_bin = feature_groups_[group]->num_total_bin_;
-        for (int i = 0; i < num_bin; ++i) {
-            data_ptr[1 + i] = {};
-        }
+        std::memset((void*)(data_ptr + 1), 0, (num_bin - 1) * sizeof(HistogramBinEntry));
         // construct histograms for smaller leaf
         if (ordered_bins[group] == nullptr) {
           // if not use ordered bin
@@ -689,9 +687,7 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
         // feature is not used
         auto data_ptr = hist_data + group_bin_boundaries_[group];
         const int num_bin = feature_groups_[group]->num_total_bin_;
-        for (int i = 0; i < num_bin; ++i) {
-            data_ptr[1 + i] = {};
-        }
+        std::memset((void*)(data_ptr + 1), 0, (num_bin - 1) * sizeof(HistogramBinEntry));
         // construct histograms for smaller leaf
         if (ordered_bins[group] == nullptr) {
           // if not use ordered bin
@@ -724,9 +720,7 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
         // feature is not used
         auto data_ptr = hist_data + group_bin_boundaries_[group];
         const int num_bin = feature_groups_[group]->num_total_bin_;
-        for (int i = 0; i < num_bin; ++i) {
-            data_ptr[1 + i] = {};
-        }
+        std::memset((void*)(data_ptr + 1), 0, (num_bin - 1) * sizeof(HistogramBinEntry));
         // construct histograms for smaller leaf
         if (ordered_bins[group] == nullptr) {
           // if not use ordered bin
@@ -754,9 +748,7 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
         // feature is not used
         auto data_ptr = hist_data + group_bin_boundaries_[group];
         const int num_bin = feature_groups_[group]->num_total_bin_;
-        for (int i = 0; i < num_bin; ++i) {
-            data_ptr[1 + i] = {};
-        }
+        std::memset((void*)(data_ptr + 1), 0, (num_bin - 1) * sizeof(HistogramBinEntry));
         // construct histograms for smaller leaf
         if (ordered_bins[group] == nullptr) {
           // if not use ordered bin

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -658,7 +658,9 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
         // feature is not used
         auto data_ptr = hist_data + group_bin_boundaries_[group];
         const int num_bin = feature_groups_[group]->num_total_bin_;
-        std::memset(data_ptr + 1, 0, (num_bin - 1) * sizeof(HistogramBinEntry));
+        for (int i = 0; i < num_bin; ++i) {
+            data_ptr[1 + i] = {};
+        }
         // construct histograms for smaller leaf
         if (ordered_bins[group] == nullptr) {
           // if not use ordered bin
@@ -687,7 +689,9 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
         // feature is not used
         auto data_ptr = hist_data + group_bin_boundaries_[group];
         const int num_bin = feature_groups_[group]->num_total_bin_;
-        std::memset(data_ptr + 1, 0, (num_bin - 1) * sizeof(HistogramBinEntry));
+        for (int i = 0; i < num_bin; ++i) {
+            data_ptr[1 + i] = {};
+        }
         // construct histograms for smaller leaf
         if (ordered_bins[group] == nullptr) {
           // if not use ordered bin
@@ -720,7 +724,9 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
         // feature is not used
         auto data_ptr = hist_data + group_bin_boundaries_[group];
         const int num_bin = feature_groups_[group]->num_total_bin_;
-        std::memset(data_ptr + 1, 0, (num_bin - 1) * sizeof(HistogramBinEntry));
+        for (int i = 0; i < num_bin; ++i) {
+            data_ptr[1 + i] = {};
+        }
         // construct histograms for smaller leaf
         if (ordered_bins[group] == nullptr) {
           // if not use ordered bin
@@ -748,7 +754,9 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
         // feature is not used
         auto data_ptr = hist_data + group_bin_boundaries_[group];
         const int num_bin = feature_groups_[group]->num_total_bin_;
-        std::memset(data_ptr + 1, 0, (num_bin - 1) * sizeof(HistogramBinEntry));
+        for (int i = 0; i < num_bin; ++i) {
+            data_ptr[1 + i] = {};
+        }
         // construct histograms for smaller leaf
         if (ordered_bins[group] == nullptr) {
           // if not use ordered bin

--- a/src/treelearner/data_parallel_tree_learner.cpp
+++ b/src/treelearner/data_parallel_tree_learner.cpp
@@ -136,7 +136,7 @@ void DataParallelTreeLearner<TREELEARNER_T>::BeforeTrain() {
     }
   });
   // copy back
-  data = *(reinterpret_cast<std::tuple<data_size_t, double, double> *>(output_buffer_.data()));
+  std::memcpy((void*)&data, output_buffer_.data(), size);
   // set global sumup info
   this->smaller_leaf_splits_->Init(std::get<1>(data), std::get<2>(data));
   // init global data count in leaf

--- a/src/treelearner/data_parallel_tree_learner.cpp
+++ b/src/treelearner/data_parallel_tree_learner.cpp
@@ -136,7 +136,7 @@ void DataParallelTreeLearner<TREELEARNER_T>::BeforeTrain() {
     }
   });
   // copy back
-  std::memcpy(&data, output_buffer_.data(), size);
+  data = *(reinterpret_cast<std::tuple<data_size_t, double, double> *>(output_buffer_.data()));
   // set global sumup info
   this->smaller_leaf_splits_->Init(std::get<1>(data), std::get<2>(data));
   // init global data count in leaf

--- a/src/treelearner/voting_parallel_tree_learner.cpp
+++ b/src/treelearner/voting_parallel_tree_learner.cpp
@@ -131,7 +131,7 @@ void VotingParallelTreeLearner<TREELEARNER_T>::BeforeTrain() {
     }
   });
 
-  std::memcpy(&data, output_buffer_.data(), size);
+  data = *(reinterpret_cast<std::tuple<data_size_t, double, double> *>(output_buffer_.data()));
 
   // set global sumup info
   smaller_leaf_splits_global_->Init(std::get<1>(data), std::get<2>(data));

--- a/src/treelearner/voting_parallel_tree_learner.cpp
+++ b/src/treelearner/voting_parallel_tree_learner.cpp
@@ -131,7 +131,7 @@ void VotingParallelTreeLearner<TREELEARNER_T>::BeforeTrain() {
     }
   });
 
-  data = *(reinterpret_cast<std::tuple<data_size_t, double, double> *>(output_buffer_.data()));
+  std::memcpy((void*)&data, output_buffer_.data(), size);
 
   // set global sumup info
   smaller_leaf_splits_global_->Init(std::get<1>(data), std::get<2>(data));


### PR DESCRIPTION
This commit will shut up the below warnings, which are raised with GCC 8.1.0.

- warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct LightGBM::HistogramBinEntry'; use assignment or value-initialization instead [-Wclass-memaccess]
- warning: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'class std::tuple<int, double, double>' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]

This is all of cmake and make logs.

[hoge.log](https://github.com/Microsoft/LightGBM/files/1987181/hoge.log)

Please review carefully.