### PR TITLE
[python] make tree rendering more clear

### DIFF
--- a/python-package/lightgbm/plotting.py
+++ b/python-package/lightgbm/plotting.py
@@ -322,7 +322,7 @@ def create_tree_digraph(booster, tree_index=0, show_info=None,
         Booster or LGBMModel instance.
     tree_index : int, optional (default=0)
         The index of a target tree to convert.
-    show_info : list or None, optional (default=None)
+    show_info : list of strings or None, optional (default=None)
         What information should be shown in nodes.
         Possible values of list items: 'split_gain', 'internal_value', 'internal_count', 'leaf_count'.
     name : string or None, optional (default=None)
@@ -340,11 +340,11 @@ def create_tree_digraph(booster, tree_index=0, show_info=None,
         Layout command used ('dot', 'neato', ...).
     encoding : string or None, optional (default=None)
         Encoding for saving the source.
-    graph_attr : dict or None, optional (default=None)
+    graph_attr : dict, list of tuples or None, optional (default=None)
         Mapping of (attribute, value) pairs set for the graph.
-    node_attr : dict or None, optional (default=None)
+    node_attr : dict, list of tuples or None, optional (default=None)
         Mapping of (attribute, value) pairs set for all nodes.
-    edge_attr : dict or None, optional (default=None)
+    edge_attr : dict, list of tuples or None, optional (default=None)
         Mapping of (attribute, value) pairs set for all edges.
     body : list of strings or None, optional (default=None)
         Lines to add to the graph body.
@@ -400,13 +400,13 @@ def plot_tree(booster, ax=None, tree_index=0, figsize=None,
         The index of a target tree to plot.
     figsize : tuple of 2 elements or None, optional (default=None)
         Figure size.
-    graph_attr : dict or None, optional (default=None)
+    graph_attr : dict, list of tuples or None, optional (default=None)
         Mapping of (attribute, value) pairs set for the graph.
-    node_attr : dict or None, optional (default=None)
+    node_attr : dict, list of tuples or None, optional (default=None)
         Mapping of (attribute, value) pairs set for all nodes.
-    edge_attr : dict or None, optional (default=None)
+    edge_attr : dict, list of tuples or None, optional (default=None)
         Mapping of (attribute, value) pairs set for all edges.
-    show_info : list or None, optional (default=None)
+    show_info : list of strings or None, optional (default=None)
         What information should be shown in nodes.
         Possible values of list items: 'split_gain', 'internal_value', 'internal_count', 'leaf_count'.
 

--- a/python-package/lightgbm/plotting.py
+++ b/python-package/lightgbm/plotting.py
@@ -271,13 +271,13 @@ def _to_graphviz(tree_info, show_info, feature_names,
         if 'split_index' in root:  # non-leaf
             name = 'split' + str(root['split_index'])
             if feature_names is not None:
-                label = 'split_feature_name:' + str(feature_names[root['split_feature']])
+                label = 'split_feature_name: ' + str(feature_names[root['split_feature']])
             else:
-                label = 'split_feature_index:' + str(root['split_feature'])
-            label += r'\nthreshold:' + str(root['threshold'])
+                label = 'split_feature_index: ' + str(root['split_feature'])
+            label += r'\nthreshold: ' + str(root['threshold'])
             for info in show_info:
                 if info in {'split_gain', 'internal_value', 'internal_count'}:
-                    label += r'\n' + info + ':' + str(root[info])
+                    label += r'\n' + info + ': ' + str(root[info])
             graph.node(name, label=label)
             if root['decision_type'] == '<=':
                 l_dec, r_dec = '<=', '>'
@@ -289,10 +289,10 @@ def _to_graphviz(tree_info, show_info, feature_names,
             add(root['right_child'], name, r_dec)
         else:  # leaf
             name = 'leaf' + str(root['leaf_index'])
-            label = 'leaf_index:' + str(root['leaf_index'])
-            label += r'\nleaf_value:' + str(root['leaf_value'])
+            label = 'leaf_index: ' + str(root['leaf_index'])
+            label += r'\nleaf_value: ' + str(root['leaf_value'])
             if 'leaf_count' in show_info:
-                label += r'\nleaf_count:' + str(root['leaf_count'])
+                label += r'\nleaf_count: ' + str(root['leaf_count'])
             graph.node(name, label=label)
         if parent is not None:
             graph.edge(parent, name, decision)

--- a/python-package/lightgbm/plotting.py
+++ b/python-package/lightgbm/plotting.py
@@ -342,10 +342,13 @@ def create_tree_digraph(booster, tree_index=0, show_info=None,
         Encoding for saving the source.
     graph_attr : dict, list of tuples or None, optional (default=None)
         Mapping of (attribute, value) pairs set for the graph.
+        All attributes and values must be strings or bytes-like objects.
     node_attr : dict, list of tuples or None, optional (default=None)
         Mapping of (attribute, value) pairs set for all nodes.
+        All attributes and values must be strings or bytes-like objects.
     edge_attr : dict, list of tuples or None, optional (default=None)
         Mapping of (attribute, value) pairs set for all edges.
+        All attributes and values must be strings or bytes-like objects.
     body : list of strings or None, optional (default=None)
         Lines to add to the graph body.
     strict : bool, optional (default=False)
@@ -402,10 +405,13 @@ def plot_tree(booster, ax=None, tree_index=0, figsize=None,
         Figure size.
     graph_attr : dict, list of tuples or None, optional (default=None)
         Mapping of (attribute, value) pairs set for the graph.
+        All attributes and values must be strings or bytes-like objects.
     node_attr : dict, list of tuples or None, optional (default=None)
         Mapping of (attribute, value) pairs set for all nodes.
+        All attributes and values must be strings or bytes-like objects.
     edge_attr : dict, list of tuples or None, optional (default=None)
         Mapping of (attribute, value) pairs set for all edges.
+        All attributes and values must be strings or bytes-like objects.
     show_info : list of strings or None, optional (default=None)
         What information should be shown in nodes.
         Possible values of list items: 'split_gain', 'internal_value', 'internal_count', 'leaf_count'.

--- a/python-package/lightgbm/plotting.py
+++ b/python-package/lightgbm/plotting.py
@@ -83,7 +83,7 @@ def plot_importance(booster, ax=None, height=0.2,
     feature_name = booster.feature_name()
 
     if not len(importance):
-        raise ValueError('Booster feature_importances are empty.')
+        raise ValueError("Booster's feature_importance is empty.")
 
     tuples = sorted(zip(feature_name, importance), key=lambda x: x[1])
     if ignore_zero:
@@ -323,7 +323,7 @@ def create_tree_digraph(booster, tree_index=0, show_info=None,
     tree_index : int, optional (default=0)
         The index of a target tree to convert.
     show_info : list or None, optional (default=None)
-        What information should be showed on nodes.
+        What information should be shown in nodes.
         Possible values of list items: 'split_gain', 'internal_value', 'internal_count', 'leaf_count'.
     name : string or None, optional (default=None)
         Graph name used in the source code.
@@ -407,7 +407,7 @@ def plot_tree(booster, ax=None, tree_index=0, figsize=None,
     edge_attr : dict or None, optional (default=None)
         Mapping of (attribute, value) pairs set for all edges.
     show_info : list or None, optional (default=None)
-        What information should be showed on nodes.
+        What information should be shown in nodes.
         Possible values of list items: 'split_gain', 'internal_value', 'internal_count', 'leaf_count'.
 
     Returns

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -478,7 +478,7 @@ class TestEngine(unittest.TestCase):
         for ret in other_ret:
             self.assertAlmostEqual(ret_origin, ret, places=5)
 
-    @unittest.skipIf(not IS_PANDAS_INSTALLED, 'pandas not installed')
+    @unittest.skipIf(not IS_PANDAS_INSTALLED, 'pandas is not installed')
     def test_pandas_categorical(self):
         X = pd.DataFrame({"A": np.random.permutation(['a', 'b', 'c', 'd'] * 75),  # str
                           "B": np.random.permutation([1, 2, 3] * 100),  # int

--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -16,7 +16,7 @@ except ImportError:
 
 class TestBasic(unittest.TestCase):
 
-    @unittest.skipIf(not matplotlib_installed, 'matplotlib not installed')
+    @unittest.skipIf(not matplotlib_installed, 'matplotlib is not installed')
     def test_plot_importance(self):
         X_train, _, y_train, _ = train_test_split(*load_breast_cancer(True), test_size=0.1, random_state=1)
         train_data = lgb.Dataset(X_train, y_train)
@@ -62,7 +62,7 @@ class TestBasic(unittest.TestCase):
     def test_plot_tree(self):
         pass
 
-    @unittest.skipIf(not matplotlib_installed, 'matplotlib not installed')
+    @unittest.skipIf(not matplotlib_installed, 'matplotlib is not installed')
     def test_plot_metrics(self):
         X_train, X_test, y_train, y_test = train_test_split(*load_breast_cancer(True), test_size=0.1, random_state=1)
         train_data = lgb.Dataset(X_train, y_train)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -200,7 +200,7 @@ class TestSklearn(unittest.TestCase):
                     except SkipTest as message:
                         warnings.warn(message, SkipTestWarning)
 
-    @unittest.skipIf(not IS_PANDAS_INSTALLED, 'pandas not installed')
+    @unittest.skipIf(not IS_PANDAS_INSTALLED, 'pandas is not installed')
     def test_pandas_categorical(self):
         X = pd.DataFrame({"A": np.random.permutation(['a', 'b', 'c', 'd'] * 75),  # str
                           "B": np.random.permutation([1, 2, 3] * 100),  # int


### PR DESCRIPTION
Made tree renders more readable by:
- adding space between name and value of the showing info piece;
- new `precision` parameter for control of digits number in float values.

before:
![untitled](https://user-images.githubusercontent.com/25141164/40982412-e134979c-68e5-11e8-8551-cc137b4dc7c4.png)

`precision=6`:
![untitled](https://user-images.githubusercontent.com/25141164/40982301-99508dbe-68e5-11e8-8a1d-05545066faa8.png)
