### PR TITLE
[python] minor fixes in sklearn wrapper

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -398,7 +398,7 @@ class LGBMModel(_LGBMModelBase):
         evals_result = {}
         params = self.get_params()
         # user can set verbose with kwargs, it has higher priority
-        if 'verbose' not in params and self.silent:
+        if not any(verbose_alias in params for verbose_alias in ('verbose', 'verbosity')) and self.silent:
             params['verbose'] = 0
         params.pop('silent', None)
         params.pop('importance_type', None)

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -668,14 +668,14 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
             ova_aliases = ("multiclassova", "multiclass_ova", "ova", "ovr")
             if self._objective not in ova_aliases and not callable(self._objective):
                 self._objective = "multiclass"
-            if eval_metric == 'logloss' or eval_metric == 'binary_logloss':
+            if eval_metric in ('logloss', 'binary_logloss'):
                 eval_metric = "multi_logloss"
-            elif eval_metric == 'error' or eval_metric == 'binary_error':
+            elif eval_metric in ('error', 'binary_error'):
                 eval_metric = "multi_error"
         else:
-            if eval_metric == 'logloss' or eval_metric == 'multi_logloss':
+            if eval_metric in ('logloss', 'multi_logloss'):
                 eval_metric = 'binary_logloss'
-            elif eval_metric == 'error' or eval_metric == 'multi_error':
+            elif eval_metric in ('error', 'multi_error'):
                 eval_metric = 'binary_error'
 
         if eval_set is not None:

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -188,7 +188,7 @@ class LGBMModel(_LGBMModelBase):
             L2 regularization term on weights.
         random_state : int or None, optional (default=None)
             Random number seed.
-            Will use default seeds in c++ code if set to None.
+            If None, default seeds in C++ code will be used.
         n_jobs : int, optional (default=-1)
             Number of parallel threads.
         silent : bool, optional (default=True)

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -407,7 +407,7 @@ class LGBMModel(_LGBMModelBase):
         if self._n_classes is not None and self._n_classes > 2:
             params['num_class'] = self._n_classes
         if hasattr(self, '_eval_at'):
-            params['ndcg_eval_at'] = self._eval_at
+            params['eval_at'] = self._eval_at
         params['objective'] = self._objective
         if self._fobj:
             params['objective'] = 'None'  # objective = nullptr for unknown objective
@@ -809,5 +809,5 @@ class LGBMRanker(LGBMModel):
                    + 'eval_metric : string, list of strings, callable or None, optional (default="ndcg")\n'
                    + _base_doc[_base_doc.find('            If string, it should be a built-in evaluation metric to use.'):_base_doc.find('early_stopping_rounds :')]
                    + 'eval_at : list of int, optional (default=[1])\n'
-                     '            The evaluation positions of NDCG.\n'
+                     '            The evaluation positions of the specified metric.\n'
                    + _base_doc[_base_doc.find('        early_stopping_rounds :'):])


### PR DESCRIPTION
- take into account `'verbosity'` alias
- use neutral `eval_at` for MAP, NDCG metrics
- define `_get_meta_data` outside the loop
- use `in` instead of multiple `==`
- fix `eval_at` description