### PR TITLE
[ci] added test for parameters consistency

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -24,7 +24,7 @@ if [[ $TASK == "check-docs" ]]; then
     # build docs and check them for broken links
     make html || exit -1
     find ./_build/html/ -type f -name '*.html' -exec \
-    sed -i -e 's;\(\.\/[^.]*\.\)rst\([^[:space:]]*\);\1html\2;g' {} \;  # emulate js function
+    sed -i'.bak' -e 's;\(\.\/[^.]*\.\)rst\([^[:space:]]*\);\1html\2;g' {} \;  # emulate js function
 #    html5validator --root ./_build/html/ || exit -1
     if [[ $TRAVIS_OS_NAME != "osx" ]]; then
         sudo apt-get install linkchecker
@@ -75,7 +75,7 @@ fi
 
 if [[ $TASK == "gpu" ]]; then
     conda install --yes -c conda-forge boost
-    sed -i 's/std::string device_type = "cpu";/std::string device_type = "gpu";/' $TRAVIS_BUILD_DIR/include/LightGBM/config.h
+    sed -i'.bak' 's/std::string device_type = "cpu";/std::string device_type = "gpu";/' $TRAVIS_BUILD_DIR/include/LightGBM/config.h
     grep -q 'std::string device_type = "gpu"' $TRAVIS_BUILD_DIR/include/LightGBM/config.h || exit -1  # make sure that changes were really done
     if [[ $METHOD == "pip" ]]; then
         cd $TRAVIS_BUILD_DIR/python-package && python setup.py sdist || exit -1

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -11,10 +11,7 @@ source activate test-env
 cd $TRAVIS_BUILD_DIR
 
 if [[ $TASK == "check-docs" ]]; then
-    if [[ $TRAVIS_OS_NAME != "osx" ]]; then
-        sudo apt-get install linkchecker
-    fi
-    if [[ ${PYTHON_VERSION} == "2.7" ]]; then
+    if [[ $PYTHON_VERSION == "2.7" ]]; then
         conda install mock
     fi
     conda install sphinx "sphinx_rtd_theme>=0.3"  # html5validator
@@ -30,6 +27,7 @@ if [[ $TASK == "check-docs" ]]; then
     sed -i -e 's;\(\.\/[^.]*\.\)rst\([^[:space:]]*\);\1html\2;g' {} \;  # emulate js function
 #    html5validator --root ./_build/html/ || exit -1
     if [[ $TRAVIS_OS_NAME != "osx" ]]; then
+        sudo apt-get install linkchecker
         linkchecker --config=.linkcheckerrc ./_build/html/*.html || exit -1
     fi
     # check the consistency of parameters' descriptions and other stuff

--- a/helper/parameter_generator.py
+++ b/helper/parameter_generator.py
@@ -222,8 +222,9 @@ def GenParameterCode(config_hpp, config_out_cpp):
 
 
 if __name__ == "__main__":
-    config_hpp = os.path.join(os.path.pardir, 'include', 'LightGBM', 'config.h')
-    config_out_cpp = os.path.join(os.path.pardir, 'src', 'io', 'config_auto.cpp')
-    params_rst = os.path.join(os.path.pardir, 'docs', 'Parameters.rst')
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    config_hpp = os.path.join(current_dir, os.path.pardir, 'include', 'LightGBM', 'config.h')
+    config_out_cpp = os.path.join(current_dir, os.path.pardir, 'src', 'io', 'config_auto.cpp')
+    params_rst = os.path.join(current_dir, os.path.pardir, 'docs', 'Parameters.rst')
     sections, descriptions = GenParameterCode(config_hpp, config_out_cpp)
     GenParameterDescription(sections, descriptions, params_rst)


### PR DESCRIPTION
Refer to https://github.com/Microsoft/LightGBM/pull/1511#issuecomment-404840307 .

Added test for consistency between parameters' description in `config.h` and `Parameters.rst` files; parameters' checks in `config.h` and `config_auto.cpp` files.

Example of new test:
this https://github.com/Microsoft/LightGBM/compare/doc-test...test?expand=1#diff-911566ea9fc4de585e528a1f5cc37268 results in this https://travis-ci.org/Microsoft/LightGBM/jobs/403637682#L908

Also fixed `sed` with `-i` option at macOS.