### PR TITLE
[python] pass params to predictor in refit

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2123,8 +2123,8 @@ class Booster(object):
         result : Booster
             Refitted Booster.
         """
-        predictor = self._to_predictor(self.params)
-        leaf_preds = predictor.predict(data, -1, pred_leaf=True, **kwargs)
+        predictor = self._to_predictor(kwargs)
+        leaf_preds = predictor.predict(data, -1, pred_leaf=True)
         nrow, ncol = leaf_preds.shape
         train_set = Dataset(data, label, silent=True)
         new_booster = Booster(self.params, train_set, silent=True)

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2123,7 +2123,7 @@ class Booster(object):
         result : Booster
             Refitted Booster.
         """
-        predictor = self._to_predictor()
+        predictor = self._to_predictor(self.params)
         leaf_preds = predictor.predict(data, -1, pred_leaf=True, **kwargs)
         nrow, ncol = leaf_preds.shape
         train_set = Dataset(data, label, silent=True)


### PR DESCRIPTION
~To be honest, I'm **not sure** is this change **needed or not**.
But I **suppose** it **may help** to suppress warnings.~

~Refer to #1628.~

I'm sorry. I confused `Booster`'s and `_InnerPredictor`'s `predict()` method interface in #1629. This PR is hotfix for it.