### PR TITLE
[ci][docs] updated temp fix for warning written to stderr, fixed conda permissions and updated bench link

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,7 @@ install:
   - ps: $env:LGB_VER = (Get-Content VERSION.txt).trim()
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda create -q -n test-env python=%PYTHON_VERSION% joblib matplotlib nose numpy pandas pytest python-graphviz scikit-learn scipy
+  - conda create -q -n test-env python=%PYTHON_VERSION% cloudpickle joblib matplotlib nose numpy pandas pytest python-graphviz scikit-learn scipy
   - activate test-env
 
 build_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,7 @@ install:
   - ps: $env:LGB_VER = (Get-Content VERSION.txt).trim()
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda create -q -n test-env python=%PYTHON_VERSION% cloudpickle joblib matplotlib nose numpy pandas pytest python-graphviz scikit-learn scipy
+  - conda create -q -n test-env python=%PYTHON_VERSION% cloudpickle=0.5.6 joblib matplotlib nose numpy pandas pytest python-graphviz scikit-learn scipy
   - activate test-env
 
 build_script:

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -56,6 +56,6 @@ fi
 
 if [[ $TRAVIS == "true" ]]; then
     sh conda.sh -b -p $HOME_DIRECTORY/miniconda
-    conda config --set always_yes yes --set changeps1 no
-    conda update -q conda
 fi
+conda config --set always_yes yes --set changeps1 no
+conda update -q conda

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -4,7 +4,7 @@ variables:
 resources:
   containers:
   - container: ubuntu1404
-    image: lightgbm/vsts-agent:ubuntu-14.04
+    image: lightgbm/vsts-agent:ubuntu-14.04-dev
 jobs:
 ###########################################
 - job: Linux
@@ -32,10 +32,8 @@ jobs:
         METHOD: source
         PYTHON_VERSION: 2.7
   steps:
-  - task: CondaEnvironment@1
-    inputs:
-      updateConda: true
   - script: |
+      echo "##vso[task.setvariable variable=PATH]$CONDA/bin:$PATH"
       echo "##vso[task.setvariable variable=HOME_DIRECTORY]$AGENT_HOMEDIRECTORY"
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
       echo "##vso[task.setvariable variable=OS_NAME]linux"
@@ -67,12 +65,9 @@ jobs:
         METHOD: source
         PYTHON_VERSION: 3.6
   steps:
-  - script: |
-      sudo chmod -R 777 /usr/share/miniconda
-    displayName: 'Fix for conda error on Linux'
   - task: CondaEnvironment@1
     inputs:
-      updateConda: true
+      updateConda: false
   - script: |
       echo "##vso[task.setvariable variable=HOME_DIRECTORY]$AGENT_HOMEDIRECTORY"
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
@@ -108,12 +103,9 @@ jobs:
       bdist:
         TASK: bdist
   steps:
-  - script: |
-      sudo chmod -R 777 /usr/local/miniconda
-    displayName: 'Fix for conda error on macOS'
   - task: CondaEnvironment@1
     inputs:
-      updateConda: true
+      updateConda: false
   - script: |
       echo "##vso[task.setvariable variable=HOME_DIRECTORY]$AGENT_HOMEDIRECTORY"
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -4,7 +4,7 @@ variables:
 resources:
   containers:
   - container: ubuntu1404
-    image: lightgbm/vsts-agent:ubuntu-14.04-dev
+    image: lightgbm/vsts-agent:ubuntu-14.04
 jobs:
 ###########################################
 - job: Linux

--- a/docs/gcc-Tips.rst
+++ b/docs/gcc-Tips.rst
@@ -19,7 +19,7 @@ Using Intel Ivy Bridge CPU on 1M x 1K Bosch dataset, the performance increases a
 
 You can find more details on the experimentation below:
 
--  `Laurae++/Benchmarks <https://sites.google.com/view/lauraepp/new-benchmarks/old-benchmarks>`__
+-  `Laurae++/Benchmarks <https://sites.google.com/view/lauraepp/benchmarks/xgb-vs-lgb-feb-2017>`__
 
 -  `Laurae2/gbt\_benchmarks <https://github.com/Laurae2/gbt_benchmarks>`__
 


### PR DESCRIPTION
Refer to https://github.com/scikit-learn/scikit-learn/issues/12226.

This temp fix should be removed after scikit-learn `0.20.1` release.

@guolinke Could you please fix dockerfile?

```
NotWritableError: The current user does not have write permissions to a required path.
path: /usr/local/miniconda/pkgs/cache/3e39a7aa.json
uid: 1001
gid: 1001

If you feel that permissions on this path are set incorrectly, you can manually
change them by executing

$ sudo chown 1001:1001 /usr/local/miniconda/pkgs/cache/3e39a7aa.json

In general, it's not advisable to use 'sudo conda'.
```