### PR TITLE
Only copy pandas categorical attribute if it exists

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2213,7 +2213,8 @@ class Booster(object):
     def _to_predictor(self, pred_parameter=None):
         """Convert to predictor."""
         predictor = _InnerPredictor(booster_handle=self.handle, pred_parameter=pred_parameter)
-        predictor.pandas_categorical = self.pandas_categorical
+        if hasattr(self, 'pandas_categorical'):
+            predictor.pandas_categorical = self.pandas_categorical
         return predictor
 
     def num_feature(self):


### PR DESCRIPTION
In case:
- a model was trained on numpy arrays (not pandas dataframe)
- was serialized with `model_to_string`
- was deserialized by instantiating a `Booster` with the `model_str` parameter (see [here](https://github.com/Microsoft/LightGBM/blob/master/python-package/lightgbm/basic.py#L1536))
- was queried with `.predict` on a numpy array again

Then the current `master` branch crashes with:
```
  File "/usr/local/lib/python2.7/site-packages/lightgbm/basic.py", line 2216, in _to_predictor
    predictor.pandas_categorical = self.pandas_categorical
AttributeError: 'Booster' object has no attribute 'pandas_categorical'
```

This PR fixes it.