### PR TITLE
add future warning for macOS users about switching to Apple Clang

### DIFF
--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -22,6 +22,8 @@ For **macOS** users, **gcc** with **OpenMP** support must be installed first. Re
 
 For **macOS** users, latest versions of LightGBM are built with **gcc-8** and cannot be launched on systems with **gcc-7** and earlier. You should update your **gcc** compiler if you don't want to build from sources or install LightGBM 2.1.1 which is the last version built with **gcc-7**.
 
+For **macOS** users, starting from version 2.1.4, the library file in distribution wheels will be built by the **Apple Clang** compiler. This means that you won't need to install the **gcc** compiler anymore. Instead of that you'll need to install the **OpenMP** library, which is required for running LightGBM on the system with the **Apple Clang** compiler. You can install the **OpenMP** library by the following command: ``brew install libomp``.
+
 Install `wheel <http://pythonwheels.com>`_ via ``pip install wheel`` first. After that download the wheel file and install from it:
 
 .. code:: sh

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -9,7 +9,10 @@ from .basic import Booster, Dataset
 from .callback import (early_stopping, print_evaluation, record_evaluation,
                        reset_parameter)
 from .engine import cv, train
+
 import os
+import warnings
+from platform import system
 
 try:
     from .sklearn import LGBMModel, LGBMRegressor, LGBMClassifier, LGBMRanker
@@ -31,3 +34,12 @@ __all__ = ['Dataset', 'Booster',
            'LGBMModel', 'LGBMRegressor', 'LGBMClassifier', 'LGBMRanker',
            'print_evaluation', 'record_evaluation', 'reset_parameter', 'early_stopping',
            'plot_importance', 'plot_metric', 'plot_tree', 'create_tree_digraph']
+
+if system() == 'Darwin':
+    warnings.warn("Starting from version 2.1.4, the library file in distribution wheels for macOS "
+                  "will be built by the Apple Clang compiler.\n"
+                  "This means that in case of installing LightGBM from PyPI via the ``pip install lightgbm`` command, "
+                  "you won't need to install the gcc compiler anymore.\n"
+                  "Instead of that, you'll need to install the OpenMP library, "
+                  "which is required for running LightGBM on the system with the Apple Clang compiler.\n"
+                  "You can install the OpenMP library by the following command: ``brew install libomp``.", FutureWarning)


### PR DESCRIPTION
Refer to https://github.com/Microsoft/LightGBM/pull/1606#issuecomment-415932865 .
Is `2.1.4` version OK? 
My thoughts are that at least one version should be uploaded to PyPI with this warning but without switching to Apple Clang.

Connected to #1523.