### PR TITLE
remove unnecessary  std::move & unused capture

### DIFF
--- a/include/LightGBM/utils/pipeline_reader.h
+++ b/include/LightGBM/utils/pipeline_reader.h
@@ -46,7 +46,7 @@ public:
     while (read_cnt > 0) {
       // start read thread
       std::thread read_worker = std::thread(
-        [&, buffer_size] {
+        [&] {
         last_read_cnt = reader->Read(buffer_read.data(), buffer_size);
       }
       );

--- a/include/LightGBM/utils/pipeline_reader.h
+++ b/include/LightGBM/utils/pipeline_reader.h
@@ -46,7 +46,7 @@ public:
     while (read_cnt > 0) {
       // start read thread
       std::thread read_worker = std::thread(
-        [&reader, &buffer_read, buffer_size, &last_read_cnt] {
+        [&, buffer_size] {
         last_read_cnt = reader->Read(buffer_read.data(), buffer_size);
       }
       );

--- a/include/LightGBM/utils/text_reader.h
+++ b/include/LightGBM/utils/text_reader.h
@@ -136,7 +136,7 @@ public:
   */
   INDEX_T ReadAllLines() {
     return ReadAllAndProcess(
-      [this](INDEX_T, const char* buffer, size_t size) {
+      [=](INDEX_T, const char* buffer, size_t size) {
       lines_.emplace_back(buffer, size);
     });
   }
@@ -221,7 +221,7 @@ public:
 
   INDEX_T CountLine() {
     return ReadAllAndProcess(
-      [this](INDEX_T, const char*, size_t) {
+      [=](INDEX_T, const char*, size_t) {
     });
   }
 

--- a/include/LightGBM/utils/text_reader.h
+++ b/include/LightGBM/utils/text_reader.h
@@ -136,7 +136,7 @@ public:
   */
   INDEX_T ReadAllLines() {
     return ReadAllAndProcess(
-      [](INDEX_T, const char* buffer, size_t size) {
+      [this](INDEX_T, const char* buffer, size_t size) {
       lines_.emplace_back(buffer, size);
     });
   }
@@ -221,7 +221,7 @@ public:
 
   INDEX_T CountLine() {
     return ReadAllAndProcess(
-      [](INDEX_T, const char*, size_t) {
+      [this](INDEX_T, const char*, size_t) {
     });
   }
 

--- a/include/LightGBM/utils/text_reader.h
+++ b/include/LightGBM/utils/text_reader.h
@@ -84,7 +84,7 @@ public:
     last_line_ = "";
     INDEX_T total_cnt = 0;
     PipelineReader::Read(filename_, skip_bytes_,
-      [this, &total_cnt, &process_fun]
+      [&]
     (const char* buffer_process, size_t read_cnt) {
       size_t cnt = 0;
       size_t i = 0;
@@ -136,7 +136,7 @@ public:
   */
   INDEX_T ReadAllLines() {
     return ReadAllAndProcess(
-      [this](INDEX_T, const char* buffer, size_t size) {
+      [](INDEX_T, const char* buffer, size_t size) {
       lines_.emplace_back(buffer, size);
     });
   }
@@ -162,7 +162,7 @@ public:
   INDEX_T SampleFromFile(Random& random, INDEX_T sample_cnt, std::vector<std::string>* out_sampled_data) {
     INDEX_T cur_sample_cnt = 0;
     return ReadAllAndProcess(
-      [this, &random, &cur_sample_cnt, &sample_cnt, &out_sampled_data]
+      [&]
     (INDEX_T line_idx, const char* buffer, size_t size) {
       if (cur_sample_cnt < sample_cnt) {
         out_sampled_data->emplace_back(buffer, size);
@@ -185,7 +185,7 @@ public:
   INDEX_T ReadAndFilterLines(const std::function<bool(INDEX_T)>& filter_fun, std::vector<INDEX_T>* out_used_data_indices) {
     out_used_data_indices->clear();
     INDEX_T total_cnt = ReadAllAndProcess(
-      [this, &out_used_data_indices, &filter_fun]
+      [&]
     (INDEX_T line_idx , const char* buffer, size_t size) {
       bool is_used = filter_fun(line_idx);
       if (is_used) { out_used_data_indices->push_back(line_idx); }
@@ -199,7 +199,7 @@ public:
     INDEX_T cur_sample_cnt = 0;
     out_used_data_indices->clear();
     INDEX_T total_cnt = ReadAllAndProcess(
-      [this, &out_used_data_indices, &filter_fun, &random, &cur_sample_cnt, &sample_cnt, &out_sampled_data]
+      [&]
     (INDEX_T line_idx, const char* buffer, size_t size) {
       bool is_used = filter_fun(line_idx);
       if (is_used) { out_used_data_indices->push_back(line_idx); }
@@ -221,7 +221,7 @@ public:
 
   INDEX_T CountLine() {
     return ReadAllAndProcess(
-      [this](INDEX_T, const char*, size_t) {
+      [](INDEX_T, const char*, size_t) {
     });
   }
 
@@ -230,7 +230,7 @@ public:
     INDEX_T total_cnt = 0;
     INDEX_T used_cnt = 0;
     PipelineReader::Read(filename_, skip_bytes_,
-      [this, &total_cnt, &process_fun,&used_cnt, &filter_fun]
+      [&]
     (const char* buffer_process, size_t read_cnt) {
       size_t cnt = 0;
       size_t i = 0;

--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -241,7 +241,7 @@ private:
         buf[features[i].first] = features[i].second;
       }
     }
-    return std::move(buf);
+    return buf;
   }
 
   /*! \brief Boosting model */

--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -63,7 +63,7 @@ public:
     const int kFeatureThreshold = 100000;
     const size_t KSparseThreshold = static_cast<size_t>(0.01 * num_feature_);
     if (predict_leaf_index) {
-      predict_fun_ = [this, kFeatureThreshold, KSparseThreshold](const std::vector<std::pair<int, double>>& features, double* output) {
+      predict_fun_ = [=](const std::vector<std::pair<int, double>>& features, double* output) {
         int tid = omp_get_thread_num();
         if (num_feature_ > kFeatureThreshold && features.size() < KSparseThreshold) {
           auto buf = CopyToPredictMap(features);
@@ -76,16 +76,16 @@ public:
         }
       };
     } else if (predict_contrib) {
-      predict_fun_ = [this](const std::vector<std::pair<int, double>>& features, double* output) {
-        int tid = omp_get_thread_num();
-        CopyToPredictBuffer(predict_buf_[tid].data(), features);
-        // get result for leaf index
-        boosting_->PredictContrib(predict_buf_[tid].data(), output, &early_stop_);
-        ClearPredictBuffer(predict_buf_[tid].data(), predict_buf_[tid].size(), features);
-      };
+	    predict_fun_ = [=](const std::vector<std::pair<int, double>>& features, double* output) {
+	      int tid = omp_get_thread_num();
+			CopyToPredictBuffer(predict_buf_[tid].data(), features);
+          // get result for leaf index
+          boosting_->PredictContrib(predict_buf_[tid].data(), output, &early_stop_);
+          ClearPredictBuffer(predict_buf_[tid].data(), predict_buf_[tid].size(), features);
+        };
     } else {
       if (is_raw_score) {
-        predict_fun_ = [this, kFeatureThreshold, KSparseThreshold](const std::vector<std::pair<int, double>>& features, double* output) {
+		predict_fun_ = [=](const std::vector<std::pair<int, double>>& features, double* output) {
           int tid = omp_get_thread_num();
           if (num_feature_ > kFeatureThreshold && features.size() < KSparseThreshold) {
             auto buf = CopyToPredictMap(features);
@@ -97,7 +97,7 @@ public:
           }
         };
       } else {
-        predict_fun_ = [this, kFeatureThreshold, KSparseThreshold](const std::vector<std::pair<int, double>>& features, double* output) {
+		predict_fun_ = [=](const std::vector<std::pair<int, double>>& features, double* output) {
           int tid = omp_get_thread_num();
           if (num_feature_ > kFeatureThreshold && features.size() < KSparseThreshold) {
             auto buf = CopyToPredictMap(features);
@@ -163,7 +163,7 @@ public:
     // function for parse data
     std::function<void(const char*, std::vector<std::pair<int, double>>*)> parser_fun;
     double tmp_label;
-    parser_fun = [this, &parser, &tmp_label, &need_adjust, &feature_names_map_]
+    parser_fun = [&]
     (const char* buffer, std::vector<std::pair<int, double>>* feature) {
       parser->ParseOneLine(buffer, feature, &tmp_label);
       if (need_adjust) {
@@ -181,9 +181,8 @@ public:
       }
     };
 
-    std::function<void(data_size_t, const std::vector<std::string>&)> process_fun =
-      [this, &parser_fun, &writer]
-    (data_size_t, const std::vector<std::string>& lines) {
+	std::function<void(data_size_t, const std::vector<std::string>&)> process_fun = [&]
+	(data_size_t, const std::vector<std::string>& lines) {
       std::vector<std::pair<int, double>> oneline_features;
       std::vector<std::string> result_to_write(lines.size());
       OMP_INIT_EX();

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1298,7 +1298,7 @@ RowFunctionFromDenseMatric(const void* data, int num_row, int num_col, int data_
   if (data_type == C_API_DTYPE_FLOAT32) {
     const float* data_ptr = reinterpret_cast<const float*>(data);
     if (is_row_major) {
-      return [data_ptr, num_col, num_row] (int row_idx) {
+      return [=] (int row_idx) {
         std::vector<double> ret(num_col);
         auto tmp_ptr = data_ptr + static_cast<size_t>(num_col) * row_idx;
         for (int i = 0; i < num_col; ++i) {
@@ -1307,7 +1307,7 @@ RowFunctionFromDenseMatric(const void* data, int num_row, int num_col, int data_
         return ret;
       };
     } else {
-      return [data_ptr, num_col, num_row] (int row_idx) {
+      return [=] (int row_idx) {
         std::vector<double> ret(num_col);
         for (int i = 0; i < num_col; ++i) {
           ret[i] = static_cast<double>(*(data_ptr + static_cast<size_t>(num_row) * i + row_idx));
@@ -1318,7 +1318,7 @@ RowFunctionFromDenseMatric(const void* data, int num_row, int num_col, int data_
   } else if (data_type == C_API_DTYPE_FLOAT64) {
     const double* data_ptr = reinterpret_cast<const double*>(data);
     if (is_row_major) {
-      return [data_ptr, num_col, num_row] (int row_idx) {
+      return [=] (int row_idx) {
         std::vector<double> ret(num_col);
         auto tmp_ptr = data_ptr + static_cast<size_t>(num_col) * row_idx;
         for (int i = 0; i < num_col; ++i) {
@@ -1327,7 +1327,7 @@ RowFunctionFromDenseMatric(const void* data, int num_row, int num_col, int data_
         return ret;
       };
     } else {
-      return [data_ptr, num_col, num_row] (int row_idx) {
+      return [=] (int row_idx) {
         std::vector<double> ret(num_col);
         for (int i = 0; i < num_col; ++i) {
           ret[i] = static_cast<double>(*(data_ptr + static_cast<size_t>(num_row) * i + row_idx));

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1358,7 +1358,7 @@ RowPairFunctionFromDenseMatric(const void* data, int num_row, int num_col, int d
 }
 
 std::function<std::vector<std::pair<int, double>>(int idx)>
-RowFunctionFromCSR(const void* indptr, int indptr_type, const int32_t* indices, const void* data, int data_type, int64_t nindptr, int64_t nelem) {
+RowFunctionFromCSR(const void* indptr, int indptr_type, const int32_t* indices, const void* data, int data_type, int64_t , int64_t ) {
   if (data_type == C_API_DTYPE_FLOAT32) {
     const float* data_ptr = reinterpret_cast<const float*>(data);
     if (indptr_type == C_API_DTYPE_INT32) {
@@ -1414,7 +1414,7 @@ RowFunctionFromCSR(const void* indptr, int indptr_type, const int32_t* indices, 
 }
 
 std::function<std::pair<int, double>(int idx)>
-IterateFunctionFromCSC(const void* col_ptr, int col_ptr_type, const int32_t* indices, const void* data, int data_type, int64_t ncol_ptr, int64_t nelem, int col_idx) {
+IterateFunctionFromCSC(const void* col_ptr, int col_ptr_type, const int32_t* indices, const void* data, int data_type, int64_t ncol_ptr, int64_t , int col_idx) {
   CHECK(col_idx < ncol_ptr && col_idx >= 0);
   if (data_type == C_API_DTYPE_FLOAT32) {
     const float* data_ptr = reinterpret_cast<const float*>(data);

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1363,7 +1363,7 @@ RowFunctionFromCSR(const void* indptr, int indptr_type, const int32_t* indices, 
     const float* data_ptr = reinterpret_cast<const float*>(data);
     if (indptr_type == C_API_DTYPE_INT32) {
       const int32_t* ptr_indptr = reinterpret_cast<const int32_t*>(indptr);
-      return [ptr_indptr, indices, data_ptr, nindptr, nelem] (int idx) {
+      return [=] (int idx) {
         std::vector<std::pair<int, double>> ret;
         int64_t start = ptr_indptr[idx];
         int64_t end = ptr_indptr[idx + 1];
@@ -1374,7 +1374,7 @@ RowFunctionFromCSR(const void* indptr, int indptr_type, const int32_t* indices, 
       };
     } else if (indptr_type == C_API_DTYPE_INT64) {
       const int64_t* ptr_indptr = reinterpret_cast<const int64_t*>(indptr);
-      return [ptr_indptr, indices, data_ptr, nindptr, nelem] (int idx) {
+      return [=] (int idx) {
         std::vector<std::pair<int, double>> ret;
         int64_t start = ptr_indptr[idx];
         int64_t end = ptr_indptr[idx + 1];
@@ -1388,7 +1388,7 @@ RowFunctionFromCSR(const void* indptr, int indptr_type, const int32_t* indices, 
     const double* data_ptr = reinterpret_cast<const double*>(data);
     if (indptr_type == C_API_DTYPE_INT32) {
       const int32_t* ptr_indptr = reinterpret_cast<const int32_t*>(indptr);
-      return [ptr_indptr, indices, data_ptr, nindptr, nelem] (int idx) {
+      return [=] (int idx) {
         std::vector<std::pair<int, double>> ret;
         int64_t start = ptr_indptr[idx];
         int64_t end = ptr_indptr[idx + 1];
@@ -1399,7 +1399,7 @@ RowFunctionFromCSR(const void* indptr, int indptr_type, const int32_t* indices, 
       };
     } else if (indptr_type == C_API_DTYPE_INT64) {
       const int64_t* ptr_indptr = reinterpret_cast<const int64_t*>(indptr);
-      return [ptr_indptr, indices, data_ptr, nindptr, nelem] (int idx) {
+      return [=] (int idx) {
         std::vector<std::pair<int, double>> ret;
         int64_t start = ptr_indptr[idx];
         int64_t end = ptr_indptr[idx + 1];
@@ -1422,7 +1422,7 @@ IterateFunctionFromCSC(const void* col_ptr, int col_ptr_type, const int32_t* ind
       const int32_t* ptr_col_ptr = reinterpret_cast<const int32_t*>(col_ptr);
       int64_t start = ptr_col_ptr[col_idx];
       int64_t end = ptr_col_ptr[col_idx + 1];
-      return [ptr_col_ptr, indices, data_ptr, ncol_ptr, nelem, start, end] (int bias) {
+      return [=] (int bias) {
         int64_t i = static_cast<int64_t>(start + bias);
         if (i >= end) {
           return std::make_pair(-1, 0.0);
@@ -1435,7 +1435,7 @@ IterateFunctionFromCSC(const void* col_ptr, int col_ptr_type, const int32_t* ind
       const int64_t* ptr_col_ptr = reinterpret_cast<const int64_t*>(col_ptr);
       int64_t start = ptr_col_ptr[col_idx];
       int64_t end = ptr_col_ptr[col_idx + 1];
-      return [ptr_col_ptr, indices, data_ptr, ncol_ptr, nelem, start, end] (int bias) {
+      return [=] (int bias) {
         int64_t i = static_cast<int64_t>(start + bias);
         if (i >= end) {
           return std::make_pair(-1, 0.0);
@@ -1451,7 +1451,7 @@ IterateFunctionFromCSC(const void* col_ptr, int col_ptr_type, const int32_t* ind
       const int32_t* ptr_col_ptr = reinterpret_cast<const int32_t*>(col_ptr);
       int64_t start = ptr_col_ptr[col_idx];
       int64_t end = ptr_col_ptr[col_idx + 1];
-      return [ptr_col_ptr, indices, data_ptr, ncol_ptr, nelem, start, end] (int bias) {
+      return [=] (int bias) {
         int64_t i = static_cast<int64_t>(start + bias);
         if (i >= end) {
           return std::make_pair(-1, 0.0);
@@ -1464,7 +1464,7 @@ IterateFunctionFromCSC(const void* col_ptr, int col_ptr_type, const int32_t* ind
       const int64_t* ptr_col_ptr = reinterpret_cast<const int64_t*>(col_ptr);
       int64_t start = ptr_col_ptr[col_idx];
       int64_t end = ptr_col_ptr[col_idx + 1];
-      return [ptr_col_ptr, indices, data_ptr, ncol_ptr, nelem, start, end] (int bias) {
+      return [=] (int bias) {
         int64_t i = static_cast<int64_t>(start + bias);
         if (i >= end) {
           return std::make_pair(-1, 0.0);


### PR DESCRIPTION
according to the [discussion](https://stackoverflow.com/questions/4986673/c11-rvalues-and-move-semantics-confusion-return-statement/4986802#4986802) here.

and the C++11 §12.8/32

```
When the criteria for elision of a copy/move operation are met, but not for an exception-declaration, and the
object to be copied is designated by an lvalue, or when the expression in a return statement is a (possibly
parenthesized) id-expression that names an object with automatic storage duration declared in the body or
parameter-declaration-clause of the innermost enclosing function or lambda-expression, overload resolution
to select the constructor for the copy is first performed as if the object were designated by an rvalue. If
the first overload resolution fails or was not performed, or if the type of the first parameter of the selected
constructor is not an rvalue reference to the object’s type (possibly cv-qualified), overload resolution is
performed again, considering the object as an lvalue. [ Note: This two-stage overload resolution must be
performed regardless of whether copy elision will occur. It determines the constructor to be called if elision
is not performed, and the selected constructor must be accessible even if the call is elided. — end note ]
```

C++11 §12.8/31
```
When certain criteria are met, an implementation is allowed to omit the copy/move construction of a class
object, even if the constructor selected for the copy/move operation and/or the destructor for the object
have side effects. In such cases, the implementation treats the source and target of the omitted copy/move
operation as simply two different ways of referring to the same object. If the first parameter of the selected
constructor is an rvalue reference to the object’s type, the destruction of that object occurs when the target
would have been destroyed; otherwise, the destruction occurs at the later of the times when the two objects
would have been destroyed without the optimization.122 This elision of copy/move operations, called copy
elision, is permitted in the following circumstances (which may be combined to eliminate multiple copies):
```
fixing #1557 

edit:
removing all the explicit captures and leave them to compilers.
