### PR TITLE
[docs] reworked GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,15 +1,26 @@
-Please search your question on previous issues, [stackoverflow](https://stackoverflow.com/questions/tagged/lightgbm) or other search engines before you open a new one.
+<!--
+Please search your question on previous issues, Stack Overflow (https://stackoverflow.com/questions/tagged/lightgbm) or other search engines before you open a new one.
+-->
 
-For bugs and unexpected issues, please provide following information, so that we could reproduce on our system.
+<!--
+For bugs and unexpected issues, please provide the following information, so that we could reproduce them on our system.
+-->
 
 ## Environment info
+
 Operating System:
+
 CPU:
+
 C++/Python/R version:
 
-## Error Message:
+## Error message
+
+<!-- Paste error log here -->
 
 ## Reproducible examples
+
+<!-- Paste examples here -->
 
 ## Steps to reproduce
 


### PR DESCRIPTION
Show instructions about posting issues only while creating the issue (achieved by html comments tag).

Also, placeholders for logs have been added to prevent the case when part of the log becomes heading (when users paste logs at the same line as heading).