### PR TITLE
[docs][examples] Clarify relationship between `xentropy` and `binary`

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -69,7 +69,7 @@ Core Parameters
 
       -  ``tweedie``, Tweedie regression with log-link. It might be useful, e.g., for modeling total loss in insurance, or for any target that might be `tweedie-distributed`_
 
-   -  ``binary``, binary `log loss`_ classification (or logistic regression). Requires labels in {0,1}; see `xentropy`_ for general probability labels in [0, 1]
+   -  ``binary``, binary `log loss`_ classification (or logistic regression). Requires labels in {0, 1}; see ``xentropy`` for general probability labels in [0, 1]
 
    -  multi-class classification application
 

--- a/examples/python-guide/README.md
+++ b/examples/python-guide/README.md
@@ -5,10 +5,10 @@ Here is an example for LightGBM to use Python-package.
 
 You should install LightGBM [Python-package](https://github.com/Microsoft/LightGBM/tree/master/python-package) first.
 
-You also need scikit-learn, pandas and matplotlib (only for plot example) to run the examples, but they are not required for the package itself. You can install them with pip:
+You also need scikit-learn, pandas, matplotlib (only for plot example), and scipy (only for logistic regression example) to run the examples, but they are not required for the package itself. You can install them with pip:
 
 ```
-pip install scikit-learn pandas matplotlib -U
+pip install scikit-learn pandas matplotlib scipy -U
 ```
 
 Now you can run examples in this folder, for example:
@@ -41,3 +41,8 @@ Examples include:
     - Self-defined objective function
     - Self-defined eval metric
     - Callback function
+- [logistic_regression.py](https://github.com/Microsoft/LightGBM/blob/master/examples/python-guide/logistic_regression.py)
+    - Use objective `xentropy` or `binary`
+    - Use `xentropy` with binary labels or probability labels
+    - Use `binary` only with binary labels
+    - Compare speed of `xentropy` versus `binary`

--- a/examples/python-guide/logistic_regression.py
+++ b/examples/python-guide/logistic_regression.py
@@ -24,11 +24,11 @@ np.random.seed(0)
 N = 1000
 X = pd.DataFrame({
     'continuous': range(N),
-    'categorical': np.repeat([0, 1, 2, 3, 4], N/5)
+    'categorical': np.repeat([0, 1, 2, 3, 4], N / 5)
 })
 CATEGORICAL_EFFECTS = [-1, -1, -2, -2, 2]
 LINEAR_TERM = np.array([
-    -0.5 + 0.01*X['continuous'][k]
+    -0.5 + 0.01 * X['continuous'][k]
     + CATEGORICAL_EFFECTS[X['categorical'][k]] for k in range(X.shape[0])
 ]) + np.random.normal(0, 1, X.shape[0])
 TRUE_PROB = expit(LINEAR_TERM)
@@ -46,7 +46,7 @@ DATA = {
 # Set up a couple of utilities for our experiments
 def log_loss(preds, labels):
     ''' logarithmic loss with non-necessarily-binary labels '''
-    log_likelihood = np.sum(labels*np.log(preds))/len(preds)
+    log_likelihood = np.sum(labels * np.log(preds)) / len(preds)
     return -log_likelihood
 
 

--- a/examples/python-guide/logistic_regression.py
+++ b/examples/python-guide/logistic_regression.py
@@ -3,9 +3,11 @@
 BLUF: The `xentropy` objective does logistic regression and generalizes
 to the case where labels are probabilistic (i.e. numbers between 0 and 1).
 
-Details: Both `binary` and `xentropy` minimize the log loss and use `boost_from_average = TRUE`
-by default. Possibly the only difference between them is that `binary` may achieve a slight
-speed improvement by assuming that the labels are binary instead of probabilistic.
+Details: Both `binary` and `xentropy` minimize the log loss and use
+`boost_from_average = TRUE` by default. Possibly the only difference
+between them with default settings is that `binary` may achieve a slight
+speed improvement by assuming that the labels are binary instead of
+probabilistic.
 '''
 
 import time
@@ -15,8 +17,9 @@ import numpy as np
 import pandas as pd
 from scipy.special import expit
 
-##################
-## Simulate some binary data with a single categorical and single continuous predictor
+#################
+# Simulate some binary data with a single categorical and
+#   single continuous predictor
 np.random.seed(0)
 N = 1000
 X = pd.DataFrame({
@@ -38,12 +41,14 @@ DATA = {
     'lgb_with_probability_labels': lgb.Dataset(X, TRUE_PROB),
 }
 
-##################
-## Set up a couple of utilities for our experiments
+
+#################
+# Set up a couple of utilities for our experiments
 def log_loss(preds, labels):
     ''' logarithmic loss with non-necessarily-binary labels '''
     log_likelihood = np.sum(labels*np.log(preds))/len(preds)
     return -log_likelihood
+
 
 def experiment(objective, label_type, data):
     '''
@@ -73,8 +78,9 @@ def experiment(objective, label_type, data):
         'logloss': log_loss(y_fitted, y_true)
     }
 
-##################
-## Observe the behavior of `binary` and `xentropy` objectives
+
+#################
+# Observe the behavior of `binary` and `xentropy` objectives
 print('Performance of `binary` objective with binary labels:')
 print(experiment('binary', label_type='binary', data=DATA))
 
@@ -87,11 +93,14 @@ print(experiment('xentropy', label_type='probability', data=DATA))
 # Trying this throws an error on non-binary values of y:
 #   experiment('binary', label_type='probability', DATA)
 
-# The speed of `binary` is not drastically different than `xentropy`. `xentropy`
-#   runs faster than `binary` in many cases, although there are reasons to suspect
-#   that `binary` should run faster when the label is an integer instead of a float
+# The speed of `binary` is not drastically different than
+#   `xentropy`. `xentropy` runs faster than `binary` in many cases, although
+#   there are reasons to suspect that `binary` should run faster when the
+#   label is an integer instead of a float
 K = 10
-A = [experiment('binary', label_type='binary', data=DATA)['time'] for k in range(K)]
-B = [experiment('xentropy', label_type='binary', data=DATA)['time'] for k in range(K)]
+A = [experiment('binary', label_type='binary', data=DATA)['time']
+     for k in range(K)]
+B = [experiment('xentropy', label_type='binary', data=DATA)['time']
+     for k in range(K)]
 print('Best `binary` time: ' + str(min(A)))
 print('Best `xentropy` time: ' + str(min(B)))


### PR DESCRIPTION
These two objectives are closely related. I included (1) a note in the docs to be explicit that `xentropy` is necessary when labels are not binary and (2) an example that makes the relationship clear for users coming at this with "logistic regression" in mind. 

Non-binary labels are a trivial extension of binary ones under log-loss; any lack of generalization is in the code (i.e. enforcing `int` instead of `float`) rather than mathematical, and so it would be understandable if a user mistakenly tried applying `binary` with non-binary labels. If fact I was doing this in R and have yet to identify why it gave reasonable results and did not crash (while `binary` with non-binary labels does crash in python).

