### PR TITLE
[ci] split mpi version test into two: source and pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,13 @@ env:
   matrix:
     - TASK=regular PYTHON_VERSION=3.6
     - TASK=regular COMPILER=clang
-    - TASK=mpi
     - TASK=pylint
     - TASK=check-docs
     - TASK=if-else
     - TASK=sdist PYTHON_VERSION=2.7
     - TASK=bdist
+    - TASK=mpi METHOD=source
+    - TASK=mpi METHOD=pip
     - TASK=gpu METHOD=source PYTHON_VERSION=3.5
     - TASK=gpu METHOD=pip PYTHON_VERSION=3.6
 

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -95,9 +95,12 @@ fi
 mkdir $TRAVIS_BUILD_DIR/build && cd $TRAVIS_BUILD_DIR/build
 
 if [[ $TASK == "mpi" ]]; then
-    cd $TRAVIS_BUILD_DIR/python-package && python setup.py sdist || exit -1
-    pip install $TRAVIS_BUILD_DIR/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--mpi || exit -1
-    cd $TRAVIS_BUILD_DIR/build
+    if [[ $METHOD == "pip" ]]; then
+        cd $TRAVIS_BUILD_DIR/python-package && python setup.py sdist || exit -1
+        pip install $TRAVIS_BUILD_DIR/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--mpi || exit -1
+        pytest $TRAVIS_BUILD_DIR/tests/python_package_test || exit -1
+        exit 0
+    fi
     cmake -DUSE_MPI=ON ..
 elif [[ $TASK == "gpu" ]]; then
     cmake -DUSE_GPU=ON -DBOOST_ROOT=$HOME/miniconda/envs/test-env/ -DOpenCL_INCLUDE_DIR=$AMDAPPSDK/include/ ..


### PR DESCRIPTION
Speed up MPI version test by splitting it to `source` and `pip` (just like GPU version).