### PR TITLE
Add R package test cases for feature penalties

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -234,7 +234,7 @@ Dataset <- R6Class(
         handle <- lgb.call("LGBM_DatasetGetSubset_R",
                            ret = handle,
                            ref_handle,
-                           private$used_indices,
+                           c(private$used_indices), # Adding c() fixes issue in R v3.5
                            length(private$used_indices),
                            params_str)
         

--- a/R-package/tests/testthat/test_parameters.R
+++ b/R-package/tests/testthat/test_parameters.R
@@ -1,0 +1,42 @@
+data(agaricus.train, package='lightgbm')
+data(agaricus.test, package='lightgbm')
+train <- agaricus.train
+test <- agaricus.test
+
+test_that("Feature penalties work properly", {
+  # Fit a series of models with varying penalty on most important variable
+  var_name <- "odor=none"
+  var_index <- which(train$data@Dimnames[[2]] == var_name)
+  
+  bst <- lapply(seq(1, 0, by = -0.1), function(x) {
+    feature_penalties <- rep(1, ncol(train$data))
+    feature_penalties[var_index] <- x
+    lightgbm(
+      data = train$data,
+      label = train$label,
+      num_leaves = 5,
+      learning_rate = 0.05,
+      nrounds = 20, 
+      objective = "binary", 
+      feature_penalty = paste0(feature_penalties, collapse = ","),
+      metric="binary_error",
+      verbose = -1
+    )
+  })
+  
+  var_gain <- lapply(bst, function(x) lgb.importance(x)[Feature == var_name, Gain])
+  var_cover <- lapply(bst, function(x) lgb.importance(x)[Feature == var_name, Cover])
+  var_freq <- lapply(bst, function(x) lgb.importance(x)[Feature == var_name, Frequency])
+  
+  # Ensure that feature gain, cover, and frequency decreases with stronger penalties
+  expect_true(all(diff(unlist(var_gain)) <= 0))
+  expect_true(all(diff(unlist(var_cover)) <= 0))
+  expect_true(all(diff(unlist(var_freq)) <= 0))
+  
+  expect_lt(min(diff(unlist(var_gain))), 0)
+  expect_lt(min(diff(unlist(var_cover))), 0)
+  expect_lt(min(diff(unlist(var_freq))), 0)
+  
+  # Ensure that feature is not used when feature_penalty = 0
+  expect_length(var_gain[[length(var_gain)]], 0)
+})


### PR DESCRIPTION
1. Add test cases for https://github.com/Microsoft/LightGBM/pull/1449

2. Small change to lgb.Dataset construct that fixes compatabilty issue with R v3.5 when using slice with indices given in 1:n syntax.  This was causing one existing test to fail:  https://github.com/Microsoft/LightGBM/blob/master/R-package/tests/testthat/test_dataset.R#L46.  If there is a better way to fix this issue directly in the C code, this change can be removed.