### PR TITLE
Update Advanced-Topics.rst

### DIFF
--- a/docs/Advanced-Topics.rst
+++ b/docs/Advanced-Topics.rst
@@ -8,7 +8,7 @@ Missing Value Handle
 
 -  LightGBM uses NA (NaN) to represent missing values by default. Change it to use zero by setting ``zero_as_missing=true``.
 
--  When ``zero_as_missing=false`` (default), the unshown values in sparse matrices (and LightSVM) are treated as zeros.
+-  When ``zero_as_missing=false`` (default), the unshown values in sparse matrices (and LightSVM) are treated as missing.
 
 -  When ``zero_as_missing=true``, NA and zeros (including unshown values in sparse matrices (and LightSVM)) are treated as missing.
 


### PR DESCRIPTION
I guess that in LightSVM format unshown should be treated as missing, zero should be still a zero.