### PR TITLE
Removed `cd build` for Linux (caused CMake error)

### DIFF
--- a/docs/GPU-Tutorial.rst
+++ b/docs/GPU-Tutorial.rst
@@ -59,7 +59,7 @@ Now we are ready to checkout LightGBM and compile it with GPU support:
 
     git clone --recursive https://github.com/Microsoft/LightGBM
     cd LightGBM
-    mkdir build ; cd build
+    mkdir build
     cmake -DUSE_GPU=1 .. 
     # if you have installed NVIDIA CUDA to a customized location, you should specify paths to OpenCL headers and library like the following:
     # cmake -DUSE_GPU=1 -DOpenCL_LIBRARY=/usr/local/cuda/lib64/libOpenCL.so -DOpenCL_INCLUDE_DIR=/usr/local/cuda/include/ ..


### PR DESCRIPTION
Under Linux, you should not to change directory to build when building `cd build`. Otherwise, CMake error will occur:

```
CMake Error: The source directory "[...]/LightGBM/build" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
```