### PR TITLE
[python] copy files silently during the installation

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -36,7 +36,7 @@ def copy_files(use_gpu=False):
         if os.path.exists(src):
             dst = os.path.join(CURRENT_DIR, 'compile', folder_name)
             shutil.rmtree(dst, ignore_errors=True)
-            distutils.dir_util.copy_tree(src, dst)
+            distutils.dir_util.copy_tree(src, dst, verbose=0)
         else:
             raise Exception('Cannot copy {0} folder'.format(src))
 
@@ -46,15 +46,19 @@ def copy_files(use_gpu=False):
         if not os.path.exists(os.path.join(CURRENT_DIR, "compile", "windows")):
             os.makedirs(os.path.join(CURRENT_DIR, "compile", "windows"))
         distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.sln"),
-                                      os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.sln"))
+                                      os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.sln"),
+                                      verbose=0)
         distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.vcxproj"),
-                                      os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.vcxproj"))
+                                      os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.vcxproj"),
+                                      verbose=0)
         if use_gpu:
             copy_files_helper('compute')
         distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "CMakeLists.txt"),
-                                      os.path.join(CURRENT_DIR, "compile", "CMakeLists.txt"))
+                                      os.path.join(CURRENT_DIR, "compile", "CMakeLists.txt"),
+                                      verbose=0)
         distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "LICENSE"),
-                                      os.path.join(CURRENT_DIR, "LICENSE"))
+                                      os.path.join(CURRENT_DIR, "LICENSE"),
+                                      verbose=0)
 
 
 def clear_path(path):
@@ -242,7 +246,8 @@ if __name__ == "__main__":
     LOG_NOTICE = "The full version of error log was saved into {0}".format(LOG_PATH)
     if os.path.isfile(os.path.join(CURRENT_DIR, os.path.pardir, 'VERSION.txt')):
         distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, 'VERSION.txt'),
-                                      os.path.join(CURRENT_DIR, 'lightgbm', 'VERSION.txt'))
+                                      os.path.join(CURRENT_DIR, 'lightgbm', 'VERSION.txt'),
+                                      verbose=0)
     version = io.open(os.path.join(CURRENT_DIR, 'lightgbm', 'VERSION.txt'), encoding='utf-8').read().strip()
     readme = io.open(os.path.join(CURRENT_DIR, 'README.rst'), encoding='utf-8').read()
 


### PR DESCRIPTION
It reduces practically useless log entries from copying files during the installation process.

In the majority of Python versions `verbose=0` is default value.