### PR TITLE
[ci] build NuGet via built-in Azure tasks

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -146,18 +146,16 @@ jobs:
     inputs:
       artifactName: PackageAssets
       downloadPath: $(Build.SourcesDirectory)/binaries
-  - powershell: |
-      $client = new-object System.Net.WebClient
-      $client.DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", "$(Build.SourcesDirectory)/.nuget/nuget.exe")
-    displayName: 'Download NuGet application'
   - script: |
-      cd %BUILD_SOURCESDIRECTORY%/.nuget
-      python create_nuget.py %BUILD_SOURCESDIRECTORY%/binaries/PackageAssets
-      nuget.exe pack LightGBM.nuspec
-      xcopy *.nupkg %BUILD_ARTIFACTSTAGINGDIRECTORY%
-    displayName: 'Build NuGet package'
+      python %BUILD_SOURCESDIRECTORY%/.nuget/create_nuget.py %BUILD_SOURCESDIRECTORY%/binaries/PackageAssets
+    displayName: 'Create NuGet configuration files'
+  - task: NuGetCommand@2
+    inputs:
+      command: pack
+      packagesToPack: '$(Build.SourcesDirectory)/.nuget/*.nuspec'
+      packDestination: '$(Build.ArtifactStagingDirectory)'
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: Nuget
+      artifactName: NuGet
       artifactType: container


### PR DESCRIPTION
If the usage of the latest `nuget.exe` version is crucial, then we can add this task https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/nuget?view=vsts, but it's not recommended:
>If you're using the Microsoft-hosted agents, you should leave this check box cleared. We update the Microsoft-hosted agents on a regular basis, but they're often slightly behind the latest version. So selecting this box will result in your build spending a lot of time updating to a newer minor version.