### PR TITLE
[docs] Fix num_leaves example

### DIFF
--- a/docs/Parameters-Tuning.rst
+++ b/docs/Parameters-Tuning.rst
@@ -22,7 +22,7 @@ To get good results using a leaf-wise tree, these are some important parameters:
    However, this simple conversion is not good in practice.
    The reason is, when number of leaves are the same, the leaf-wise tree is much deeper than depth-wise tree. As a result, it may be over-fitting.
    Thus, when trying to tune the ``num_leaves``, we should let it be smaller than ``2^(max_depth)``.
-   For example, when the ``max_depth=6`` the depth-wise tree can get good accuracy,
+   For example, when the ``max_depth=7`` the depth-wise tree can get good accuracy,
    but setting ``num_leaves`` to ``127`` may cause over-fitting, and setting it to ``70`` or ``80`` may get better accuracy than depth-wise.
    Actually, the concept ``depth`` can be forgotten in leaf-wise tree, since it doesn't have a correct mapping from ``leaves`` to ``depth``.
 


### PR DESCRIPTION
The document says `num_leaves` should be smaller than `2^(max_depth)`.
But, its example says `70` or `80` may get better in case of `max_depth=6`.
2^6 is 64. 70 and 80 are greater than 64. The example doesn't make sense.

Changed `max_depth` from 6 to 7.

Issue: https://github.com/Microsoft/LightGBM/issues/1394