### PR TITLE
[ci] temporarily disable gpu tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ env:
     - TASK=if-else
     - TASK=sdist PYTHON_VERSION=3.4
     - TASK=bdist PYTHON_VERSION=3.5
-    - TASK=gpu METHOD=source
-    - TASK=gpu METHOD=pip
+#    - TASK=gpu METHOD=source
+#    - TASK=gpu METHOD=pip
 
 matrix:
   exclude:

--- a/docs/GPU-Targets.rst
+++ b/docs/GPU-Targets.rst
@@ -286,7 +286,7 @@ Keep in mind that using the integrated graphics card is not directly possible wi
 
 .. _Intel SDK for OpenCL: https://software.intel.com/en-us/articles/opencl-drivers
 
-.. _AMD APP SDK: http://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/
+.. _AMD APP SDK: http://developer.amd.com/  # amd-accelerated-parallel-processing-app-sdk/
 
 .. _NVIDIA CUDA Toolkit: https://developer.nvidia.com/cuda-downloads
 

--- a/docs/GPU-Windows.rst
+++ b/docs/GPU-Windows.rst
@@ -568,7 +568,7 @@ And open an issue in GitHub `here`_ with that log.
 
 .. _Intel SDK for OpenCL: https://software.intel.com/en-us/articles/opencl-drivers
 
-.. _AMD APP SDK: http://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/
+.. _AMD APP SDK: http://developer.amd.com/  # amd-accelerated-parallel-processing-app-sdk/
 
 .. _CUDA Toolkit: https://developer.nvidia.com/cuda-downloads
 

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -392,7 +392,7 @@ This will generate a JAR file containing the LightGBM `C API <./Development-Guid
 
 .. _Intel SDK for OpenCL: https://software.intel.com/en-us/articles/opencl-drivers
 
-.. _AMD APP SDK: http://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/
+.. _AMD APP SDK: http://developer.amd.com/  # amd-accelerated-parallel-processing-app-sdk/
 
 .. _CUDA Toolkit: https://developer.nvidia.com/cuda-downloads
 


### PR DESCRIPTION
Refer to #1342.

This PR should be reverted.

I think it'll take much time to fix links. So it's better to stop run gpu tests until they fix download links.