### PR TITLE
[python] save pandas_categorical to model string and JSON

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1568,7 +1568,6 @@ class Booster(object):
     def __deepcopy__(self, _):
         model_str = self.model_to_string(num_iteration=-1)
         booster = Booster({'model_str': model_str})
-        booster.pandas_categorical = self.pandas_categorical
         return booster
 
     def __getstate__(self):

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2109,7 +2109,8 @@ class Booster(object):
                 ctypes.byref(tmp_out_len),
                 ptr_string_buffer))
         ret = json.loads(string_buffer.value.decode())
-        ret['pandas_categorical'] = self.pandas_categorical
+        ret['pandas_categorical'] = json.loads(json.dumps(self.pandas_categorical,
+                                                          default=json_default_with_numpy))
         return ret
 
     def predict(self, data, num_iteration=None,

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2094,7 +2094,9 @@ class Booster(object):
                 ctypes.c_int64(actual_len),
                 ctypes.byref(tmp_out_len),
                 ptr_string_buffer))
-        return json.loads(string_buffer.value.decode())
+        ret = json.loads(string_buffer.value.decode())
+        ret['pandas_categorical'] = self.pandas_categorical
+        return ret
 
     def predict(self, data, num_iteration=None,
                 raw_score=False, pred_leaf=False, pred_contrib=False,

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -560,27 +560,27 @@ class TestEngine(unittest.TestCase):
         }
         lgb_train = lgb.Dataset(X, y)
         gbm0 = lgb.train(params, lgb_train, num_boost_round=10, verbose_eval=False)
-        pred0 = list(gbm0.predict(X_test))
+        pred0 = gbm0.predict(X_test)
         lgb_train = lgb.Dataset(X, pd.DataFrame(y))  # also test that label can be one-column pd.DataFrame
         gbm1 = lgb.train(params, lgb_train, num_boost_round=10, verbose_eval=False,
                          categorical_feature=[0])
-        pred1 = list(gbm1.predict(X_test))
+        pred1 = gbm1.predict(X_test)
         lgb_train = lgb.Dataset(X, pd.Series(y))  # also test that label can be pd.Series
         gbm2 = lgb.train(params, lgb_train, num_boost_round=10, verbose_eval=False,
                          categorical_feature=['A'])
-        pred2 = list(gbm2.predict(X_test))
+        pred2 = gbm2.predict(X_test)
         lgb_train = lgb.Dataset(X, y)
         gbm3 = lgb.train(params, lgb_train, num_boost_round=10, verbose_eval=False,
                          categorical_feature=['A', 'B', 'C', 'D'])
-        pred3 = list(gbm3.predict(X_test))
+        pred3 = gbm3.predict(X_test)
         gbm3.save_model('categorical.model')
         gbm4 = lgb.Booster(model_file='categorical.model')
-        pred4 = list(gbm4.predict(X_test))
+        pred4 = gbm4.predict(X_test)
         model_str = gbm4.model_to_string()
         gbm4.model_from_string(model_str, False)
-        pred5 = list(gbm4.predict(X_test))
+        pred5 = gbm4.predict(X_test)
         gbm5 = lgb.Booster({'model_str': model_str})
-        pred6 = list(gbm5.predict(X_test))
+        pred6 = gbm5.predict(X_test)
         np.testing.assert_almost_equal(pred0, pred1)
         np.testing.assert_almost_equal(pred0, pred2)
         np.testing.assert_almost_equal(pred0, pred3)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -576,10 +576,17 @@ class TestEngine(unittest.TestCase):
         gbm3.save_model('categorical.model')
         gbm4 = lgb.Booster(model_file='categorical.model')
         pred4 = list(gbm4.predict(X_test))
+        model_str = gbm4.model_to_string()
+        gbm4.model_from_string(model_str, False)
+        pred5 = list(gbm4.predict(X_test))
+        gbm5 = lgb.Booster({'model_str': model_str})
+        pred6 = list(gbm5.predict(X_test))
         np.testing.assert_almost_equal(pred0, pred1)
         np.testing.assert_almost_equal(pred0, pred2)
         np.testing.assert_almost_equal(pred0, pred3)
         np.testing.assert_almost_equal(pred0, pred4)
+        np.testing.assert_almost_equal(pred0, pred5)
+        np.testing.assert_almost_equal(pred0, pred6)
 
     def test_reference_chain(self):
         X = np.random.normal(size=(100, 2))


### PR DESCRIPTION
Suppress #1764.

Despite the fact that the issue, described in #1764, was caused by the usage of the undocumented feature, I think that saving `pandas_categorical` field to the model not only in `save_model`, but in `model_to_string` and `dump_model`, is good idea.