### PR TITLE
[docs] Fixed some typos in Python API Docs

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -320,7 +320,7 @@ class _InnerPredictor(object):
     Note: Can convert from Booster, but cannot convert to Booster
     """
     def __init__(self, model_file=None, booster_handle=None, pred_parameter=None):
-        """Initialize the _InnerPredictor. Not expose to user
+        """Initialize the _InnerPredictor. Not exposed to user
 
         Parameters
         ----------
@@ -629,7 +629,7 @@ class Dataset(object):
                  weight=None, group=None, init_score=None, silent=False,
                  feature_name='auto', categorical_feature='auto', params=None,
                  free_raw_data=True):
-        """Constract Dataset.
+        """Construct Dataset.
 
         Parameters
         ----------
@@ -657,7 +657,7 @@ class Dataset(object):
             If list of strings, interpreted as feature names (need to specify ``feature_name`` as well).
             If 'auto' and data is pandas DataFrame, pandas categorical columns are used.
             All values in categorical features should be less than int32 max value (2147483647).
-            Large values could be memory consuming. Consider to use consecutive integers started from zero.
+            Large values could be memory consuming. Consider using consecutive integers starting from zero.
             All negative values in categorical features will be treated as missing values.
         params : dict or None, optional (default=None)
             Other parameters.
@@ -1046,7 +1046,7 @@ class Dataset(object):
         return ret
 
     def save_binary(self, filename):
-        """Save Dataset to binary file.
+        """Save Dataset to a binary file.
 
         Parameters
         ----------
@@ -1212,7 +1212,7 @@ class Dataset(object):
         Parameters
         ----------
         reference : Dataset
-            Reference that is used as a template to consturct the current Dataset.
+            Reference that is used as a template to construct the current Dataset.
 
         Returns
         -------

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -58,7 +58,7 @@ def train(params, train_set, num_boost_round=100,
         If list of strings, interpreted as feature names (need to specify ``feature_name`` as well).
         If 'auto' and data is pandas DataFrame, pandas categorical columns are used.
         All values in categorical features should be less than int32 max value (2147483647).
-        Large values could be memory consuming. Consider to use consecutive integers started from zero.
+        Large values could be memory consuming. Consider using consecutive integers starting from zero.
         All negative values in categorical features will be treated as missing values.
     early_stopping_rounds: int or None, optional (default=None)
         Activates early stopping. The model will train until the validation score stops improving.
@@ -347,7 +347,7 @@ def cv(params, train_set, num_boost_round=100,
     num_boost_round : int, optional (default=100)
         Number of boosting iterations.
     folds : generator or iterator of (train_idx, test_idx) tuples, scikit-learn splitter object or None, optional (default=None)
-        If generator or iterator, it should yield the train and test indices for the each fold.
+        If generator or iterator, it should yield the train and test indices for each fold.
         If object, it should be one of the scikit-learn splitter classes
         (http://scikit-learn.org/stable/modules/classes.html#splitter-classes)
         and have ``split`` method.
@@ -382,7 +382,7 @@ def cv(params, train_set, num_boost_round=100,
         If list of strings, interpreted as feature names (need to specify ``feature_name`` as well).
         If 'auto' and data is pandas DataFrame, pandas categorical columns are used.
         All values in categorical features should be less than int32 max value (2147483647).
-        Large values could be memory consuming. Consider to use consecutive integers started from zero.
+        Large values could be memory consuming. Consider using consecutive integers starting from zero.
         All negative values in categorical features will be treated as missing values.
     early_stopping_rounds: int or None, optional (default=None)
         Activates early stopping.

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -316,7 +316,7 @@ class LGBMModel(_LGBMModelBase):
         group : array-like or None, optional (default=None)
             Group data of training data.
         eval_set : list or None, optional (default=None)
-            A list of (X, y) tuple pairs to use as a validation sets.
+            A list of (X, y) tuple pairs to use as a validation set.
         eval_names : list of strings or None, optional (default=None)
             Names of eval_set.
         eval_sample_weight : list of arrays or None, optional (default=None)
@@ -349,7 +349,7 @@ class LGBMModel(_LGBMModelBase):
             If list of strings, interpreted as feature names (need to specify ``feature_name`` as well).
             If 'auto' and data is pandas DataFrame, pandas categorical columns are used.
             All values in categorical features should be less than int32 max value (2147483647).
-            Large values could be memory consuming. Consider to use consecutive integers started from zero.
+            Large values could be memory consuming. Consider using consecutive integers starting from zero.
             All negative values in categorical features will be treated as missing values.
         callbacks : list of callback functions or None, optional (default=None)
             List of callback functions that are applied at each iteration.

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -316,7 +316,7 @@ class LGBMModel(_LGBMModelBase):
         group : array-like or None, optional (default=None)
             Group data of training data.
         eval_set : list or None, optional (default=None)
-            A list of (X, y) tuple pairs to use as a validation set.
+            A list of (X, y) tuple pairs to use as validation sets.
         eval_names : list of strings or None, optional (default=None)
             Names of eval_set.
         eval_sample_weight : list of arrays or None, optional (default=None)


### PR DESCRIPTION
Just fixed some typos in Python API docs. 

Contributed as a part of Hacktoberfest 2018