### PR TITLE
[python] copy old Booster's attributes to new one in refit method

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2131,6 +2131,8 @@ class Booster(object):
             ptr_data,
             ctypes.c_int(nrow),
             ctypes.c_int(ncol)))
+        new_booster.network = self.network
+        new_booster.__attr = self.__attr
         return new_booster
 
     def get_leaf_output(self, tree_id, leaf_id):

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1736,7 +1736,7 @@ class Booster(object):
         is_finished = ctypes.c_int(0)
         if fobj is None:
             if self.__set_objective_to_none:
-                raise ValueError('Cannot update due to null objective function.')
+                raise LightGBMError('Cannot update due to null objective function.')
             _safe_call(_LIB.LGBM_BoosterUpdateOneIter(
                 self.handle,
                 ctypes.byref(is_finished)))
@@ -2144,6 +2144,8 @@ class Booster(object):
         result : Booster
             Refitted Booster.
         """
+        if self.__set_objective_to_none:
+            raise LightGBMError('Cannot refit due to null objective function.')
         predictor = self._to_predictor(kwargs)
         leaf_preds = predictor.predict(data, -1, pred_leaf=True)
         nrow, ncol = leaf_preds.shape

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2132,7 +2132,7 @@ class Booster(object):
             ctypes.c_int(nrow),
             ctypes.c_int(ncol)))
         new_booster.network = self.network
-        new_booster.__attr = self.__attr
+        new_booster.__attr = self.__attr.copy()
         return new_booster
 
     def get_leaf_output(self, tree_id, leaf_id):


### PR DESCRIPTION
Fixed #1657.

I'm confused about the need to copy
https://github.com/Microsoft/LightGBM/blob/a760eae4ff06fa8d522ed53e7df8c31d9e8298f0/python-package/lightgbm/basic.py#L1438

Also, I'm not sure whether `__attr` should be **copied**.

But I suppose that it's logically correct to reset the info connected to the previous data (e.g. `__train_data_name`, `best_iteration`, `valid_sets`, etc.) after calling the `refit` method.