### PR TITLE
add average_output & objective fields to JSON format

### DIFF
--- a/src/boosting/gbdt_model_text.cpp
+++ b/src/boosting/gbdt_model_text.cpp
@@ -22,6 +22,10 @@ std::string GBDT::DumpModel(int start_iteration, int num_iteration) const {
   str_buf << "\"num_tree_per_iteration\":" << num_tree_per_iteration_ << "," << '\n';
   str_buf << "\"label_index\":" << label_idx_ << "," << '\n';
   str_buf << "\"max_feature_idx\":" << max_feature_idx_ << "," << '\n';
+  str_buf << "\"average_output\":" << (average_output_ ? "true" : "false") << ",\n";
+  if (objective_function_ != nullptr) {
+    str_buf << "\"objective\":\"" << objective_function_->ToString() << "\",\n";
+  }
 
   str_buf << "\"feature_names\":[\""
     << Common::Join(feature_names_, "\",\"") << "\"],"


### PR DESCRIPTION
Hi!

I would like to complete JSON format with `average_output (bool)` and `objective (string)` fields.
Without these fields it is impossible to restore model behavior from JSON format.

What do you think about this?