### PR TITLE
[docs] corrected verbose argument description in fit method

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -369,8 +369,17 @@ class LGBMModel(_LGBMModelBase):
             to continue training.
             Requires at least one validation data and one metric.
             If there's more than one, will check all of them. But the training data is ignored anyway.
-        verbose : bool, optional (default=True)
-            If True and an evaluation set is used, writes the evaluation progress.
+        verbose : bool or int, optional (default=True)
+            Requires at least one evaluation data.
+            If True, the eval metric on the eval set is printed at each boosting stage.
+            If int, the eval metric on the eval set is printed at every ``verbose`` boosting stage.
+            The last boosting stage or the boosting stage found by using ``early_stopping_rounds`` is also printed.
+
+            Example
+            -------
+            With ``verbose`` = 4 and at least one item in ``eval_set``,
+            an evaluation metric is printed every 4 (instead of 1) boosting stages.
+
         feature_name : list of strings or 'auto', optional (default='auto')
             Feature names.
             If 'auto' and data is pandas DataFrame, data columns names are used.


### PR DESCRIPTION
Fixed #1779.

Enhanced description (copied from `train` function) of the `verbose` argument of the `fit` method in sklearn wrapper.

https://github.com/Microsoft/LightGBM/blob/3ad9cba0321a8ac2e5f625da6dcc6f7c1516a750/python-package/lightgbm/engine.py#L82-L92