### PR TITLE
[ci] downgrade Xcode version on Azure

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -4,6 +4,9 @@ if [[ $OS_NAME == "macos" ]]; then
     if  [[ $COMPILER == "clang" ]]; then
         brew install libomp
         brew reinstall cmake  # CMake >=3.12 is needed to find OpenMP at macOS
+        if [[ $AZURE == "true" ]]; then
+            sudo xcode-select -s /Applications/Xcode_8.3.1.app/Contents/Developer
+        fi
     else
         if [[ $TRAVIS == "true" ]]; then
             sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3"  # fix "fatal error: _stdio.h: No such file or directory"

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -22,7 +22,7 @@ For **Linux** users, **glibc** >= 2.14 is required.
 
 For **macOS** users:
 
-- Starting from version 2.2.1, the library file in distribution wheels is built by the **Apple Clang** (Xcode_9.4.1) compiler. This means that you don't need to install the **gcc** compiler anymore. Instead of that you need to install the **OpenMP** library, which is required for running LightGBM on the system with the **Apple Clang** compiler. You can install the **OpenMP** library by the following command: ``brew install libomp``.
+- Starting from version 2.2.1, the library file in distribution wheels is built by the **Apple Clang** (Xcode_8.3.1) compiler. This means that you don't need to install the **gcc** compiler anymore. Instead of that you need to install the **OpenMP** library, which is required for running LightGBM on the system with the **Apple Clang** compiler. You can install the **OpenMP** library by the following command: ``brew install libomp``.
 
 - For version smaller than 2.2.1 and not smaller than 2.1.2, **gcc-8** with **OpenMP** support must be installed first. Refer to `Installation Guide <https://github.com/Microsoft/LightGBM/blob/master/docs/Installation-Guide.rst#gcc>`__ for installation of **gcc-8** with **OpenMP** support.
 

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -38,7 +38,7 @@ __all__ = ['Dataset', 'Booster',
 # REMOVEME: remove warning after 2.3.0 version release
 if system() == 'Darwin':
     warnings.warn("Starting from version 2.2.1, the library file in distribution wheels for macOS "
-                  "is built by the Apple Clang (Xcode_9.4.1) compiler.\n"
+                  "is built by the Apple Clang (Xcode_8.3.1) compiler.\n"
                   "This means that in case of installing LightGBM from PyPI via the ``pip install lightgbm`` command, "
                   "you don't need to install the gcc compiler anymore.\n"
                   "Instead of that, you need to install the OpenMP library, "


### PR DESCRIPTION
Refer to https://github.com/Microsoft/LightGBM/pull/1740#issuecomment-429195138.

Use the lowest possible version of Xcode on Azure.

To be honest, I'm not sure whether it's good decision or not... macOS users tend to use the latest version of the OS. So maybe it's better to focus on the latest AppleClang version?