### PR TITLE
fix R's overflow

### DIFF
--- a/include/LightGBM/R_object_helper.h
+++ b/include/LightGBM/R_object_helper.h
@@ -124,9 +124,13 @@ typedef union { VECTOR_SER s; double align; } SEXPREC_ALIGN;
 
 #define R_INT_PTR(x)  ((int *) DATAPTR(x))
 
+#define R_INT64_PTR(x)  ((int64_t *) DATAPTR(x))
+
 #define R_REAL_PTR(x)     ((double *) DATAPTR(x))
 
 #define R_AS_INT(x) (*((int *) DATAPTR(x)))
+
+#define R_AS_INT64(x) (*((int64_t *) DATAPTR(x)))
 
 #define R_IS_NULL(x) ((*(LGBM_SE)(x)).sxpinfo.type == 0)
 

--- a/src/lightgbm_R.cpp
+++ b/src/lightgbm_R.cpp
@@ -466,7 +466,7 @@ LGBM_SE LGBM_BoosterGetNumPredict_R(LGBM_SE handle,
   R_API_BEGIN();
   int64_t len;
   CHECK_CALL(LGBM_BoosterGetNumPredict(R_GET_PTR(handle), R_AS_INT(data_idx), &len));
-  R_INT_PTR(out)[0] = static_cast<int>(len);
+  R_INT64_PTR(out)[0] = len;
   R_API_END();
 }
 


### PR DESCRIPTION
fix #1884
ping @Laurae2 , any other places we can use int64_t? 
I remember the length of string, and the number of elements in CSC are still limited by int32.