### PR TITLE
When loading a binary file, take feature penalty from config if given there.

### DIFF
--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -381,10 +381,19 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
     dataset->monotone_types_.clear();
   }
 
-  const double* tmp_ptr_feature_penalty = reinterpret_cast<const double*>(mem_ptr);
-  dataset->feature_penalty_.clear();
-  for (int i = 0; i < dataset->num_features_; ++i) {
-    dataset->feature_penalty_.push_back(tmp_ptr_feature_penalty[i]);
+  if(!config_.feature_contri.empty()){
+    CHECK(dataset->num_features_ == config_.feature_contri.size());
+    dataset->feature_penalty_.resize(dataset->num_features_);
+    for(int i = 0; i < dataset->num_features_; ++i){
+      dataset->feature_penalty_[dataset->InnerFeatureIndex(i)] = config_.feature_contri[i];
+    }
+  }
+  else{
+    const double* tmp_ptr_feature_penalty = reinterpret_cast<const double*>(mem_ptr);
+    dataset->feature_penalty_.clear();
+    for (int i = 0; i < dataset->num_features_; ++i) {
+      dataset->feature_penalty_.push_back(tmp_ptr_feature_penalty[i]);
+    }
   }
   mem_ptr += sizeof(double) * (dataset->num_features_);
 


### PR DESCRIPTION
This enables users to override the feature penalty when loading a dataset from a binary file.
For instance, it enables disabling/enabling features via:
```Python
dataset = lgbm.Dataset('data.bin',params={'feature_contri': [0,1,1,0]})
....
```
The above is especially useful when the data set is large, so the cost of recreating the data set from the source data is large.