### PR TITLE
v2.2.1 release

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -2,7 +2,7 @@ Package: lightgbm
 Type: Package
 Title: Light Gradient Boosting Machine
 Version: 2.2.1
-Date: 2018-09-18
+Date: 2018-10-03
 Authors@R: c(
 	person("Guolin", "Ke", email = "guolin.ke@microsoft.com", role = c("aut", "cre")),
 	person("Damien", "Soukhavong", email = "damien.soukhavong@skema.edu", role = c("ctb")),


### PR DESCRIPTION
Since 2.2.0 requires higher glibc, and therefore cannot be run in some systems. 
I think we release the new binaries ASAP.

- [x] #1726 
- [x] #1728