### PR TITLE
Fix index out-of-range exception generated by BaggingHelper on small datasets.

### DIFF
--- a/src/boosting/goss.hpp
+++ b/src/boosting/goss.hpp
@@ -150,6 +150,7 @@ public:
       if (cur_start > num_data_) { continue; }
       data_size_t cur_cnt = inner_size;
       if (cur_start + cur_cnt > num_data_) { cur_cnt = num_data_ - cur_start; }
+      if (cur_cnt == 0) { continue; }
       Random cur_rand(config_->bagging_seed + iter * num_threads_ + i);
       data_size_t cur_left_count = BaggingHelper(cur_rand, cur_start, cur_cnt,
                                                  tmp_indices_.data() + cur_start, tmp_indice_right_.data() + cur_start);


### PR DESCRIPTION
Prior to this change, the line "score_t threshold = tmp_gradients[top_k - 1];" would generate an exception, since tmp_gradients would be empty when the cnt input value to the function is zero.