### PR TITLE
[ci] update Xcode on Travis

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -9,11 +9,9 @@ if [[ $OS_NAME == "macos" ]]; then
         fi
     else
         if [[ $TRAVIS == "true" ]]; then
-            # Fix "fatal error: _stdio.h: No such file or directory"
-            softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"
-            rm '/usr/local/include/c++'
+#            rm '/usr/local/include/c++'  # previous variant to deal with conflict link
 #            brew cask uninstall oclint  #  reserve variant to deal with conflict link
-#            brew link --overwrite gcc  # previous variant to deal with conflict link
+            brew link --overwrite gcc
         fi
         if [[ $TASK != "mpi" ]]; then
             brew install gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ git:
 os:
   - linux
   - osx
+osx_image: xcode10.1
 
 env:
   global:  # default values


### PR DESCRIPTION
Continuation of #1822.

Previous update for fix works, but it is unstable:
https://github.com/Microsoft/LightGBM/commit/b0a938aee175232bc1f20f0041346d07ff049827#commitcomment-31186324

This PR completely eliminate the need of `softwareupdate` command by the usage of latest `Xcode` version.

BTW, I think it's good point to build artifacts on Azure Pipelines with the lowest possible `Xcode` and sometimes to test building process on Travis with latest `Xcode` (instead of default `9.4`).