### PR TITLE
[docs][python][R] early_stopping_rounds doesn't check all of eval_set

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -50,7 +50,7 @@ CVBooster <- R6Class(
 #' @param early_stopping_rounds int
 #'        Activates early stopping.
 #'        Requires at least one validation data and one metric
-#'        If there's more than one, will check all of them
+#'        If there's more than one, will check all of them except the training data
 #'        Returns the model with (best_iter + early_stopping_rounds)
 #'        If early stopping occurs, the model will have 'best_iter' field
 #' @param callbacks list of callback functions

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -24,7 +24,7 @@
 #' @param early_stopping_rounds int
 #'        Activates early stopping.
 #'        Requires at least one validation data and one metric
-#'        If there's more than one, will check all of them
+#'        If there's more than one, will check all of them except the training data
 #'        Returns the model with (best_iter + early_stopping_rounds)
 #'        If early stopping occurs, the model will have 'best_iter' field
 #' @param reset_data Boolean, setting it to TRUE (not the default value) will transform the booster model into a predictor model which frees up memory and the original datasets

--- a/R-package/man/lgb.train.Rd
+++ b/R-package/man/lgb.train.Rd
@@ -68,7 +68,7 @@ type str represents feature names}
 \item{early_stopping_rounds}{int
 Activates early stopping.
 Requires at least one validation data and one metric
-If there's more than one, will check all of them
+If there's more than one, will check all of them except the training data
 Returns the model with (best_iter + early_stopping_rounds)
 If early stopping occurs, the model will have 'best_iter' field}
 
@@ -128,7 +128,7 @@ type str represents feature names}
 \item{early_stopping_rounds}{int
 Activates early stopping.
 Requires at least one validation data and one metric
-If there's more than one, will check all of them
+If there's more than one, will check all of them except the training data
 Returns the model with (best_iter + early_stopping_rounds)
 If early stopping occurs, the model will have 'best_iter' field}
 

--- a/docs/Python-Intro.rst
+++ b/docs/Python-Intro.rst
@@ -185,7 +185,7 @@ Early Stopping
 --------------
 
 If you have a validation set, you can use early stopping to find the optimal number of boosting rounds.
-Early stopping requires at least one set in ``valid_sets``. If there is more than one, it will use all of them:
+Early stopping requires at least one set in ``valid_sets``. If there is more than one, it will use all of them except the training data:
 
 .. code:: python
 
@@ -199,7 +199,7 @@ If early stopping occurs, the model will have an additional field: ``bst.best_it
 Note that ``train()`` will return a model from the best iteration.
 
 This works with both metrics to minimize (L2, log loss, etc.) and to maximize (NDCG, AUC).
-Note that if you specify more than one evaluation metric, all of them will be used for early stopping.
+Note that if you specify more than one evaluation metric, all of them except the training data will be used for early stopping.
 
 Prediction
 ----------

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -152,7 +152,7 @@ def early_stopping(stopping_rounds, verbose=True):
     ----
     Activates early stopping.
     Requires at least one validation data and one metric.
-    If there's more than one, will check all of them.
+    If there's more than one, will check all of them except the training data.
 
     Parameters
     ----------

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -56,7 +56,7 @@ def train(params, train_set, num_boost_round=100,
         All values should be less than int32 max value (2147483647).
     early_stopping_rounds: int or None, optional (default=None)
         Activates early stopping. The model will train until the validation score stops improving.
-        Requires at least one validation data and one metric. If there's more than one, will check all of them.
+        Requires at least one validation data and one metric. If there's more than one, will check all of them except the training data.
         If early stopping occurs, the model will add ``best_iteration`` field.
     evals_result: dict or None, optional (default=None)
         This dictionary used to store all evaluation results of all the items in ``valid_sets``.

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -328,7 +328,7 @@ class LGBMModel(_LGBMModelBase):
             In either case, the ``metric`` from the model parameters will be evaluated and used as well.
         early_stopping_rounds : int or None, optional (default=None)
             Activates early stopping. The model will train until the validation score stops improving.
-            If there's more than one, will check all of them.
+            If there's more than one, will check all of them except the training data.
             Validation error needs to decrease at least every ``early_stopping_rounds`` round(s)
             to continue training.
         verbose : bool, optional (default=True)


### PR DESCRIPTION
The document of `early_stopping_rounds` says it will check all of
eval_set. But, this is not true. It doesn't check the dataset
specified as the training data.

This change appends an extra phrase "except the training data" to all
of the sentences "If there's more than one, will check all of them" in
documents.