### PR TITLE
[ci] generate fresh config_auto.cpp at CI side

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,6 +34,8 @@ install:
   - activate test-env
 
 build_script:
+  - cd helper && python parameter_generator.py
+  - cd ..
   - mkdir build && cd build
   - cmake -DCMAKE_GENERATOR_PLATFORM=x64 .. && cmake --build . --target ALL_BUILD --config Release
   - cd ..

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -55,6 +55,9 @@ if [[ ${TASK} == "pylint" ]]; then
     exit 0
 fi
 
+cd $TRAVIS_BUILD_DIR/helper && python parameter_generator.py || exit -1
+cd $TRAVIS_BUILD_DIR
+
 if [[ ${TASK} == "if-else" ]]; then
     conda install numpy
     mkdir build && cd build && cmake .. && make lightgbm || exit -1


### PR DESCRIPTION
I think it's good to always have fresh `config_auto.cpp` at CI side and in consequence in all artifacts.

But we cannot completely remove pre-generated `config_auto.cpp` from the repo, because we cannot force users, who compiles from sources, to run python code on their machines, right?