### PR TITLE
[docs] replaced MSBuild with VS Build Tools

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -14,7 +14,7 @@ Note: 32-bit R/Rtools is not supported.
 
 Installing [Rtools](https://cran.r-project.org/bin/windows/Rtools/) is mandatory, and only support the 64-bit version. It requires to add to PATH the Rtools MinGW64 folder, if it was not done automatically during installation.
 
-The default compiler is Visual Studio (or [MS Build](https://visualstudio.microsoft.com/downloads/)) in Windows, with an automatic fallback to Rtools or any [MinGW64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/) (x86_64-posix-seh) available (this means if you have only Rtools and CMake, it will compile fine).
+The default compiler is Visual Studio (or [VS Build Tools](https://visualstudio.microsoft.com/downloads/)) in Windows, with an automatic fallback to Rtools or any [MinGW64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/) (x86_64-posix-seh) available (this means if you have only Rtools and CMake, it will compile fine).
 
 To force the usage of Rtools / MinGW, you can set `use_mingw` to `TRUE` in `R-package/src/install.libs.R`.
 
@@ -43,7 +43,7 @@ Rscript build_r.R
 
 The `build_r.R` script builds the package in a temporary directory called `lightgbm_r`. It will destroy and recreate that directory each time you run the script.
 
-Note: for the build with Visual Studio/MSBuild in Windows, you should use the Windows CMD or Powershell.
+Note: for the build with Visual Studio/VS Build Tools in Windows, you should use the Windows CMD or Powershell.
 
 Windows users may need to run with administrator rights (either R or the command prompt, depending on the way you are installing this package). Linux users might require the appropriate user write permissions for packages.
 

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -30,12 +30,12 @@ On Windows LightGBM can be built using
 
 - **Visual Studio**;
 
-- **CMake** and **MSBuild**;
+- **CMake** and **VS Build Tools**;
 
 - **CMake** and **MinGW**.
 
-Visual Studio (or MSBuild)
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Visual Studio (or VS Build Tools)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 With GUI
 ********
@@ -55,7 +55,7 @@ The exe file will be in ``LightGBM-master/windows/x64/Release`` folder.
 From Command Line
 *****************
 
-1. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `MSBuild`_ (**MSBuild** is not needed if **Visual Studio** (2015 or newer) is already installed).
+1. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
 
 2. Run the following commands:
 
@@ -192,7 +192,7 @@ On Windows MPI version of LightGBM can be built using
 
 - **MS MPI** and **Visual Studio**;
 
-- **MS MPI**, **CMake** and **MSBuild**.
+- **MS MPI**, **CMake** and **VS Build Tools**.
 
 With GUI
 ********
@@ -216,7 +216,7 @@ From Command Line
 
 1. You need to install `MS MPI`_ first. Both ``msmpisdk.msi`` and ``MSMpiSetup.exe`` are needed.
 
-2. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `MSBuild`_ (**MSBuild** is not needed if **Visual Studio** (2015 or newer) is already installed).
+2. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
 
 3. Run the following commands:
 
@@ -357,13 +357,13 @@ To build LightGBM GPU version, run the following commands:
 Windows
 ^^^^^^^
 
-On Windows GPU version of LightGBM can be built using **OpenCL**, **Boost**, **CMake** and **MSBuild** or **MinGW**.
+On Windows GPU version of LightGBM can be built using **OpenCL**, **Boost**, **CMake** and **VS Build Tools** or **MinGW**.
 
 If you use **MinGW**, the build procedure is similar to the build on Linux. Refer to `GPU Windows Compilation <./GPU-Windows.rst>`__ to get more details.
 
 Following procedure is for the **MSVC** (Microsoft Visual C++) build.
 
-1. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `MSBuild`_ (**MSBuild** is not needed if **Visual Studio** (2015 or newer) is installed).
+1. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is installed).
 
 2. Install **OpenCL** for Windows. The installation depends on the brand (NVIDIA, AMD, Intel) of your GPU card.
 
@@ -432,12 +432,12 @@ By the following instructions you can generate a JAR file containing the LightGB
 Windows
 ^^^^^^^
 
-On Windows Java wrapper of LightGBM can be built using **Java**, **SWIG**, **CMake** and **MSBuild** or **MinGW**.
+On Windows Java wrapper of LightGBM can be built using **Java**, **SWIG**, **CMake** and **VS Build Tools** or **MinGW**.
 
-MSBuild
-*******
+VS Build Tools
+**************
 
-1. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `MSBuild`_ (**MSBuild** is not needed if **Visual Studio** (2015 or newer) is already installed).
+1. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
 
 2. Install `SWIG`_ and **Java** (also make sure that ``JAVA_HOME`` is set properly).
 
@@ -476,7 +476,7 @@ The jar file will be in ``LightGBM/build`` folder and the dll files will be in `
 
 **Note**: You may need to run the ``cmake -G "MinGW Makefiles" -DUSE_SWIG=ON ..`` one more time if you encounter the ``sh.exe was found in your PATH`` error.
 
-It is recommended to use **MSBuild (Visual Studio)** for its better multithreading efficiency in **Windows** for many-core systems (see `FAQ <./FAQ.rst#lightgbm>`__ Question 4 and Question 8).
+It is recommended to use **VS Build Tools (Visual Studio)** for its better multithreading efficiency in **Windows** for many-core systems (see `FAQ <./FAQ.rst#lightgbm>`__ Question 4 and Question 8).
 
 Also, you may want to read `gcc Tips <./gcc-Tips.rst>`__.
 

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -508,7 +508,7 @@ On Linux Java wrapper of LightGBM can be built using **Java**, **SWIG**, **CMake
 
 .. _CMake: https://cmake.org/
 
-.. _MSBuild: https://visualstudio.microsoft.com/downloads/
+.. _VS Build Tools: https://visualstudio.microsoft.com/downloads/
 
 .. _MinGW-w64: https://mingw-w64.org/doku.php/download
 

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -41,7 +41,7 @@ For **Linux** and **macOS** users, installation from sources requires installed 
 
 For **macOS** users, you can perform installation either with **Apple Clang** or **gcc**. In case you prefer **Apple Clang**, you should install **OpenMP** (details for installation can be found in `Installation Guide <https://github.com/Microsoft/LightGBM/blob/master/docs/Installation-Guide.rst#apple-clang>`__) first and **CMake** version 3.12 or higher is required. In case you prefer **gcc**, you need to install it (details for installation can be found in `Installation Guide <https://github.com/Microsoft/LightGBM/blob/master/docs/Installation-Guide.rst#gcc>`__) and specify compilers by running ``export CXX=g++-7 CC=gcc-7`` (replace "7" with version of **gcc** installed on your machine) first.
 
-For **Windows** users, **Visual Studio** (or `MS Build <https://visualstudio.microsoft.com/downloads/>`_) is needed. If you get any errors during installation, you may need to install `CMake`_ (version 3.8 or higher).
+For **Windows** users, **Visual Studio** (or `VS Build Tools <https://visualstudio.microsoft.com/downloads/>`_) is needed. If you get any errors during installation, you may need to install `CMake`_ (version 3.8 or higher).
 
 Build MPI Version
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Refer to https://github.com/Microsoft/LightGBM/pull/1621#issuecomment-417984823.

To be not confused with `MSBuild.exe` https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild?view=vs-2017