### PR TITLE
[ci] fixed CMake update on Travis

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -3,7 +3,7 @@
 if [[ $OS_NAME == "macos" ]]; then
     if  [[ $COMPILER == "clang" ]]; then
         brew install libomp
-        brew reinstall cmake  # CMake >=3.12 is needed to find OpenMP at macOS
+        brew upgrade cmake  # CMake >=3.12 is needed to find OpenMP at macOS
         if [[ $AZURE == "true" ]]; then
             sudo xcode-select -s /Applications/Xcode_8.3.1.app/Contents/Developer
         fi


### PR DESCRIPTION
`brew reinstall` ends up with old CMake on Travis:

```
==> Reinstalling cmake 
==> Downloading https://homebrew.bintray.com/bottles/cmake-3.11.4.high_sierra.bo
Already downloaded: /Users/travis/Library/Caches/Homebrew/cmake-3.11.4.high_sierra.bottle.tar.gz
==> Pouring cmake-3.11.4.high_sierra.bottle.tar.gz
==> Caveats
Emacs Lisp files have been installed to:
  /usr/local/share/emacs/site-lisp/cmake
==> Summary
🍺  /usr/local/Cellar/cmake/3.11.4: 2,363 files, 32.7MB
```