### PR TITLE
When loading a binary file, take feature penalty from config if given there.

### DIFF
--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -370,13 +370,13 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
   }
   mem_ptr += sizeof(int) * (dataset->num_groups_);
 
-  if(!config_.monotone_constraints.empty()){
+  if(!config_.monotone_constraints.empty()) {
     CHECK(dataset->num_total_features_ == config_.monotone_constraints.size());
     dataset->monotone_types_.resize(dataset->num_features_);
     for(int i = 0; i < dataset->num_total_features_; ++i){
       int inner_fidx = dataset->InnerFeatureIndex(i);
       if(inner_fidx >= 0) {
-	dataset->monotone_types_[inner_fidx] = config_.monotone_constraints[i];
+        dataset->monotone_types_[inner_fidx] = config_.monotone_constraints[i];
       }
     }
   }
@@ -393,13 +393,13 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
     dataset->monotone_types_.clear();
   }
 
-  if(!config_.feature_contri.empty()){
+  if(!config_.feature_contri.empty()) {
     CHECK(dataset->num_total_features_ == config_.feature_contri.size());
     dataset->feature_penalty_.resize(dataset->num_features_);
     for(int i = 0; i < dataset->num_total_features_; ++i){
       int inner_fidx = dataset->InnerFeatureIndex(i);
       if(inner_fidx >= 0) {
-	dataset->feature_penalty_[inner_fidx] = config_.feature_contri[i];
+        dataset->feature_penalty_[inner_fidx] = config_.feature_contri[i];
       }
     }
   }

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -381,10 +381,19 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
     dataset->monotone_types_.clear();
   }
 
-  const double* tmp_ptr_feature_penalty = reinterpret_cast<const double*>(mem_ptr);
-  dataset->feature_penalty_.clear();
-  for (int i = 0; i < dataset->num_features_; ++i) {
-    dataset->feature_penalty_.push_back(tmp_ptr_feature_penalty[i]);
+  if(!config_.feature_contri.empty()){
+    CHECK(dataset->num_features_ == config_.feature_contri.size());
+    dataset->feature_penalty_.resize(dataset->num_features_);
+    for(int i = 0; i < dataset->num_features_; ++i){
+      dataset->feature_penalty_[dataset->InnerFeatureIndex(i)] = config_.feature_contri[i];
+    }
+  }
+  else{
+    const double* tmp_ptr_feature_penalty = reinterpret_cast<const double*>(mem_ptr);
+    dataset->feature_penalty_.clear();
+    for (int i = 0; i < dataset->num_features_; ++i) {
+      dataset->feature_penalty_.push_back(tmp_ptr_feature_penalty[i]);
+    }
   }
   mem_ptr += sizeof(double) * (dataset->num_features_);
 

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -370,10 +370,22 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
   }
   mem_ptr += sizeof(int) * (dataset->num_groups_);
 
-  const int8_t* tmp_ptr_monotone_type = reinterpret_cast<const int8_t*>(mem_ptr);
-  dataset->monotone_types_.clear();
-  for (int i = 0; i < dataset->num_features_; ++i) {
-    dataset->monotone_types_.push_back(tmp_ptr_monotone_type[i]);
+  if(!config_.monotone_constraints.empty()){
+    CHECK(dataset->num_total_features_ == config_.monotone_constraints.size());
+    dataset->monotone_types_.resize(dataset->num_features_);
+    for(int i = 0; i < dataset->num_total_features_; ++i){
+      int inner_fidx = dataset->InnerFeatureIndex(i);
+      if(inner_fidx >= 0) {
+	dataset->monotone_types_[inner_fidx] = config_.monotone_constraints[i];
+      }
+    }
+  }
+  else {
+    const int8_t* tmp_ptr_monotone_type = reinterpret_cast<const int8_t*>(mem_ptr);
+    dataset->monotone_types_.clear();
+    for (int i = 0; i < dataset->num_features_; ++i) {
+      dataset->monotone_types_.push_back(tmp_ptr_monotone_type[i]);
+    }
   }
   mem_ptr += sizeof(int8_t) * (dataset->num_features_);
 
@@ -391,7 +403,7 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
       }
     }
   }
-  else{
+  else {
     const double* tmp_ptr_feature_penalty = reinterpret_cast<const double*>(mem_ptr);
     dataset->feature_penalty_.clear();
     for (int i = 0; i < dataset->num_features_; ++i) {


### PR DESCRIPTION
This is https://github.com/Microsoft/LightGBM/pull/1862 , rebased on top of master.

This enables users to override the feature penalty when loading a dataset from a binary file.
For instance, it enables disabling/enabling features via:
```Python
dataset = lgbm.Dataset('data.bin',params={'feature_contri': [0,1,1,0]})
....
```
The above is especially useful when the data set is large, so the cost of recreating the data set from the source data is large.