### PR TITLE
[R] Fix multiclass demo

### DIFF
--- a/R-package/demo/multiclass_custom_objective.R
+++ b/R-package/demo/multiclass_custom_objective.R
@@ -8,14 +8,20 @@ data(iris)
 # For instance: 0, 1, 2, 3, 4, 5...
 iris$Species <- as.numeric(as.factor(iris$Species)) - 1
 
-# We cut the data set into 80% train and 20% validation
+# Create imbalanced training data (20, 30, 40 examples for classes 0, 1, 2)
+train <- as.matrix(iris[c(1:20, 51:80, 101:140), ])
 # The 10 last samples of each class are for validation
-
-train <- as.matrix(iris[c(1:40, 51:90, 101:140), ])
 test <- as.matrix(iris[c(41:50, 91:100, 141:150), ])
+
 dtrain <- lgb.Dataset(data = train[, 1:4], label = train[, 5])
 dtest <- lgb.Dataset.create.valid(dtrain, data = test[, 1:4], label = test[, 5])
-valids <- list(test = dtest)
+
+# Built-in method uses class mean as initial score by default
+# Set to zero for equivalence with custom objective function
+setinfo(dtrain, "init_score", matrix(0, nrow = nrow(dtrain), ncol = 3))
+setinfo(dtest,  "init_score", matrix(0, nrow = nrow(dtest), ncol = 3))
+
+valids <- list(train = dtrain, test = dtest)
 
 # Method 1 of training with built-in multiclass objective
 model_builtin <- lgb.train(list(),
@@ -29,7 +35,8 @@ model_builtin <- lgb.train(list(),
                            metric = "multi_logloss",
                            num_class = 3)
 
-preds_builtin <- predict(model_builtin, test[, 1:4], rawscore = TRUE)
+preds_builtin <- predict(model_builtin, test[, 1:4], rawscore = TRUE, reshape = TRUE)
+probs_builtin <- exp(preds_builtin) / rowSums(exp(preds_builtin))
 
 # Method 2 of training with custom objective function
 
@@ -64,7 +71,6 @@ custom_multiclass_metric = function(preds, dtrain) {
     return(list(name = "error",
                 value = -mean(log(prob[cbind(1:length(labels), labels + 1)])),
                 higher_better = FALSE))
-
 }
 
 model_custom <- lgb.train(list(),
@@ -78,8 +84,9 @@ model_custom <- lgb.train(list(),
                           eval = custom_multiclass_metric,
                           num_class = 3)
 
-preds_custom <- predict(model_custom, test[, 1:4], rawscore = TRUE)
+preds_custom <- predict(model_custom, test[, 1:4], rawscore = TRUE, reshape = TRUE)
+probs_custom <- exp(preds_custom) / rowSums(exp(preds_custom))
 
 # compare predictions
-identical(preds_builtin, preds_custom)
-
+stopifnot(identical(probs_builtin, probs_custom))
+stopifnot(identical(preds_builtin, preds_custom))

--- a/R-package/demo/multiclass_custom_objective.R
+++ b/R-package/demo/multiclass_custom_objective.R
@@ -15,17 +15,12 @@ test <- as.matrix(iris[c(41:50, 91:100, 141:150), ])
 
 dtrain <- lgb.Dataset(data = train[, 1:4], label = train[, 5])
 dtest <- lgb.Dataset.create.valid(dtrain, data = test[, 1:4], label = test[, 5])
-
-# Built-in method uses class mean as initial score by default
-# Set to zero for equivalence with custom objective function
-setinfo(dtrain, "init_score", matrix(0, nrow = nrow(dtrain), ncol = 3))
-setinfo(dtest,  "init_score", matrix(0, nrow = nrow(dtest), ncol = 3))
-
 valids <- list(train = dtrain, test = dtest)
 
 # Method 1 of training with built-in multiclass objective
 model_builtin <- lgb.train(list(),
                            dtrain,
+                           boost_from_average = FALSE,
                            100,
                            valids,
                            min_data = 1,

--- a/R-package/demo/multiclass_custom_objective.R
+++ b/R-package/demo/multiclass_custom_objective.R
@@ -18,6 +18,8 @@ dtest <- lgb.Dataset.create.valid(dtrain, data = test[, 1:4], label = test[, 5])
 valids <- list(train = dtrain, test = dtest)
 
 # Method 1 of training with built-in multiclass objective
+# Note: need to turn off boost from average to match custom objective
+# (https://github.com/Microsoft/LightGBM/issues/1846)
 model_builtin <- lgb.train(list(),
                            dtrain,
                            boost_from_average = FALSE,

--- a/R-package/demo/multiclass_custom_objective.R
+++ b/R-package/demo/multiclass_custom_objective.R
@@ -87,3 +87,4 @@ probs_custom <- exp(preds_custom) / rowSums(exp(preds_custom))
 # compare predictions
 stopifnot(identical(probs_builtin, probs_custom))
 stopifnot(identical(preds_builtin, preds_custom))
+


### PR DESCRIPTION
This PR solves two issues with the R demo for custom multiclass objectives as mentioned in #1846:

- Currently, the built-in method and the custom method do not return the same predictions in the sample script (the last statement evaluates as `FALSE`)
- The two methods do return the same probabilities but only if the classes are balanced

Both issues are due to the fact that the built-in method boosts from an `init_score` equal to the class mean by default. By contrast, the custom method boosts from zero. In the case of balanced classes, we are off only by a constant (hence we get the same probabilities); the case of imbalanced classes is more problematic.

Setting `boost_from_average=FALSE` fixes this. Alternatively, we could set `init_score` to zero explicitly.