### PR TITLE
fixed cpplint whitespaces and new lines errors

### DIFF
--- a/helpers/parameter_generator.py
+++ b/helpers/parameter_generator.py
@@ -298,9 +298,9 @@ def gen_parameter_code(config_hpp, config_out_cpp):
             name = y["name"][0]
             if "vector" in param_type:
                 if "int8" in param_type:
-                    str_to_write += "  str_buf << \"[%s: \" << Common::Join(Common::ArrayCast<int8_t, int>(%s),\",\") << \"]\\n\";\n" % (name, name)
+                    str_to_write += "  str_buf << \"[%s: \" << Common::Join(Common::ArrayCast<int8_t, int>(%s), \",\") << \"]\\n\";\n" % (name, name)
                 else:
-                    str_to_write += "  str_buf << \"[%s: \" << Common::Join(%s,\",\") << \"]\\n\";\n" % (name, name)
+                    str_to_write += "  str_buf << \"[%s: \" << Common::Join(%s, \",\") << \"]\\n\";\n" % (name, name)
             else:
                 str_to_write += "  str_buf << \"[%s: \" << %s << \"]\\n\";\n" % (name, name)
     # tails

--- a/include/LightGBM/R_object_helper.h
+++ b/include/LightGBM/R_object_helper.h
@@ -185,4 +185,4 @@ inline void* R_GET_PTR(LGBM_SE x) {
 
 #endif
 
-#endif // R_OBJECT_HELPER_H_
+#endif  // R_OBJECT_HELPER_H_

--- a/include/LightGBM/application.h
+++ b/include/LightGBM/application.h
@@ -33,7 +33,6 @@ public:
   inline void Run();
 
 private:
-
   /*! \brief Load parameters from command line and config file*/
   void LoadParameters(int argc, char** argv);
 

--- a/include/LightGBM/bin.h
+++ b/include/LightGBM/bin.h
@@ -143,7 +143,7 @@ public:
   * \param use_missing True to enable missing value handle
   * \param zero_as_missing True to use zero as missing value
   */
-  void FindBin(double* values, int num_values, size_t total_sample_cnt, int max_bin, int min_data_in_bin, int min_split_data, BinType bin_type, 
+  void FindBin(double* values, int num_values, size_t total_sample_cnt, int max_bin, int min_data_in_bin, int min_split_data, BinType bin_type,
                bool use_missing, bool zero_as_missing);
 
   /*!
@@ -384,7 +384,7 @@ public:
   * \param gt_indices After called this function. The greater data indices will store on this object.
   * \return The number of less than or equal data.
   */
-  virtual data_size_t Split(uint32_t min_bin, uint32_t max_bin, 
+  virtual data_size_t Split(uint32_t min_bin, uint32_t max_bin,
     uint32_t default_bin, MissingType missing_type, bool default_left, uint32_t threshold,
     data_size_t* data_indices, data_size_t num_data,
     data_size_t* lte_indices, data_size_t* gt_indices) const = 0;

--- a/include/LightGBM/boosting.h
+++ b/include/LightGBM/boosting.h
@@ -291,7 +291,6 @@ public:
   * \return The boosting object
   */
   static Boosting* CreateBoosting(const std::string& type, const char* filename);
-
 };
 
 class GBDTBase : public Boosting {

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -813,13 +813,13 @@ LIGHTGBM_C_EXPORT int LGBM_NetworkInit(const char* machines,
 */
 LIGHTGBM_C_EXPORT int LGBM_NetworkFree();
 
-LIGHTGBM_C_EXPORT int LGBM_NetworkInitWithFunctions(int num_machines, int rank, 
-                                                    void* reduce_scatter_ext_fun, 
+LIGHTGBM_C_EXPORT int LGBM_NetworkInitWithFunctions(int num_machines, int rank,
+                                                    void* reduce_scatter_ext_fun,
                                                     void* allgather_ext_fun);
 
 
 #if defined(_MSC_VER)
-#define THREAD_LOCAL __declspec(thread) 
+#define THREAD_LOCAL __declspec(thread)
 #else
 #define THREAD_LOCAL thread_local
 #endif
@@ -831,4 +831,4 @@ inline void LGBM_SetLastError(const char* msg) {
   std::strcpy(LastErrorMsg(), msg);
 }
 
-#endif // LIGHTGBM_C_API_H_
+#endif  // LIGHTGBM_C_API_H_

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -337,7 +337,7 @@ public:
   // desc = used for the categorical features
   // desc = this can reduce the effect of noises in categorical features, especially for categories with few data
   double cat_smooth = 10.0;
-  
+
   // check = >0
   // desc = when number of categories of one feature smaller than or equal to ``max_cat_to_onehot``, one-vs-other split algorithm will be used
   int max_cat_to_onehot = 4;
@@ -362,7 +362,7 @@ public:
   // desc = used to control feature's split gain, will use ``gain[i] = max(0, feature_contri[i]) * gain[i]`` to replace the split gain of i-th feature
   // desc = you need to specify all features in order
   std::vector<double> feature_contri;
-  
+
   // alias = fs, forced_splits_filename, forced_splits_file, forced_splits
   // desc = path to a ``.json`` file that specifies splits to force at the top of every decision tree before best-first learning commences
   // desc = ``.json`` file can be arbitrarily nested, and each split contains ``feature``, ``threshold`` fields, as well as ``left`` and ``right`` fields representing subsplits
@@ -771,6 +771,7 @@ public:
   LIGHTGBM_EXPORT void Set(const std::unordered_map<std::string, std::string>& params);
   static std::unordered_map<std::string, std::string> alias_table;
   static std::unordered_set<std::string> parameter_set;
+
 private:
   void CheckParamConflict();
   void GetMembersFromString(const std::unordered_map<std::string, std::string>& params);
@@ -837,10 +838,10 @@ struct ParameterAlias {
     std::unordered_map<std::string, std::string> tmp_map;
     for (const auto& pair : *params) {
       auto alias = Config::alias_table.find(pair.first);
-      if (alias != Config::alias_table.end()) { // found alias
+      if (alias != Config::alias_table.end()) {  // found alias
         auto alias_set = tmp_map.find(alias->second);
-        if (alias_set != tmp_map.end()) { // alias already set
-                                          // set priority by length & alphabetically to ensure reproducible behavior
+        if (alias_set != tmp_map.end()) {  // alias already set
+                                           // set priority by length & alphabetically to ensure reproducible behavior
           if (alias_set->second.size() < pair.first.size() ||
             (alias_set->second.size() == pair.first.size() && alias_set->second < pair.first)) {
             Log::Warning("%s is set with %s=%s, %s=%s will be ignored. Current value: %s=%s",
@@ -852,7 +853,7 @@ struct ParameterAlias {
                          pair.first.c_str(), pair.second.c_str(), alias->second.c_str(), pair.second.c_str());
             tmp_map[alias->second] = pair.first;
           }
-        } else { // alias not set
+        } else {  // alias not set
           tmp_map.emplace(alias->second, pair.first);
         }
       } else if (Config::parameter_set.find(pair.first) == Config::parameter_set.end()) {
@@ -861,7 +862,7 @@ struct ParameterAlias {
     }
     for (const auto& pair : tmp_map) {
       auto alias = params->find(pair.first);
-      if (alias == params->end()) { // not find
+      if (alias == params->end()) {  // not find
         params->emplace(pair.first, params->at(pair.second));
         params->erase(pair.second);
       } else {

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -117,8 +117,7 @@ public:
   * \param idx Index of this record
   * \param value Label value of this record
   */
-  inline void SetLabelAt(data_size_t idx, label_t value)
-  {
+  inline void SetLabelAt(data_size_t idx, label_t value) {
     label_[idx] = value;
   }
 
@@ -127,8 +126,7 @@ public:
   * \param idx Index of this record
   * \param value Weight value of this record
   */
-  inline void SetWeightAt(data_size_t idx, label_t value)
-  {
+  inline void SetWeightAt(data_size_t idx, label_t value) {
     weights_[idx] = value;
   }
 
@@ -137,8 +135,7 @@ public:
   * \param idx Index of this record
   * \param value Query Id value of this record
   */
-  inline void SetQueryAt(data_size_t idx, data_size_t value)
-  {
+  inline void SetQueryAt(data_size_t idx, data_size_t value) {
     queries_[idx] = static_cast<data_size_t>(value);
   }
 
@@ -251,7 +248,6 @@ private:
 /*! \brief Interface for Parser */
 class Parser {
 public:
-
   /*! \brief virtual destructor */
   virtual ~Parser() {}
 
@@ -463,7 +459,7 @@ public:
       return false;
     }
   }
-  
+
   inline int FeatureGroupNumBin(int group) const {
     return feature_groups_[group]->num_total_bin_;
   }
@@ -478,7 +474,7 @@ public:
     const int group = feature2group_[i];
     return feature_groups_[group]->bin_data_.get();
   }
-  
+
   inline const Bin* FeatureGroupBin(int group) const {
     return feature_groups_[group]->bin_data_.get();
   }
@@ -496,7 +492,7 @@ public:
   inline BinIterator* FeatureGroupIterator(int group) const {
     return feature_groups_[group]->FeatureGroupIterator();
   }
-  
+
   inline double RealThreshold(int i, uint32_t threshold) const {
     const int group = feature2group_[i];
     const int sub_feature = feature2subfeature_[i];
@@ -550,13 +546,13 @@ public:
     feature_names_ = std::vector<std::string>(feature_names);
     // replace ' ' in feature_names with '_'
     bool spaceInFeatureName = false;
-    for (auto& feature_name: feature_names_){
-      if (feature_name.find(' ') != std::string::npos){
+    for (auto& feature_name : feature_names_) {
+      if (feature_name.find(' ') != std::string::npos) {
         spaceInFeatureName = true;
         std::replace(feature_name.begin(), feature_name.end(), ' ', '_');
       }
     }
-    if (spaceInFeatureName){
+    if (spaceInFeatureName) {
       Log::Warning("Find whitespaces in feature_names, replace with underlines");
     }
   }

--- a/include/LightGBM/dataset_loader.h
+++ b/include/LightGBM/dataset_loader.h
@@ -7,7 +7,6 @@ namespace LightGBM {
 
 class DatasetLoader {
 public:
-
   LIGHTGBM_EXPORT DatasetLoader(const Config& io_config, const PredictFunction& predict_fun, int num_class, const char* filename);
 
   LIGHTGBM_EXPORT ~DatasetLoader();
@@ -30,7 +29,6 @@ public:
   DatasetLoader(const DatasetLoader&) = delete;
 
 private:
-
   Dataset* LoadFromBinFile(const char* data_filename, const char* bin_filename, int rank, int num_machines, int* num_global_data, std::vector<data_size_t>* used_data_indices);
 
   void SetHeader(const char* filename);
@@ -77,4 +75,4 @@ private:
 
 }
 
-#endif // LIGHTGBM_DATASET_LOADER_H_
+#endif  // LIGHTGBM_DATASET_LOADER_H_

--- a/include/LightGBM/export.h
+++ b/include/LightGBM/export.h
@@ -14,7 +14,7 @@
 #define LIGHTGBM_EXPORT __declspec(dllexport)
 #define LIGHTGBM_C_EXPORT LIGHTGBM_EXTERN_C __declspec(dllexport)
 #else
-#define LIGHTGBM_EXPORT 
+#define LIGHTGBM_EXPORT
 #define LIGHTGBM_C_EXPORT LIGHTGBM_EXTERN_C
 #endif
 

--- a/include/LightGBM/feature_group.h
+++ b/include/LightGBM/feature_group.h
@@ -145,7 +145,7 @@ public:
     uint32_t default_bin = bin_mappers_[sub_feature]->GetDefaultBin();
     return bin_data_->GetIterator(min_bin, max_bin, default_bin);
   }
-  
+
   /*!
    * \brief Returns a BinIterator that can access the entire feature group's raw data.
    *        The RawGet() function of the iterator should be called for best efficiency.
@@ -176,7 +176,6 @@ public:
     } else {
       return bin_data_->SplitCategorical(min_bin, max_bin, default_bin, threshold, num_threshold, data_indices, num_data, lte_indices, gt_indices);
     }
-
   }
   /*!
   * \brief From bin to feature value

--- a/include/LightGBM/json11.hpp
+++ b/include/LightGBM/json11.hpp
@@ -57,7 +57,7 @@
 #include <initializer_list>
 
 #ifdef _MSC_VER
-    #if _MSC_VER <= 1800 // VS 2013
+    #if _MSC_VER <= 1800  // VS 2013
         #ifndef noexcept
             #define noexcept throw()
         #endif
@@ -88,18 +88,18 @@ public:
     typedef std::map<std::string, Json> object;
 
     // Constructors for the various types of JSON value.
-    Json() noexcept;                // NUL
-    Json(std::nullptr_t) noexcept;  // NUL
-    Json(double value);             // NUMBER
-    Json(int value);                // NUMBER
-    Json(bool value);               // BOOL
-    Json(const std::string &value); // STRING
-    Json(std::string &&value);      // STRING
-    Json(const char * value);       // STRING
-    Json(const array &values);      // ARRAY
-    Json(array &&values);           // ARRAY
-    Json(const object &values);     // OBJECT
-    Json(object &&values);          // OBJECT
+    Json() noexcept;                 // NUL
+    Json(std::nullptr_t) noexcept;   // NUL
+    Json(double value);              // NUMBER
+    Json(int value);                 // NUMBER
+    Json(bool value);                // BOOL
+    Json(const std::string &value);  // STRING
+    Json(std::string &&value);       // STRING
+    Json(const char * value);        // STRING
+    Json(const array &values);       // ARRAY
+    Json(array &&values);            // ARRAY
+    Json(const object &values);      // OBJECT
+    Json(object &&values);           // OBJECT
 
     // Implicit constructor: anything with a to_json() function.
     template <class T, class = decltype(&T::to_json)>
@@ -229,4 +229,4 @@ protected:
     virtual ~JsonValue() {}
 };
 
-} // namespace json11
+}  // namespace json11

--- a/include/LightGBM/lightgbm_R.h
+++ b/include/LightGBM/lightgbm_R.h
@@ -242,7 +242,7 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCreateFromModelfile_R(LGBM_SE filename,
 LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterLoadModelFromString_R(LGBM_SE model_str,
   LGBM_SE out,
   LGBM_SE call_state);
-  
+
 /*!
 * \brief Merge model in two boosters to first handle
 * \param handle handle, will merge other handle to this
@@ -522,4 +522,4 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterDumpModel_R(LGBM_SE handle,
   LGBM_SE out_str,
   LGBM_SE call_state);
 
-#endif // LIGHTGBM_R_H_
+#endif  // LIGHTGBM_R_H_

--- a/include/LightGBM/metric.h
+++ b/include/LightGBM/metric.h
@@ -51,7 +51,6 @@ public:
   * \param config Config for metric
   */
   LIGHTGBM_EXPORT static Metric* CreateMetric(const std::string& type, const Config& config);
-
 };
 
 /*!
@@ -59,7 +58,6 @@ public:
 */
 class DCGCalculator {
 public:
-  
   static void DefaultEvalAt(std::vector<int>* eval_at);
   static void DefaultLabelGain(std::vector<double>* label_gain);
   /*!

--- a/include/LightGBM/network.h
+++ b/include/LightGBM/network.h
@@ -257,7 +257,6 @@ public:
   }
 
 private:
-
   static void AllgatherBruck(char* input, const comm_size_t* block_start, const comm_size_t* block_len, char* output, comm_size_t all_size);
 
   static void AllgatherRecursiveDoubling(char* input, const comm_size_t* block_start, const comm_size_t* block_len, char* output, comm_size_t all_size);

--- a/include/LightGBM/prediction_early_stop.h
+++ b/include/LightGBM/prediction_early_stop.h
@@ -29,4 +29,4 @@ LIGHTGBM_EXPORT PredictionEarlyStopInstance CreatePredictionEarlyStopInstance(co
 
 }   // namespace LightGBM
 
-#endif // LIGHTGBM_PREDICTION_EARLY_STOP_H_
+#endif  // LIGHTGBM_PREDICTION_EARLY_STOP_H_

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -204,7 +204,6 @@ public:
   void RecomputeMaxDepth();
 
 private:
-
   std::string NumericalDecisionIfElse(int node) const;
 
   std::string CategoricalDecisionIfElse(int node) const;
@@ -332,7 +331,7 @@ private:
     PathElement(int i, double z, double o, double w) : feature_index(i), zero_fraction(z), one_fraction(o), pweight(w) {}
   };
 
-  /*! \brief Polynomial time algorithm for SHAP values (https://arxiv.org/abs/1706.06060) */
+  /*! \brief Polynomial time algorithm for SHAP values (https://arxiv.org/abs/1706.06060)*/
   void TreeSHAP(const double *feature_values, double *phi,
                 int node, int unique_depth,
                 PathElement *parent_unique_path, double parent_zero_fraction,

--- a/include/LightGBM/tree_learner.h
+++ b/include/LightGBM/tree_learner.h
@@ -47,7 +47,7 @@ public:
   * \param is_constant_hessian True if all hessians share the same value
   * \return A trained tree
   */
-  virtual Tree* Train(const score_t* gradients, const score_t* hessians, bool is_constant_hessian, 
+  virtual Tree* Train(const score_t* gradients, const score_t* hessians, bool is_constant_hessian,
                       Json& forced_split_json) = 0;
 
   /*!

--- a/include/LightGBM/utils/array_args.h
+++ b/include/LightGBM/utils/array_args.h
@@ -22,7 +22,7 @@ public:
     }
     int step = std::max(1, (static_cast<int>(array.size()) + num_threads - 1) / num_threads);
     std::vector<size_t> arg_maxs(num_threads, 0);
-    #pragma omp parallel for schedule(static,1)
+    #pragma omp parallel for schedule(static, 1)
     for (int i = 0; i < num_threads; ++i) {
       size_t start = step * i;
       if (start >= array.size()) { continue; }
@@ -124,7 +124,7 @@ public:
     for (int k = end - 2; k >= q; k--, i++) { std::swap(ref[i], ref[k]); }
     *l = j;
     *r = i;
-  };
+  }
 
   // Note: k refer to index here. e.g. k=0 means get the max number.
   inline static int ArgMaxAtK(std::vector<VAL_T>* arr, int start, int end, int k) {
@@ -184,7 +184,6 @@ public:
     }
     return true;
   }
-
 };
 
 }  // namespace LightGBM

--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -317,16 +317,16 @@ inline static unsigned CountDecimalDigit32(uint32_t n) {
 
 inline static void Uint32ToStr(uint32_t value, char* buffer) {
   const char kDigitsLut[200] = {
-    '0','0','0','1','0','2','0','3','0','4','0','5','0','6','0','7','0','8','0','9',
-    '1','0','1','1','1','2','1','3','1','4','1','5','1','6','1','7','1','8','1','9',
-    '2','0','2','1','2','2','2','3','2','4','2','5','2','6','2','7','2','8','2','9',
-    '3','0','3','1','3','2','3','3','3','4','3','5','3','6','3','7','3','8','3','9',
-    '4','0','4','1','4','2','4','3','4','4','4','5','4','6','4','7','4','8','4','9',
-    '5','0','5','1','5','2','5','3','5','4','5','5','5','6','5','7','5','8','5','9',
-    '6','0','6','1','6','2','6','3','6','4','6','5','6','6','6','7','6','8','6','9',
-    '7','0','7','1','7','2','7','3','7','4','7','5','7','6','7','7','7','8','7','9',
-    '8','0','8','1','8','2','8','3','8','4','8','5','8','6','8','7','8','8','8','9',
-    '9','0','9','1','9','2','9','3','9','4','9','5','9','6','9','7','9','8','9','9'
+    '0', '0', '0', '1', '0', '2', '0', '3', '0', '4', '0', '5', '0', '6', '0', '7', '0', '8', '0', '9',
+    '1', '0', '1', '1', '1', '2', '1', '3', '1', '4', '1', '5', '1', '6', '1', '7', '1', '8', '1', '9',
+    '2', '0', '2', '1', '2', '2', '2', '3', '2', '4', '2', '5', '2', '6', '2', '7', '2', '8', '2', '9',
+    '3', '0', '3', '1', '3', '2', '3', '3', '3', '4', '3', '5', '3', '6', '3', '7', '3', '8', '3', '9',
+    '4', '0', '4', '1', '4', '2', '4', '3', '4', '4', '4', '5', '4', '6', '4', '7', '4', '8', '4', '9',
+    '5', '0', '5', '1', '5', '2', '5', '3', '5', '4', '5', '5', '5', '6', '5', '7', '5', '8', '5', '9',
+    '6', '0', '6', '1', '6', '2', '6', '3', '6', '4', '6', '5', '6', '6', '6', '7', '6', '8', '6', '9',
+    '7', '0', '7', '1', '7', '2', '7', '3', '7', '4', '7', '5', '7', '6', '7', '7', '7', '8', '7', '9',
+    '8', '0', '8', '1', '8', '2', '8', '3', '8', '4', '8', '5', '8', '6', '8', '7', '8', '8', '8', '9',
+    '9', '0', '9', '1', '9', '2', '9', '3', '9', '4', '9', '5', '9', '6', '9', '7', '9', '8', '9', '9'
   };
   unsigned digit = CountDecimalDigit32(value);
   buffer += digit;
@@ -358,7 +358,7 @@ inline static void Int32ToStr(int32_t value, char* buffer) {
   Uint32ToStr(u, buffer);
 }
 
-inline static void DoubleToStr(double value, char* buffer, size_t 
+inline static void DoubleToStr(double value, char* buffer, size_t
                                #ifdef _MSC_VER
                                buffer_len
                                #endif
@@ -395,14 +395,14 @@ inline static std::vector<T2> ArrayCast(const std::vector<T>& arr) {
 
 template<typename T, bool is_float, bool is_unsign>
 struct __TToStringHelperFast {
-  void operator()(T value, char* buffer, size_t ) const {
+  void operator()(T value, char* buffer, size_t) const {
     Int32ToStr(value, buffer);
   }
 };
 
 template<typename T>
 struct __TToStringHelperFast<T, true, false> {
-  void operator()(T value, char* buffer, size_t 
+  void operator()(T value, char* buffer, size_t
                   #ifdef _MSC_VER
                   buf_len
                   #endif
@@ -417,7 +417,7 @@ struct __TToStringHelperFast<T, true, false> {
 
 template<typename T>
 struct __TToStringHelperFast<T, false, true> {
-  void operator()(T value, char* buffer, size_t ) const {
+  void operator()(T value, char* buffer, size_t) const {
     Uint32ToStr(value, buffer);
   }
 };
@@ -512,7 +512,7 @@ struct __StringToTHelperFast<T, true> {
   const char* operator()(const char*p, T* out) const {
     double tmp = 0.0f;
     auto ret = Atof(p, &tmp);
-    *out= static_cast<T>(tmp);
+    *out = static_cast<T>(tmp);
     return ret;
   }
 };
@@ -637,7 +637,6 @@ inline static void SortForPair(std::vector<T1>& keys, std::vector<T2>& values, s
     keys[i] = arr[i].first;
     values[i] = arr[i].second;
   }
-
 }
 
 template <typename T>
@@ -661,7 +660,7 @@ inline static std::vector<int> VectorSize(const std::vector<std::vector<T>>& dat
 inline static double AvoidInf(double x) {
   if (x >= 1e300) {
     return 1e300;
-  } else if(x <= -1e300) {
+  } else if (x <= -1e300) {
     return -1e300;
   } else {
     return x;
@@ -700,7 +699,7 @@ static void ParallelSort(_RanIt _First, _RanIt _Last, _Pr _Pred, _VTRanIt*) {
   size_t inner_size = (len + num_threads - 1) / num_threads;
   inner_size = std::max(inner_size, kMinInnerLen);
   num_threads = static_cast<int>((len + inner_size - 1) / inner_size);
-  #pragma omp parallel for schedule(static,1)
+  #pragma omp parallel for schedule(static, 1)
   for (int i = 0; i < num_threads; ++i) {
     size_t left = inner_size*i;
     size_t right = left + inner_size;
@@ -716,7 +715,7 @@ static void ParallelSort(_RanIt _First, _RanIt _Last, _Pr _Pred, _VTRanIt*) {
   // Recursive merge
   while (s < len) {
     int loop_size = static_cast<int>((len + s * 2 - 1) / (s * 2));
-    #pragma omp parallel for schedule(static,1)
+    #pragma omp parallel for schedule(static, 1)
     for (int i = 0; i < loop_size; ++i) {
       size_t left = i * 2 * s;
       size_t mid = left + s;
@@ -738,7 +737,7 @@ static void ParallelSort(_RanIt _First, _RanIt _Last, _Pr _Pred) {
 // Check that all y[] are in interval [ymin, ymax] (end points included); throws error if not
 template <typename T>
 inline static void CheckElementsIntervalClosed(const T *y, T ymin, T ymax, int ny, const char *callername) {
-  auto fatal_msg = [&y, &ymin, &ymax, &callername](int i) { 
+  auto fatal_msg = [&y, &ymin, &ymax, &callername](int i) {
     std::ostringstream os;
     os << "[%s]: does not tolerate element [#%i = " << y[i] << "] outside [" << ymin << ", " << ymax << "]";
     Log::Fatal(os.str().c_str(), callername, i);
@@ -758,7 +757,7 @@ inline static void CheckElementsIntervalClosed(const T *y, T ymin, T ymax, int n
       }
     }
   }
-  if (ny & 1) { // odd
+  if (ny & 1) {  // odd
     if (y[ny - 1] < ymin || y[ny - 1] > ymax) {
       fatal_msg(ny - 1);
     }
@@ -773,12 +772,12 @@ inline static void ObtainMinMaxSum(const T1 *w, int nw, T1 *mi, T1 *ma, T2 *su) 
   T1 maxw;
   T1 sumw;
   int i;
-  if (nw & 1) { // odd
+  if (nw & 1) {  // odd
     minw = w[0];
     maxw = w[0];
     sumw = w[0];
     i = 2;
-  } else { // even
+  } else {  // even
     if (w[0] < w[1]) {
       minw = w[0];
       maxw = w[1];

--- a/include/LightGBM/utils/file_io.h
+++ b/include/LightGBM/utils/file_io.h
@@ -7,13 +7,13 @@
 #include <cstdlib>
 #include <cstring>
 
-namespace LightGBM{
+namespace LightGBM {
 
 /*!
  * \brief An interface for writing files from buffers
  */
 struct VirtualFileWriter {
-  virtual ~VirtualFileWriter() {};
+  virtual ~VirtualFileWriter() {}
   /*!
    * \brief Initialize the writer
    * \return True when the file is available for writes
@@ -48,7 +48,7 @@ struct VirtualFileReader {
    * \brief Constructor
    * \param filename Filename of the data
    */
-  virtual ~VirtualFileReader() {};
+  virtual ~VirtualFileReader() {}
   /*!
    * \brief Initialize the reader
    * \return True when the file is available for read

--- a/include/LightGBM/utils/log.h
+++ b/include/LightGBM/utils/log.h
@@ -12,7 +12,7 @@
 namespace LightGBM {
 
 #if defined(_MSC_VER)
-#define THREAD_LOCAL __declspec(thread) 
+#define THREAD_LOCAL __declspec(thread)
 #else
 #define THREAD_LOCAL thread_local
 #endif
@@ -84,7 +84,6 @@ public:
   }
 
 private:
-
   static void Write(LogLevel level, const char* level_str, const char *format, va_list val) {
     if (level <= GetLevel()) {  // omit the message with low level
       // write to STDOUT
@@ -98,7 +97,6 @@ private:
   // a trick to use static variable in header file.
   // May be not good, but avoid to use an additional cpp file
   static LogLevel& GetLevel() { static THREAD_LOCAL LogLevel level = LogLevel::Info; return level; }
-
 };
 
 }  // namespace LightGBM

--- a/include/LightGBM/utils/openmp_wrapper.h
+++ b/include/LightGBM/utils/openmp_wrapper.h
@@ -12,11 +12,11 @@
 
 class ThreadExceptionHelper {
 public:
-  ThreadExceptionHelper() { 
-    ex_ptr_ = nullptr; 
+  ThreadExceptionHelper() {
+    ex_ptr_ = nullptr;
   }
 
-  ~ThreadExceptionHelper() { 
+  ~ThreadExceptionHelper() {
     ReThrow();
   }
   void ReThrow() {
@@ -38,7 +38,6 @@ private:
 
 #define OMP_INIT_EX() ThreadExceptionHelper omp_except_helper
 #define OMP_LOOP_EX_BEGIN() try {
-
 #define OMP_LOOP_EX_END() } \
 catch(std::exception& ex) { Log::Warning(ex.what()); omp_except_helper.CaptureException(); } \
 catch(...) { omp_except_helper.CaptureException();  }
@@ -47,7 +46,7 @@ catch(...) { omp_except_helper.CaptureException();  }
 #else
 
 #ifdef _MSC_VER
-  #pragma warning( disable : 4068 ) // disable unknown pragma warning
+  #pragma warning(disable: 4068)  // disable unknown pragma warning
 #endif
 
 #ifdef __cplusplus
@@ -61,7 +60,7 @@ catch(...) { omp_except_helper.CaptureException();  }
   inline int omp_get_num_threads() {return 1;}
   inline int omp_get_thread_num() {return 0;}
 #ifdef __cplusplus
-}; // extern "C"
+};  // extern "C"
 #endif
 
 #define OMP_INIT_EX()

--- a/include/LightGBM/utils/pipeline_reader.h
+++ b/include/LightGBM/utils/pipeline_reader.h
@@ -12,7 +12,7 @@
 #include <vector>
 #include "file_io.h"
 
-namespace LightGBM{
+namespace LightGBM {
 
 /*!
 * \brief A pipeline file reader, use 2 threads, one read block from file, the other process the block
@@ -24,13 +24,13 @@ public:
   * \param filename Filename of data
   * \process_fun Process function
   */
-  static size_t Read(const char* filename, int skip_bytes, const std::function<size_t (const char*, size_t)>& process_fun) {
+  static size_t Read(const char* filename, int skip_bytes, const std::function<size_t(const char*, size_t)>& process_fun) {
     auto reader = VirtualFileReader::Make(filename);
     if (!reader->Init()) {
       return 0;
     }
     size_t cnt = 0;
-    const size_t buffer_size =  16 * 1024 * 1024 ;
+    const size_t buffer_size =  16 * 1024 * 1024;
     // buffer used for the process_fun
     auto buffer_process = std::vector<char>(buffer_size);
     // buffer used for the file reading
@@ -49,8 +49,7 @@ public:
       std::thread read_worker = std::thread(
         [&] {
         last_read_cnt = reader->Read(buffer_read.data(), buffer_size);
-      }
-      );
+      });
       // start process
       cnt += process_fun(buffer_process.data(), read_cnt);
       // wait for read thread
@@ -61,7 +60,6 @@ public:
     }
     return cnt;
   }
-
 };
 
 }  // namespace LightGBM

--- a/include/LightGBM/utils/random.h
+++ b/include/LightGBM/utils/random.h
@@ -93,6 +93,7 @@ public:
     }
     return ret;
   }
+
 private:
   inline int RandInt16() {
     x = (214013 * x + 2531011);

--- a/include/LightGBM/utils/text_reader.h
+++ b/include/LightGBM/utils/text_reader.h
@@ -26,7 +26,7 @@ public:
   * \param is_skip_first_line True if need to skip header
   */
   TextReader(const char* filename, bool is_skip_first_line):
-    filename_(filename), is_skip_first_line_(is_skip_first_line){
+    filename_(filename), is_skip_first_line_(is_skip_first_line) {
     if (is_skip_first_line_) {
       auto reader = VirtualFileReader::Make(filename);
       if (!reader->Init()) {
@@ -210,7 +210,7 @@ public:
         }
         else {
           const size_t idx = static_cast<size_t>(random.NextInt(0, static_cast<int>(out_used_data_indices->size())));
-          if (idx < static_cast<size_t>(sample_cnt) ) {
+          if (idx < static_cast<size_t>(sample_cnt)) {
             out_sampled_data->operator[](idx) = std::string(buffer, size);
           }
         }
@@ -225,7 +225,7 @@ public:
     });
   }
 
-  INDEX_T ReadAllAndProcessParallelWithFilter(const std::function<void(INDEX_T, const std::vector<std::string>&)>& process_fun, const std::function<bool(INDEX_T,INDEX_T)>& filter_fun) {
+  INDEX_T ReadAllAndProcessParallelWithFilter(const std::function<void(INDEX_T, const std::vector<std::string>&)>& process_fun, const std::function<bool(INDEX_T, INDEX_T)>& filter_fun) {
     last_line_ = "";
     INDEX_T total_cnt = 0;
     INDEX_T used_cnt = 0;
@@ -296,7 +296,7 @@ public:
 
   INDEX_T ReadPartAndProcessParallel(const std::vector<INDEX_T>& used_data_indices, const std::function<void(INDEX_T, const std::vector<std::string>&)>& process_fun) {
     return ReadAllAndProcessParallelWithFilter(process_fun,
-      [&used_data_indices](INDEX_T used_cnt ,INDEX_T total_cnt) {
+      [&used_data_indices](INDEX_T used_cnt, INDEX_T total_cnt) {
       if (static_cast<size_t>(used_cnt) < used_data_indices.size() && total_cnt == used_data_indices[used_cnt]) {
         return true;
       }
@@ -314,7 +314,7 @@ private:
   /*! \brief Buffer for last line */
   std::string last_line_;
   /*! \brief first line */
-  std::string first_line_="";
+  std::string first_line_ = "";
   /*! \brief is skip first line */
   bool is_skip_first_line_ = false;
   /*! \brief is skip first line */

--- a/include/LightGBM/utils/threading.h
+++ b/include/LightGBM/utils/threading.h
@@ -10,7 +10,6 @@ namespace LightGBM {
 
 class Threading {
 public:
-
   template<typename INDEX_T>
   static inline void For(INDEX_T start, INDEX_T end, const std::function<void(int, INDEX_T, INDEX_T)>& inner_fun) {
     int num_threads = 1;
@@ -22,7 +21,7 @@ public:
     INDEX_T num_inner = (end - start + num_threads - 1) / num_threads;
     if (num_inner <= 0) { num_inner = 1; }
     OMP_INIT_EX();
-    #pragma omp parallel for schedule(static,1)
+    #pragma omp parallel for schedule(static, 1)
     for (int i = 0; i < num_threads; ++i) {
       OMP_LOOP_EX_BEGIN();
       INDEX_T inner_start = start + num_inner * i;

--- a/src/application/application.cpp
+++ b/src/application/application.cpp
@@ -136,8 +136,7 @@ void Application::LoadData() {
         dataset_loader.LoadFromFileAlignWithOtherDataset(
           config_.valid[i].c_str(),
           config_.valid_data_initscores[i].c_str(),
-          train_data_.get())
-        );
+          train_data_.get()));
       valid_datas_.push_back(std::move(new_dataset));
       // need save binary file
       if (config_.save_binary) {
@@ -212,7 +211,6 @@ void Application::Train() {
 }
 
 void Application::Predict() {
-
   if (config_.task == TaskType::KRefitTree) {
     // create predictor
     Predictor predictor(boosting_.get(), -1, false, true, false, false, 1, 1);

--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -35,7 +35,6 @@ public:
   Predictor(Boosting* boosting, int num_iteration,
             bool is_raw_score, bool predict_leaf_index, bool predict_contrib,
             bool early_stop, int early_stop_freq, double early_stop_margin) {
-
     early_stop_ = CreatePredictionEarlyStopInstance("none", LightGBM::PredictionEarlyStopConfig());
     if (early_stop && !boosting->NeedAccuratePrediction()) {
       PredictionEarlyStopConfig pred_early_stop_config;
@@ -76,16 +75,16 @@ public:
         }
       };
     } else if (predict_contrib) {
-	    predict_fun_ = [=](const std::vector<std::pair<int, double>>& features, double* output) {
-	      int tid = omp_get_thread_num();
-			CopyToPredictBuffer(predict_buf_[tid].data(), features);
+        predict_fun_ = [=](const std::vector<std::pair<int, double>>& features, double* output) {
+          int tid = omp_get_thread_num();
+          CopyToPredictBuffer(predict_buf_[tid].data(), features);
           // get result for leaf index
           boosting_->PredictContrib(predict_buf_[tid].data(), output, &early_stop_);
           ClearPredictBuffer(predict_buf_[tid].data(), predict_buf_[tid].size(), features);
         };
     } else {
       if (is_raw_score) {
-		predict_fun_ = [=](const std::vector<std::pair<int, double>>& features, double* output) {
+        predict_fun_ = [=](const std::vector<std::pair<int, double>>& features, double* output) {
           int tid = omp_get_thread_num();
           if (num_feature_ > kFeatureThreshold && features.size() < KSparseThreshold) {
             auto buf = CopyToPredictMap(features);
@@ -97,7 +96,7 @@ public:
           }
         };
       } else {
-		predict_fun_ = [=](const std::vector<std::pair<int, double>>& features, double* output) {
+        predict_fun_ = [=](const std::vector<std::pair<int, double>>& features, double* output) {
           int tid = omp_get_thread_num();
           if (num_feature_ > kFeatureThreshold && features.size() < KSparseThreshold) {
             auto buf = CopyToPredictMap(features);
@@ -173,7 +172,7 @@ public:
             (*feature)[i].first = feature_names_map_[(*feature)[i].first];
             ++i;
           } else {
-            //move the non-used features to the end of the feature vector
+            // move the non-used features to the end of the feature vector
             std::swap((*feature)[i], (*feature)[--j]);
           }
         }
@@ -181,8 +180,8 @@ public:
       }
     };
 
-	std::function<void(data_size_t, const std::vector<std::string>&)> process_fun = [&]
-	(data_size_t, const std::vector<std::string>& lines) {
+    std::function<void(data_size_t, const std::vector<std::string>&)> process_fun = [&]
+    (data_size_t, const std::vector<std::string>& lines) {
       std::vector<std::pair<int, double>> oneline_features;
       std::vector<std::string> result_to_write(lines.size());
       OMP_INIT_EX();
@@ -209,7 +208,6 @@ public:
   }
 
 private:
-
   void CopyToPredictBuffer(double* pred_buf, const std::vector<std::pair<int, double>>& features) {
     int loop_size = static_cast<int>(features.size());
     for (int i = 0; i < loop_size; ++i) {

--- a/src/boosting/dart.hpp
+++ b/src/boosting/dart.hpp
@@ -78,7 +78,7 @@ public:
     *out_len = static_cast<int64_t>(train_score_updater_->num_data()) * num_class_;
     return train_score_updater_->score();
   }
-  
+
   bool EvalAndCheckEarlyStopping() override {
     GBDT::OutputMetric(iter_);
     return false;

--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -30,7 +30,6 @@ num_iteration_for_pred_(0),
 shrinkage_rate_(0.1f),
 num_init_iteration_(0),
 need_re_bagging_(false) {
-
   #pragma omp parallel
   #pragma omp master
   {
@@ -41,7 +40,6 @@ need_re_bagging_(false) {
 }
 
 GBDT::~GBDT() {
-
 }
 
 void GBDT::Init(const Config* config, const Dataset* train_data, const ObjectiveFunction* objective_function,
@@ -57,7 +55,7 @@ void GBDT::Init(const Config* config, const Dataset* train_data, const Objective
   shrinkage_rate_ = config_->learning_rate;
 
   std::string forced_splits_path = config->forcedsplits_filename;
-  //load forced_splits file
+  // load forced_splits file
   if (forced_splits_path != "") {
       std::ifstream forced_splits_file(forced_splits_path.c_str());
       std::stringstream buffer;
@@ -188,7 +186,7 @@ void GBDT::Bagging(int iter) {
     data_size_t inner_size = (num_data_ + num_threads_ - 1) / num_threads_;
     if (inner_size < min_inner_size) { inner_size = min_inner_size; }
     OMP_INIT_EX();
-    #pragma omp parallel for schedule(static,1)
+    #pragma omp parallel for schedule(static, 1)
     for (int i = 0; i < num_threads_; ++i) {
       OMP_LOOP_EX_BEGIN();
       left_cnts_buf_[i] = 0;
@@ -451,7 +449,6 @@ bool GBDT::EvalAndCheckEarlyStopping() {
 }
 
 void GBDT::UpdateScore(const Tree* tree, const int cur_tree_id) {
-
   // update training score
   if (!is_use_subset_) {
     train_score_updater_->AddScore(tree_learner_.get(), tree, cur_tree_id);
@@ -624,7 +621,6 @@ void GBDT::GetPredictAt(int data_idx, double* out_result, int64_t* out_len) {
 
 void GBDT::ResetTrainingData(const Dataset* train_data, const ObjectiveFunction* objective_function,
                              const std::vector<const Metric*>& training_metrics) {
-
   if (train_data != train_data_ && !train_data_->CheckAlign(*train_data)) {
     Log::Fatal("Cannot reset training data, since new training data has different bin mappers");
   }

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -25,7 +25,6 @@ namespace LightGBM {
 */
 class GBDT : public GBDTBase {
 public:
-
   /*!
   * \brief Constructor
   */
@@ -212,7 +211,7 @@ public:
         num_preb_in_one_row *= max_iteration;
       }
     } else if (is_pred_contrib) {
-      num_preb_in_one_row = num_tree_per_iteration_ * (max_feature_idx_ + 2); // +1 for 0-based indexing, +1 for baseline
+      num_preb_in_one_row = num_tree_per_iteration_ * (max_feature_idx_ + 2);  // +1 for 0-based indexing, +1 for baseline
     }
     return num_preb_in_one_row;
   }
@@ -356,7 +355,6 @@ public:
   virtual const char* SubModelName() const override { return "tree"; }
 
 protected:
-
   /*!
   * \brief Print eval result and check early stopping
   */
@@ -488,7 +486,6 @@ protected:
   std::string loaded_parameter_;
 
   Json forced_splits_json_;
-
 };
 
 }  // namespace LightGBM

--- a/src/boosting/gbdt_model_text.cpp
+++ b/src/boosting/gbdt_model_text.cpp
@@ -194,7 +194,7 @@ std::string GBDT::ModelToIfElse(int num_iteration) const {
   str_buf << "\t" << "}" << '\n';
   str_buf << "}" << '\n';
 
-  //PredictLeafIndexByMap
+  // PredictLeafIndexByMap
   str_buf << "double (*PredictTreeLeafByMapPtr[])(const std::unordered_map<int, double>&) = { ";
   for (int i = 0; i < num_used_model; ++i) {
     if (i > 0) {
@@ -511,7 +511,6 @@ bool GBDT::LoadModelFromString(const char* buffer, size_t len) {
 }
 
 std::vector<double> GBDT::FeatureImportance(int num_iteration, int importance_type) const {
-
   int num_used_model = static_cast<int>(models_.size());
   if (num_iteration > 0) {
     num_iteration += 0;

--- a/src/boosting/goss.hpp
+++ b/src/boosting/goss.hpp
@@ -29,7 +29,6 @@ public:
   * \brief Constructor
   */
   GOSS() : GBDT() {
-
   }
 
   ~GOSS() {
@@ -86,7 +85,7 @@ public:
   }
 
   data_size_t BaggingHelper(Random& cur_rand, data_size_t start, data_size_t cnt, data_size_t* buffer, data_size_t* buffer_right) {
-    if (cnt <= 0) { 
+    if (cnt <= 0) {
       return 0;
     }
     std::vector<score_t> tmp_gradients(cnt, 0.0f);

--- a/src/boosting/prediction_early_stop.cpp
+++ b/src/boosting/prediction_early_stop.cpp
@@ -15,7 +15,7 @@ PredictionEarlyStopInstance CreateNone(const PredictionEarlyStopConfig&) {
     [](const double*, int) {
     return false;
   },
-    std::numeric_limits<int>::max() // make sure the lambda is almost never called
+    std::numeric_limits<int>::max()  // make sure the lambda is almost never called
   };
 }
 
@@ -69,7 +69,7 @@ PredictionEarlyStopInstance CreateBinary(const PredictionEarlyStopConfig& config
   };
 }
 
-}
+}  // namespace
 
 namespace LightGBM {
 
@@ -86,4 +86,4 @@ PredictionEarlyStopInstance CreatePredictionEarlyStopInstance(const std::string&
   }
 }
 
-}
+}  // namespace LightGBM

--- a/src/boosting/rf.hpp
+++ b/src/boosting/rf.hpp
@@ -17,7 +17,6 @@ namespace LightGBM {
 */
 class RF : public GBDT {
 public:
-
   RF() : GBDT() {
     average_output_ = true;
   }
@@ -106,7 +105,6 @@ public:
       std::unique_ptr<Tree> new_tree(new Tree(2));
       size_t bias = static_cast<size_t>(cur_tree_id)* num_data_;
       if (class_need_train_[cur_tree_id]) {
-
         auto grad = gradients + bias;
         auto hess = hessians + bias;
 
@@ -202,12 +200,10 @@ public:
   };
 
 private:
-
   std::vector<score_t> tmp_grad_;
   std::vector<score_t> tmp_hess_;
   std::vector<double> init_scores_;
-
 };
 
 }  // namespace LightGBM
-#endif   // LIGHTGBM_BOOSTING_RF_H_
+#endif  // LIGHTGBM_BOOSTING_RF_H_

--- a/src/boosting/score_updater.hpp
+++ b/src/boosting/score_updater.hpp
@@ -46,7 +46,6 @@ public:
   }
   /*! \brief Destructor */
   ~ScoreUpdater() {
-
   }
 
   inline bool has_init_score() const { return has_init_score_; }
@@ -109,6 +108,7 @@ public:
   ScoreUpdater& operator=(const ScoreUpdater&) = delete;
   /*! \brief Disable copy */
   ScoreUpdater(const ScoreUpdater&) = delete;
+
 private:
   /*! \brief Number of total data */
   data_size_t num_data_;

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -37,7 +37,6 @@ inline int LGBM_APIHandleException(const std::string& ex) {
 }
 
 #define API_BEGIN() try {
-
 #define API_END() } \
 catch(std::exception& ex) { return LGBM_APIHandleException(ex); } \
 catch(std::string& ex) { return LGBM_APIHandleException(ex); } \
@@ -77,7 +76,6 @@ public:
     }
     boosting_->Init(&config_, train_data_, objective_fun_.get(),
                     Common::ConstPtrInVectorWrapper<Metric>(train_metric_));
-
   }
 
   void MergeFrom(const Booster* other) {
@@ -86,7 +84,6 @@ public:
   }
 
   ~Booster() {
-
   }
 
   void CreateObjectiveAndMetrics() {
@@ -158,7 +155,6 @@ public:
     }
 
     boosting_->ResetConfig(&config_);
-
   }
 
   void AddValidData(const Dataset* valid_data) {
@@ -275,7 +271,7 @@ public:
     return boosting_->SaveModelToString(start_iteration, num_iteration);
   }
 
-  std::string DumpModel(int start_iteration,int num_iteration) {
+  std::string DumpModel(int start_iteration, int num_iteration) {
     return boosting_->DumpModel(start_iteration, num_iteration);
   }
 
@@ -328,7 +324,6 @@ public:
   const Boosting* GetBoosting() const { return boosting_.get(); }
 
 private:
-
   const Dataset* train_data_;
   std::unique_ptr<Boosting> boosting_;
   /*! \brief All configs */
@@ -343,7 +338,7 @@ private:
   std::mutex mutex_;
 };
 
-}
+}  // namespace LightGBM
 
 using namespace LightGBM;
 
@@ -394,7 +389,7 @@ int LGBM_DatasetCreateFromFile(const char* filename,
   if (config.num_threads > 0) {
     omp_set_num_threads(config.num_threads);
   }
-  DatasetLoader loader(config,nullptr, 1, filename);
+  DatasetLoader loader(config, nullptr, 1, filename);
   if (reference == nullptr) {
     if (Network::num_machines() == 1) {
       *out = loader.LoadFromFile(filename, "");
@@ -545,7 +540,7 @@ int LGBM_DatasetCreateFromMats(int32_t nmat,
   for (int j = 0; j < nmat; ++j) {
     get_row_fun.push_back(RowFunctionFromDenseMatric(data[j], nrow[j], ncol, data_type, is_row_major));
   }
-  
+
   if (reference == nullptr) {
     // sample data first
     Random rand(config.data_random_seed);
@@ -563,7 +558,7 @@ int LGBM_DatasetCreateFromMats(int32_t nmat,
         offset += nrow[j];
         ++j;
       }
-      
+
       auto row = get_row_fun[j](static_cast<int>(idx - offset));
       for (size_t k = 0; k < row.size(); ++k) {
         if (std::fabs(row[k]) > kZeroThreshold || std::isnan(row[k])) {
@@ -1249,7 +1244,7 @@ int LGBM_BoosterSaveModel(BoosterHandle handle,
 int LGBM_BoosterSaveModelToString(BoosterHandle handle,
                                   int start_iteration,
                                   int num_iteration,
-                                  int64_t buffer_len, 
+                                  int64_t buffer_len,
                                   int64_t* out_len,
                                   char* out_str) {
   API_BEGIN();

--- a/src/io/bin.cpp
+++ b/src/io/bin.cpp
@@ -44,7 +44,6 @@ namespace LightGBM {
   }
 
   BinMapper::~BinMapper() {
-
   }
 
   bool NeedFilter(const std::vector<int>& cnt_in_bin, int total_cnt, int filter_cnt, BinType bin_type) {

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -19,7 +19,7 @@ void Config::KV2Map(std::unordered_map<std::string, std::string>& params, const 
     std::string value = Common::RemoveQuotationSymbol(Common::Trim(tmp_strs[1]));
     if (key.size() > 0) {
       auto value_search = params.find(key);
-      if (value_search == params.end()) { // not set
+      if (value_search == params.end()) {  // not set
         params.emplace(key, value);
       } else {
         Log::Warning("%s is set=%s, %s=%s will be ignored. Current value: %s=%s",
@@ -151,7 +151,6 @@ void GetTreeLearnerType(const std::unordered_map<std::string, std::string>& para
 }
 
 void Config::Set(const std::unordered_map<std::string, std::string>& params) {
-
   // generate seeds by seed.
   if (GetInt(params, "seed", &seed)) {
     Random rand(seed);
@@ -202,10 +201,10 @@ bool CheckMultiClassObjective(const std::string& objective) {
 void Config::CheckParamConflict() {
   // check if objective, metric, and num_class match
   int num_class_check = num_class;
-  bool objective_custom = objective == std::string("none") || objective == std::string("null") 
+  bool objective_custom = objective == std::string("none") || objective == std::string("null")
                                        || objective == std::string("custom") || objective == std::string("na");
   bool objective_type_multiclass = CheckMultiClassObjective(objective) || (objective_custom && num_class_check > 1);
-  
+
   if (objective_type_multiclass) {
     if (num_class_check <= 1) {
       Log::Fatal("Number of classes should be specified and greater than 1 for multiclass training");
@@ -216,7 +215,7 @@ void Config::CheckParamConflict() {
     }
   }
   for (std::string metric_type : metric) {
-    bool metric_custom_or_none = metric_type == std::string("none") || metric_type == std::string("null") 
+    bool metric_custom_or_none = metric_type == std::string("none") || metric_type == std::string("null")
                                  || metric_type == std::string("custom") || metric_type == std::string("na");
     bool metric_type_multiclass = (CheckMultiClassObjective(metric_type)
                                    || metric_type == std::string("multi_logloss")
@@ -259,7 +258,7 @@ void Config::CheckParamConflict() {
   // Check max_depth and num_leaves
   if (max_depth > 0) {
     int full_num_leaves = static_cast<int>(std::pow(2, max_depth));
-    if (full_num_leaves > num_leaves 
+    if (full_num_leaves > num_leaves
         && num_leaves == kDefaultNumLeaves) {
       Log::Warning("Accuracy may be bad since you didn't set num_leaves and 2^max_depth > num_leaves");
     }

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -524,7 +524,7 @@ void Config::GetMembersFromString(const std::unordered_map<std::string, std::str
 std::string Config::SaveMembersToString() const {
   std::stringstream str_buf;
   str_buf << "[data: " << data << "]\n";
-  str_buf << "[valid: " << Common::Join(valid,",") << "]\n";
+  str_buf << "[valid: " << Common::Join(valid, ",") << "]\n";
   str_buf << "[num_iterations: " << num_iterations << "]\n";
   str_buf << "[learning_rate: " << learning_rate << "]\n";
   str_buf << "[num_leaves: " << num_leaves << "]\n";
@@ -556,8 +556,8 @@ std::string Config::SaveMembersToString() const {
   str_buf << "[cat_smooth: " << cat_smooth << "]\n";
   str_buf << "[max_cat_to_onehot: " << max_cat_to_onehot << "]\n";
   str_buf << "[top_k: " << top_k << "]\n";
-  str_buf << "[monotone_constraints: " << Common::Join(Common::ArrayCast<int8_t, int>(monotone_constraints),",") << "]\n";
-  str_buf << "[feature_contri: " << Common::Join(feature_contri,",") << "]\n";
+  str_buf << "[monotone_constraints: " << Common::Join(Common::ArrayCast<int8_t, int>(monotone_constraints), ",") << "]\n";
+  str_buf << "[feature_contri: " << Common::Join(feature_contri, ",") << "]\n";
   str_buf << "[forcedsplits_filename: " << forcedsplits_filename << "]\n";
   str_buf << "[refit_decay_rate: " << refit_decay_rate << "]\n";
   str_buf << "[verbosity: " << verbosity << "]\n";
@@ -571,7 +571,7 @@ std::string Config::SaveMembersToString() const {
   str_buf << "[input_model: " << input_model << "]\n";
   str_buf << "[output_result: " << output_result << "]\n";
   str_buf << "[initscore_filename: " << initscore_filename << "]\n";
-  str_buf << "[valid_data_initscores: " << Common::Join(valid_data_initscores,",") << "]\n";
+  str_buf << "[valid_data_initscores: " << Common::Join(valid_data_initscores, ",") << "]\n";
   str_buf << "[pre_partition: " << pre_partition << "]\n";
   str_buf << "[enable_bundle: " << enable_bundle << "]\n";
   str_buf << "[max_conflict_rate: " << max_conflict_rate << "]\n";
@@ -608,10 +608,10 @@ std::string Config::SaveMembersToString() const {
   str_buf << "[poisson_max_delta_step: " << poisson_max_delta_step << "]\n";
   str_buf << "[tweedie_variance_power: " << tweedie_variance_power << "]\n";
   str_buf << "[max_position: " << max_position << "]\n";
-  str_buf << "[label_gain: " << Common::Join(label_gain,",") << "]\n";
+  str_buf << "[label_gain: " << Common::Join(label_gain, ",") << "]\n";
   str_buf << "[metric_freq: " << metric_freq << "]\n";
   str_buf << "[is_provide_training_metric: " << is_provide_training_metric << "]\n";
-  str_buf << "[eval_at: " << Common::Join(eval_at,",") << "]\n";
+  str_buf << "[eval_at: " << Common::Join(eval_at, ",") << "]\n";
   str_buf << "[num_machines: " << num_machines << "]\n";
   str_buf << "[local_listen_port: " << local_listen_port << "]\n";
   str_buf << "[time_out: " << time_out << "]\n";

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -86,7 +86,7 @@ std::vector<std::vector<int>> FindGroups(const std::vector<std::unique_ptr<BinMa
     bool need_new_group = true;
     std::vector<int> available_groups;
     for (int gid = 0; gid < static_cast<int>(features_in_group.size()); ++gid) {
-      if (group_non_zero_cnt[gid] + cur_non_zero_cnt <= total_sample_cnt + max_error_cnt){
+      if (group_non_zero_cnt[gid] + cur_non_zero_cnt <= total_sample_cnt + max_error_cnt) {
         if (!is_use_gpu || group_num_bin[gid] + bin_mappers[fidx]->num_bin() + (bin_mappers[fidx]->GetDefaultBin() == 0 ? -1 : 0)
             <= gpu_max_bin_per_group) {
           available_groups.push_back(gid);
@@ -188,7 +188,7 @@ std::vector<std::vector<int>> FastFeatureBundling(std::vector<std::unique_ptr<Bi
         cnt_non_zero += static_cast<int>(num_data * (1.0f - bin_mappers[fidx]->sparse_rate()));
       }
       double sparse_rate = 1.0f - static_cast<double>(cnt_non_zero) / (num_data);
-      // take apart small sparse group, due it will not gain on speed 
+      // take apart small sparse group, due it will not gain on speed
       if (sparse_rate >= sparse_threshold && is_enable_sparse) {
         for (size_t j = 0; j < features_in_group[i].size(); ++j) {
           const int fidx = features_in_group[i][j];
@@ -216,7 +216,6 @@ void Dataset::Construct(
   const int* num_per_col,
   size_t total_sample_cnt,
   const Config& io_config) {
-
   num_total_features_ = static_cast<int>(bin_mappers.size());
   sparse_threshold_ = io_config.sparse_threshold;
   // get num_features
@@ -699,7 +698,6 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
                                   score_t* ordered_gradients, score_t* ordered_hessians,
                                   bool is_constant_hessian,
                                   HistogramBinEntry* hist_data) const {
-
   if (leaf_idx < 0 || num_data < 0 || hist_data == nullptr) {
     return;
   }

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -18,7 +18,6 @@ DatasetLoader::DatasetLoader(const Config& io_config, const PredictFunction& pre
 }
 
 DatasetLoader::~DatasetLoader() {
-
 }
 
 void DatasetLoader::SetHeader(const char* filename) {
@@ -382,12 +381,12 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
   }
   mem_ptr += sizeof(int) * (dataset->num_groups_);
 
-  if(!config_.monotone_constraints.empty()) {
+  if (!config_.monotone_constraints.empty()) {
     CHECK(static_cast<size_t>(dataset->num_total_features_) == config_.monotone_constraints.size());
     dataset->monotone_types_.resize(dataset->num_features_);
-    for(int i = 0; i < dataset->num_total_features_; ++i){
+    for (int i = 0; i < dataset->num_total_features_; ++i) {
       int inner_fidx = dataset->InnerFeatureIndex(i);
-      if(inner_fidx >= 0) {
+      if (inner_fidx >= 0) {
         dataset->monotone_types_[inner_fidx] = config_.monotone_constraints[i];
       }
     }
@@ -405,12 +404,12 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
     dataset->monotone_types_.clear();
   }
 
-  if(!config_.feature_contri.empty()) {
+  if (!config_.feature_contri.empty()) {
     CHECK(static_cast<size_t>(dataset->num_total_features_) == config_.feature_contri.size());
     dataset->feature_penalty_.resize(dataset->num_features_);
-    for(int i = 0; i < dataset->num_total_features_; ++i){
+    for (int i = 0; i < dataset->num_total_features_; ++i) {
       int inner_fidx = dataset->InnerFeatureIndex(i);
-      if(inner_fidx >= 0) {
+      if (inner_fidx >= 0) {
         dataset->feature_penalty_[inner_fidx] = config_.feature_contri[i];
       }
     }
@@ -526,8 +525,7 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
     dataset->feature_groups_.emplace_back(std::unique_ptr<FeatureGroup>(
       new FeatureGroup(buffer.data(),
                        *num_global_data,
-                       *used_data_indices)
-      ));
+                       *used_data_indices)));
   }
   dataset->feature_groups_.shrink_to_fit();
   dataset->is_finish_load_ = true;
@@ -782,8 +780,8 @@ std::vector<std::string> DatasetLoader::SampleTextDataFromFile(const char* filen
         [this, rank, num_machines, &qid, &query_boundaries, &is_query_used, num_queries]
       (data_size_t line_idx) {
         if (qid >= num_queries) {
-          Log::Fatal("Query id exceeds the range of the query file, \
-                      please ensure the query file is correct");
+          Log::Fatal("Query id exceeds the range of the query file, "
+                     "please ensure the query file is correct");
         }
         if (line_idx >= query_boundaries[qid + 1]) {
           // if is new query
@@ -801,7 +799,6 @@ std::vector<std::string> DatasetLoader::SampleTextDataFromFile(const char* filen
 }
 
 void DatasetLoader::ConstructBinMappersFromTextData(int rank, int num_machines, const std::vector<std::string>& sample_data, const Parser* parser, Dataset* dataset) {
-
   std::vector<std::vector<double>> sample_values;
   std::vector<std::vector<int>> sample_indices;
   std::vector<std::pair<int, double>> oneline_features;
@@ -1143,7 +1140,6 @@ std::string DatasetLoader::CheckCanLoadFromBin(const char* filename) {
   } else {
     return std::string();
   }
-
 }
 
-}
+}  // namespace LightGBM

--- a/src/io/dense_nbits_bin.hpp
+++ b/src/io/dense_nbits_bin.hpp
@@ -45,7 +45,6 @@ public:
   }
 
   ~Dense4bitsBin() {
-
   }
 
   void Push(int, data_size_t idx, uint32_t value) override {
@@ -72,11 +71,9 @@ public:
   void ConstructHistogram(const data_size_t* data_indices, data_size_t num_data,
                           const score_t* ordered_gradients, const score_t* ordered_hessians,
                           HistogramBinEntry* out) const override {
-
     const data_size_t rest = num_data & 0x3;
     data_size_t i = 0;
     for (; i < num_data - rest; i += 4) {
-
       const data_size_t idx0 = data_indices[i];
       const auto bin0 = (data_[idx0 >> 1] >> ((idx0 & 1) << 2)) & 0xf;
 
@@ -103,7 +100,6 @@ public:
       ++out[bin1].cnt;
       ++out[bin2].cnt;
       ++out[bin3].cnt;
-
     }
 
     for (; i < num_data; ++i) {
@@ -121,7 +117,6 @@ public:
     const data_size_t rest = num_data & 0x3;
     data_size_t i = 0;
     for (; i < num_data - rest; i += 4) {
-
       const auto bin0 = (data_[i >> 1]) & 0xf;
       const auto bin1 = (data_[i >> 1] >> 4) & 0xf;
       const auto bin2 = (data_[(i >> 1) + 1]) & 0xf;

--- a/src/io/file_io.cpp
+++ b/src/io/file_io.cpp
@@ -8,7 +8,7 @@
 #include <hdfs.h>
 #endif
 
-namespace LightGBM{
+namespace LightGBM {
 
 struct LocalFile : VirtualFileReader, VirtualFileWriter {
   LocalFile(const std::string& filename, const std::string& mode) : filename_(filename), mode_(mode) {}
@@ -148,7 +148,7 @@ std::unordered_map<std::string, hdfsFS> HDFSFile::fs_cache_ = std::unordered_map
 #define WITH_HDFS(x) x
 #else
 #define WITH_HDFS(x) Log::Fatal("HDFS support is not enabled")
-#endif // USE_HDFS
+#endif  // USE_HDFS
 
 std::unique_ptr<VirtualFileReader> VirtualFileReader::Make(const std::string& filename) {
   if (0 == filename.find(kHdfsProto)) {

--- a/src/io/json11.cpp
+++ b/src/io/json11.cpp
@@ -148,7 +148,6 @@ void Json::dump(string &out) const {
 template <Json::Type tag, typename T>
 class Value : public JsonValue {
 protected:
-
     // Constructors
     explicit Value(const T &value) : m_value(value) {}
     explicit Value(T &&value)      : m_value(move(value)) {}
@@ -345,7 +344,6 @@ namespace {
  * Object that tracks all state of an in-progress parse.
  */
 struct JsonParser final {
-
     /* State
      */
     const string &str;
@@ -397,7 +395,7 @@ struct JsonParser final {
           }
           comment_found = true;
         }
-        else if (str[i] == '*') { // multiline comment
+        else if (str[i] == '*') {  // multiline comment
           i++;
           if (i > str.size()-2)
             return fail("Unexpected end of input inside multi-line comment", false);
@@ -422,14 +420,14 @@ struct JsonParser final {
      */
     void consume_garbage() {
       consume_whitespace();
-      if(strategy == JsonParse::COMMENTS) {
+      if (strategy == JsonParse::COMMENTS) {
         bool comment_found = false;
         do {
           comment_found = consume_comment();
           if (failed) return;
           consume_whitespace();
         }
-        while(comment_found);
+        while (comment_found);
       }
     }
 
@@ -726,7 +724,7 @@ struct JsonParser final {
         return fail("Expected value, got " + esc(ch));
     }
 };
-}//namespace {
+}  // namespace
 
 Json Json::parse(const string &in, string &err, JsonParse strategy) {
     JsonParser parser { in, 0, err, false, strategy };
@@ -784,4 +782,4 @@ bool Json::has_shape(const shape & types, string & err) const {
     return true;
 }
 
-} // namespace json11
+}  // namespace json11

--- a/src/io/metadata.cpp
+++ b/src/io/metadata.cpp
@@ -125,7 +125,6 @@ void Metadata::Init(const Metadata& fullset, const data_size_t* used_indices, da
   } else {
     num_queries_ = 0;
   }
-
 }
 
 void Metadata::PartitionLabel(const std::vector<data_size_t>& used_indices) {
@@ -516,7 +515,6 @@ void Metadata::SaveBinaryToFile(const VirtualFileWriter* writer) const {
   if (!query_boundaries_.empty()) {
     writer->Write(query_boundaries_.data(), sizeof(data_size_t) * (num_queries_ + 1));
   }
-
 }
 
 size_t Metadata::SizesInByte() const  {

--- a/src/io/ordered_sparse_bin.hpp
+++ b/src/io/ordered_sparse_bin.hpp
@@ -87,7 +87,6 @@ public:
     data_size_t i = start;
     // use data on current leaf to construct histogram
     for (; i < end - rest; i += 4) {
-
       const VAL_T bin0 = ordered_pair_[i].bin;
       const VAL_T bin1 = ordered_pair_[i + 1].bin;
       const VAL_T bin2 = ordered_pair_[i + 2].bin;
@@ -119,7 +118,6 @@ public:
     }
 
     for (; i < end; ++i) {
-
       const VAL_T bin0 = ordered_pair_[i].bin;
 
       const auto g0 = gradient[ordered_pair_[i].ridx];
@@ -129,7 +127,6 @@ public:
       out[bin0].sum_hessians += h0;
       ++out[bin0].cnt;
     }
-
   }
 
   void ConstructHistogram(int leaf, const score_t* gradient,
@@ -141,7 +138,6 @@ public:
     data_size_t i = start;
     // use data on current leaf to construct histogram
     for (; i < end - rest; i += 4) {
-
       const VAL_T bin0 = ordered_pair_[i].bin;
       const VAL_T bin1 = ordered_pair_[i + 1].bin;
       const VAL_T bin2 = ordered_pair_[i + 2].bin;

--- a/src/io/parser.hpp
+++ b/src/io/parser.hpp
@@ -44,6 +44,7 @@ public:
   inline int TotalColumns() const override {
     return total_columns_;
   }
+
 private:
   int label_idx_ = 0;
   int total_columns_ = -1;
@@ -79,6 +80,7 @@ public:
   inline int TotalColumns() const override {
     return total_columns_;
   }
+
 private:
   int label_idx_ = 0;
   int total_columns_ = -1;
@@ -118,6 +120,7 @@ public:
   inline int TotalColumns() const override {
     return -1;
   }
+
 private:
   int label_idx_ = 0;
 };

--- a/src/io/sparse_bin.hpp
+++ b/src/io/sparse_bin.hpp
@@ -41,7 +41,7 @@ public:
   inline uint32_t RawGet(data_size_t idx) override;
   inline VAL_T InnerRawGet(data_size_t idx);
 
-  inline uint32_t Get( data_size_t idx) override {
+  inline uint32_t Get(data_size_t idx) override {
     VAL_T ret = InnerRawGet(idx);
     if (ret >= min_bin_ && ret <= max_bin_) {
       return ret - min_bin_ + bias_;
@@ -51,6 +51,7 @@ public:
   }
 
   inline void Reset(data_size_t idx) override;
+
 private:
   const SparseBin<VAL_T>* bin_data_;
   data_size_t cur_pos_;
@@ -82,7 +83,6 @@ public:
   }
 
   ~SparseBin() {
-
   }
 
   void ReSize(data_size_t num_data) override {
@@ -188,7 +188,7 @@ public:
       if ((default_left && missing_type == MissingType::Zero) || (default_bin <= threshold && missing_type != MissingType::Zero)) {
         default_indices = lte_indices;
         default_count = &lte_count;
-      } 
+      }
       for (data_size_t i = 0; i < num_data; ++i) {
         const data_size_t idx = data_indices[i];
         const VAL_T bin = iterator.InnerRawGet(idx);
@@ -200,7 +200,7 @@ public:
           lte_indices[lte_count++] = idx;
         }
       }
-    } 
+    }
     return lte_count;
   }
 

--- a/src/io/tree.cpp
+++ b/src/io/tree.cpp
@@ -17,7 +17,6 @@ namespace LightGBM {
 
 Tree::Tree(int max_leaves)
   :max_leaves_(max_leaves) {
-
   left_child_.resize(max_leaves_ - 1);
   right_child_.resize(max_leaves_ - 1);
   split_feature_inner_.resize(max_leaves_ - 1);
@@ -45,7 +44,6 @@ Tree::Tree(int max_leaves)
 }
 
 Tree::~Tree() {
-
 }
 
 int Tree::Split(int leaf, int feature, int real_feature, uint32_t threshold_bin,
@@ -379,7 +377,7 @@ std::string Tree::ToIfElse(int index, bool predict_leaf_index) const {
   }
   str_buf << " }" << '\n';
 
-  //Predict func by Map to ifelse
+  // Predict func by Map to ifelse
   str_buf << "double PredictTree" << index;
   if (predict_leaf_index) {
     str_buf << "LeafByMap";
@@ -480,7 +478,7 @@ Tree::Tree(const char* str, size_t* used_len) {
   while (read_line < max_num_line) {
     if (*p == '\r' || *p == '\n') break;
     auto start = p;
-    while (*p != '=') ++p; 
+    while (*p != '=') ++p;
     std::string key(start, p - start);
     ++p;
     start = p;
@@ -652,7 +650,6 @@ void Tree::TreeSHAP(const double *feature_values, double *phi,
                     int node, int unique_depth,
                     PathElement *parent_unique_path, double parent_zero_fraction,
                     double parent_one_fraction, int parent_feature_index) const {
-
   // extend the unique path
   PathElement* unique_path = parent_unique_path + unique_depth;
   if (unique_depth > 0) std::copy(parent_unique_path, parent_unique_path + unique_depth, unique_path);

--- a/src/lightgbm_R.cpp
+++ b/src/lightgbm_R.cpp
@@ -19,7 +19,6 @@
 
 #define R_API_BEGIN() \
   try {
-
 #define R_API_END() } \
   catch(std::exception& ex) { R_INT_PTR(call_state)[0] = -1; LGBM_SetLastError(ex.what()); return call_state;} \
   catch(std::string& ex) { R_INT_PTR(call_state)[0] = -1; LGBM_SetLastError(ex.c_str()); return call_state; } \
@@ -54,7 +53,6 @@ LGBM_SE LGBM_DatasetCreateFromFile_R(LGBM_SE filename,
   LGBM_SE reference,
   LGBM_SE out,
   LGBM_SE call_state) {
-
   R_API_BEGIN();
   DatasetHandle handle = nullptr;
   CHECK_CALL(LGBM_DatasetCreateFromFile(R_CHAR_PTR(filename), R_CHAR_PTR(parameters),
@@ -96,7 +94,6 @@ LGBM_SE LGBM_DatasetCreateFromMat_R(LGBM_SE data,
   LGBM_SE reference,
   LGBM_SE out,
   LGBM_SE call_state) {
-
   R_API_BEGIN();
   int32_t nrow = static_cast<int32_t>(R_AS_INT(num_row));
   int32_t ncol = static_cast<int32_t>(R_AS_INT(num_col));
@@ -114,7 +111,6 @@ LGBM_SE LGBM_DatasetGetSubset_R(LGBM_SE handle,
   LGBM_SE parameters,
   LGBM_SE out,
   LGBM_SE call_state) {
-
   R_API_BEGIN();
   int len = R_AS_INT(len_used_row_indices);
   std::vector<int> idxvec(len);
@@ -151,7 +147,6 @@ LGBM_SE LGBM_DatasetGetFeatureNames_R(LGBM_SE handle,
   LGBM_SE actual_len,
   LGBM_SE feature_names,
   LGBM_SE call_state) {
-
   R_API_BEGIN();
   int len = 0;
   CHECK_CALL(LGBM_DatasetGetNumFeature(R_GET_PTR(handle), &len));
@@ -204,7 +199,7 @@ LGBM_SE LGBM_DatasetSetField_R(LGBM_SE handle,
       vec[i] = static_cast<int32_t>(R_INT_PTR(field_data)[i]);
     }
     CHECK_CALL(LGBM_DatasetSetField(R_GET_PTR(handle), name, vec.data(), len, C_API_DTYPE_INT32));
-  } else if(!strcmp("init_score", name)) {
+  } else if (!strcmp("init_score", name)) {
     CHECK_CALL(LGBM_DatasetSetField(R_GET_PTR(handle), name, R_REAL_PTR(field_data), len, C_API_DTYPE_FLOAT64));
   } else {
     std::vector<float> vec(len);
@@ -221,7 +216,6 @@ LGBM_SE LGBM_DatasetGetField_R(LGBM_SE handle,
   LGBM_SE field_name,
   LGBM_SE field_data,
   LGBM_SE call_state) {
-
   R_API_BEGIN();
   const char* name = R_CHAR_PTR(field_name);
   int out_len = 0;
@@ -256,7 +250,6 @@ LGBM_SE LGBM_DatasetGetFieldSize_R(LGBM_SE handle,
   LGBM_SE field_name,
   LGBM_SE out,
   LGBM_SE call_state) {
-
   R_API_BEGIN();
   const char* name = R_CHAR_PTR(field_name);
   int out_len = 0;
@@ -323,7 +316,6 @@ LGBM_SE LGBM_BoosterCreate_R(LGBM_SE train_data,
 LGBM_SE LGBM_BoosterCreateFromModelfile_R(LGBM_SE filename,
   LGBM_SE out,
   LGBM_SE call_state) {
-
   R_API_BEGIN();
   int out_num_iterations = 0;
   BoosterHandle handle = nullptr;
@@ -335,7 +327,6 @@ LGBM_SE LGBM_BoosterCreateFromModelfile_R(LGBM_SE filename,
 LGBM_SE LGBM_BoosterLoadModelFromString_R(LGBM_SE model_str,
   LGBM_SE out,
   LGBM_SE call_state) {
-
   R_API_BEGIN();
   int out_num_iterations = 0;
   BoosterHandle handle = nullptr;
@@ -422,7 +413,6 @@ LGBM_SE LGBM_BoosterRollbackOneIter_R(LGBM_SE handle,
 LGBM_SE LGBM_BoosterGetCurrentIteration_R(LGBM_SE handle,
   LGBM_SE out,
   LGBM_SE call_state) {
-
   int out_iteration;
   R_API_BEGIN();
   CHECK_CALL(LGBM_BoosterGetCurrentIteration(R_GET_PTR(handle), &out_iteration));
@@ -435,7 +425,6 @@ LGBM_SE LGBM_BoosterGetEvalNames_R(LGBM_SE handle,
   LGBM_SE actual_len,
   LGBM_SE eval_names,
   LGBM_SE call_state) {
-
   R_API_BEGIN();
   int len;
   CHECK_CALL(LGBM_BoosterGetEvalCounts(R_GET_PTR(handle), &len));
@@ -552,7 +541,6 @@ LGBM_SE LGBM_BoosterPredictForCSC_R(LGBM_SE handle,
   LGBM_SE parameter,
   LGBM_SE out_result,
   LGBM_SE call_state) {
-
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
 
@@ -583,7 +571,6 @@ LGBM_SE LGBM_BoosterPredictForMat_R(LGBM_SE handle,
   LGBM_SE parameter,
   LGBM_SE out_result,
   LGBM_SE call_state) {
-
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
 

--- a/src/metric/binary_metric.hpp
+++ b/src/metric/binary_metric.hpp
@@ -20,11 +20,9 @@ template<typename PointWiseLossCalculator>
 class BinaryMetric: public Metric {
 public:
   explicit BinaryMetric(const Config&) {
-
   }
 
   virtual ~BinaryMetric() {
-
   }
 
   void Init(const Metadata& metadata, data_size_t num_data) override {
@@ -157,7 +155,6 @@ public:
 class AUCMetric: public Metric {
 public:
   explicit AUCMetric(const Config&) {
-
   }
 
   virtual ~AUCMetric() {

--- a/src/metric/multiclass_metric.hpp
+++ b/src/metric/multiclass_metric.hpp
@@ -20,11 +20,9 @@ public:
   }
 
   virtual ~MulticlassMetric() {
-
   }
 
   void Init(const Metadata& metadata, data_size_t num_data) override {
-
     name_.emplace_back(PointWiseLossCalculator::Name());
     num_data_ = num_data;
     // get label

--- a/src/metric/regression_metric.hpp
+++ b/src/metric/regression_metric.hpp
@@ -19,7 +19,6 @@ public:
   }
 
   virtual ~RegressionMetric() {
-
   }
 
   const std::vector<std::string>& GetName() const override {
@@ -87,7 +86,6 @@ public:
     }
     double loss = PointWiseLossCalculator::AverageLoss(sum_loss, sum_weights_);
     return std::vector<double>(1, loss);
-
   }
 
   inline static double AverageLoss(double sum_loss, double sum_weights) {
@@ -259,7 +257,7 @@ public:
     const double theta = -1.0 / score;
     const double a = psi;
     const double b = -Common::SafeLog(-theta);
-    const double c = 1. / psi * Common::SafeLog(label / psi) - Common::SafeLog(label) - 0; // 0 = std::lgamma(1.0 / psi) = std::lgamma(1.0);
+    const double c = 1. / psi * Common::SafeLog(label / psi) - Common::SafeLog(label) - 0;  // 0 = std::lgamma(1.0 / psi) = std::lgamma(1.0);
     return -((label * theta - b) / a + c);
   }
   inline static const char* Name() {

--- a/src/metric/xentropy_metric.hpp
+++ b/src/metric/xentropy_metric.hpp
@@ -66,7 +66,7 @@ namespace LightGBM {
 //
 class CrossEntropyMetric : public Metric {
 public:
-	explicit CrossEntropyMetric(const Config&) {}
+  explicit CrossEntropyMetric(const Config&) {}
   virtual ~CrossEntropyMetric() {}
 
   void Init(const Metadata& metadata, data_size_t num_data) override {
@@ -105,12 +105,12 @@ public:
       if (weights_ == nullptr) {
         #pragma omp parallel for schedule(static) reduction(+:sum_loss)
         for (data_size_t i = 0; i < num_data_; ++i) {
-          sum_loss += XentLoss(label_[i], score[i]); // NOTE: does not work unless score is a probability
+          sum_loss += XentLoss(label_[i], score[i]);  // NOTE: does not work unless score is a probability
         }
       } else {
         #pragma omp parallel for schedule(static) reduction(+:sum_loss)
         for (data_size_t i = 0; i < num_data_; ++i) {
-          sum_loss += XentLoss(label_[i], score[i]) * weights_[i]; // NOTE: does not work unless score is a probability
+          sum_loss += XentLoss(label_[i], score[i]) * weights_[i];  // NOTE: does not work unless score is a probability
         }
       }
     } else {
@@ -139,7 +139,7 @@ public:
   }
 
   double factor_to_bigger_better() const override {
-    return -1.0f; // negative means smaller loss is better, positive means larger loss is better
+    return -1.0f;  // negative means smaller loss is better, positive means larger loss is better
   }
 
 private:
@@ -182,7 +182,6 @@ public:
         Log::Fatal("[%s:%s]: (metric) all weights must be positive", GetName()[0].c_str(), __func__);
       }
     }
-
   }
 
   std::vector<double> Eval(const double* score, const ObjectiveFunction* objective) const override {
@@ -191,13 +190,13 @@ public:
       if (weights_ == nullptr) {
         #pragma omp parallel for schedule(static) reduction(+:sum_loss)
         for (data_size_t i = 0; i < num_data_; ++i) {
-          double hhat = std::log(1.0f + std::exp(score[i])); // auto-convert
+          double hhat = std::log(1.0f + std::exp(score[i]));  // auto-convert
           sum_loss += XentLambdaLoss(label_[i], 1.0f, hhat);
         }
       } else {
         #pragma omp parallel for schedule(static) reduction(+:sum_loss)
         for (data_size_t i = 0; i < num_data_; ++i) {
-          double hhat = std::log(1.0f + std::exp(score[i])); // auto-convert
+          double hhat = std::log(1.0f + std::exp(score[i]));  // auto-convert
           sum_loss += XentLambdaLoss(label_[i], weights_[i], hhat);
         }
       }
@@ -206,14 +205,14 @@ public:
         #pragma omp parallel for schedule(static) reduction(+:sum_loss)
         for (data_size_t i = 0; i < num_data_; ++i) {
           double hhat = 0;
-          objective->ConvertOutput(&score[i], &hhat); // NOTE: this only works if objective = "xentlambda"
+          objective->ConvertOutput(&score[i], &hhat);  // NOTE: this only works if objective = "xentlambda"
           sum_loss += XentLambdaLoss(label_[i], 1.0f, hhat);
         }
       } else {
         #pragma omp parallel for schedule(static) reduction(+:sum_loss)
         for (data_size_t i = 0; i < num_data_; ++i) {
           double hhat = 0;
-          objective->ConvertOutput(&score[i], &hhat); // NOTE: this only works if objective = "xentlambda"
+          objective->ConvertOutput(&score[i], &hhat);  // NOTE: this only works if objective = "xentlambda"
           sum_loss += XentLambdaLoss(label_[i], weights_[i], hhat);
         }
       }
@@ -300,12 +299,12 @@ public:
       if (weights_ == nullptr) {
         #pragma omp parallel for schedule(static) reduction(+:sum_loss)
         for (data_size_t i = 0; i < num_data_; ++i) {
-          sum_loss += XentLoss(label_[i], score[i]); // NOTE: does not work unless score is a probability
+          sum_loss += XentLoss(label_[i], score[i]);  // NOTE: does not work unless score is a probability
         }
       } else {
         #pragma omp parallel for schedule(static) reduction(+:sum_loss)
         for (data_size_t i = 0; i < num_data_; ++i) {
-          sum_loss += XentLoss(label_[i], score[i]) * weights_[i]; // NOTE: does not work unless score is a probability
+          sum_loss += XentLoss(label_[i], score[i]) * weights_[i];  // NOTE: does not work unless score is a probability
         }
       }
     } else {
@@ -352,6 +351,6 @@ private:
   std::vector<std::string> name_;
 };
 
-} // end namespace LightGBM
+}  // end namespace LightGBM
 
-#endif // end #ifndef LIGHTGBM_METRIC_XENTROPY_METRIC_HPP_
+#endif  // end #ifndef LIGHTGBM_METRIC_XENTROPY_METRIC_HPP_

--- a/src/network/linkers.h
+++ b/src/network/linkers.h
@@ -222,9 +222,8 @@ inline void Linkers::Recv(int rank, char* data, int len) const {
   int recv_cnt = 0;
   while (recv_cnt < len) {
     recv_cnt += linkers_[rank]->Recv(data + recv_cnt,
-      //len - recv_cnt
-      std::min(len - recv_cnt, SocketConfig::kMaxReceiveSize)
-    );
+      // len - recv_cnt
+      std::min(len - recv_cnt, SocketConfig::kMaxReceiveSize));
   }
 }
 

--- a/src/network/linkers_mpi.cpp
+++ b/src/network/linkers_mpi.cpp
@@ -29,4 +29,4 @@ Linkers::~Linkers() {
 
 
 }  // namespace LightGBM
-#endif // USE_MPI
+#endif  // USE_MPI

--- a/src/network/linkers_socket.cpp
+++ b/src/network/linkers_socket.cpp
@@ -117,7 +117,6 @@ void Linkers::ParseMachineList(const std::string& machines, const std::string& f
     Log::Warning("World size is larger than the machine_list size, change world size to %d", client_ips_.size());
     num_machines_ = static_cast<int>(client_ips_.size());
   }
-
 }
 
 void Linkers::TryBind(int port) {

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -137,7 +137,7 @@ void Network::Allgather(char* input, const comm_size_t* block_start, const comm_
   if (allgather_ext_fun_ != nullptr) {
     return allgather_ext_fun_(input, block_len[rank_], block_start, block_len, num_machines_, output, all_size);
   }
-  const comm_size_t kRingThreshold = 10 * 1024 * 1024; // 10MB
+  const comm_size_t kRingThreshold = 10 * 1024 * 1024;  // 10MB
   const int kRingNodeThreshold = 64;
   if (all_size > kRingThreshold && num_machines_ < kRingNodeThreshold) {
     // when num_machines is small and data is large
@@ -234,7 +234,7 @@ void Network::ReduceScatter(char* input, comm_size_t input_size, int type_size,
   if (reduce_scatter_ext_fun_ != nullptr) {
     return reduce_scatter_ext_fun_(input, input_size, type_size, block_start, block_len, num_machines_, output, output_size, reducer);
   }
-  const comm_size_t kRingThreshold = 10 * 1024 * 1024; // 10MB
+  const comm_size_t kRingThreshold = 10 * 1024 * 1024;  // 10MB
   if (recursive_halving_map_.is_power_of_2 || input_size < kRingThreshold) {
     ReduceScatterRecursiveHalving(input, input_size, type_size, block_start, block_len, output, output_size, reducer);
   } else {

--- a/src/network/socket_wrapper.hpp
+++ b/src/network/socket_wrapper.hpp
@@ -51,8 +51,7 @@ const int INVALID_SOCKET = -1;
 #ifdef _WIN32
 #ifndef _MSC_VER
 // not using visual studio in windows
-inline int inet_pton(int af, const char *src, void *dst)
-{
+inline int inet_pton(int af, const char *src, void *dst) {
   struct sockaddr_storage ss;
   int size = sizeof(ss);
   char src_copy[INET6_ADDRSTRLEN + 1];
@@ -119,11 +118,11 @@ public:
     if (sockfd_ == INVALID_SOCKET) {
       return;
     }
-    
+
     if (setsockopt(sockfd_, SOL_SOCKET, SO_RCVBUF, reinterpret_cast<const char*>(&SocketConfig::kSocketBufferSize), sizeof(SocketConfig::kSocketBufferSize)) != 0) {
       Log::Warning("Set SO_RCVBUF failed, please increase your net.core.rmem_max to 100k at least");
     }
-    
+
     if (setsockopt(sockfd_, SOL_SOCKET, SO_SNDBUF, reinterpret_cast<const char*>(&SocketConfig::kSocketBufferSize), sizeof(SocketConfig::kSocketBufferSize)) != 0) {
       Log::Warning("Set SO_SNDBUF failed, please increase your net.core.wmem_max to 100k at least");
     }

--- a/src/objective/binary_objective.hpp
+++ b/src/objective/binary_objective.hpp
@@ -19,7 +19,7 @@ public:
     }
     is_unbalance_ = config.is_unbalance;
     scale_pos_weight_ = static_cast<double>(config.scale_pos_weight);
-    if(is_unbalance_ && std::fabs(scale_pos_weight_ - 1.0f) > 1e-6) {
+    if (is_unbalance_ && std::fabs(scale_pos_weight_ - 1.0f) > 1e-6) {
       Log::Fatal("Cannot set is_unbalance and scale_pos_weight at the same time");
     }
     is_pos_ = is_pos;
@@ -54,7 +54,7 @@ public:
     // REMOVEME: remove the warning after 2.4 version release
     Log::Warning("Starting from the 2.1.2 version, default value for "
                  "the \"boost_from_average\" parameter in \"binary\" objective is true.\n"
-                 "This may cause significantly different results comparing to the previous versions of LightGBM.\n" 
+                 "This may cause significantly different results comparing to the previous versions of LightGBM.\n"
                  "Try to set boost_from_average=false, if your old models produce bad results");
     // count for positive and negative samples
     #pragma omp parallel for schedule(static) reduction(+:cnt_positive, cnt_negative)
@@ -123,13 +123,13 @@ public:
       }
     }
   }
-  
+
   // implement custom average to boost from (if enabled among options)
   double BoostFromScore(int) const override {
     double suml = 0.0f;
     double sumw = 0.0f;
     if (weights_ != nullptr) {
-      #pragma omp parallel for schedule(static) reduction(+:suml,sumw)
+      #pragma omp parallel for schedule(static) reduction(+:suml, sumw)
       for (data_size_t i = 0; i < num_data_; ++i) {
         suml += is_pos_(label_[i]) * weights_[i];
         sumw += weights_[i];
@@ -149,7 +149,7 @@ public:
     return initscore;
   }
 
-  bool ClassNeedTrain(int /*class_id*/) const override { 
+  bool ClassNeedTrain(int /*class_id*/) const override {
     return need_train_;
   }
 

--- a/src/objective/multiclass_objective.hpp
+++ b/src/objective/multiclass_objective.hpp
@@ -35,7 +35,6 @@ public:
   }
 
   ~MulticlassSoftmax() {
-
   }
 
   void Init(const Metadata& metadata, data_size_t num_data) override {
@@ -138,8 +137,8 @@ public:
     return std::log(std::max<double>(kEpsilon, class_init_probs_[class_id]));
   }
 
-  bool ClassNeedTrain(int class_id) const override { 
-    if (std::fabs(class_init_probs_[class_id]) <= kEpsilon 
+  bool ClassNeedTrain(int class_id) const override {
+    if (std::fabs(class_init_probs_[class_id]) <= kEpsilon
         || std::fabs(class_init_probs_[class_id]) >= 1.0 - kEpsilon) {
       return false;
     } else {
@@ -197,7 +196,6 @@ public:
   }
 
   ~MulticlassOVA() {
-
   }
 
   void Init(const Metadata& metadata, data_size_t num_data) override {

--- a/src/objective/objective_function.cpp
+++ b/src/objective/objective_function.cpp
@@ -9,7 +9,7 @@ namespace LightGBM {
 
 ObjectiveFunction* ObjectiveFunction::CreateObjectiveFunction(const std::string& type, const Config& config) {
   if (type == std::string("regression") || type == std::string("regression_l2")
-      || type == std::string("mean_squared_error") || type == std::string("mse") 
+      || type == std::string("mean_squared_error") || type == std::string("mse")
       || type == std::string("l2_root") || type == std::string("root_mean_squared_error") || type == std::string("rmse")) {
     return new RegressionL2loss(config);
   } else if (type == std::string("regression_l1") || type == std::string("mean_absolute_error")  || type == std::string("mae")) {

--- a/src/objective/rank_objective.hpp
+++ b/src/objective/rank_objective.hpp
@@ -34,11 +34,9 @@ public:
   }
 
   explicit LambdarankNDCG(const std::vector<std::string>&) {
-
   }
 
   ~LambdarankNDCG() {
-
   }
   void Init(const Metadata& metadata, data_size_t num_data) override {
     num_data_ = num_data;

--- a/src/objective/regression_objective.hpp
+++ b/src/objective/regression_objective.hpp
@@ -78,7 +78,7 @@ public:
       }
     }
   }
-  
+
   ~RegressionL2loss() {
   }
 
@@ -146,7 +146,7 @@ public:
     double suml = 0.0f;
     double sumw = 0.0f;
     if (weights_ != nullptr) {
-      #pragma omp parallel for schedule(static) reduction(+:suml,sumw)
+      #pragma omp parallel for schedule(static) reduction(+:suml, sumw)
       for (data_size_t i = 0; i < num_data_; ++i) {
         suml += label_[i] * weights_[i];
         sumw += weights_[i];
@@ -221,7 +221,7 @@ public:
 
   bool IsRenewTreeOutput() const override { return true; }
 
-  double RenewTreeOutput(double, const double* pred, 
+  double RenewTreeOutput(double, const double* pred,
                          const data_size_t* index_mapper,
                          const data_size_t* bagging_mapper,
                          data_size_t num_data_in_leaf) const override {
@@ -253,7 +253,7 @@ public:
     }
   }
 
-  double RenewTreeOutput(double, double pred, 
+  double RenewTreeOutput(double, double pred,
                          const data_size_t* index_mapper,
                          const data_size_t* bagging_mapper,
                          data_size_t num_data_in_leaf) const override {
@@ -362,7 +362,6 @@ public:
   }
 
   explicit RegressionFairLoss(const std::vector<std::string>& strs): RegressionL2loss(strs) {
-
   }
 
   ~RegressionFairLoss() {}
@@ -414,7 +413,6 @@ public:
   }
 
   explicit RegressionPoissonLoss(const std::vector<std::string>& strs): RegressionL2loss(strs) {
-
   }
 
   ~RegressionPoissonLoss() {}
@@ -492,7 +490,6 @@ public:
   }
 
   explicit RegressionQuantileloss(const std::vector<std::string>& strs): RegressionL2loss(strs) {
-
   }
 
   ~RegressionQuantileloss() {}
@@ -620,7 +617,6 @@ public:
   }
 
   explicit RegressionMAPELOSS(const std::vector<std::string>& strs) : RegressionL1loss(strs) {
-
   }
 
   ~RegressionMAPELOSS() {}
@@ -727,7 +723,6 @@ public:
 
 private:
   std::vector<label_t> label_weight_;
-
 };
 
 
@@ -741,7 +736,6 @@ public:
   }
 
   explicit RegressionGammaLoss(const std::vector<std::string>& strs) : RegressionPoissonLoss(strs) {
-
   }
 
   ~RegressionGammaLoss() {}
@@ -766,7 +760,6 @@ public:
   const char* GetName() const override {
     return "gamma";
   }
- 
 };
 
 /*!
@@ -779,7 +772,6 @@ public:
   }
 
   explicit RegressionTweedieLoss(const std::vector<std::string>& strs) : RegressionPoissonLoss(strs) {
-
   }
 
   ~RegressionTweedieLoss() {}
@@ -790,7 +782,7 @@ public:
       #pragma omp parallel for schedule(static)
       for (data_size_t i = 0; i < num_data_; ++i) {
         gradients[i] = static_cast<score_t>(-label_[i] * std::exp((1 - rho_) * score[i]) + std::exp((2 - rho_) * score[i]));
-        hessians[i] = static_cast<score_t>(-label_[i] * (1 - rho_) * std::exp((1 - rho_) * score[i]) + 
+        hessians[i] = static_cast<score_t>(-label_[i] * (1 - rho_) * std::exp((1 - rho_) * score[i]) +
           (2 - rho_) * std::exp((2 - rho_) * score[i]));
       }
     } else {
@@ -806,6 +798,7 @@ public:
   const char* GetName() const override {
     return "tweedie";
   }
+
 private:
   double rho_;
 };

--- a/src/objective/xentropy_objective.hpp
+++ b/src/objective/xentropy_objective.hpp
@@ -65,7 +65,6 @@ public:
         Log::Fatal("[%s]: sum of weights is zero", GetName());
       }
     }
-
   }
 
   void GetGradients(const double* score, score_t* gradients, score_t* hessians) const override {
@@ -108,7 +107,7 @@ public:
     double suml = 0.0f;
     double sumw = 0.0f;
     if (weights_ != nullptr) {
-      #pragma omp parallel for schedule(static) reduction(+:suml,sumw)
+      #pragma omp parallel for schedule(static) reduction(+:suml, sumw)
       for (data_size_t i = 0; i < num_data_; ++i) {
         suml += label_[i] * weights_[i];
         sumw += weights_[i];
@@ -161,7 +160,6 @@ public:
     Log::Info("[%s:%s]: (objective) labels passed interval [0, 1] check",  GetName(), __func__);
 
     if (weights_ != nullptr) {
-
       Common::ObtainMinMaxSum(weights_, num_data_, &min_weight_, &max_weight_, (label_t*)nullptr);
       if (min_weight_ <= 0.0f) {
         Log::Fatal("[%s]: at least one weight is non-positive", GetName());
@@ -196,7 +194,7 @@ public:
         const double epf = std::exp(score[i]);
         const double hhat = std::log(1.0f + epf);
         const double z = 1.0f - std::exp(-w*hhat);
-        const double enf = 1.0f / epf; // = std::exp(-score[i]);
+        const double enf = 1.0f / epf;  // = std::exp(-score[i]);
         gradients[i] = static_cast<score_t>((1.0f - y / z) * w / (1.0f + enf));
         const double c = 1.0f / (1.0f - z);
         double d = 1.0f + epf;
@@ -235,7 +233,7 @@ public:
     double suml = 0.0f;
     double sumw = 0.0f;
     if (weights_ != nullptr) {
-      #pragma omp parallel for schedule(static) reduction(+:suml,sumw)
+      #pragma omp parallel for schedule(static) reduction(+:suml, sumw)
       for (data_size_t i = 0; i < num_data_; ++i) {
         suml += label_[i] * weights_[i];
         sumw += weights_[i];

--- a/src/treelearner/data_parallel_tree_learner.cpp
+++ b/src/treelearner/data_parallel_tree_learner.cpp
@@ -14,7 +14,6 @@ DataParallelTreeLearner<TREELEARNER_T>::DataParallelTreeLearner(const Config* co
 
 template <typename TREELEARNER_T>
 DataParallelTreeLearner<TREELEARNER_T>::~DataParallelTreeLearner() {
-
 }
 
 template <typename TREELEARNER_T>

--- a/src/treelearner/data_partition.hpp
+++ b/src/treelearner/data_partition.hpp
@@ -48,7 +48,6 @@ public:
     temp_right_indices_.resize(num_data_);
   }
   ~DataPartition() {
-
   }
 
   /*!

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -9,8 +9,7 @@
 #include <cstring>
 #include <cmath>
 
-namespace LightGBM
-{
+namespace LightGBM {
 
 class FeatureMetainfo {
 public:
@@ -83,7 +82,6 @@ public:
 
   void FindBestThresholdNumerical(double sum_gradient, double sum_hessian, data_size_t num_data, double min_constraint, double max_constraint,
                                   SplitInfo* output) {
-
     is_splittable_ = false;
     double gain_shift = GetLeafSplitGain(sum_gradient, sum_hessian,
                                          meta_->config->lambda_l1, meta_->config->lambda_l2, meta_->config->max_delta_step);
@@ -118,7 +116,7 @@ public:
     double best_sum_left_gradient = 0;
     double best_sum_left_hessian = 0;
     double gain_shift = GetLeafSplitGain(sum_gradient, sum_hessian, meta_->config->lambda_l1, meta_->config->lambda_l2, meta_->config->max_delta_step);
-    
+
     double min_gain_shift = gain_shift + meta_->config->min_gain_to_split;
     bool is_full_categorical = meta_->missing_type == MissingType::None;
     int used_bin = meta_->num_bin - 1 + is_full_categorical;
@@ -336,7 +334,7 @@ public:
       output->gain = kMinScore;
       Log::Warning("'Forced Split' will be ignored since the gain getting worse. ");
       return;
-    };
+    }
 
     // update split information
     output->threshold = threshold;
@@ -452,7 +450,6 @@ public:
   }
 
 private:
-
   static double GetSplitGains(double sum_left_gradients, double sum_left_hessians,
                               double sum_right_gradients, double sum_right_hessians,
                               double l1, double l2, double max_delta_step,
@@ -502,7 +499,6 @@ private:
 
   void FindBestThresholdSequence(double sum_gradient, double sum_hessian, data_size_t num_data, double min_constraint, double max_constraint,
                                  double min_gain_shift, SplitInfo* output, int dir, bool skip_default_bin, bool use_na_as_missing) {
-
     const int8_t bias = meta_->bias;
 
     double best_sum_left_gradient = NAN;
@@ -512,7 +508,6 @@ private:
     uint32_t best_threshold = static_cast<uint32_t>(meta_->num_bin);
 
     if (dir == -1) {
-
       double sum_right_gradient = 0.0f;
       double sum_right_hessian = kEpsilon;
       data_size_t right_count = 0;
@@ -522,7 +517,6 @@ private:
 
       // from right to left, and we don't need data in bin0
       for (; t >= t_end; --t) {
-
         // need to skip default bin
         if (skip_default_bin && (t + bias) == static_cast<int>(meta_->default_bin)) { continue; }
 
@@ -581,7 +575,6 @@ private:
       }
 
       for (; t <= t_end; ++t) {
-
         // need to skip default bin
         if (skip_default_bin && (t + bias) == static_cast<int>(meta_->default_bin)) { continue; }
         if (t >= 0) {
@@ -645,7 +638,7 @@ private:
   const FeatureMetainfo* meta_;
   /*! \brief sum of gradient of each bin */
   HistogramBinEntry* data_;
-  //std::vector<HistogramBinEntry> data_;
+  // std::vector<HistogramBinEntry> data_;
   bool is_splittable_ = true;
 
   std::function<void(double, double, data_size_t, double, double, SplitInfo*)> find_best_threshold_fun_;
@@ -701,7 +694,7 @@ public:
     if (feature_metas_.empty()) {
       int num_feature = train_data->num_features();
       feature_metas_.resize(num_feature);
-      #pragma omp parallel for schedule(static, 512) if(num_feature >= 1024)
+      #pragma omp parallel for schedule(static, 512) if (num_feature >= 1024)
       for (int i = 0; i < num_feature; ++i) {
         feature_metas_[i].num_bin = train_data->FeatureNumBin(i);
         feature_metas_[i].default_bin = train_data->FeatureBinMapper(i)->GetDefaultBin();
@@ -751,7 +744,7 @@ public:
 
   void ResetConfig(const Config* config) {
     int size = static_cast<int>(feature_metas_.size());
-    #pragma omp parallel for schedule(static, 512) if(size >= 1024)
+    #pragma omp parallel for schedule(static, 512) if (size >= 1024)
     for (int i = 0; i < size; ++i) {
       feature_metas_[i].config = config;
     }
@@ -772,7 +765,7 @@ public:
       last_used_time_[slot] = ++cur_time_;
       return true;
     } else {
-      // choose the least used slot 
+      // choose the least used slot
       int slot = static_cast<int>(ArrayArgs<int>::ArgMin(last_used_time_));
       *out = pool_[slot].get();
       last_used_time_[slot] = ++cur_time_;
@@ -810,6 +803,7 @@ public:
     last_used_time_[slot] = ++cur_time_;
     inverse_mapper_[slot] = dst_idx;
   }
+
 private:
   std::vector<std::unique_ptr<FeatureHistogram[]>> pool_;
   std::vector<std::vector<HistogramBinEntry>> data_;

--- a/src/treelearner/feature_parallel_tree_learner.cpp
+++ b/src/treelearner/feature_parallel_tree_learner.cpp
@@ -14,7 +14,6 @@ FeatureParallelTreeLearner<TREELEARNER_T>::FeatureParallelTreeLearner(const Conf
 
 template <typename TREELEARNER_T>
 FeatureParallelTreeLearner<TREELEARNER_T>::~FeatureParallelTreeLearner() {
-
 }
 
 template <typename TREELEARNER_T>

--- a/src/treelearner/gpu_tree_learner.cpp
+++ b/src/treelearner/gpu_tree_learner.cpp
@@ -56,15 +56,14 @@ void PrintHistograms(HistogramBinEntry* h, size_t size) {
   printf("\nTotal examples: %lu\n", total);
 }
 
-union Float_t
-{
+union Float_t {
     int64_t i;
     double f;
     static int64_t ulp_diff(Float_t a, Float_t b) {
       return abs(a.i - b.i);
     }
 };
-  
+
 
 void CompareHistograms(HistogramBinEntry* h1, HistogramBinEntry* h2, size_t size, int feature_id) {
   size_t i;
@@ -144,7 +143,7 @@ void GPUTreeLearner::GPUHistogram(data_size_t leaf_num_data, bool use_all_featur
   printf("Setting exp_workgroups_per_feature to %d, using %u work groups\n", exp_workgroups_per_feature, num_workgroups);
   printf("Constructing histogram with %d examples\n", leaf_num_data);
   #endif
-  
+
   // the GPU kernel will process all features in one call, and each
   // 2^exp_workgroups_per_feature (compile time constant) workgroup will
   // process one feature4 tuple
@@ -184,7 +183,7 @@ void GPUTreeLearner::GPUHistogram(data_size_t leaf_num_data, bool use_all_featur
   // copy the results asynchronously. Size depends on if double precision is used
   size_t output_size = num_dense_feature4_ * dword_features_ * device_bin_size_ * hist_bin_entry_sz_;
   boost::compute::event histogram_wait_event;
-  host_histogram_outputs_ = (void*)queue_.enqueue_map_buffer_async(device_histogram_outputs_, boost::compute::command_queue::map_read, 
+  host_histogram_outputs_ = (void*)queue_.enqueue_map_buffer_async(device_histogram_outputs_, boost::compute::command_queue::map_read,
                                                                    0, output_size, histogram_wait_event, kernel_wait_obj_);
   // we will wait for this object in WaitAndGetHistograms
   histograms_wait_obj_ = boost::compute::wait_list(histogram_wait_event);
@@ -196,13 +195,13 @@ void GPUTreeLearner::WaitAndGetHistograms(HistogramBinEntry* histograms) {
   // when the output is ready, the computation is done
   histograms_wait_obj_.wait();
   #pragma omp parallel for schedule(static)
-  for(int i = 0; i < num_dense_feature_groups_; ++i) {
+  for (int i = 0; i < num_dense_feature_groups_; ++i) {
     if (!feature_masks_[i]) {
       continue;
     }
     int dense_group_index = dense_feature_group_map_[i];
     auto old_histogram_array = histograms + train_data_->GroupBinBoundary(dense_group_index);
-    int bin_size = train_data_->FeatureGroupNumBin(dense_group_index); 
+    int bin_size = train_data_->FeatureGroupNumBin(dense_group_index);
     if (device_bin_mults_[i] == 1) {
       for (int j = 0; j < bin_size; ++j) {
         old_histogram_array[j].sum_gradients = hist_outputs[i * device_bin_size_+ j].sum_gradients;
@@ -265,36 +264,36 @@ void GPUTreeLearner::AllocateGPUMemory() {
   if (ptr_pinned_feature_masks_) {
     queue_.enqueue_unmap_buffer(pinned_feature_masks_, ptr_pinned_feature_masks_);
   }
-  // make ordered_gradients and hessians larger (including extra room for prefetching), and pin them 
+  // make ordered_gradients and hessians larger (including extra room for prefetching), and pin them
   ordered_gradients_.reserve(allocated_num_data_);
   ordered_hessians_.reserve(allocated_num_data_);
-  pinned_gradients_ = boost::compute::buffer(); // deallocate
-  pinned_gradients_ = boost::compute::buffer(ctx_, allocated_num_data_ * sizeof(score_t), 
-                                             boost::compute::memory_object::read_write | boost::compute::memory_object::use_host_ptr, 
+  pinned_gradients_ = boost::compute::buffer();  // deallocate
+  pinned_gradients_ = boost::compute::buffer(ctx_, allocated_num_data_ * sizeof(score_t),
+                                             boost::compute::memory_object::read_write | boost::compute::memory_object::use_host_ptr,
                                              ordered_gradients_.data());
-  ptr_pinned_gradients_ = queue_.enqueue_map_buffer(pinned_gradients_, boost::compute::command_queue::map_write_invalidate_region, 
+  ptr_pinned_gradients_ = queue_.enqueue_map_buffer(pinned_gradients_, boost::compute::command_queue::map_write_invalidate_region,
                                                     0, allocated_num_data_ * sizeof(score_t));
-  pinned_hessians_ = boost::compute::buffer(); // deallocate
-  pinned_hessians_  = boost::compute::buffer(ctx_, allocated_num_data_ * sizeof(score_t), 
-                                             boost::compute::memory_object::read_write | boost::compute::memory_object::use_host_ptr, 
+  pinned_hessians_ = boost::compute::buffer();  // deallocate
+  pinned_hessians_  = boost::compute::buffer(ctx_, allocated_num_data_ * sizeof(score_t),
+                                             boost::compute::memory_object::read_write | boost::compute::memory_object::use_host_ptr,
                                              ordered_hessians_.data());
-  ptr_pinned_hessians_ = queue_.enqueue_map_buffer(pinned_hessians_, boost::compute::command_queue::map_write_invalidate_region, 
+  ptr_pinned_hessians_ = queue_.enqueue_map_buffer(pinned_hessians_, boost::compute::command_queue::map_write_invalidate_region,
                                                    0, allocated_num_data_ * sizeof(score_t));
   // allocate space for gradients and hessians on device
   // we will copy gradients and hessians in after ordered_gradients_ and ordered_hessians_ are constructed
-  device_gradients_ = boost::compute::buffer(); // deallocate
-  device_gradients_ = boost::compute::buffer(ctx_, allocated_num_data_ * sizeof(score_t), 
+  device_gradients_ = boost::compute::buffer();  // deallocate
+  device_gradients_ = boost::compute::buffer(ctx_, allocated_num_data_ * sizeof(score_t),
                       boost::compute::memory_object::read_only, nullptr);
-  device_hessians_ = boost::compute::buffer(); // deallocate
-  device_hessians_  = boost::compute::buffer(ctx_, allocated_num_data_ * sizeof(score_t), 
+  device_hessians_ = boost::compute::buffer();  // deallocate
+  device_hessians_  = boost::compute::buffer(ctx_, allocated_num_data_ * sizeof(score_t),
                       boost::compute::memory_object::read_only, nullptr);
   // allocate feature mask, for disabling some feature-groups' histogram calculation
   feature_masks_.resize(num_dense_feature4_ * dword_features_);
-  device_feature_masks_ = boost::compute::buffer(); // deallocate
-  device_feature_masks_ = boost::compute::buffer(ctx_, num_dense_feature4_ * dword_features_, 
+  device_feature_masks_ = boost::compute::buffer();  // deallocate
+  device_feature_masks_ = boost::compute::buffer(ctx_, num_dense_feature4_ * dword_features_,
                           boost::compute::memory_object::read_only, nullptr);
-  pinned_feature_masks_ = boost::compute::buffer(ctx_, num_dense_feature4_ * dword_features_, 
-                                             boost::compute::memory_object::read_write | boost::compute::memory_object::use_host_ptr, 
+  pinned_feature_masks_ = boost::compute::buffer(ctx_, num_dense_feature4_ * dword_features_,
+                                             boost::compute::memory_object::read_write | boost::compute::memory_object::use_host_ptr,
                                              feature_masks_.data());
   ptr_pinned_feature_masks_ = queue_.enqueue_map_buffer(pinned_feature_masks_, boost::compute::command_queue::map_write_invalidate_region,
                                                         0, num_dense_feature4_ * dword_features_);
@@ -320,7 +319,7 @@ void GPUTreeLearner::AllocateGPUMemory() {
   boost::compute::fill(sync_counters_->begin(), sync_counters_->end(), 0, queue_);
   // The output buffer is allocated to host directly, to overlap compute and data transfer
   device_histogram_outputs_ = boost::compute::buffer(); // deallocate
-  device_histogram_outputs_ = boost::compute::buffer(ctx_, num_dense_feature4_ * dword_features_ * device_bin_size_ * hist_bin_entry_sz_, 
+  device_histogram_outputs_ = boost::compute::buffer(ctx_, num_dense_feature4_ * dword_features_ * device_bin_size_ * hist_bin_entry_sz_,
                            boost::compute::memory_object::write_only | boost::compute::memory_object::alloc_host_ptr, nullptr);
   // find the dense feature-groups and group then into Feature4 data structure (several feature-groups packed into 4 bytes)
   int k = 0, copied_feature4 = 0;
@@ -342,7 +341,7 @@ void GPUTreeLearner::AllocateGPUMemory() {
     else {
       sparse_feature_group_map_.push_back(i);
     }
-    // found 
+    // found
     if (k == dword_features_) {
       k = 0;
       for (int j = 0; j < dword_features_; ++j) {
@@ -362,8 +361,8 @@ void GPUTreeLearner::AllocateGPUMemory() {
   // preallocate arrays for all threads, and pin them
   for (int i = 0; i < nthreads; ++i) {
     host4_vecs[i] = (Feature4*)boost::alignment::aligned_alloc(4096, num_data_ * sizeof(Feature4));
-    host4_bufs[i] = boost::compute::buffer(ctx_, num_data_ * sizeof(Feature4), 
-                    boost::compute::memory_object::read_write | boost::compute::memory_object::use_host_ptr, 
+    host4_bufs[i] = boost::compute::buffer(ctx_, num_data_ * sizeof(Feature4),
+                    boost::compute::memory_object::read_write | boost::compute::memory_object::use_host_ptr,
                     host4_vecs[i]);
     host4_ptrs[i] = (Feature4*)queue_.enqueue_map_buffer(host4_bufs[i], boost::compute::command_queue::map_write_invalidate_region,
                     0, num_data_ * sizeof(Feature4));
@@ -402,13 +401,13 @@ void GPUTreeLearner::AllocateGPUMemory() {
         *static_cast<Dense4bitsBinIterator*>(bin_iters[6]),
         *static_cast<Dense4bitsBinIterator*>(bin_iters[7])};
       for (int j = 0; j < num_data_; ++j) {
-        host4[j].s[0] = (uint8_t)((iters[0].RawGet(j) * dev_bin_mult[0] + ((j+0) & (dev_bin_mult[0] - 1))) 
+        host4[j].s[0] = (uint8_t)((iters[0].RawGet(j) * dev_bin_mult[0] + ((j+0) & (dev_bin_mult[0] - 1)))
                       |((iters[1].RawGet(j) * dev_bin_mult[1] + ((j+1) & (dev_bin_mult[1] - 1))) << 4));
-        host4[j].s[1] = (uint8_t)((iters[2].RawGet(j) * dev_bin_mult[2] + ((j+2) & (dev_bin_mult[2] - 1))) 
+        host4[j].s[1] = (uint8_t)((iters[2].RawGet(j) * dev_bin_mult[2] + ((j+2) & (dev_bin_mult[2] - 1)))
                       |((iters[3].RawGet(j) * dev_bin_mult[3] + ((j+3) & (dev_bin_mult[3] - 1))) << 4));
-        host4[j].s[2] = (uint8_t)((iters[4].RawGet(j) * dev_bin_mult[4] + ((j+4) & (dev_bin_mult[4] - 1))) 
+        host4[j].s[2] = (uint8_t)((iters[4].RawGet(j) * dev_bin_mult[4] + ((j+4) & (dev_bin_mult[4] - 1)))
                       |((iters[5].RawGet(j) * dev_bin_mult[5] + ((j+5) & (dev_bin_mult[5] - 1))) << 4));
-        host4[j].s[3] = (uint8_t)((iters[6].RawGet(j) * dev_bin_mult[6] + ((j+6) & (dev_bin_mult[6] - 1))) 
+        host4[j].s[3] = (uint8_t)((iters[6].RawGet(j) * dev_bin_mult[6] + ((j+6) & (dev_bin_mult[6] - 1)))
                       |((iters[7].RawGet(j) * dev_bin_mult[7] + ((j+7) & (dev_bin_mult[7] - 1))) << 4));
       }
     }
@@ -432,7 +431,7 @@ void GPUTreeLearner::AllocateGPUMemory() {
           }
         }
         else {
-          Log::Fatal("Bug in GPU tree builder: only DenseBin and Dense4bitsBin are supported"); 
+          Log::Fatal("Bug in GPU tree builder: only DenseBin and Dense4bitsBin are supported");
         }
       }
     }
@@ -481,7 +480,7 @@ void GPUTreeLearner::AllocateGPUMemory() {
           DenseBinIterator<uint8_t> iter = *static_cast<DenseBinIterator<uint8_t>*>(bin_iter);
           #pragma omp parallel for schedule(static)
           for (int j = 0; j < num_data_; ++j) {
-            host4[j].s[i] = (uint8_t)(iter.RawGet(j) * device_bin_mults_[copied_feature4 * dword_features_ + i] 
+            host4[j].s[i] = (uint8_t)(iter.RawGet(j) * device_bin_mults_[copied_feature4 * dword_features_ + i]
                           + ((j+i) & (device_bin_mults_[copied_feature4 * dword_features_ + i] - 1)));
           }
         }
@@ -489,12 +488,12 @@ void GPUTreeLearner::AllocateGPUMemory() {
           Dense4bitsBinIterator iter = *static_cast<Dense4bitsBinIterator*>(bin_iter);
           #pragma omp parallel for schedule(static)
           for (int j = 0; j < num_data_; ++j) {
-            host4[j].s[i] = (uint8_t)(iter.RawGet(j) * device_bin_mults_[copied_feature4 * dword_features_ + i] 
+            host4[j].s[i] = (uint8_t)(iter.RawGet(j) * device_bin_mults_[copied_feature4 * dword_features_ + i]
                           + ((j+i) & (device_bin_mults_[copied_feature4 * dword_features_ + i] - 1)));
           }
         }
         else {
-          Log::Fatal("BUG in GPU tree builder: only DenseBin and Dense4bitsBin are supported"); 
+          Log::Fatal("BUG in GPU tree builder: only DenseBin and Dense4bitsBin are supported");
         }
       }
       else {
@@ -538,8 +537,8 @@ void GPUTreeLearner::AllocateGPUMemory() {
   }
   // data transfer time
   std::chrono::duration<double, std::milli> end_time = std::chrono::steady_clock::now() - start_time;
-  Log::Info("%d dense feature groups (%.2f MB) transferred to GPU in %f secs. %d sparse feature groups", 
-            dense_feature_group_map_.size(), ((dense_feature_group_map_.size() + (dword_features_ - 1)) / dword_features_) * num_data_ * sizeof(Feature4) / (1024.0 * 1024.0), 
+  Log::Info("%d dense feature groups (%.2f MB) transferred to GPU in %f secs. %d sparse feature groups",
+            dense_feature_group_map_.size(), ((dense_feature_group_map_.size() + (dword_features_ - 1)) / dword_features_) * num_data_ * sizeof(Feature4) / (1024.0 * 1024.0),
             end_time * 1e-3, sparse_feature_group_map_.size());
   #if GPU_DEBUG >= 1
   printf("Dense feature group list (size %lu): ", dense_feature_group_map_.size());
@@ -596,7 +595,7 @@ void GPUTreeLearner::BuildGPUKernels() {
     OMP_LOOP_EX_BEGIN();
     boost::compute::program program;
     std::ostringstream opts;
-    // compile the GPU kernel depending if double precision is used, constant hessian is used, etc 
+    // compile the GPU kernel depending if double precision is used, constant hessian is used, etc.
     opts << " -D POWER_FEATURE_WORKGROUPS=" << i
          << " -D USE_CONSTANT_BUF=" << use_constants << " -D USE_DP_FLOAT=" << int(config_->gpu_use_dp)
          << " -D CONST_HESSIAN=" << int(is_constant_hessian_)
@@ -617,7 +616,7 @@ void GPUTreeLearner::BuildGPUKernels() {
       }
     }
     histogram_kernels_[i] = program.create_kernel(kernel_name_);
-    
+
     // kernel with all features enabled, with elimited branches
     opts << " -D ENABLE_ALL_FEATURES=1";
     try {
@@ -661,7 +660,7 @@ void GPUTreeLearner::SetupKernelArguments() {
   for (int i = 0; i <= kMaxLogWorkgroupsPerFeature; ++i) {
     // The only argument that needs to be changed later is num_data_
     if (is_constant_hessian_) {
-      // hessian is passed as a parameter, but it is not available now. 
+      // hessian is passed as a parameter, but it is not available now.
       // hessian will be set in BeforeTrain()
       histogram_kernels_[i].set_args(*device_features_, device_feature_masks_, num_data_,
                                          *device_data_indices_, num_data_, device_gradients_, 0.0f,
@@ -711,9 +710,9 @@ void GPUTreeLearner::InitGPU(int platform_id, int device_id) {
       if ((int)platform_devices.size() > device_id) {
         Log::Info("Using requested OpenCL platform %d device %d", platform_id, device_id);
         dev_ = platform_devices[device_id];
-      }   
-    }   
-  }   
+      }
+    }
+  }
   // determine which kernel to use based on the max number of bins
   if (max_num_bin_ <= 16) {
     kernel_source_ = kernel16_src_;
@@ -727,7 +726,7 @@ void GPUTreeLearner::InitGPU(int platform_id, int device_id) {
     device_bin_size_ = 64;
     dword_features_ = 4;
   }
-  else if ( max_num_bin_ <= 256) {
+  else if (max_num_bin_ <= 256) {
     kernel_source_ = kernel256_src_;
     kernel_name_ = "histogram256";
     device_bin_size_ = 256;
@@ -736,10 +735,10 @@ void GPUTreeLearner::InitGPU(int platform_id, int device_id) {
   else {
     Log::Fatal("bin size %d cannot run on GPU", max_num_bin_);
   }
-  if(max_num_bin_ == 65) {
+  if (max_num_bin_ == 65) {
     Log::Warning("Setting max_bin to 63 is sugguested for best performance");
   }
-  if(max_num_bin_ == 17) {
+  if (max_num_bin_ == 17) {
     Log::Warning("Setting max_bin to 15 is sugguested for best performance");
   }
   ctx_ = boost::compute::context(dev_);
@@ -774,7 +773,6 @@ void GPUTreeLearner::ResetTrainingData(const Dataset* train_data) {
 }
 
 void GPUTreeLearner::BeforeTrain() {
-
   #if GPU_DEBUG >= 2
   printf("Copying intial full gradients and hessians to device\n");
   #endif
@@ -861,7 +859,7 @@ bool GPUTreeLearner::BeforeFindBestSplit(const Tree* tree, int left_leaf, int ri
     // copy indices to the GPU:
     #if GPU_DEBUG >= 2
     Log::Info("Copying indices, gradients and hessians to GPU...");
-    printf("Indices size %d being copied (left = %d, right = %d)\n", end - begin,num_data_in_left_child,num_data_in_right_child);
+    printf("Indices size %d being copied (left = %d, right = %d)\n", end - begin, num_data_in_left_child, num_data_in_right_child);
     #endif
     indices_future_ = boost::compute::copy_async(indices + begin, indices + end, device_data_indices_->begin(), queue_);
 
@@ -893,7 +891,6 @@ bool GPUTreeLearner::ConstructGPUHistogramsAsync(
   const data_size_t* data_indices, data_size_t num_data,
   const score_t* gradients, const score_t* hessians,
   score_t* ordered_gradients, score_t* ordered_hessians) {
-
   if (num_data <= 0) {
     return false;
   }
@@ -901,7 +898,7 @@ bool GPUTreeLearner::ConstructGPUHistogramsAsync(
   if (!num_dense_feature_groups_) {
     return false;
   }
-  
+
   // copy data indices if it is not null
   if (data_indices != nullptr && num_data != num_data_) {
     indices_future_ = boost::compute::copy_async(data_indices, data_indices + num_data, device_data_indices_->begin(), queue_);
@@ -934,15 +931,15 @@ bool GPUTreeLearner::ConstructGPUHistogramsAsync(
   }
   // converted indices in is_feature_used to feature-group indices
   std::vector<int8_t> is_feature_group_used(num_feature_groups_, 0);
-  #pragma omp parallel for schedule(static,1024) if (num_features_ >= 2048)
+  #pragma omp parallel for schedule(static, 1024) if (num_features_ >= 2048)
   for (int i = 0; i < num_features_; ++i) {
-    if(is_feature_used[i]) {
+    if (is_feature_used[i]) {
       is_feature_group_used[train_data_->Feature2Group(i)] = 1;
     }
   }
   // construct the feature masks for dense feature-groups
   int used_dense_feature_groups = 0;
-  #pragma omp parallel for schedule(static,1024) reduction(+:used_dense_feature_groups) if (num_dense_feature_groups_ >= 2048)
+  #pragma omp parallel for schedule(static, 1024) reduction(+:used_dense_feature_groups) if (num_dense_feature_groups_ >= 2048)
   for (int i = 0; i < num_dense_feature_groups_; ++i) {
     if (is_feature_group_used[dense_feature_group_map_[i]]) {
       feature_masks_[i] = 1;
@@ -1036,7 +1033,7 @@ void GPUTreeLearner::ConstructHistograms(const std::vector<int8_t>& is_feature_u
       num_data,
       num_data != num_data_ ? ordered_gradients_.data() : gradients_,
       num_data != num_data_ ? ordered_hessians_.data() : hessians_,
-      current_histogram); 
+      current_histogram);
     CompareHistograms(gpu_histogram, current_histogram, size, dense_feature_group_index);
     std::copy(gpu_histogram, gpu_histogram + size, current_histogram);
     delete [] gpu_histogram;
@@ -1083,7 +1080,7 @@ void GPUTreeLearner::FindBestSplits() {
       smaller_leaf_histogram_array_[feature_index].set_is_splittable(false);
       continue;
     }
-    size_t bin_size = train_data_->FeatureNumBin(feature_index) + 1; 
+    size_t bin_size = train_data_->FeatureNumBin(feature_index) + 1;
     printf("Feature %d smaller leaf:\n", feature_index);
     PrintHistograms(smaller_leaf_histogram_array_[feature_index].RawData() - 1, bin_size);
     if (larger_leaf_splits_ == nullptr || larger_leaf_splits_->LeafIndex() < 0) { continue; }
@@ -1124,4 +1121,4 @@ void GPUTreeLearner::Split(Tree* tree, int best_Leaf, int* left_leaf, int* right
 }
 
 }   // namespace LightGBM
-#endif // USE_GPU
+#endif  // USE_GPU

--- a/src/treelearner/gpu_tree_learner.h
+++ b/src/treelearner/gpu_tree_learner.h
@@ -63,12 +63,13 @@ protected:
   void FindBestSplits() override;
   void Split(Tree* tree, int best_Leaf, int* left_leaf, int* right_leaf) override;
   void ConstructHistograms(const std::vector<int8_t>& is_feature_used, bool use_subtract) override;
+
 private:
   /*! \brief 4-byte feature tuple used by GPU kernels */
   struct Feature4 {
       uint8_t s[4];
   };
-  
+
   /*! \brief Single precision histogram entiry for GPU */
   struct GPUHistogramBinEntry {
     score_t sum_gradients;
@@ -82,7 +83,7 @@ private:
   * \return Log2 of the best number for workgroups per feature, in range 0...kMaxLogWorkgroupsPerFeature
   */
   int GetNumWorkgroupsPerFeature(data_size_t leaf_num_data);
-  
+
   /*!
   * \brief Initialize GPU device, context and command queues
   *        Also compiles the OpenCL kernel
@@ -100,7 +101,7 @@ private:
   * \brief Compile OpenCL GPU source code to kernel binaries
   */
   void BuildGPUKernels();
-  
+
   /*!
    * \brief Returns OpenCL kernel build log when compiled with option opts
    * \param opts OpenCL build options 
@@ -120,7 +121,7 @@ private:
    * \param use_all_features Set to true to not use feature masks, with a faster kernel
   */
   void GPUHistogram(data_size_t leaf_num_data, bool use_all_features);
-  
+
   /*!
    * \brief Wait for GPU kernel execution and read histogram
    * \param histograms Destination of histogram results from GPU.
@@ -151,7 +152,7 @@ private:
 
 
   /*! brief Log2 of max number of workgroups per feature*/
-  const int kMaxLogWorkgroupsPerFeature = 10; // 2^10
+  const int kMaxLogWorkgroupsPerFeature = 10;  // 2^10
   /*! brief Max total number of workgroups with preallocated workspace.
    *        If we use more than this number of workgroups, we have to reallocate subhistograms */
   int preallocd_max_num_wg_ = 1024;
@@ -166,15 +167,15 @@ private:
   /*! \brief GPU command queue object */
   boost::compute::command_queue queue_;
   /*! \brief GPU kernel for 256 bins */
-  const char *kernel256_src_ = 
+  const char *kernel256_src_ =
   #include "ocl/histogram256.cl"
   ;
   /*! \brief GPU kernel for 64 bins */
-  const char *kernel64_src_ = 
+  const char *kernel64_src_ =
   #include "ocl/histogram64.cl"
   ;
   /*! \brief GPU kernel for 16 bins */
-  const char *kernel16_src_ = 
+  const char *kernel16_src_ =
   #include "ocl/histogram16.cl"
   ;
   /*! \brief Currently used kernel source */
@@ -266,7 +267,7 @@ private:
 // When GPU support is not compiled in, quit with an error message
 
 namespace LightGBM {
-    
+
 class GPUTreeLearner: public SerialTreeLearner {
 public:
   #pragma warning(disable : 4702)
@@ -276,7 +277,7 @@ public:
   }
 };
 
-}
+}  // namespace LightGBM
 
 #endif   // USE_GPU
 

--- a/src/treelearner/leaf_splits.hpp
+++ b/src/treelearner/leaf_splits.hpp
@@ -129,7 +129,7 @@ public:
 
   /*! \brief Get sum of gradients of current leaf */
   double sum_gradients() const { return sum_gradients_; }
-  
+
   /*! \brief Get sum of hessians of current leaf */
   double sum_hessians() const { return sum_hessians_; }
 

--- a/src/treelearner/parallel_tree_learner.h
+++ b/src/treelearner/parallel_tree_learner.h
@@ -51,6 +51,7 @@ public:
   ~DataParallelTreeLearner();
   void Init(const Dataset* train_data, bool is_constant_hessian) override;
   void ResetConfig(const Config* config) override;
+
 protected:
   void BeforeTrain() override;
   void FindBestSplits() override;
@@ -104,6 +105,7 @@ public:
   ~VotingParallelTreeLearner() { }
   void Init(const Dataset* train_data, bool is_constant_hessian) override;
   void ResetConfig(const Config* config) override;
+
 protected:
   void BeforeTrain() override;
   bool BeforeFindBestSplit(const Tree* tree, int left_leaf, int right_leaf) override;
@@ -185,7 +187,7 @@ inline void SyncUpGlobalBestSplit(char* input_buffer_, char* output_buffer_, Spl
   int size = SplitInfo::Size(max_cat_threshold);
   smaller_best_split->CopyTo(input_buffer_);
   larger_best_split->CopyTo(input_buffer_ + size);
-  Network::Allreduce(input_buffer_, size * 2, size, output_buffer_, 
+  Network::Allreduce(input_buffer_, size * 2, size, output_buffer_,
                      [] (const char* src, char* dst, int size, comm_size_t len) {
     comm_size_t used_size = 0;
     LightSplitInfo p1, p2;

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -18,7 +18,7 @@ std::chrono::duration<double, std::milli> hist_time;
 std::chrono::duration<double, std::milli> find_split_time;
 std::chrono::duration<double, std::milli> split_time;
 std::chrono::duration<double, std::milli> ordered_bin_time;
-#endif // TIMETAG
+#endif  // TIMETAG
 
 SerialTreeLearner::SerialTreeLearner(const Config* config)
   :config_(config) {
@@ -253,7 +253,6 @@ Tree* SerialTreeLearner::FitByExistingTree(const Tree* old_tree, const std::vect
 }
 
 void SerialTreeLearner::BeforeTrain() {
-
   // reset histogram pool
   histogram_pool_.ResetMap();
 
@@ -322,7 +321,7 @@ void SerialTreeLearner::BeforeTrain() {
       const data_size_t* indices = data_partition_->indices();
       data_size_t begin = data_partition_->leaf_begin(0);
       data_size_t end = begin + data_partition_->leaf_count(0);
-      #pragma omp parallel for schedule(static, 512) if(end - begin >= 1024)
+      #pragma omp parallel for schedule(static, 512) if (end - begin >= 1024)
       for (data_size_t i = begin; i < end; ++i) {
         is_data_in_leaf_[indices[i]] = 1;
       }
@@ -335,7 +334,7 @@ void SerialTreeLearner::BeforeTrain() {
         OMP_LOOP_EX_END();
       }
       OMP_THROW_EX();
-      #pragma omp parallel for schedule(static, 512) if(end - begin >= 1024)
+      #pragma omp parallel for schedule(static, 512) if (end - begin >= 1024)
       for (data_size_t i = begin; i < end; ++i) {
         is_data_in_leaf_[indices[i]] = 0;
       }
@@ -401,7 +400,7 @@ bool SerialTreeLearner::BeforeFindBestSplit(const Tree* tree, int left_leaf, int
       end = begin + right_cnt;
       mark = 0;
     }
-    #pragma omp parallel for schedule(static, 512) if(end - begin >= 1024)
+    #pragma omp parallel for schedule(static, 512) if (end - begin >= 1024)
     for (data_size_t i = begin; i < end; ++i) {
       is_data_in_leaf_[indices[i]] = 1;
     }
@@ -414,7 +413,7 @@ bool SerialTreeLearner::BeforeFindBestSplit(const Tree* tree, int left_leaf, int
       OMP_LOOP_EX_END();
     }
     OMP_THROW_EX();
-    #pragma omp parallel for schedule(static, 512) if(end - begin >= 1024)
+    #pragma omp parallel for schedule(static, 512) if (end - begin >= 1024)
     for (data_size_t i = begin; i < end; ++i) {
       is_data_in_leaf_[indices[i]] = 0;
     }
@@ -427,7 +426,7 @@ bool SerialTreeLearner::BeforeFindBestSplit(const Tree* tree, int left_leaf, int
 
 void SerialTreeLearner::FindBestSplits() {
   std::vector<int8_t> is_feature_used(num_features_, 0);
-  #pragma omp parallel for schedule(static,1024) if (num_features_ >= 2048)
+  #pragma omp parallel for schedule(static, 1024) if (num_features_ >= 2048)
   for (int feature_index = 0; feature_index < num_features_; ++feature_index) {
     if (!is_feature_used_[feature_index]) continue;
     if (parent_leaf_histogram_array_ != nullptr
@@ -542,7 +541,7 @@ void SerialTreeLearner::FindBestSplitsFromHistograms(const std::vector<int8_t>& 
 }
 
 int32_t SerialTreeLearner::ForceSplits(Tree* tree, Json& forced_split_json, int* left_leaf,
-                                       int* right_leaf, int *cur_depth, 
+                                       int* right_leaf, int *cur_depth,
                                        bool *aborted_last_force_split) {
   int32_t result_count = 0;
   // start at root leaf
@@ -553,8 +552,7 @@ int32_t SerialTreeLearner::ForceSplits(Tree* tree, Json& forced_split_json, int*
   bool left_smaller = true;
   std::unordered_map<int, SplitInfo> forceSplitMap;
   q.push(std::make_pair(forced_split_json, *left_leaf));
-  while(!q.empty()) {
-
+  while (!q.empty()) {
     // before processing next node from queue, store info for current left/right leaf
     // store "best split" for left and right, even if they might be overwritten by forced split
     if (BeforeFindBestSplit(tree, *left_leaf, *right_leaf)) {
@@ -815,7 +813,7 @@ void SerialTreeLearner::RenewTreeOutput(Tree* tree, const ObjectiveFunction* obj
       for (int i = 0; i < tree->num_leaves(); ++i) {
         tree->SetLeafOutput(i, outputs[i] / n_nozeroworker_perleaf[i]);
       }
-    } 
+    }
   }
 }
 

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -103,9 +103,8 @@ protected:
 
   /* Force splits with forced_split_json dict and then return num splits forced.*/
   virtual int32_t ForceSplits(Tree* tree, Json& forced_split_json, int* left_leaf,
-                              int* right_leaf, int* cur_depth, 
+                              int* right_leaf, int* cur_depth,
                               bool *aborted_last_force_split);
-
 
   /*!
   * \brief Get the number of data in a leaf

--- a/src/treelearner/split_info.hpp
+++ b/src/treelearner/split_info.hpp
@@ -185,7 +185,6 @@ public:
       return local_feature == other_feature;
     }
   }
-
 };
 
 struct LightSplitInfo {
@@ -280,7 +279,6 @@ public:
       return local_feature == other_feature;
     }
   }
-
 };
 
 }  // namespace LightGBM

--- a/src/treelearner/voting_parallel_tree_learner.cpp
+++ b/src/treelearner/voting_parallel_tree_learner.cpp
@@ -370,7 +370,6 @@ void VotingParallelTreeLearner<TREELEARNER_T>::FindBestSplits() {
 
 template <typename TREELEARNER_T>
 void VotingParallelTreeLearner<TREELEARNER_T>::FindBestSplitsFromHistograms(const std::vector<int8_t>&, bool) {
-
   std::vector<SplitInfo> smaller_bests_per_thread(this->num_threads_);
   std::vector<SplitInfo> larger_best_per_thread(this->num_threads_);
   // find best split from local aggregated histograms
@@ -506,4 +505,4 @@ void VotingParallelTreeLearner<TREELEARNER_T>::Split(Tree* tree, int best_Leaf, 
 // instantiate template classes, otherwise linker cannot find the code
 template class VotingParallelTreeLearner<GPUTreeLearner>;
 template class VotingParallelTreeLearner<SerialTreeLearner>;
-}  // namespace FTLBoost
+}  // namespace LightGBM


### PR DESCRIPTION
Fixed redundant/required new lines and whitespaces, excess semicolons, closing namespace comments.

Report has been gotten from **cpplint** https://github.com/cpplint/cpplint .

Later it can be used as part of `pylint` CI task.