### PR TITLE
Small optimizations and fixes

### DIFF
--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -220,7 +220,7 @@ private:
   }
 
   void ClearPredictBuffer(double* pred_buf, size_t buf_size, const std::vector<std::pair<int, double>>& features) {
-    if (features.size() < static_cast<size_t>(buf_size / 2)) {
+    if (features.size() > static_cast<size_t>(buf_size / 2)) {
       std::memset(pred_buf, 0, sizeof(double)*(buf_size));
     } else {
       int loop_size = static_cast<int>(features.size());

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1382,6 +1382,9 @@ RowFunctionFromCSR(const void* indptr, int indptr_type, const int32_t* indices, 
         std::vector<std::pair<int, double>> ret;
         int64_t start = ptr_indptr[idx];
         int64_t end = ptr_indptr[idx + 1];
+        if (end - start > 0)  {
+          ret.reserve(end - start);
+        }
         for (int64_t i = start; i < end; ++i) {
           ret.emplace_back(indices[i], data_ptr[i]);
         }
@@ -1393,6 +1396,9 @@ RowFunctionFromCSR(const void* indptr, int indptr_type, const int32_t* indices, 
         std::vector<std::pair<int, double>> ret;
         int64_t start = ptr_indptr[idx];
         int64_t end = ptr_indptr[idx + 1];
+        if (end - start > 0)  {
+          ret.reserve(end - start);
+        }
         for (int64_t i = start; i < end; ++i) {
           ret.emplace_back(indices[i], data_ptr[i]);
         }
@@ -1407,6 +1413,9 @@ RowFunctionFromCSR(const void* indptr, int indptr_type, const int32_t* indices, 
         std::vector<std::pair<int, double>> ret;
         int64_t start = ptr_indptr[idx];
         int64_t end = ptr_indptr[idx + 1];
+        if (end - start > 0)  {
+          ret.reserve(end - start);
+        }
         for (int64_t i = start; i < end; ++i) {
           ret.emplace_back(indices[i], data_ptr[i]);
         }
@@ -1418,6 +1427,9 @@ RowFunctionFromCSR(const void* indptr, int indptr_type, const int32_t* indices, 
         std::vector<std::pair<int, double>> ret;
         int64_t start = ptr_indptr[idx];
         int64_t end = ptr_indptr[idx + 1];
+        if (end - start > 0)  {
+          ret.reserve(end - start);
+        }
         for (int64_t i = start; i < end; ++i) {
           ret.emplace_back(indices[i], data_ptr[i]);
         }


### PR DESCRIPTION
Please consider my changes.
1. Exploit the fact that we know `std::vector` size before filling in `RowFunctionFromCSR`
2. I suppose here is typo in `ClearPredictBuffer`. In mine opinion we should use memset in the case when more than a half of elements are non-zeros.