### PR TITLE
[python] added kwargs in refit method

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2095,7 +2095,7 @@ class Booster(object):
             num_iteration = self.best_iteration
         return predictor.predict(data, num_iteration, raw_score, pred_leaf, pred_contrib, data_has_header, is_reshape)
 
-    def refit(self, data, label, decay_rate=0.9):
+    def refit(self, data, label, decay_rate=0.9, **kwargs):
         """Refit the existing Booster by new data.
 
         Parameters
@@ -2107,6 +2107,8 @@ class Booster(object):
             Label for refit.
         decay_rate : float, optional (default=0.9)
             Decay rate of refit, will use ``leaf_output = decay_rate * old_leaf_output + (1.0 - decay_rate) * new_leaf_output`` to refit trees.
+        **kwargs : other parameters for refit
+            These parameters will be passed to ``predict`` method.
 
         Returns
         -------
@@ -2114,9 +2116,8 @@ class Booster(object):
             Refitted Booster.
         """
         predictor = self._to_predictor()
-        leaf_preds = predictor.predict(data, -1, pred_leaf=True)
-        nrow = leaf_preds.shape[0]
-        ncol = leaf_preds.shape[1]
+        leaf_preds = predictor.predict(data, -1, pred_leaf=True, **kwargs)
+        nrow, ncol = leaf_preds.shape
         train_set = Dataset(data, label)
         new_booster = Booster(self.params, train_set, silent=True)
         # Copy models


### PR DESCRIPTION
Refer to https://github.com/Microsoft/LightGBM/pull/1603#issuecomment-417114777.


Maybe it's better to predict here with **best** iteration, not **all**?
https://github.com/Microsoft/LightGBM/blob/abd737651f5c8f3c42fde693fb1a18c30bb68be3/python-package/lightgbm/basic.py#L2117



However, `Dataset` creation here is still left nonparameterized. Maybe at least add new `group` param for allowing to refit for ranking task?
https://github.com/Microsoft/LightGBM/blob/abd737651f5c8f3c42fde693fb1a18c30bb68be3/python-package/lightgbm/basic.py#L2120