### PR TITLE
Enforce R-package dependencies in build_r.R before compilation begins

### DIFF
--- a/build_r.R
+++ b/build_r.R
@@ -5,6 +5,22 @@
 # Sys.setenv("CXX" = "/usr/local/bin/g++-8")
 # Sys.setenv("CC" = "/usr/local/bin/gcc-8")
 
+# Identify R-packages required for build_r.R to complete
+pkgs = list(
+    installed = rownames(installed.packages()),
+    required = c("testthat", "roxygen2", "devtools")
+)
+pkgs$missing = setdiff(pkgs$required, pkgs$installed)
+if(length(pkgs$missing) > 0){
+    pkgs_string = paste0("    ", pkgs$missing, "\n")
+    message = paste0(
+        "The following R-packages are required for ",
+        "the LightGBM R-package install: \n",
+        paste0(pkgs_string, collapse = ''),
+        "Please try `Rscript build_r.R` again after installing them.")
+    stop(message)
+}
+
 # R returns FALSE (not a non-zero exit code) if a file copy operation
 # breaks. Let's fix that
 .handle_result <- function(res){

--- a/build_r.R
+++ b/build_r.R
@@ -5,21 +5,9 @@
 # Sys.setenv("CXX" = "/usr/local/bin/g++-8")
 # Sys.setenv("CC" = "/usr/local/bin/gcc-8")
 
-# Identify R-packages required for build_r.R to complete
-pkgs = list(
-    installed = rownames(installed.packages()),
-    required = c("testthat", "roxygen2", "devtools")
-)
-pkgs$missing = setdiff(pkgs$required, pkgs$installed)
-if(length(pkgs$missing) > 0){
-    pkgs_string = paste0("    ", pkgs$missing, "\n")
-    message = paste0(
-        "The following R-packages are required for ",
-        "the LightGBM R-package install: \n",
-        paste0(pkgs_string, collapse = ''),
-        "Please try `Rscript build_r.R` again after installing them.")
-    stop(message)
-}
+library(testthat)
+library(roxygen2)
+library(devtools)
 
 # R returns FALSE (not a non-zero exit code) if a file copy operation
 # breaks. Let's fix that


### PR DESCRIPTION
I found myself forgetting to install a couple of R-package dependencies repeatedly on successive LightGBM installations. This wasted some time because compilation runs for quite a while before getting to the part where these packages are required.