### PR TITLE
[docs] is_provide_training_metric param can be used only in CLI version

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -795,6 +795,8 @@ Metric Parameters
 
    -  set this to ``true`` to output metric result over training dataset
 
+   -  **Note**: can be used only in CLI version
+
 -  ``eval_at`` :raw-html:`<a id="eval_at" title="Permalink to this parameter" href="#eval_at">&#x1F517;&#xFE0E;</a>`, default = ``1,2,3,4,5``, type = multi-int, aliases: ``ndcg_eval_at``, ``ndcg_at``, ``map_eval_at``, ``map_at``
 
    -  used only with ``ndcg`` and ``map`` metrics

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -703,6 +703,7 @@ public:
 
   // alias = training_metric, is_training_metric, train_metric
   // desc = set this to ``true`` to output metric result over training dataset
+  // desc = **Note**: can be used only in CLI version
   bool is_provide_training_metric = false;
 
   // type = multi-int


### PR DESCRIPTION
Closed #1794.