### PR TITLE
[python] fixed result shape in case of predict_proba with raw_score arg

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -796,7 +796,7 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
         """
         result = super(LGBMClassifier, self).predict(X, raw_score, num_iteration,
                                                      pred_leaf, pred_contrib, **kwargs)
-        if self._n_classes > 2 or pred_leaf or pred_contrib:
+        if self._n_classes > 2 or raw_score or pred_leaf or pred_contrib:
             return result
         else:
             return np.vstack((1. - result, result)).transpose()


### PR DESCRIPTION
Fixed #1859.

I'm just a little bit confused about the inconsistency in case of one-class classification.
`predict_proba()` returns
```
array([[nan, nan],
       [nan, nan],
       [nan, nan],
       [nan, nan],
           ...
       [nan, nan]])
```
but in `predict()` `np.argmax()` transforms this into
```
array([0, 0, 0, ..., 0])
```