### PR TITLE
fix error when using distributed quantile regression

### DIFF
--- a/include/LightGBM/network.h
+++ b/include/LightGBM/network.h
@@ -234,7 +234,7 @@ public:
 
   template<class T>
   static void GlobalSum(std::vector<T>& local) {
-    std::vector<T> global;
+    std::vector<T> global(local.size(), 0);
     Allreduce(reinterpret_cast<char*>(local.data()),
               static_cast<comm_size_t>(sizeof(T) * local.size()), sizeof(T),
               reinterpret_cast<char*>(global.data()),


### PR DESCRIPTION
This fixes the seg fault error in LightGBM quantile regression when there are more than 2 workers (distributed workflow) found by users here:
https://github.com/Azure/mmlspark/issues/341

I was able to reproduce the "hanging issue" locally in a notebook with 2 partitions, but it was actually a seg fault that occurred when I looked at the debug.  The debug code to track down the issue is located here:
https://github.com/imatiach-msft/LightGBM/commit/9b810a6a08debc4ca20d8a679d2a885223459e3f

When I executed with only 1 worker I did not see any errors.

I'm not very familiar with this code, specifically how Allreduce works in LightGBM, but I was able to confirm that after the fix I was no longer getting any seg faults.

Tagging @guolinke @peay @ezerhoun 