### PR TITLE
[docs] updated Boost docs

### DIFF
--- a/docs/GPU-Windows.rst
+++ b/docs/GPU-Windows.rst
@@ -167,7 +167,7 @@ Adjust ``C:\boost`` if you install it elsewhere.
 
 We can now start downloading and compiling the required Boost libraries:
 
--  Download `Boost`_ (boost\_1\_63\_0.zip)
+-  Download `Boost`_ (for example, the filename for 1.63.0 version is ``boost_1_63_0.zip``)
 
 -  Extract the archive to ``C:\boost``
 
@@ -220,7 +220,7 @@ This is what you should (approximately) get at the end of Boost compilation:
 
 If you are getting an error:
 
--  Wipe your boost directory
+-  Wipe your Boost directory
 
 -  Close the command prompt
 
@@ -228,7 +228,7 @@ If you are getting an error:
    ``C:\boost\boost-build\bin``, ``C:\boost\boost-build\include\boost`` to
    your PATH (adjust accordingly if you use another folder)
 
--  Do the boost compilation steps again (extract => command prompt => ``cd`` => ``bootstrap`` => ``b2`` => ``cd`` => ``b2``
+-  Do the Boost compilation steps again (extract => command prompt => ``cd`` => ``bootstrap`` => ``b2`` => ``cd`` => ``b2``
 
 --------------
 
@@ -268,7 +268,7 @@ Installing CMake requires one download first and then a lot of configuration for
    :align: center
    :target: ./_static/images/screenshot-downloading-cmake.png
 
--  Download `CMake`_ 3.8.0
+-  Download `CMake`_ (3.8 or higher)
 
 -  Install CMake
 
@@ -572,7 +572,7 @@ And open an issue in GitHub `here`_ with that log.
 
 .. _this: http://iweb.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe
 
-.. _Boost: http://www.boost.org/users/history/version_1_63_0.html
+.. _Boost: https://www.boost.org/users/history/
 
 .. _link: https://git-scm.com/download/win
 

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -524,7 +524,7 @@ Following procedure is for the **MSVC** (Microsoft Visual C++) build.
 
    Further reading and correspondence table: `GPU SDK Correspondence and Device Targeting Table <./GPU-Targets.rst>`__.
 
-3. Install `Boost Binary`_.
+3. Install `Boost Binaries`_.
 
    **Note**: Match your Visual C++ version:
    
@@ -536,8 +536,8 @@ Following procedure is for the **MSVC** (Microsoft Visual C++) build.
 
    .. code::
 
-     Set BOOST_ROOT=C:\local\boost_1_64_0\
-     Set BOOST_LIBRARYDIR=C:\local\boost_1_64_0\lib64-msvc-14.0
+     Set BOOST_ROOT=C:\local\boost_1_63_0\
+     Set BOOST_LIBRARYDIR=C:\local\boost_1_63_0\lib64-msvc-14.0
      git clone --recursive https://github.com/Microsoft/LightGBM
      cd LightGBM
      mkdir build
@@ -545,7 +545,7 @@ Following procedure is for the **MSVC** (Microsoft Visual C++) build.
      cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DUSE_GPU=1 ..
      cmake --build . --target ALL_BUILD --config Release
 
-   **Note**: ``C:\local\boost_1_64_0\`` and ``C:\local\boost_1_64_0\lib64-msvc-14.0`` are locations of your **Boost** binaries. You also can set them to the environment variable to avoid ``Set ...`` commands when build.
+   **Note**: ``C:\local\boost_1_63_0\`` and ``C:\local\boost_1_63_0\lib64-msvc-14.0`` are locations of your **Boost** binaries (assuming you've downloaded 1.63.0 version). You also can set them to the environment variable to avoid ``Set ...`` commands when build.
 
 Docker
 ^^^^^^
@@ -676,6 +676,6 @@ On Linux Java wrapper of LightGBM can be built using **Java**, **SWIG**, **CMake
 
 .. _CUDA Toolkit: https://developer.nvidia.com/cuda-downloads
 
-.. _Boost Binary: https://sourceforge.net/projects/boost/files/boost-binaries/1.64.0/
+.. _Boost Binaries: https://bintray.com/boostorg/release/boost-binaries/_latestVersion#files
 
 .. _SWIG: http://www.swig.org/download.html


### PR DESCRIPTION
- Use the same version (1.63.0) across all docs for examples.
- Encourage users to download the latest version: explicitly point to the latest version for binaries and remove hardcoded version from the link to sources.

From Boost readme:
> Starting with 1.64.0 these binaries have been uploaded to Bintray, previous versions can still be found at Sourceforge.