### PR TITLE
[ci] refined command status check 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,6 +48,7 @@ test_script:
       (Get-Content "plot_example.py").replace('graph.render(view=True)', 'graph.render(view=False)') | Set-Content "plot_example.py"
   - ps: >-
       foreach ($file in @(Get-ChildItem *.py)) {
+        @("import sys, warnings", "warnings.showwarning = lambda message, category, filename, lineno, file=None, line=None: sys.stdout.write(warnings.formatwarning(message, category, filename, lineno, line))") + (Get-Content $file) | Set-Content $file
         python $file
         if (!$?) { $host.SetShouldExit(-1) }
       }  # run all examples

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,7 +49,7 @@ test_script:
   - ps: >-
       foreach ($file in @(Get-ChildItem *.py)) {
         python $file
-        if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+        if (!$?) { $host.SetShouldExit(-1) }
       }  # run all examples
   - cd %APPVEYOR_BUILD_FOLDER%\examples\python-guide\notebooks
   - conda install -y -n test-env ipywidgets notebook

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -1,42 +1,42 @@
 function Check-Output {
-  param( [int]$ExitCode )
-  if ($ExitCode -ne 0) {
-    $host.SetShouldExit($ExitCode)
+  param( [bool]$success )
+  if (!$success) {
+    $host.SetShouldExit(-1)
     Exit -1
   }
 }
 
 if ($env:TASK -eq "regular") {
   mkdir $env:BUILD_SOURCESDIRECTORY/build; cd $env:BUILD_SOURCESDIRECTORY/build
-  cmake -DCMAKE_GENERATOR_PLATFORM=x64 .. ; cmake --build . --target ALL_BUILD --config Release ; Check-Output $LastExitCode
+  cmake -DCMAKE_GENERATOR_PLATFORM=x64 .. ; cmake --build . --target ALL_BUILD --config Release ; Check-Output $?
   cd $env:BUILD_SOURCESDIRECTORY/python-package
-  python setup.py install --precompile ; Check-Output $LastExitCode
+  python setup.py install --precompile ; Check-Output $?
   cp $env:BUILD_SOURCESDIRECTORY/Release/lib_lightgbm.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
   cp $env:BUILD_SOURCESDIRECTORY/Release/lightgbm.exe $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 }
 elseif ($env:TASK -eq "sdist") {
   cd $env:BUILD_SOURCESDIRECTORY/python-package
-  python setup.py sdist --formats gztar ; Check-Output $LastExitCode
-  cd dist; pip install @(Get-ChildItem *.gz) -v ; Check-Output $LastExitCode
+  python setup.py sdist --formats gztar ; Check-Output $?
+  cd dist; pip install @(Get-ChildItem *.gz) -v ; Check-Output $?
 }
 elseif ($env:TASK -eq "bdist") {
   cd $env:BUILD_SOURCESDIRECTORY/python-package
-  python setup.py bdist_wheel --plat-name=win-amd64 --universal ; Check-Output $LastExitCode
-  cd dist; pip install @(Get-ChildItem *.whl) ; Check-Output $LastExitCode
+  python setup.py bdist_wheel --plat-name=win-amd64 --universal ; Check-Output $?
+  cd dist; pip install @(Get-ChildItem *.whl) ; Check-Output $?
   cp @(Get-ChildItem *.whl) $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 }
 
 $tests = $env:BUILD_SOURCESDIRECTORY + $(If ($env:TASK -eq "sdist") {"/tests/python_package_test"} Else {"/tests"})  # cannot test C API with "sdist" task
-pytest $tests ; Check-Output $LastExitCode
+pytest $tests ; Check-Output $?
 
 if ($env:TASK -eq "regular") {
   cd $env:BUILD_SOURCESDIRECTORY/examples/python-guide
   @("import matplotlib", "matplotlib.use('Agg')") + (Get-Content "plot_example.py") | Set-Content "plot_example.py"
   (Get-Content "plot_example.py").replace('graph.render(view=True)', 'graph.render(view=False)') | Set-Content "plot_example.py"
   foreach ($file in @(Get-ChildItem *.py)) {
-    python $file ; Check-Output $LastExitCode
+    python $file ; Check-Output $?
   }  # run all examples
   cd $env:BUILD_SOURCESDIRECTORY/examples/python-guide/notebooks
   conda install -y -n $env:CONDA_ENV ipywidgets notebook
-  jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb ; Check-Output $LastExitCode  # run all notebooks
+  jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb ; Check-Output $?  # run all notebooks
 }

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -34,6 +34,7 @@ if ($env:TASK -eq "regular") {
   @("import matplotlib", "matplotlib.use('Agg')") + (Get-Content "plot_example.py") | Set-Content "plot_example.py"
   (Get-Content "plot_example.py").replace('graph.render(view=True)', 'graph.render(view=False)') | Set-Content "plot_example.py"
   foreach ($file in @(Get-ChildItem *.py)) {
+    @("import sys, warnings", "warnings.showwarning = lambda message, category, filename, lineno, file=None, line=None: sys.stdout.write(warnings.formatwarning(message, category, filename, lineno, line))") + (Get-Content $file) | Set-Content $file
     python $file ; Check-Output $?
   }  # run all examples
   cd $env:BUILD_SOURCESDIRECTORY/examples/python-guide/notebooks


### PR DESCRIPTION
It seems that `$?` is more reliable than `$LastExitCode`: https://stackoverflow.com/questions/10666035/difference-between-and-lastexitcode-in-powershell.
After switching to `$?` any python warning causes build failure. So, I've redirected them to stdout. As a bonus there are no annoying red lines at Appveyor like the folowing
```
python : C:\Miniconda36-x64\envs\test-env\lib\site-packages\lightgbm\basic.py:1205: UserWarning: categorical_feature in Dataset is overridden.
At line:2 char:3
+   python $file
+   ~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (C:\Miniconda36-... is overridden.:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
```