### PR TITLE
[python][ci] start to support Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,25 +12,25 @@ os:
 env:
   global:  # default values
     - COMPILER=gcc
-    - PYTHON_VERSION=3.6
+    - PYTHON_VERSION=3.7
   matrix:
     - TASK=regular
     - TASK=regular COMPILER=clang
-    - TASK=mpi PYTHON_VERSION=2.7
+    - TASK=mpi
     - TASK=pylint
     - TASK=check-docs
     - TASK=if-else
-    - TASK=sdist PYTHON_VERSION=3.4
-    - TASK=bdist PYTHON_VERSION=3.5
-    - TASK=gpu METHOD=source
-    - TASK=gpu METHOD=pip
+    - TASK=sdist PYTHON_VERSION=2.7
+    - TASK=bdist
+    - TASK=gpu METHOD=source PYTHON_VERSION=3.5
+    - TASK=gpu METHOD=pip PYTHON_VERSION=3.6
 
 matrix:
   exclude:
     - os: osx
-      env: TASK=gpu METHOD=source
+      env: TASK=gpu METHOD=source PYTHON_VERSION=3.5
     - os: osx
-      env: TASK=gpu METHOD=pip
+      env: TASK=gpu METHOD=pip PYTHON_VERSION=3.6
     - os: osx
       env: TASK=if-else
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - COMPILER=gcc
     - PYTHON_VERSION=3.7
   matrix:
-    - TASK=regular
+    - TASK=regular PYTHON_VERSION=3.6
     - TASK=regular COMPILER=clang
     - TASK=mpi
     - TASK=pylint

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -286,4 +286,5 @@ if __name__ == "__main__":
                        'Programming Language :: Python :: 3.4',
                        'Programming Language :: Python :: 3.5',
                        'Programming Language :: Python :: 3.6',
+                       'Programming Language :: Python :: 3.7',
                        'Topic :: Scientific/Engineering :: Artificial Intelligence'])


### PR DESCRIPTION
GPU task fails with Python 3.7. I suppose it's due to the miss of the `boost` library for py37 at conda.

Drop Python 3.4 task as misleading because there are no packages for it at conda and conda silently replaces `3.4 -> 3.7` ([log](https://travis-ci.org/Microsoft/LightGBM/jobs/415410861)) in this case (Travis scenario). Appveyor has pinned Miniconda versions and in this case conda doesn't replace missed version with the newest one, but simply crashes:
```
UnsatisfiableError: The following specifications were found to be in conflict:
  - python 3.4*
  - python-graphviz -> python 3.5*
Use "conda info <package>" to see the dependencies for each package.
Command exited with code 1
```