### PR TITLE
[R-package] Fix demos not using lgb.Dataset.create.valid

### DIFF
--- a/R-package/demo/boost_from_prediction.R
+++ b/R-package/demo/boost_from_prediction.R
@@ -5,7 +5,7 @@ require(methods)
 data(agaricus.train, package = "lightgbm")
 data(agaricus.test, package = "lightgbm")
 dtrain <- lgb.Dataset(agaricus.train$data, label = agaricus.train$label)
-dtest <- lgb.Dataset(agaricus.test$data, label = agaricus.test$label)
+dtest <- lgb.Dataset.create.valid(dtrain, data = agaricus.test$data, label = agaricus.test$label)
 
 valids <- list(eval = dtest, train = dtrain)
 #--------------------Advanced features ---------------------------

--- a/R-package/demo/categorical_features_rules.R
+++ b/R-package/demo/categorical_features_rules.R
@@ -70,8 +70,9 @@ my_data_test <- as.matrix(bank_test[, 1:16, with = FALSE])
 # The categorical features can be passed to lgb.train to not copy and paste a lot
 dtrain <- lgb.Dataset(data = my_data_train,
                       label = bank_train$y)
-dtest <- lgb.Dataset(data = my_data_test,
-                     label = bank_test$y)
+dtest <- lgb.Dataset.create.valid(dtrain,
+                                  data = my_data_test,
+                                  label = bank_test$y)
 
 # We can now train a model
 model <- lgb.train(list(objective = "binary",

--- a/R-package/demo/cross_validation.R
+++ b/R-package/demo/cross_validation.R
@@ -3,7 +3,7 @@ require(lightgbm)
 data(agaricus.train, package = "lightgbm")
 data(agaricus.test, package = "lightgbm")
 dtrain <- lgb.Dataset(agaricus.train$data, label = agaricus.train$label)
-dtest <- lgb.Dataset(agaricus.test$data, label = agaricus.test$label)
+dtest <- lgb.Dataset.create.valid(dtrain, data = agaricus.test$data, label = agaricus.test$label)
 
 nrounds <- 2
 param <- list(num_leaves = 4,

--- a/R-package/demo/early_stopping.R
+++ b/R-package/demo/early_stopping.R
@@ -6,7 +6,7 @@ data(agaricus.train, package = "lightgbm")
 data(agaricus.test, package = "lightgbm")
 
 dtrain <- lgb.Dataset(agaricus.train$data, label = agaricus.train$label)
-dtest <- lgb.Dataset(agaricus.test$data, label = agaricus.test$label)
+dtest <- lgb.Dataset.create.valid(dtrain, data = agaricus.test$data, label = agaricus.test$label)
 
 # Note: for customized objective function, we leave objective as default
 # Note: what we are getting is margin value in prediction


### PR DESCRIPTION
Validation in R-package should use lgb.Dataset.create.valid as pointed out in #1988.

Currently blocking #1987 (2.2.3 release)

As for the "Hand edit broken commit", this is because #1992 (it didn't seem to push the commit anywhere, not even a branch)