### PR TITLE
fixed modifiers indent

### DIFF
--- a/include/LightGBM/application.h
+++ b/include/LightGBM/application.h
@@ -23,7 +23,7 @@ class Metric;
 *        and save the score to disk.
 */
 class Application {
-public:
+ public:
   Application(int argc, char** argv);
 
   /*! \brief Destructor */
@@ -32,7 +32,7 @@ public:
   /*! \brief To call this funciton to run application*/
   inline void Run();
 
-private:
+ private:
   /*! \brief Load parameters from command line and config file*/
   void LoadParameters(int argc, char** argv);
 

--- a/include/LightGBM/bin.h
+++ b/include/LightGBM/bin.h
@@ -27,7 +27,7 @@ enum MissingType {
 
 /*! \brief Store data for one histogram bin */
 struct HistogramBinEntry {
-public:
+ public:
   /*! \brief Sum of gradients on this bin */
   double sum_gradients = 0.0f;
   /*! \brief Sum of hessians on this bin */
@@ -59,7 +59,7 @@ public:
 /*! \brief This class used to convert feature values into bin,
 *          and store some meta information for bin*/
 class BinMapper {
-public:
+ public:
   BinMapper();
   BinMapper(const BinMapper& other);
   explicit BinMapper(const void* memory);
@@ -184,7 +184,7 @@ public:
     }
   }
 
-private:
+ private:
   /*! \brief Number of bins */
   int num_bin_;
   MissingType missing_type_;
@@ -217,7 +217,7 @@ private:
 *        So we only using ordered bin for sparse situations.
 */
 class OrderedBin {
-public:
+ public:
   /*! \brief virtual destructor */
   virtual ~OrderedBin() {}
 
@@ -265,7 +265,7 @@ public:
 
 /*! \brief Iterator for one bin column */
 class BinIterator {
-public:
+ public:
   /*!
   * \brief Get bin data on specific row index
   * \param idx Index of this data
@@ -284,7 +284,7 @@ public:
 *        but it doesn't need to re-order operation, So it will be faster than OrderedBin for dense feature
 */
 class Bin {
-public:
+ public:
   /*! \brief virtual destructor */
   virtual ~Bin() {}
   /*!

--- a/include/LightGBM/boosting.h
+++ b/include/LightGBM/boosting.h
@@ -20,7 +20,7 @@ struct PredictionEarlyStopInstance;
 * \brief The interface for Boosting
 */
 class LIGHTGBM_EXPORT Boosting {
-public:
+ public:
   /*! \brief virtual destructor */
   virtual ~Boosting() {}
 
@@ -294,7 +294,7 @@ public:
 };
 
 class GBDTBase : public Boosting {
-public:
+ public:
   virtual double GetLeafValue(int tree_idx, int leaf_idx) const = 0;
   virtual void SetLeafValue(int tree_idx, int leaf_idx, double val) = 0;
 };

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -25,7 +25,7 @@ enum TaskType {
 const int kDefaultNumLeaves = 31;
 
 struct Config {
-public:
+ public:
   std::string ToString() const;
   /*!
   * \brief Get string value by specific name of key
@@ -772,7 +772,7 @@ public:
   static std::unordered_map<std::string, std::string> alias_table;
   static std::unordered_set<std::string> parameter_set;
 
-private:
+ private:
   void CheckParamConflict();
   void GetMembersFromString(const std::unordered_map<std::string, std::string>& params);
   std::string SaveMembersToString() const;

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -34,7 +34,7 @@ class DatasetLoader;
 *        5. Initial score. optional. if exsitng, the model will boost from this score, otherwise will start from 0.
 */
 class Metadata {
-public:
+ public:
   /*!
   * \brief Null costructor
   */
@@ -206,7 +206,7 @@ public:
   /*! \brief Disable copy */
   Metadata(const Metadata&) = delete;
 
-private:
+ private:
   /*! \brief Load initial scores from file */
   void LoadInitialScore(const char* initscore_file);
   /*! \brief Load wights from file */
@@ -247,7 +247,7 @@ private:
 
 /*! \brief Interface for Parser */
 class Parser {
-public:
+ public:
   /*! \brief virtual destructor */
   virtual ~Parser() {}
 
@@ -276,7 +276,7 @@ public:
 *          which are used to traning or validation
 */
 class Dataset {
-public:
+ public:
   friend DatasetLoader;
 
   LIGHTGBM_EXPORT Dataset();
@@ -581,7 +581,7 @@ public:
   /*! \brief Disable copy */
   Dataset(const Dataset&) = delete;
 
-private:
+ private:
   std::string data_filename_;
   /*! \brief Store used features */
   std::vector<std::unique_ptr<FeatureGroup>> feature_groups_;

--- a/include/LightGBM/dataset_loader.h
+++ b/include/LightGBM/dataset_loader.h
@@ -6,7 +6,7 @@
 namespace LightGBM {
 
 class DatasetLoader {
-public:
+ public:
   LIGHTGBM_EXPORT DatasetLoader(const Config& io_config, const PredictFunction& predict_fun, int num_class, const char* filename);
 
   LIGHTGBM_EXPORT ~DatasetLoader();
@@ -28,7 +28,7 @@ public:
   /*! \brief Disable copy */
   DatasetLoader(const DatasetLoader&) = delete;
 
-private:
+ private:
   Dataset* LoadFromBinFile(const char* data_filename, const char* bin_filename, int rank, int num_machines, int* num_global_data, std::vector<data_size_t>* used_data_indices);
 
   void SetHeader(const char* filename);

--- a/include/LightGBM/feature_group.h
+++ b/include/LightGBM/feature_group.h
@@ -16,7 +16,7 @@ class Dataset;
 class DatasetLoader;
 /*! \brief Using to store data and providing some operations on one feature group*/
 class FeatureGroup {
-public:
+ public:
   friend Dataset;
   friend DatasetLoader;
   /*!
@@ -214,7 +214,7 @@ public:
   /*! \brief Disable copy */
   FeatureGroup(const FeatureGroup&) = delete;
 
-private:
+ private:
   /*! \brief Number of features */
   int num_feature_;
   /*! \brief Bin mapper for sub features */

--- a/include/LightGBM/json11.hpp
+++ b/include/LightGBM/json11.hpp
@@ -204,13 +204,13 @@ public:
     typedef std::initializer_list<std::pair<std::string, Type>> shape;
     bool has_shape(const shape & types, std::string & err) const;
 
-private:
+ private:
     std::shared_ptr<JsonValue> m_ptr;
 };
 
 // Internal class hierarchy - JsonValue objects are not exposed to users of this API.
 class JsonValue {
-protected:
+ protected:
     friend class Json;
     friend class JsonInt;
     friend class JsonDouble;

--- a/include/LightGBM/metric.h
+++ b/include/LightGBM/metric.h
@@ -18,7 +18,7 @@ namespace LightGBM {
 *        Metric is used to calculate metric result
 */
 class Metric {
-public:
+ public:
   /*! \brief virtual destructor */
   virtual ~Metric() {}
 
@@ -57,7 +57,7 @@ public:
 * \brief Static class, used to calculate DCG score
 */
 class DCGCalculator {
-public:
+ public:
   static void DefaultEvalAt(std::vector<int>* eval_at);
   static void DefaultLabelGain(std::vector<double>* label_gain);
   /*!
@@ -123,7 +123,7 @@ public:
   */
   inline static double GetDiscount(data_size_t k) { return discount_[k]; }
 
-private:
+ private:
   /*! \brief store gains for different label */
   static std::vector<double> label_gain_;
   /*! \brief store discount score for different position */

--- a/include/LightGBM/network.h
+++ b/include/LightGBM/network.h
@@ -17,7 +17,7 @@ class Linkers;
 
 /*! \brief The network structure for all_gather */
 class BruckMap {
-public:
+ public:
   /*! \brief The communication times for one all gather operation */
   int k;
   /*! \brief in_ranks[i] means the incomming rank on i-th communication */
@@ -51,7 +51,7 @@ enum RecursiveHalvingNodeType {
 
 /*! \brief Network structure for recursive halving algorithm */
 class RecursiveHalvingMap {
-public:
+ public:
   /*! \brief Communication times for one recursize halving algorithm  */
   int k;
   /*! \brief Node type */
@@ -84,7 +84,7 @@ public:
 
 /*! \brief A static class that contains some collective communication algorithm */
 class Network {
-public:
+ public:
   /*!
   * \brief Initialize
   * \param config Config of network setting
@@ -256,7 +256,7 @@ public:
     }
   }
 
-private:
+ private:
   static void AllgatherBruck(char* input, const comm_size_t* block_start, const comm_size_t* block_len, char* output, comm_size_t all_size);
 
   static void AllgatherRecursiveDoubling(char* input, const comm_size_t* block_start, const comm_size_t* block_len, char* output, comm_size_t all_size);

--- a/include/LightGBM/objective_function.h
+++ b/include/LightGBM/objective_function.h
@@ -11,7 +11,7 @@ namespace LightGBM {
 * \brief The interface of Objective Function.
 */
 class ObjectiveFunction {
-public:
+ public:
   /*! \brief virtual destructor */
   virtual ~ObjectiveFunction() {}
 

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -18,7 +18,7 @@ namespace LightGBM {
 * \brief Tree model
 */
 class Tree {
-public:
+ public:
   /*!
   * \brief Constructor
   * \param max_leaves The number of max leaves
@@ -203,7 +203,7 @@ public:
 
   void RecomputeMaxDepth();
 
-private:
+ private:
   std::string NumericalDecisionIfElse(int node) const;
 
   std::string CategoricalDecisionIfElse(int node) const;

--- a/include/LightGBM/tree_learner.h
+++ b/include/LightGBM/tree_learner.h
@@ -21,7 +21,7 @@ class ObjectiveFunction;
 * \brief Interface for tree learner
 */
 class TreeLearner {
-public:
+ public:
   /*! \brief virtual destructor */
   virtual ~TreeLearner() {}
 

--- a/include/LightGBM/utils/array_args.h
+++ b/include/LightGBM/utils/array_args.h
@@ -12,7 +12,7 @@ namespace LightGBM {
 */
 template<typename VAL_T>
 class ArrayArgs {
-public:
+ public:
   inline static size_t ArgMaxMT(const std::vector<VAL_T>& array) {
     int num_threads = 1;
 #pragma omp parallel

--- a/include/LightGBM/utils/log.h
+++ b/include/LightGBM/utils/log.h
@@ -41,7 +41,7 @@ enum class LogLevel: int {
 * \brief A static Log class
 */
 class Log {
-public:
+ public:
   /*!
   * \brief Resets the minimal log level. It is INFO by default.
   * \param level The new minimal log level.
@@ -83,7 +83,7 @@ public:
     throw std::runtime_error(std::string(str_buf));
   }
 
-private:
+ private:
   static void Write(LogLevel level, const char* level_str, const char *format, va_list val) {
     if (level <= GetLevel()) {  // omit the message with low level
       // write to STDOUT

--- a/include/LightGBM/utils/openmp_wrapper.h
+++ b/include/LightGBM/utils/openmp_wrapper.h
@@ -11,7 +11,7 @@
 #include "log.h"
 
 class ThreadExceptionHelper {
-public:
+ public:
   ThreadExceptionHelper() {
     ex_ptr_ = nullptr;
   }
@@ -31,7 +31,8 @@ public:
     if (ex_ptr_ != nullptr) { return; }
     ex_ptr_ = std::current_exception();
   }
-private:
+
+ private:
   std::exception_ptr ex_ptr_;
   std::mutex lock_;
 };

--- a/include/LightGBM/utils/pipeline_reader.h
+++ b/include/LightGBM/utils/pipeline_reader.h
@@ -18,7 +18,7 @@ namespace LightGBM {
 * \brief A pipeline file reader, use 2 threads, one read block from file, the other process the block
 */
 class PipelineReader {
-public:
+ public:
   /*!
   * \brief Read data from a file, use pipeline methods
   * \param filename Filename of data

--- a/include/LightGBM/utils/random.h
+++ b/include/LightGBM/utils/random.h
@@ -13,7 +13,7 @@ namespace LightGBM {
 * \brief A wrapper for random generator
 */
 class Random {
-public:
+ public:
   /*!
   * \brief Constructor, with random seed
   */
@@ -94,7 +94,7 @@ public:
     return ret;
   }
 
-private:
+ private:
   inline int RandInt16() {
     x = (214013 * x + 2531011);
     return static_cast<int>((x >> 16) & 0x7FFF);

--- a/include/LightGBM/utils/text_reader.h
+++ b/include/LightGBM/utils/text_reader.h
@@ -19,7 +19,7 @@ namespace LightGBM {
 */
 template<typename INDEX_T>
 class TextReader {
-public:
+ public:
   /*!
   * \brief Constructor
   * \param filename Filename of data
@@ -306,7 +306,7 @@ public:
     });
   }
 
-private:
+ private:
   /*! \brief Filename of text data */
   const char* filename_;
   /*! \brief Cache the read text data */

--- a/include/LightGBM/utils/threading.h
+++ b/include/LightGBM/utils/threading.h
@@ -9,7 +9,7 @@
 namespace LightGBM {
 
 class Threading {
-public:
+ public:
   template<typename INDEX_T>
   static inline void For(INDEX_T start, INDEX_T end, const std::function<void(int, INDEX_T, INDEX_T)>& inner_fun) {
     int num_threads = 1;

--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -23,7 +23,7 @@ namespace LightGBM {
 * \brief Used to predict data with input model
 */
 class Predictor {
-public:
+ public:
   /*!
   * \brief Constructor
   * \param boosting Input boosting model
@@ -207,7 +207,7 @@ public:
     predict_data_reader.ReadAllAndProcessParallel(process_fun);
   }
 
-private:
+ private:
   void CopyToPredictBuffer(double* pred_buf, const std::vector<std::pair<int, double>>& features) {
     int loop_size = static_cast<int>(features.size());
     for (int i = 0; i < loop_size; ++i) {

--- a/src/boosting/dart.hpp
+++ b/src/boosting/dart.hpp
@@ -15,7 +15,7 @@ namespace LightGBM {
 * \brief DART algorithm implementation. including Training, prediction, bagging.
 */
 class DART: public GBDT {
-public:
+ public:
   /*!
   * \brief Constructor
   */
@@ -84,7 +84,7 @@ public:
     return false;
   }
 
-private:
+ private:
   /*!
   * \brief drop trees based on drop_rate
   */

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -24,7 +24,7 @@ namespace LightGBM {
 * \brief GBDT algorithm implementation. including Training, prediction, bagging.
 */
 class GBDT : public GBDTBase {
-public:
+ public:
   /*!
   * \brief Constructor
   */
@@ -354,7 +354,7 @@ public:
   */
   virtual const char* SubModelName() const override { return "tree"; }
 
-protected:
+ protected:
   /*!
   * \brief Print eval result and check early stopping
   */

--- a/src/boosting/goss.hpp
+++ b/src/boosting/goss.hpp
@@ -24,7 +24,7 @@ std::chrono::duration<double, std::milli> re_init_tree_time;
 #endif
 
 class GOSS: public GBDT {
-public:
+ public:
   /*!
   * \brief Constructor
   */
@@ -208,7 +208,7 @@ public:
     }
   }
 
-private:
+ private:
   std::vector<data_size_t> tmp_indice_right_;
 };
 

--- a/src/boosting/rf.hpp
+++ b/src/boosting/rf.hpp
@@ -16,7 +16,7 @@ namespace LightGBM {
 * \brief Rondom Forest implementation
 */
 class RF : public GBDT {
-public:
+ public:
   RF() : GBDT() {
     average_output_ = true;
   }
@@ -199,7 +199,7 @@ public:
     return true;
   };
 
-private:
+ private:
   std::vector<score_t> tmp_grad_;
   std::vector<score_t> tmp_hess_;
   std::vector<double> init_scores_;

--- a/src/boosting/score_updater.hpp
+++ b/src/boosting/score_updater.hpp
@@ -15,7 +15,7 @@ namespace LightGBM {
 * \brief Used to store and update score for data
 */
 class ScoreUpdater {
-public:
+ public:
   /*!
   * \brief Constructor, will pass a const pointer of dataset
   * \param data This class will bind with this data set
@@ -109,7 +109,7 @@ public:
   /*! \brief Disable copy */
   ScoreUpdater(const ScoreUpdater&) = delete;
 
-private:
+ private:
   /*! \brief Number of total data */
   data_size_t num_data_;
   /*! \brief Pointer of data set */

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -44,7 +44,7 @@ catch(...) { return LGBM_APIHandleException("unknown exception"); } \
 return 0;
 
 class Booster {
-public:
+ public:
   explicit Booster(const char* filename) {
     boosting_.reset(Boosting::CreateBoosting("gbdt", filename));
   }
@@ -323,7 +323,7 @@ public:
 
   const Boosting* GetBoosting() const { return boosting_.get(); }
 
-private:
+ private:
   const Dataset* train_data_;
   std::unique_ptr<Boosting> boosting_;
   /*! \brief All configs */
@@ -356,7 +356,7 @@ RowFunctionFromCSR(const void* indptr, int indptr_type, const int32_t* indices,
 
 // Row iterator of on column for CSC matrix
 class CSC_RowIterator {
-public:
+ public:
   CSC_RowIterator(const void* col_ptr, int col_ptr_type, const int32_t* indices,
                   const void* data, int data_type, int64_t ncol_ptr, int64_t nelem, int col_idx);
   ~CSC_RowIterator() {}
@@ -364,7 +364,8 @@ public:
   double Get(int idx);
   // return next non-zero pair, if index < 0, means no more data
   std::pair<int, double> NextNonZero();
-private:
+
+ private:
   int nonzero_idx_ = 0;
   int cur_idx_ = -1;
   double cur_val_ = 0.0f;

--- a/src/io/dense_bin.hpp
+++ b/src/io/dense_bin.hpp
@@ -14,7 +14,7 @@ class DenseBin;
 
 template <typename VAL_T>
 class DenseBinIterator: public BinIterator {
-public:
+ public:
   explicit DenseBinIterator(const DenseBin<VAL_T>* bin_data, uint32_t min_bin, uint32_t max_bin, uint32_t default_bin)
     : bin_data_(bin_data), min_bin_(static_cast<VAL_T>(min_bin)),
     max_bin_(static_cast<VAL_T>(max_bin)),
@@ -28,7 +28,8 @@ public:
   inline uint32_t RawGet(data_size_t idx) override;
   inline uint32_t Get(data_size_t idx) override;
   inline void Reset(data_size_t) override { }
-private:
+
+ private:
   const DenseBin<VAL_T>* bin_data_;
   VAL_T min_bin_;
   VAL_T max_bin_;
@@ -41,7 +42,7 @@ private:
 */
 template <typename VAL_T>
 class DenseBin: public Bin {
-public:
+ public:
   friend DenseBinIterator<VAL_T>;
   DenseBin(data_size_t num_data)
     : num_data_(num_data), data_(num_data_, static_cast<VAL_T>(0)) {
@@ -310,7 +311,7 @@ public:
     return sizeof(VAL_T) * num_data_;
   }
 
-protected:
+ protected:
   data_size_t num_data_;
   std::vector<VAL_T> data_;
 };

--- a/src/io/dense_nbits_bin.hpp
+++ b/src/io/dense_nbits_bin.hpp
@@ -12,7 +12,7 @@ namespace LightGBM {
 class Dense4bitsBin;
 
 class Dense4bitsBinIterator : public BinIterator {
-public:
+ public:
   explicit Dense4bitsBinIterator(const Dense4bitsBin* bin_data, uint32_t min_bin, uint32_t max_bin, uint32_t default_bin)
     : bin_data_(bin_data), min_bin_(static_cast<uint8_t>(min_bin)),
     max_bin_(static_cast<uint8_t>(max_bin)),
@@ -26,7 +26,8 @@ public:
   inline uint32_t RawGet(data_size_t idx) override;
   inline uint32_t Get(data_size_t idx) override;
   inline void Reset(data_size_t) override {}
-private:
+
+ private:
   const Dense4bitsBin* bin_data_;
   uint8_t min_bin_;
   uint8_t max_bin_;
@@ -35,7 +36,7 @@ private:
 };
 
 class Dense4bitsBin : public Bin {
-public:
+ public:
   friend Dense4bitsBinIterator;
   Dense4bitsBin(data_size_t num_data)
     : num_data_(num_data) {
@@ -362,7 +363,7 @@ public:
     return sizeof(uint8_t) * data_.size();
   }
 
-protected:
+ protected:
   data_size_t num_data_;
   std::vector<uint8_t> data_;
   std::vector<uint8_t> buf_;

--- a/src/io/file_io.cpp
+++ b/src/io/file_io.cpp
@@ -42,7 +42,7 @@ struct LocalFile : VirtualFileReader, VirtualFileWriter {
     return fwrite(buffer, bytes, 1, file_) == 1 ? bytes : 0;
   }
 
-private:
+ private:
   FILE* file_ = NULL;
   const std::string filename_;
   const std::string mode_;
@@ -86,7 +86,7 @@ struct HDFSFile : VirtualFileReader, VirtualFileWriter {
     return FileOperation<const void*>(data, bytes, &hdfsWrite);
   }
 
-private:
+ private:
   template <typename BufferType>
   using fileOp = tSize(*)(hdfsFS, hdfsFile, BufferType, tSize);
 

--- a/src/io/json11.cpp
+++ b/src/io/json11.cpp
@@ -147,7 +147,7 @@ void Json::dump(string &out) const {
 
 template <Json::Type tag, typename T>
 class Value : public JsonValue {
-protected:
+ protected:
     // Constructors
     explicit Value(const T &value) : m_value(value) {}
     explicit Value(T &&value)      : m_value(move(value)) {}
@@ -174,7 +174,7 @@ class JsonDouble final : public Value<Json::NUMBER, double> {
     int int_value() const override { return static_cast<int>(m_value); }
     bool equals(const JsonValue * other) const override { return m_value == other->number_value(); }
     bool less(const JsonValue * other)   const override { return m_value <  other->number_value(); }
-public:
+ public:
     explicit JsonDouble(double value) : Value(value) {}
 };
 
@@ -183,19 +183,19 @@ class JsonInt final : public Value<Json::NUMBER, int> {
     int int_value() const override { return m_value; }
     bool equals(const JsonValue * other) const override { return m_value == other->number_value(); }
     bool less(const JsonValue * other)   const override { return m_value <  other->number_value(); }
-public:
+ public:
     explicit JsonInt(int value) : Value(value) {}
 };
 
 class JsonBoolean final : public Value<Json::BOOL, bool> {
     bool bool_value() const override { return m_value; }
-public:
+ public:
     explicit JsonBoolean(bool value) : Value(value) {}
 };
 
 class JsonString final : public Value<Json::STRING, string> {
     const string &string_value() const override { return m_value; }
-public:
+ public:
     explicit JsonString(const string &value) : Value(value) {}
     explicit JsonString(string &&value)      : Value(move(value)) {}
 };
@@ -203,7 +203,7 @@ public:
 class JsonArray final : public Value<Json::ARRAY, Json::array> {
     const Json::array &array_items() const override { return m_value; }
     const Json & operator[](size_t i) const override;
-public:
+ public:
     explicit JsonArray(const Json::array &value) : Value(value) {}
     explicit JsonArray(Json::array &&value)      : Value(move(value)) {}
 };
@@ -211,13 +211,13 @@ public:
 class JsonObject final : public Value<Json::OBJECT, Json::object> {
     const Json::object &object_items() const override { return m_value; }
     const Json & operator[](const string &key) const override;
-public:
+ public:
     explicit JsonObject(const Json::object &value) : Value(value) {}
     explicit JsonObject(Json::object &&value)      : Value(move(value)) {}
 };
 
 class JsonNull final : public Value<Json::NUL, NullStruct> {
-public:
+ public:
     JsonNull() : Value({}) {}
 };
 

--- a/src/io/ordered_sparse_bin.hpp
+++ b/src/io/ordered_sparse_bin.hpp
@@ -24,7 +24,7 @@ namespace LightGBM {
 */
 template <typename VAL_T>
 class OrderedSparseBin: public OrderedBin {
-public:
+ public:
   /*! \brief Pair to store one bin entry */
   struct SparsePair {
     data_size_t ridx;  // data(row) index
@@ -192,7 +192,7 @@ public:
   /*! \brief Disable copy */
   OrderedSparseBin<VAL_T>(const OrderedSparseBin<VAL_T>&) = delete;
 
-private:
+ private:
   const SparseBin<VAL_T>* bin_data_;
   /*! \brief Store non-zero pair , group by leaf */
   std::vector<SparsePair> ordered_pair_;

--- a/src/io/parser.hpp
+++ b/src/io/parser.hpp
@@ -13,7 +13,7 @@
 namespace LightGBM {
 
 class CSVParser: public Parser {
-public:
+ public:
   explicit CSVParser(int label_idx, int total_columns)
     :label_idx_(label_idx), total_columns_(total_columns) {
   }
@@ -45,13 +45,13 @@ public:
     return total_columns_;
   }
 
-private:
+ private:
   int label_idx_ = 0;
   int total_columns_ = -1;
 };
 
 class TSVParser: public Parser {
-public:
+ public:
   explicit TSVParser(int label_idx, int total_columns)
     :label_idx_(label_idx), total_columns_(total_columns) {
   }
@@ -81,13 +81,13 @@ public:
     return total_columns_;
   }
 
-private:
+ private:
   int label_idx_ = 0;
   int total_columns_ = -1;
 };
 
 class LibSVMParser: public Parser {
-public:
+ public:
   explicit LibSVMParser(int label_idx)
     :label_idx_(label_idx) {
     if (label_idx > 0) {
@@ -121,7 +121,7 @@ public:
     return -1;
   }
 
-private:
+ private:
   int label_idx_ = 0;
 };
 

--- a/src/io/sparse_bin.hpp
+++ b/src/io/sparse_bin.hpp
@@ -20,7 +20,7 @@ const size_t kNumFastIndex = 64;
 
 template <typename VAL_T>
 class SparseBinIterator: public BinIterator {
-public:
+ public:
   SparseBinIterator(const SparseBin<VAL_T>* bin_data,
     uint32_t min_bin, uint32_t max_bin, uint32_t default_bin)
     : bin_data_(bin_data), min_bin_(static_cast<VAL_T>(min_bin)),
@@ -52,7 +52,7 @@ public:
 
   inline void Reset(data_size_t idx) override;
 
-private:
+ private:
   const SparseBin<VAL_T>* bin_data_;
   data_size_t cur_pos_;
   data_size_t i_delta_;
@@ -67,7 +67,7 @@ class OrderedSparseBin;
 
 template <typename VAL_T>
 class SparseBin: public Bin {
-public:
+ public:
   friend class SparseBinIterator<VAL_T>;
   friend class OrderedSparseBin<VAL_T>;
 
@@ -407,7 +407,7 @@ public:
     GetFastIndex();
   }
 
-protected:
+ protected:
   data_size_t num_data_;
   std::vector<uint8_t> deltas_;
   std::vector<VAL_T> vals_;

--- a/src/metric/binary_metric.hpp
+++ b/src/metric/binary_metric.hpp
@@ -18,7 +18,7 @@ namespace LightGBM {
 */
 template<typename PointWiseLossCalculator>
 class BinaryMetric: public Metric {
-public:
+ public:
   explicit BinaryMetric(const Config&) {
   }
 
@@ -92,7 +92,7 @@ public:
     return std::vector<double>(1, loss);
   }
 
-private:
+ private:
   /*! \brief Number of data */
   data_size_t num_data_;
   /*! \brief Pointer of label */
@@ -109,7 +109,7 @@ private:
 * \brief Log loss metric for binary classification task.
 */
 class BinaryLoglossMetric: public BinaryMetric<BinaryLoglossMetric> {
-public:
+ public:
   explicit BinaryLoglossMetric(const Config& config) :BinaryMetric<BinaryLoglossMetric>(config) {}
 
   inline static double LossOnPoint(label_t label, double prob) {
@@ -133,7 +133,7 @@ public:
 * \brief Error rate metric for binary classification task.
 */
 class BinaryErrorMetric: public BinaryMetric<BinaryErrorMetric> {
-public:
+ public:
   explicit BinaryErrorMetric(const Config& config) :BinaryMetric<BinaryErrorMetric>(config) {}
 
   inline static double LossOnPoint(label_t label, double prob) {
@@ -153,7 +153,7 @@ public:
 * \brief Auc Metric for binary classification task.
 */
 class AUCMetric: public Metric {
-public:
+ public:
   explicit AUCMetric(const Config&) {
   }
 
@@ -246,7 +246,7 @@ public:
     return std::vector<double>(1, auc);
   }
 
-private:
+ private:
   /*! \brief Number of data */
   data_size_t num_data_;
   /*! \brief Pointer of label */

--- a/src/metric/map_metric.hpp
+++ b/src/metric/map_metric.hpp
@@ -13,7 +13,7 @@
 namespace LightGBM {
 
 class MapMetric:public Metric {
-public:
+ public:
   explicit MapMetric(const Config& config) {
     // get eval position
     eval_at_ = config.eval_at;
@@ -142,7 +142,7 @@ public:
     return result;
   }
 
-private:
+ private:
   /*! \brief Number of data */
   data_size_t num_data_;
   /*! \brief Pointer of label */

--- a/src/metric/multiclass_metric.hpp
+++ b/src/metric/multiclass_metric.hpp
@@ -14,7 +14,7 @@ namespace LightGBM {
 */
 template<typename PointWiseLossCalculator>
 class MulticlassMetric: public Metric {
-public:
+ public:
   explicit MulticlassMetric(const Config& config) {
     num_class_ = config.num_class;
   }
@@ -112,7 +112,7 @@ public:
     return std::vector<double>(1, loss);
   }
 
-private:
+ private:
   /*! \brief Number of data */
   data_size_t num_data_;
   /*! \brief Pointer of label */
@@ -128,7 +128,7 @@ private:
 
 /*! \brief L2 loss for multiclass task */
 class MultiErrorMetric: public MulticlassMetric<MultiErrorMetric> {
-public:
+ public:
   explicit MultiErrorMetric(const Config& config) :MulticlassMetric<MultiErrorMetric>(config) {}
 
   inline static double LossOnPoint(label_t label, std::vector<double>& score) {
@@ -148,7 +148,7 @@ public:
 
 /*! \brief Logloss for multiclass task */
 class MultiSoftmaxLoglossMetric: public MulticlassMetric<MultiSoftmaxLoglossMetric> {
-public:
+ public:
   explicit MultiSoftmaxLoglossMetric(const Config& config) :MulticlassMetric<MultiSoftmaxLoglossMetric>(config) {}
 
   inline static double LossOnPoint(label_t label, std::vector<double>& score) {

--- a/src/metric/rank_metric.hpp
+++ b/src/metric/rank_metric.hpp
@@ -13,7 +13,7 @@
 namespace LightGBM {
 
 class NDCGMetric:public Metric {
-public:
+ public:
   explicit NDCGMetric(const Config& config) {
     // get eval position
     eval_at_ = config.eval_at;
@@ -143,7 +143,7 @@ public:
     return result;
   }
 
-private:
+ private:
   /*! \brief Number of data */
   data_size_t num_data_;
   /*! \brief Pointer of label */

--- a/src/metric/regression_metric.hpp
+++ b/src/metric/regression_metric.hpp
@@ -14,7 +14,7 @@ namespace LightGBM {
 */
 template<typename PointWiseLossCalculator>
 class RegressionMetric: public Metric {
-public:
+ public:
   explicit RegressionMetric(const Config& config) :config_(config) {
   }
 
@@ -95,7 +95,7 @@ public:
   inline static void CheckLabel(label_t) {
   }
 
-private:
+ private:
   /*! \brief Number of data */
   data_size_t num_data_;
   /*! \brief Pointer of label */
@@ -111,7 +111,7 @@ private:
 
 /*! \brief RMSE loss for regression task */
 class RMSEMetric: public RegressionMetric<RMSEMetric> {
-public:
+ public:
   explicit RMSEMetric(const Config& config) :RegressionMetric<RMSEMetric>(config) {}
 
   inline static double LossOnPoint(label_t label, double score, const Config&) {
@@ -130,7 +130,7 @@ public:
 
 /*! \brief L2 loss for regression task */
 class L2Metric: public RegressionMetric<L2Metric> {
-public:
+ public:
   explicit L2Metric(const Config& config) :RegressionMetric<L2Metric>(config) {}
 
   inline static double LossOnPoint(label_t label, double score, const Config&) {
@@ -144,7 +144,7 @@ public:
 
 /*! \brief L2 loss for regression task */
 class QuantileMetric : public RegressionMetric<QuantileMetric> {
-public:
+ public:
   explicit QuantileMetric(const Config& config) :RegressionMetric<QuantileMetric>(config) {
   }
 
@@ -165,7 +165,7 @@ public:
 
 /*! \brief L1 loss for regression task */
 class L1Metric: public RegressionMetric<L1Metric> {
-public:
+ public:
   explicit L1Metric(const Config& config) :RegressionMetric<L1Metric>(config) {}
 
   inline static double LossOnPoint(label_t label, double score, const Config&) {
@@ -178,7 +178,7 @@ public:
 
 /*! \brief Huber loss for regression task */
 class HuberLossMetric: public RegressionMetric<HuberLossMetric> {
-public:
+ public:
   explicit HuberLossMetric(const Config& config) :RegressionMetric<HuberLossMetric>(config) {
   }
 
@@ -199,7 +199,7 @@ public:
 /*! \brief Fair loss for regression task */
 // http://research.microsoft.com/en-us/um/people/zhang/INRIA/Publis/Tutorial-Estim/node24.html
 class FairLossMetric: public RegressionMetric<FairLossMetric> {
-public:
+ public:
   explicit FairLossMetric(const Config& config) :RegressionMetric<FairLossMetric>(config) {
   }
 
@@ -216,7 +216,7 @@ public:
 
 /*! \brief Poisson regression loss for regression task */
 class PoissonMetric: public RegressionMetric<PoissonMetric> {
-public:
+ public:
   explicit PoissonMetric(const Config& config) :RegressionMetric<PoissonMetric>(config) {
   }
 
@@ -235,7 +235,7 @@ public:
 
 /*! \brief Mape regression loss for regression task */
 class MAPEMetric : public RegressionMetric<MAPEMetric> {
-public:
+ public:
   explicit MAPEMetric(const Config& config) :RegressionMetric<MAPEMetric>(config) {
   }
 
@@ -248,7 +248,7 @@ public:
 };
 
 class GammaMetric : public RegressionMetric<GammaMetric> {
-public:
+ public:
   explicit GammaMetric(const Config& config) :RegressionMetric<GammaMetric>(config) {
   }
 
@@ -271,7 +271,7 @@ public:
 
 
 class GammaDevianceMetric : public RegressionMetric<GammaDevianceMetric> {
-public:
+ public:
   explicit GammaDevianceMetric(const Config& config) :RegressionMetric<GammaDevianceMetric>(config) {
   }
 
@@ -292,7 +292,7 @@ public:
 };
 
 class TweedieMetric : public RegressionMetric<TweedieMetric> {
-public:
+ public:
   explicit TweedieMetric(const Config& config) :RegressionMetric<TweedieMetric>(config) {
   }
 

--- a/src/metric/xentropy_metric.hpp
+++ b/src/metric/xentropy_metric.hpp
@@ -65,7 +65,7 @@ namespace LightGBM {
 // CrossEntropyMetric : "xentropy" : (optional) weights are used linearly
 //
 class CrossEntropyMetric : public Metric {
-public:
+ public:
   explicit CrossEntropyMetric(const Config&) {}
   virtual ~CrossEntropyMetric() {}
 
@@ -142,7 +142,7 @@ public:
     return -1.0f;  // negative means smaller loss is better, positive means larger loss is better
   }
 
-private:
+ private:
   /*! \brief Number of data points */
   data_size_t num_data_;
   /*! \brief Pointer to label */
@@ -160,7 +160,7 @@ private:
 // ATTENTION: Supposed to be used when the objective also is "xentlambda"
 //
 class CrossEntropyLambdaMetric : public Metric {
-public:
+ public:
   explicit CrossEntropyLambdaMetric(const Config&) {}
   virtual ~CrossEntropyLambdaMetric() {}
 
@@ -228,7 +228,7 @@ public:
     return -1.0f;
   }
 
-private:
+ private:
   /*! \brief Number of data points */
   data_size_t num_data_;
   /*! \brief Pointer to label */
@@ -243,7 +243,7 @@ private:
 // KullbackLeiblerDivergence : "kldiv" : (optional) weights are used linearly
 //
 class KullbackLeiblerDivergence : public Metric {
-public:
+ public:
   explicit KullbackLeiblerDivergence(const Config&) {}
   virtual ~KullbackLeiblerDivergence() {}
 
@@ -336,7 +336,7 @@ public:
     return -1.0f;
   }
 
-private:
+ private:
   /*! \brief Number of data points */
   data_size_t num_data_;
   /*! \brief Pointer to label */

--- a/src/network/linkers.h
+++ b/src/network/linkers.h
@@ -32,7 +32,7 @@ namespace LightGBM {
 * This class will wrap all linkers to other machines if needs
 */
 class Linkers {
-public:
+ public:
   Linkers() {
     is_init_ = false;
   }
@@ -136,7 +136,7 @@ public:
   #endif  // USE_SOCKET
 
 
-private:
+ private:
   /*! \brief Rank of local machine */
   int rank_;
   /*! \brief Total number machines */

--- a/src/network/socket_wrapper.hpp
+++ b/src/network/socket_wrapper.hpp
@@ -86,7 +86,7 @@ const bool kNoDelay = true;
 }
 
 class TcpSocket {
-public:
+ public:
   TcpSocket() {
     sockfd_ = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (sockfd_ == INVALID_SOCKET) {
@@ -291,7 +291,7 @@ public:
     }
   }
 
-private:
+ private:
   SOCKET sockfd_;
 };
 

--- a/src/objective/binary_objective.hpp
+++ b/src/objective/binary_objective.hpp
@@ -11,7 +11,7 @@ namespace LightGBM {
 * \brief Objective function for binary classification
 */
 class BinaryLogloss: public ObjectiveFunction {
-public:
+ public:
   explicit BinaryLogloss(const Config& config, std::function<bool(label_t)> is_pos = nullptr) {
     sigmoid_ = static_cast<double>(config.sigmoid);
     if (sigmoid_ <= 0.0) {
@@ -172,7 +172,7 @@ public:
 
   bool NeedAccuratePrediction() const override { return false; }
 
-private:
+ private:
   /*! \brief Number of data */
   data_size_t num_data_;
   /*! \brief Pointer of label */

--- a/src/objective/multiclass_objective.hpp
+++ b/src/objective/multiclass_objective.hpp
@@ -14,7 +14,7 @@ namespace LightGBM {
 * \brief Objective function for multiclass classification, use softmax as objective functions
 */
 class MulticlassSoftmax: public ObjectiveFunction {
-public:
+ public:
   explicit MulticlassSoftmax(const Config& config) {
     num_class_ = config.num_class;
   }
@@ -146,7 +146,7 @@ public:
     }
   }
 
-private:
+ private:
   /*! \brief Number of data */
   data_size_t num_data_;
   /*! \brief Number of classes */
@@ -164,7 +164,7 @@ private:
 * \brief Objective function for multiclass classification, use one-vs-all binary objective function
 */
 class MulticlassOVA: public ObjectiveFunction {
-public:
+ public:
   explicit MulticlassOVA(const Config& config) {
     num_class_ = config.num_class;
     for (int i = 0; i < num_class_; ++i) {
@@ -246,7 +246,7 @@ public:
     return binary_loss_[class_id]->ClassNeedTrain(0);
   }
 
-private:
+ private:
   /*! \brief Number of data */
   data_size_t num_data_;
   /*! \brief Number of classes */

--- a/src/objective/rank_objective.hpp
+++ b/src/objective/rank_objective.hpp
@@ -17,7 +17,7 @@ namespace LightGBM {
 * \brief Objective function for Lambdrank with NDCG
 */
 class LambdarankNDCG: public ObjectiveFunction {
-public:
+ public:
   explicit LambdarankNDCG(const Config& config) {
     sigmoid_ = static_cast<double>(config.sigmoid);
     label_gain_ = config.label_gain;
@@ -205,7 +205,7 @@ public:
 
   bool NeedAccuratePrediction() const override { return false; }
 
-private:
+ private:
   /*! \brief Gains for labels */
   std::vector<double> label_gain_;
   /*! \brief Cache inverse max DCG, speed up calculation */

--- a/src/objective/regression_objective.hpp
+++ b/src/objective/regression_objective.hpp
@@ -69,7 +69,7 @@ namespace LightGBM {
 * \brief Objective function for regression
 */
 class RegressionL2loss: public ObjectiveFunction {
-public:
+ public:
   explicit RegressionL2loss(const Config& config) {
     sqrt_ = config.reg_sqrt;
   }
@@ -165,7 +165,7 @@ public:
     return suml / sumw;
   }
 
-protected:
+ protected:
   bool sqrt_;
   /*! \brief Number of data */
   data_size_t num_data_;
@@ -180,7 +180,7 @@ protected:
 * \brief L1 regression loss
 */
 class RegressionL1loss: public RegressionL2loss {
-public:
+ public:
   explicit RegressionL1loss(const Config& config): RegressionL2loss(config) {
   }
 
@@ -298,7 +298,7 @@ public:
 * \brief Huber regression loss
 */
 class RegressionHuberLoss: public RegressionL2loss {
-public:
+ public:
   explicit RegressionHuberLoss(const Config& config): RegressionL2loss(config) {
     alpha_ = static_cast<double>(config.alpha);
     if (sqrt_) {
@@ -352,7 +352,7 @@ public:
     return false;
   }
 
-private:
+ private:
   /*! \brief delta for Huber loss */
   double alpha_;
 };
@@ -360,7 +360,7 @@ private:
 
 // http://research.microsoft.com/en-us/um/people/zhang/INRIA/Publis/Tutorial-Estim/node24.html
 class RegressionFairLoss: public RegressionL2loss {
-public:
+ public:
   explicit RegressionFairLoss(const Config& config): RegressionL2loss(config) {
     c_ = static_cast<double>(config.fair_c);
   }
@@ -397,7 +397,7 @@ public:
     return false;
   }
 
-private:
+ private:
   /*! \brief c for Fair loss */
   double c_;
 };
@@ -407,7 +407,7 @@ private:
 * \brief Objective function for Poisson regression
 */
 class RegressionPoissonLoss: public RegressionL2loss {
-public:
+ public:
   explicit RegressionPoissonLoss(const Config& config): RegressionL2loss(config) {
     max_delta_step_ = static_cast<double>(config.poisson_max_delta_step);
     if (sqrt_) {
@@ -481,13 +481,13 @@ public:
     return false;
   }
 
-private:
+ private:
   /*! \brief used to safeguard optimization */
   double max_delta_step_;
 };
 
 class RegressionQuantileloss : public RegressionL2loss {
-public:
+ public:
   explicit RegressionQuantileloss(const Config& config): RegressionL2loss(config) {
     alpha_ = static_cast<score_t>(config.alpha);
     CHECK(alpha_ > 0 && alpha_ < 1);
@@ -607,7 +607,7 @@ public:
     }
   }
 
-private:
+ private:
   score_t alpha_;
 };
 
@@ -616,7 +616,7 @@ private:
 * \brief Mape Regression Loss
 */
 class RegressionMAPELOSS : public RegressionL1loss {
-public:
+ public:
   explicit RegressionMAPELOSS(const Config& config) : RegressionL1loss(config) {
   }
 
@@ -725,7 +725,7 @@ public:
     return true;
   }
 
-private:
+ private:
   std::vector<label_t> label_weight_;
 };
 
@@ -735,7 +735,7 @@ private:
 * \brief Objective function for Gamma regression
 */
 class RegressionGammaLoss : public RegressionPoissonLoss {
-public:
+ public:
   explicit RegressionGammaLoss(const Config& config) : RegressionPoissonLoss(config) {
   }
 
@@ -770,7 +770,7 @@ public:
 * \brief Objective function for Tweedie regression
 */
 class RegressionTweedieLoss: public RegressionPoissonLoss {
-public:
+ public:
   explicit RegressionTweedieLoss(const Config& config) : RegressionPoissonLoss(config) {
     rho_ = config.tweedie_variance_power;
   }
@@ -803,7 +803,7 @@ public:
     return "tweedie";
   }
 
-private:
+ private:
   double rho_;
 };
 

--- a/src/objective/xentropy_objective.hpp
+++ b/src/objective/xentropy_objective.hpp
@@ -36,7 +36,7 @@ namespace LightGBM {
 * \brief Objective function for cross-entropy (with optional linear weights)
 */
 class CrossEntropy: public ObjectiveFunction {
-public:
+ public:
   explicit CrossEntropy(const Config&) {
   }
 
@@ -127,7 +127,7 @@ public:
     return initscore;
   }
 
-private:
+ private:
   /*! \brief Number of data points */
   data_size_t num_data_;
   /*! \brief Pointer for label */
@@ -140,7 +140,7 @@ private:
 * \brief Objective function for alternative parameterization of cross-entropy (see top of file for explanation)
 */
 class CrossEntropyLambda: public ObjectiveFunction {
-public:
+ public:
   explicit CrossEntropyLambda(const Config&) {
     min_weight_ = max_weight_ = 0.0f;
   }

--- a/src/treelearner/data_partition.hpp
+++ b/src/treelearner/data_partition.hpp
@@ -15,7 +15,7 @@ namespace LightGBM {
 * \brief DataPartition is used to store the the partition of data on tree.
 */
 class DataPartition {
-public:
+ public:
   DataPartition(data_size_t num_data, int num_leaves)
     :num_data_(num_data), num_leaves_(num_leaves) {
     leaf_begin_.resize(num_leaves_);
@@ -188,7 +188,7 @@ public:
   /*! \brief Get number of leaves */
   int num_leaves() const { return num_leaves_; }
 
-private:
+ private:
   /*! \brief Number of all data */
   data_size_t num_data_;
   /*! \brief Number of all leaves */

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -12,7 +12,7 @@
 namespace LightGBM {
 
 class FeatureMetainfo {
-public:
+ public:
   int num_bin;
   MissingType missing_type;
   int8_t bias = 0;
@@ -27,7 +27,7 @@ public:
 * \brief FeatureHistogram is used to construct and store a histogram for a feature.
 */
 class FeatureHistogram {
-public:
+ public:
   FeatureHistogram() {
     data_ = nullptr;
   }
@@ -449,7 +449,7 @@ public:
     }
   }
 
-private:
+ private:
   static double GetSplitGains(double sum_left_gradients, double sum_left_hessians,
                               double sum_right_gradients, double sum_right_hessians,
                               double l1, double l2, double max_delta_step,
@@ -644,7 +644,7 @@ private:
   std::function<void(double, double, data_size_t, double, double, SplitInfo*)> find_best_threshold_fun_;
 };
 class HistogramPool {
-public:
+ public:
   /*!
   * \brief Constructor
   */
@@ -804,7 +804,7 @@ public:
     inverse_mapper_[slot] = dst_idx;
   }
 
-private:
+ private:
   std::vector<std::unique_ptr<FeatureHistogram[]>> pool_;
   std::vector<std::vector<HistogramBinEntry>> data_;
   std::vector<FeatureMetainfo> feature_metas_;

--- a/src/treelearner/gpu_tree_learner.h
+++ b/src/treelearner/gpu_tree_learner.h
@@ -36,7 +36,7 @@ namespace LightGBM {
 * \brief GPU-based parallel learning algorithm.
 */
 class GPUTreeLearner: public SerialTreeLearner {
-public:
+ public:
   explicit GPUTreeLearner(const Config* tree_config);
   ~GPUTreeLearner();
   void Init(const Dataset* train_data, bool is_constant_hessian) override;
@@ -57,14 +57,14 @@ public:
     use_bagging_ = false;
   }
 
-protected:
+ protected:
   void BeforeTrain() override;
   bool BeforeFindBestSplit(const Tree* tree, int left_leaf, int right_leaf) override;
   void FindBestSplits() override;
   void Split(Tree* tree, int best_Leaf, int* left_leaf, int* right_leaf) override;
   void ConstructHistograms(const std::vector<int8_t>& is_feature_used, bool use_subtract) override;
 
-private:
+ private:
   /*! \brief 4-byte feature tuple used by GPU kernels */
   struct Feature4 {
       uint8_t s[4];
@@ -269,7 +269,7 @@ private:
 namespace LightGBM {
 
 class GPUTreeLearner: public SerialTreeLearner {
-public:
+ public:
   #pragma warning(disable : 4702)
   explicit GPUTreeLearner(const Config* tree_config) : SerialTreeLearner(tree_config) {
     Log::Fatal("GPU Tree Learner was not enabled in this build.\n"

--- a/src/treelearner/leaf_splits.hpp
+++ b/src/treelearner/leaf_splits.hpp
@@ -14,7 +14,7 @@ namespace LightGBM {
 * \brief used to find split candidates for a leaf
 */
 class LeafSplits {
-public:
+ public:
   LeafSplits(data_size_t num_data)
     :num_data_in_leaf_(num_data), num_data_(num_data),
     data_indices_(nullptr) {
@@ -141,7 +141,7 @@ public:
   const data_size_t* data_indices() const { return data_indices_; }
 
 
-private:
+ private:
   /*! \brief current leaf index */
   int leaf_index_;
   /*! \brief number of data on current leaf */

--- a/src/treelearner/parallel_tree_learner.h
+++ b/src/treelearner/parallel_tree_learner.h
@@ -20,15 +20,16 @@ namespace LightGBM {
 */
 template <typename TREELEARNER_T>
 class FeatureParallelTreeLearner: public TREELEARNER_T {
-public:
+ public:
   explicit FeatureParallelTreeLearner(const Config* config);
   ~FeatureParallelTreeLearner();
   void Init(const Dataset* train_data, bool is_constant_hessian) override;
 
-protected:
+ protected:
   void BeforeTrain() override;
   void FindBestSplitsFromHistograms(const std::vector<int8_t>& is_feature_used, bool use_subtract) override;
-private:
+
+ private:
   /*! \brief rank of local machine */
   int rank_;
   /*! \brief Number of machines of this parallel task */
@@ -46,13 +47,13 @@ private:
 */
 template <typename TREELEARNER_T>
 class DataParallelTreeLearner: public TREELEARNER_T {
-public:
+ public:
   explicit DataParallelTreeLearner(const Config* config);
   ~DataParallelTreeLearner();
   void Init(const Dataset* train_data, bool is_constant_hessian) override;
   void ResetConfig(const Config* config) override;
 
-protected:
+ protected:
   void BeforeTrain() override;
   void FindBestSplits() override;
   void FindBestSplitsFromHistograms(const std::vector<int8_t>& is_feature_used, bool use_subtract) override;
@@ -66,7 +67,7 @@ protected:
     }
   }
 
-private:
+ private:
   /*! \brief Rank of local machine */
   int rank_;
   /*! \brief Number of machines of this parallel task */
@@ -100,13 +101,13 @@ private:
 */
 template <typename TREELEARNER_T>
 class VotingParallelTreeLearner: public TREELEARNER_T {
-public:
+ public:
   explicit VotingParallelTreeLearner(const Config* config);
   ~VotingParallelTreeLearner() { }
   void Init(const Dataset* train_data, bool is_constant_hessian) override;
   void ResetConfig(const Config* config) override;
 
-protected:
+ protected:
   void BeforeTrain() override;
   bool BeforeFindBestSplit(const Tree* tree, int left_leaf, int right_leaf) override;
   void FindBestSplits() override;
@@ -136,7 +137,7 @@ protected:
   void CopyLocalHistogram(const std::vector<int>& smaller_top_features,
     const std::vector<int>& larger_top_features);
 
-private:
+ private:
   /*! \brief Tree config used in local mode */
   Config local_config_;
   /*! \brief Voting size */

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -32,7 +32,7 @@ namespace LightGBM {
 * \brief Used for learning a tree by single machine
 */
 class SerialTreeLearner: public TreeLearner {
-public:
+ public:
   explicit SerialTreeLearner(const Config* config);
 
   ~SerialTreeLearner();
@@ -75,7 +75,7 @@ public:
   void RenewTreeOutput(Tree* tree, const ObjectiveFunction* obj, double prediction,
                        data_size_t total_num_data, const data_size_t* bag_indices, data_size_t bag_cnt) const override;
 
-protected:
+ protected:
   /*!
   * \brief Some initial works before training
   */

--- a/src/treelearner/split_info.hpp
+++ b/src/treelearner/split_info.hpp
@@ -15,7 +15,7 @@ namespace LightGBM {
 * \brief Used to store some information for gain split point
 */
 struct SplitInfo {
-public:
+ public:
   /*! \brief Feature index */
   int feature = -1;
   /*! \brief Split threshold */
@@ -188,7 +188,7 @@ public:
 };
 
 struct LightSplitInfo {
-public:
+ public:
   /*! \brief Feature index */
   int feature = -1;
   /*! \brief Split gain */


### PR DESCRIPTION
Refer to #1990.
Address problem about `public/protected/private: should be indented +1 space inside class A  [whitespace/indent] [3]`.

```
cpplint --linelength=999 --recursive ./src ./include
```

<details>

<summary><b>Report (Clickable):</b></summary>

```
./src\boosting\score_updater.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\boosting\score_updater.hpp:1:  #ifndef header guard has wrong style, please use: SRC_BOOSTING_SCORE_UPDATER_HPP_  [build/header_guard] [5]
./src\boosting\score_updater.hpp:123:  #endif line should be "#endif  // SRC_BOOSTING_SCORE_UPDATER_HPP_"  [build/header_guard] [5]
./src\boosting\score_updater.hpp:118:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing ./src\boosting\score_updater.hpp
./include\LightGBM\tree_learner.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\tree_learner.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_TREE_LEARNER_H_  [build/header_guard] [5]
./include\LightGBM\tree_learner.h:100:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_TREE_LEARNER_H_"  [build/header_guard] [5]
./include\LightGBM\tree_learner.h:9:  Found C++ system header after other header. Should be: tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./include\LightGBM\tree_learner.h:11:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
./include\LightGBM\tree_learner.h:51:  Is this a non-const reference? If so, make const or use a pointer: Json& forced_split_json  [runtime/references] [2]
./include\LightGBM\tree_learner.h:94:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./include\LightGBM\tree_learner.h
./include\LightGBM\lightgbm_R.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\lightgbm_R.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_LIGHTGBM_R_H_  [build/header_guard] [5]
./include\LightGBM\lightgbm_R.h:525:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_LIGHTGBM_R_H_"  [build/header_guard] [5]
./include\LightGBM\lightgbm_R.h:7:  Found C system header after C++ system header. Should be: lightgbm_R.h, c system, c++ system, other.  [build/include_order] [4]
Done processing ./include\LightGBM\lightgbm_R.h
./src\treelearner\gpu_tree_learner.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\gpu_tree_learner.cpp:2:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\treelearner\gpu_tree_learner.cpp:6:  Found C system header after other header. Should be: gpu_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\gpu_tree_learner.cpp:7:  Found C system header after other header. Should be: gpu_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\gpu_tree_learner.cpp:8:  Found C system header after other header. Should be: gpu_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\gpu_tree_learner.cpp:10:  Found C++ system header after other header. Should be: gpu_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\gpu_tree_learner.cpp:11:  Found C++ system header after other header. Should be: gpu_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\gpu_tree_learner.cpp:106:  Using C-style cast.  Use static_cast<int>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:111:  Using C-style cast.  Use static_cast<int>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:113:  Using C-style cast.  Use static_cast<int>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:154:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:154:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:173:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:173:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:178:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:178:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:186:  Using C-style cast.  Use reinterpret_cast<void*>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:194:  Using C-style cast.  Use reinterpret_cast<HistType*>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:212:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:212:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:321:  At least two spaces is best between code and comments  [whitespace/comments] [2]
./src\treelearner\gpu_tree_learner.cpp:332:  Using C-style cast.  Use static_cast<double>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:334:  Using C-style cast.  Use static_cast<int>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:341:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:341:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:356:  Using C-style cast.  Use static_cast<int>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:363:  Using C-style cast.  Use reinterpret_cast<Feature4*>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:367:  Using C-style cast.  Use reinterpret_cast<Feature4*>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:372:  Using C-style cast.  Use static_cast<int>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:414:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:414:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:426:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:426:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:433:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:433:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:438:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:438:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:473:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:473:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:477:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:477:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:487:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:487:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:495:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:495:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:499:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:499:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:513:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:513:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:675:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:675:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:708:  Using C-style cast.  Use static_cast<int>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:710:  Using C-style cast.  Use static_cast<int>(...) instead  [readability/casting] [4]
./src\treelearner\gpu_tree_learner.cpp:723:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:723:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:729:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:729:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:735:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:735:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:785:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:785:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:819:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:819:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:915:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:915:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:928:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:928:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:948:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:948:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:985:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:985:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:1010:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:1010:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:1064:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\gpu_tree_learner.cpp:1064:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\treelearner\gpu_tree_learner.cpp:564:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./src\treelearner\gpu_tree_learner.cpp
./include\LightGBM\R_object_helper.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\R_object_helper.h:6:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_R_OBJECT_HELPER_H_  [build/header_guard] [5]
./include\LightGBM\R_object_helper.h:188:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_R_OBJECT_HELPER_H_"  [build/header_guard] [5]
./include\LightGBM\R_object_helper.h:121:  Using C-style cast.  Use reinterpret_cast<SEXPREC_ALIGN *>(...) instead  [readability/casting] [4]
./include\LightGBM\R_object_helper.h:123:  Using C-style cast.  Use reinterpret_cast<char *>(...) instead  [readability/casting] [4]
./include\LightGBM\R_object_helper.h:125:  Using C-style cast.  Use reinterpret_cast<int *>(...) instead  [readability/casting] [4]
./include\LightGBM\R_object_helper.h:127:  Using C-style cast.  Use reinterpret_cast<int64_t *>(...) instead  [readability/casting] [4]
./include\LightGBM\R_object_helper.h:129:  Using C-style cast.  Use reinterpret_cast<double *>(...) instead  [readability/casting] [4]
./include\LightGBM\R_object_helper.h:131:  Using C-style cast.  Use reinterpret_cast<int *>(...) instead  [readability/casting] [4]
./include\LightGBM\R_object_helper.h:133:  Using C-style cast.  Use reinterpret_cast<int64_t *>(...) instead  [readability/casting] [4]
./include\LightGBM\R_object_helper.h:140:  Using C-style cast.  Use reinterpret_cast<int64_t *>(...) instead  [readability/casting] [4]
./include\LightGBM\R_object_helper.h:154:  Using C-style cast.  Use reinterpret_cast<void *>(...) instead  [readability/casting] [4]
./include\LightGBM\R_object_helper.h:164:  Using C-style cast.  Use reinterpret_cast<int32_t *>(...) instead  [readability/casting] [4]
./include\LightGBM\R_object_helper.h:178:  Using C-style cast.  Use reinterpret_cast<void *>(...) instead  [readability/casting] [4]
Done processing ./include\LightGBM\R_object_helper.h
./src\io\dense_bin.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\dense_bin.hpp:1:  #ifndef header guard has wrong style, please use: SRC_IO_DENSE_BIN_HPP_  [build/header_guard] [5]
./src\io\dense_bin.hpp:340:  #endif line should be "#endif  // SRC_IO_DENSE_BIN_HPP_"  [build/header_guard] [5]
./src\io\dense_bin.hpp:47:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./src\io\dense_bin.hpp:191:  "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]
./src\io\dense_bin.hpp:252:  "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]
Done processing ./src\io\dense_bin.hpp
./include\LightGBM\prediction_early_stop.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\prediction_early_stop.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_PREDICTION_EARLY_STOP_H_  [build/header_guard] [5]
./include\LightGBM\prediction_early_stop.h:32:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_PREDICTION_EARLY_STOP_H_"  [build/header_guard] [5]
./include\LightGBM\prediction_early_stop.h:7:  Found C system header after C++ system header. Should be: prediction_early_stop.h, c system, c++ system, other.  [build/include_order] [4]
Done processing ./include\LightGBM\prediction_early_stop.h
./src\objective\objective_function.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
Done processing ./src\objective\objective_function.cpp
./include\LightGBM\json11.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\json11.hpp:80:  public: should be indented +1 space inside class Json  [whitespace/indent] [3]
./include\LightGBM\json11.hpp:92:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:93:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:94:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:95:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:96:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:97:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:98:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:99:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:100:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:101:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:102:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:106:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:113:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:119:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:123:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./include\LightGBM\json11.hpp:156:  Is this a non-const reference? If so, make const or use a pointer: std::string &out  [runtime/references] [2]
./include\LightGBM\json11.hpp:165:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
./include\LightGBM\json11.hpp:168:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
./include\LightGBM\json11.hpp:180:  Is this a non-const reference? If so, make const or use a pointer: std::string::size_type & parser_stop_pos  [runtime/references] [2]
./include\LightGBM\json11.hpp:181:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
./include\LightGBM\json11.hpp:186:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
./include\LightGBM\json11.hpp:205:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
./include\LightGBM\json11.hpp:220:  Is this a non-const reference? If so, make const or use a pointer: std::string &out  [runtime/references] [2]
./include\LightGBM\json11.hpp:204:  Add #include <utility> for pair<>  [build/include_what_you_use] [4]
Done processing ./include\LightGBM\json11.hpp
./include\LightGBM\utils\threading.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\utils\threading.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_UTILS_THREADING_H_  [build/header_guard] [5]
./include\LightGBM\utils\threading.h:41:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_UTILS_THREADING_H_"  [build/header_guard] [5]
Done processing ./include\LightGBM\utils\threading.h
./include\LightGBM\boosting.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\boosting.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_BOOSTING_H_  [build/header_guard] [5]
./include\LightGBM\boosting.h:304:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_BOOSTING_H_"  [build/header_guard] [5]
Done processing ./include\LightGBM\boosting.h
./src\io\dataset_loader.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\dataset_loader.cpp:394:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\io\dataset_loader.cpp:394:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\io\dataset_loader.cpp:417:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\io\dataset_loader.cpp:417:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
Done processing ./src\io\dataset_loader.cpp
./include\LightGBM\utils\text_reader.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\utils\text_reader.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_UTILS_TEXT_READER_H_  [build/header_guard] [5]
./include\LightGBM\utils\text_reader.h:326:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_UTILS_TEXT_READER_H_"  [build/header_guard] [5]
./include\LightGBM\utils\text_reader.h:104:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./include\LightGBM\utils\text_reader.h:104:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./include\LightGBM\utils\text_reader.h:114:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./include\LightGBM\utils\text_reader.h:114:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./include\LightGBM\utils\text_reader.h:162:  Is this a non-const reference? If so, make const or use a pointer: Random& random  [runtime/references] [2]
./include\LightGBM\utils\text_reader.h:171:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./include\LightGBM\utils\text_reader.h:171:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./include\LightGBM\utils\text_reader.h:198:  Is this a non-const reference? If so, make const or use a pointer: Random& random  [runtime/references] [2]
./include\LightGBM\utils\text_reader.h:211:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./include\LightGBM\utils\text_reader.h:211:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./include\LightGBM\utils\text_reader.h:254:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./include\LightGBM\utils\text_reader.h:254:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./include\LightGBM\utils\text_reader.h:267:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./include\LightGBM\utils\text_reader.h:267:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./include\LightGBM\utils\text_reader.h:303:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./include\LightGBM\utils\text_reader.h:303:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
Done processing ./include\LightGBM\utils\text_reader.h
./src\metric\metric.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
Done processing ./src\metric\metric.cpp
./src\network\network.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\network\network.cpp:5:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\network\network.cpp:7:  Found C++ system header after other header. Should be: network.h, c system, c++ system, other.  [build/include_order] [4]
./src\network\network.cpp:8:  Found C++ system header after other header. Should be: network.h, c system, c++ system, other.  [build/include_order] [4]
Done processing ./src\network\network.cpp
./src\metric\multiclass_metric.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\metric\multiclass_metric.hpp:1:  #ifndef header guard has wrong style, please use: SRC_METRIC_MULTICLASS_METRIC_HPP_  [build/header_guard] [5]
./src\metric\multiclass_metric.hpp:169:  #endif line should be "#endif  // SRC_METRIC_MULTICLASS_METRIC_HPP_"  [build/header_guard] [5]
./src\metric\multiclass_metric.hpp:134:  Is this a non-const reference? If so, make const or use a pointer: std::vector<double>& score  [runtime/references] [2]
./src\metric\multiclass_metric.hpp:154:  Is this a non-const reference? If so, make const or use a pointer: std::vector<double>& score  [runtime/references] [2]
./src\metric\multiclass_metric.hpp:125:  Add #include <string> for string  [build/include_what_you_use] [4]
./src\metric\multiclass_metric.hpp:154:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing ./src\metric\multiclass_metric.hpp
./include\LightGBM\utils\file_io.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\utils\file_io.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_UTILS_FILE_IO_H_  [build/header_guard] [5]
./include\LightGBM\utils\file_io.h:74:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_UTILS_FILE_IO_H_"  [build/header_guard] [5]
./include\LightGBM\utils\file_io.h:69:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./include\LightGBM\utils\file_io.h
./include\LightGBM\utils\log.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\utils\log.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_UTILS_LOG_H_  [build/header_guard] [5]
./include\LightGBM\utils\log.h:103:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_UTILS_LOG_H_"  [build/header_guard] [5]
./include\LightGBM\utils\log.h:83:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./include\LightGBM\utils\log.h
./src\treelearner\leaf_splits.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\leaf_splits.hpp:1:  #ifndef header guard has wrong style, please use: SRC_TREELEARNER_LEAF_SPLITS_HPP_  [build/header_guard] [5]
./src\treelearner\leaf_splits.hpp:162:  #endif line should be "#endif  // SRC_TREELEARNER_LEAF_SPLITS_HPP_"  [build/header_guard] [5]
./src\treelearner\leaf_splits.hpp:6:  Found C system header after C++ system header. Should be: leaf_splits.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\leaf_splits.hpp:9:  Found C++ system header after other header. Should be: leaf_splits.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\leaf_splits.hpp:18:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
Done processing ./src\treelearner\leaf_splits.hpp
./src\io\parser.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\parser.cpp:25:  Is this a non-const reference? If so, make const or use a pointer: std::string& str  [runtime/references] [2]
./src\io\parser.cpp:39:  Is this a non-const reference? If so, make const or use a pointer: std::string& str  [runtime/references] [2]
./src\io\parser.cpp:52:  Is this a non-const reference? If so, make const or use a pointer: std::string& str  [runtime/references] [2]
./src\io\parser.cpp:72:  Is this a non-const reference? If so, make const or use a pointer: std::string& line  [runtime/references] [2]
./src\io\parser.cpp:72:  Is this a non-const reference? If so, make const or use a pointer: std::vector<char>& buffer  [runtime/references] [2]
./src\io\parser.cpp:154:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\io\parser.cpp:154:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\io\parser.cpp:158:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\io\parser.cpp:158:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\io\parser.cpp:100:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./src\io\parser.cpp
./include\LightGBM\objective_function.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\objective_function.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_OBJECTIVE_FUNCTION_H_  [build/header_guard] [5]
./include\LightGBM\objective_function.h:93:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_OBJECTIVE_FUNCTION_H_"  [build/header_guard] [5]
./include\LightGBM\objective_function.h:88:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./include\LightGBM\objective_function.h
./src\io\dense_nbits_bin.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\dense_nbits_bin.hpp:1:  #ifndef header guard has wrong style, please use: SRC_IO_DENSE_NBITS_BIN_HPP_  [build/header_guard] [5]
./src\io\dense_nbits_bin.hpp:390:  #endif line should be "#endif  // SRC_IO_DENSE_NBITS_BIN_HPP_"  [build/header_guard] [5]
./src\io\dense_nbits_bin.hpp:41:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./src\io\dense_nbits_bin.hpp:214:  "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]
./src\io\dense_nbits_bin.hpp:275:  "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]
Done processing ./src\io\dense_nbits_bin.hpp
./src\treelearner\split_info.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\split_info.hpp:1:  #ifndef header guard has wrong style, please use: SRC_TREELEARNER_SPLIT_INFO_HPP_  [build/header_guard] [5]
./src\treelearner\split_info.hpp:285:  #endif line should be "#endif  // SRC_TREELEARNER_SPLIT_INFO_HPP_"  [build/header_guard] [5]
./src\treelearner\split_info.hpp:42:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing ./src\treelearner\split_info.hpp
./include\LightGBM\utils\common.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\utils\common.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_UTILS_COMMON_H_  [build/header_guard] [5]
./include\LightGBM\utils\common.h:881:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_UTILS_COMMON_H_"  [build/header_guard] [5]
./include\LightGBM\utils\common.h:21:  Include the directory when naming .h files  [build/include_subdir] [4]
./include\LightGBM\utils\common.h:297:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
./include\LightGBM\utils\common.h:343:  Using deprecated casting style.  Use static_cast<char>(...) instead  [readability/casting] [4]
./include\LightGBM\utils\common.h:345:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./include\LightGBM\utils\common.h:345:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./include\LightGBM\utils\common.h:369:  Never use sprintf. Use snprintf instead.  [runtime/printf] [5]
./include\LightGBM\utils\common.h:409:  Closing ) should be moved to the previous line  [whitespace/parens] [2]
./include\LightGBM\utils\common.h:413:  Never use sprintf. Use snprintf instead.  [runtime/printf] [5]
./include\LightGBM\utils\common.h:622:  Is this a non-const reference? If so, make const or use a pointer: std::vector<T1>& keys  [runtime/references] [2]
./include\LightGBM\utils\common.h:622:  Is this a non-const reference? If so, make const or use a pointer: std::vector<T2>& values  [runtime/references] [2]
./include\LightGBM\utils\common.h:643:  Is this a non-const reference? If so, make const or use a pointer: std::vector<std::vector<T>>& data  [runtime/references] [2]
./include\LightGBM\utils\common.h:557:  Add #include <limits> for numeric_limits<>  [build/include_what_you_use] [4]
./include\LightGBM\utils\common.h:632:  Add #include <utility> for pair<>  [build/include_what_you_use] [4]
Done processing ./include\LightGBM\utils\common.h
./src\objective\binary_objective.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\objective\binary_objective.hpp:1:  #ifndef header guard has wrong style, please use: SRC_OBJECTIVE_BINARY_OBJECTIVE_HPP_  [build/header_guard] [5]
./src\objective\binary_objective.hpp:196:  #endif line should be "#endif  // SRC_OBJECTIVE_BINARY_OBJECTIVE_HPP_"  [build/header_guard] [5]
./src\objective\binary_objective.hpp:31:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
./src\objective\binary_objective.hpp:146:  Add #include <algorithm> for max  [build/include_what_you_use] [4]
./src\objective\binary_objective.hpp:164:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./src\objective\binary_objective.hpp
./src\boosting\gbdt.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\boosting\gbdt.cpp:1:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\boosting\gbdt.cpp:14:  <chrono> is an unapproved C++11 header.  [build/c++11] [5]
./src\boosting\gbdt.cpp:264:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing ./src\boosting\gbdt.cpp
./include\LightGBM\meta.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\meta.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_META_H_  [build/header_guard] [5]
./include\LightGBM\meta.h:67:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_META_H_"  [build/header_guard] [5]
./include\LightGBM\meta.h:46:  Add #include <utility> for pair<>  [build/include_what_you_use] [4]
Done processing ./include\LightGBM\meta.h
./src\application\predictor.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\application\predictor.hpp:1:  #ifndef header guard has wrong style, please use: SRC_APPLICATION_PREDICTOR_HPP_  [build/header_guard] [5]
./src\application\predictor.hpp:257:  #endif line should be "#endif  // SRC_APPLICATION_PREDICTOR_HPP_"  [build/header_guard] [5]
./src\application\predictor.hpp:41:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\application\predictor.hpp:42:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
Done processing ./src\application\predictor.hpp
./src\io\config.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\config.cpp:157:  Use int16/int64/etc, rather than the C type short  [runtime/int] [4]
Done processing ./src\io\config.cpp
./src\boosting\gbdt_model_text.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\boosting\gbdt_model_text.cpp:1:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\boosting\gbdt_model_text.cpp:13:  For a static/global string constant, use a C style string instead: "const char kModelVersion[]".  [runtime/string] [4]
./src\boosting\gbdt_model_text.cpp:241:  Using C-style cast.  Use static_cast<bool>(...) instead  [readability/casting] [4]
./src\boosting\gbdt_model_text.cpp:340:  Using C-style cast.  Use static_cast<bool>(...) instead  [readability/casting] [4]
./src\boosting\gbdt_model_text.cpp:359:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\boosting\gbdt_model_text.cpp:359:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\boosting\gbdt_model_text.cpp:362:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\boosting\gbdt_model_text.cpp:362:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\boosting\gbdt_model_text.cpp:371:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\boosting\gbdt_model_text.cpp:371:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\boosting\gbdt_model_text.cpp:454:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\boosting\gbdt_model_text.cpp:454:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
Done processing ./src\boosting\gbdt_model_text.cpp
./src\application\application.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\application\application.cpp:16:  Found C system header after other header. Should be: application.h, c system, c++ system, other.  [build/include_order] [4]
./src\application\application.cpp:18:  Found C++ system header after other header. Should be: application.h, c system, c++ system, other.  [build/include_order] [4]
./src\application\application.cpp:19:  Found C++ system header after other header. Should be: application.h, c system, c++ system, other.  [build/include_order] [4]
./src\application\application.cpp:21:  Found C++ system header after other header. Should be: application.h, c system, c++ system, other.  [build/include_order] [4]
./src\application\application.cpp:21:  <chrono> is an unapproved C++11 header.  [build/c++11] [5]
./src\application\application.cpp:22:  Found C++ system header after other header. Should be: application.h, c system, c++ system, other.  [build/include_order] [4]
./src\application\application.cpp:23:  Found C++ system header after other header. Should be: application.h, c system, c++ system, other.  [build/include_order] [4]
./src\application\application.cpp:24:  Found C++ system header after other header. Should be: application.h, c system, c++ system, other.  [build/include_order] [4]
./src\application\application.cpp:25:  Found C++ system header after other header. Should be: application.h, c system, c++ system, other.  [build/include_order] [4]
./src\application\application.cpp:26:  Found C++ system header after other header. Should be: application.h, c system, c++ system, other.  [build/include_order] [4]
Done processing ./src\application\application.cpp
./src\network\linkers.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\network\linkers.h:1:  #ifndef header guard has wrong style, please use: SRC_NETWORK_LINKERS_H_  [build/header_guard] [5]
./src\network\linkers.h:307:  #endif line should be "#endif  // SRC_NETWORK_LINKERS_H_"  [build/header_guard] [5]
./src\network\linkers.h:10:  <chrono> is an unapproved C++11 header.  [build/c++11] [5]
./src\network\linkers.h:12:  <thread> is an unapproved C++11 header.  [build/c++11] [5]
./src\network\linkers.h:19:  Found C system header after other header. Should be: linkers.h, c system, c++ system, other.  [build/include_order] [4]
Done processing ./src\network\linkers.h
./include\LightGBM\export.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\export.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_EXPORT_H_  [build/header_guard] [5]
./include\LightGBM\export.h:21:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_EXPORT_H_"  [build/header_guard] [5]
Done processing ./include\LightGBM\export.h
./src\metric\regression_metric.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\metric\regression_metric.hpp:1:  #ifndef header guard has wrong style, please use: SRC_METRIC_REGRESSION_METRIC_HPP_  [build/header_guard] [5]
./src\metric\regression_metric.hpp:316:  #endif line should be "#endif  // SRC_METRIC_REGRESSION_METRIC_HPP_"  [build/header_guard] [5]
./src\metric\regression_metric.hpp:268:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\metric\regression_metric.hpp:290:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\metric\regression_metric.hpp:109:  Add #include <string> for string  [build/include_what_you_use] [4]
./src\metric\regression_metric.hpp:109:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
./src\metric\regression_metric.hpp:243:  Add #include <algorithm> for max  [build/include_what_you_use] [4]
Done processing ./src\metric\regression_metric.hpp
./src\treelearner\data_partition.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\data_partition.hpp:1:  #ifndef header guard has wrong style, please use: SRC_TREELEARNER_DATA_PARTITION_HPP_  [build/header_guard] [5]
./src\treelearner\data_partition.hpp:225:  #endif line should be "#endif  // SRC_TREELEARNER_DATA_PARTITION_HPP_"  [build/header_guard] [5]
./src\treelearner\data_partition.hpp:83:  Add #include <algorithm> for copy  [build/include_what_you_use] [4]
Done processing ./src\treelearner\data_partition.hpp
./src\metric\xentropy_metric.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\metric\xentropy_metric.hpp:1:  #ifndef header guard has wrong style, please use: SRC_METRIC_XENTROPY_METRIC_HPP_  [build/header_guard] [5]
./src\metric\xentropy_metric.hpp:356:  #endif line should be "#endif  // SRC_METRIC_XENTROPY_METRIC_HPP_"  [build/header_guard] [5]
./src\metric\xentropy_metric.hpp:89:  Using C-style cast.  Use reinterpret_cast<label_t*>(...) instead  [readability/casting] [4]
./src\metric\xentropy_metric.hpp:180:  Using C-style cast.  Use reinterpret_cast<label_t*>(...) instead  [readability/casting] [4]
./src\metric\xentropy_metric.hpp:264:  Using C-style cast.  Use reinterpret_cast<label_t*>(...) instead  [readability/casting] [4]
./src\metric\xentropy_metric.hpp:351:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./src\metric\xentropy_metric.hpp
./src\treelearner\data_parallel_tree_learner.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\data_parallel_tree_learner.cpp:1:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\treelearner\data_parallel_tree_learner.cpp:3:  Found C++ system header after other header. Should be: data_parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\data_parallel_tree_learner.cpp:5:  Found C++ system header after other header. Should be: data_parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\data_parallel_tree_learner.cpp:6:  Found C++ system header after other header. Should be: data_parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\data_parallel_tree_learner.cpp:138:  Using C-style cast.  Use reinterpret_cast<void*>(...) instead  [readability/casting] [4]
Done processing ./src\treelearner\data_parallel_tree_learner.cpp
./src\treelearner\parallel_tree_learner.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\parallel_tree_learner.h:1:  #ifndef header guard has wrong style, please use: SRC_TREELEARNER_PARALLEL_TREE_LEARNER_H_  [build/header_guard] [5]
./src\treelearner\parallel_tree_learner.h:212:  #endif line should be "#endif  // SRC_TREELEARNER_PARALLEL_TREE_LEARNER_H_"  [build/header_guard] [5]
./src\treelearner\parallel_tree_learner.h:4:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\treelearner\parallel_tree_learner.h:5:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\treelearner\parallel_tree_learner.h:6:  Found C system header after other header. Should be: parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\parallel_tree_learner.h:8:  Found C system header after other header. Should be: parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\parallel_tree_learner.h:10:  Found C++ system header after other header. Should be: parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\parallel_tree_learner.h:11:  Found C++ system header after other header. Should be: parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\parallel_tree_learner.h:12:  Found C++ system header after other header. Should be: parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
Done processing ./src\treelearner\parallel_tree_learner.h
./include\LightGBM\tree.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\tree.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_TREE_H_  [build/header_guard] [5]
./include\LightGBM\tree.h:517:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_TREE_H_"  [build/header_guard] [5]
./include\LightGBM\tree.h:262:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
./include\LightGBM\tree.h:271:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
./include\LightGBM\tree.h:334:  Complex multi-line /*...*/-style comment found. Lint may give bogus warnings.  Consider replacing these with //-style comments, with #if 0...#endif, or with more clearly structured multi-line comments.  [readability/multiline_comment] [5]
./include\LightGBM\tree.h:334:  At least two spaces is best between code and comments  [whitespace/comments] [2]
./include\LightGBM\tree.h:334:  Should have a space between // and comment  [whitespace/comments] [4]
./include\LightGBM\tree.h:334:  Extra space for operator !   [whitespace/operators] [4]
./include\LightGBM\tree.h:469:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
Done processing ./include\LightGBM\tree.h
./src\io\sparse_bin.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\sparse_bin.hpp:1:  #ifndef header guard has wrong style, please use: SRC_IO_SPARSE_BIN_HPP_  [build/header_guard] [5]
./src\io\sparse_bin.hpp:456:  #endif line should be "#endif  // SRC_IO_SPARSE_BIN_HPP_"  [build/header_guard] [5]
./src\io\sparse_bin.hpp:74:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./src\io\sparse_bin.hpp:144:  "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]
./src\io\sparse_bin.hpp:207:  "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]
./src\io\sparse_bin.hpp:254:  Add #include <algorithm> for sort  [build/include_what_you_use] [4]
./src\io\sparse_bin.hpp:416:  Add #include <utility> for pair<>  [build/include_what_you_use] [4]
Done processing ./src\io\sparse_bin.hpp
./include\LightGBM\utils\openmp_wrapper.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\utils\openmp_wrapper.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_UTILS_OPENMP_WRAPPER_H_  [build/header_guard] [5]
./include\LightGBM\utils\openmp_wrapper.h:76:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_UTILS_OPENMP_WRAPPER_H_"  [build/header_guard] [5]
./include\LightGBM\utils\openmp_wrapper.h:8:  <mutex> is an unapproved C++11 header.  [build/c++11] [5]
./include\LightGBM\utils\openmp_wrapper.h:11:  Include the directory when naming .h files  [build/include_subdir] [4]
Done processing ./include\LightGBM\utils\openmp_wrapper.h
./src\boosting\goss.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\boosting\goss.hpp:1:  #ifndef header guard has wrong style, please use: SRC_BOOSTING_GOSS_HPP_  [build/header_guard] [5]
./src\boosting\goss.hpp:216:  #endif line should be "#endif  // SRC_BOOSTING_GOSS_HPP_"  [build/header_guard] [5]
./src\boosting\goss.hpp:10:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\boosting\goss.hpp:12:  Found C++ system header after other header. Should be: goss.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\goss.hpp:13:  Found C++ system header after other header. Should be: goss.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\goss.hpp:14:  Found C++ system header after other header. Should be: goss.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\goss.hpp:15:  Found C++ system header after other header. Should be: goss.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\goss.hpp:16:  Found C++ system header after other header. Should be: goss.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\goss.hpp:16:  <chrono> is an unapproved C++11 header.  [build/c++11] [5]
./src\boosting\goss.hpp:17:  Found C++ system header after other header. Should be: goss.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\goss.hpp:87:  Is this a non-const reference? If so, make const or use a pointer: Random& cur_rand  [runtime/references] [2]
Done processing ./src\boosting\goss.hpp
./src\io\metadata.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
Done processing ./src\io\metadata.cpp
./src\treelearner\voting_parallel_tree_learner.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\voting_parallel_tree_learner.cpp:1:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\treelearner\voting_parallel_tree_learner.cpp:3:  Found C system header after other header. Should be: voting_parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\voting_parallel_tree_learner.cpp:5:  Found C++ system header after other header. Should be: voting_parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\voting_parallel_tree_learner.cpp:6:  Found C++ system header after other header. Should be: voting_parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\voting_parallel_tree_learner.cpp:7:  Found C++ system header after other header. Should be: voting_parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\voting_parallel_tree_learner.cpp:134:  Using C-style cast.  Use reinterpret_cast<void*>(...) instead  [readability/casting] [4]
Done processing ./src\treelearner\voting_parallel_tree_learner.cpp
./src\main.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\main.cpp:2:  Found C system header after C++ system header. Should be: main.h, c system, c++ system, other.  [build/include_order] [4]
Done processing ./src\main.cpp
./src\boosting\gbdt_prediction.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\boosting\gbdt_prediction.cpp:1:  Include the directory when naming .h files  [build/include_subdir] [4]
Done processing ./src\boosting\gbdt_prediction.cpp
./src\io\parser.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\parser.hpp:1:  #ifndef header guard has wrong style, please use: SRC_IO_PARSER_HPP_  [build/header_guard] [5]
./src\io\parser.hpp:129:  #endif line should be "#endif  // SRC_IO_PARSER_HPP_"  [build/header_guard] [5]
./src\io\parser.hpp:32:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\io\parser.hpp:32:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
Done processing ./src\io\parser.hpp
./src\treelearner\tree_learner.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\tree_learner.cpp:3:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\treelearner\tree_learner.cpp:4:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\treelearner\tree_learner.cpp:5:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\treelearner\tree_learner.cpp:21:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\treelearner\tree_learner.cpp:21:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
Done processing ./src\treelearner\tree_learner.cpp
./src\metric\binary_metric.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\metric\binary_metric.hpp:1:  #ifndef header guard has wrong style, please use: SRC_METRIC_BINARY_METRIC_HPP_  [build/header_guard] [5]
./src\metric\binary_metric.hpp:263:  #endif line should be "#endif  // SRC_METRIC_BINARY_METRIC_HPP_"  [build/header_guard] [5]
./src\metric\binary_metric.hpp:259:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./src\metric\binary_metric.hpp
./include\LightGBM\dataset_loader.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\dataset_loader.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_DATASET_LOADER_H_  [build/header_guard] [5]
./include\LightGBM\dataset_loader.h:78:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_DATASET_LOADER_H_"  [build/header_guard] [5]
./include\LightGBM\dataset_loader.h:47:  Is this a non-const reference? If so, make const or use a pointer: std::vector<std::string>& text_data  [runtime/references] [2]
./include\LightGBM\dataset_loader.h:76:  Namespace should be terminated with "// namespace LightGBM"  [readability/namespace] [5]
./include\LightGBM\dataset_loader.h:71:  Add #include <string> for string  [build/include_what_you_use] [4]
./include\LightGBM\dataset_loader.h:71:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing ./include\LightGBM\dataset_loader.h
./src\objective\regression_objective.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\objective\regression_objective.hpp:1:  #ifndef header guard has wrong style, please use: SRC_OBJECTIVE_REGRESSION_OBJECTIVE_HPP_  [build/header_guard] [5]
./src\objective\regression_objective.hpp:814:  #endif line should be "#endif  // SRC_OBJECTIVE_REGRESSION_OBJECTIVE_HPP_"  [build/header_guard] [5]
./src\objective\regression_objective.hpp:61:  Missing space before ( in if(  [whitespace/parens] [5]
./src\objective\regression_objective.hpp:61:  Missing space before {  [whitespace/braces] [5]
./src\objective\regression_objective.hpp:433:  Using C-style cast.  Use reinterpret_cast<label_t*>(...) instead  [readability/casting] [4]
./src\objective\regression_objective.hpp:645:  Add #include <algorithm> for max  [build/include_what_you_use] [4]
./src\objective\regression_objective.hpp:778:  Add #include <string> for string  [build/include_what_you_use] [4]
./src\objective\regression_objective.hpp:778:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing ./src\objective\regression_objective.hpp
./src\objective\xentropy_objective.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\objective\xentropy_objective.hpp:1:  #ifndef header guard has wrong style, please use: SRC_OBJECTIVE_XENTROPY_OBJECTIVE_HPP_  [build/header_guard] [5]
./src\objective\xentropy_objective.hpp:269:  #endif line should be "#endif  // SRC_OBJECTIVE_XENTROPY_OBJECTIVE_HPP_"  [build/header_guard] [5]
./src\objective\xentropy_objective.hpp:60:  Using C-style cast.  Use reinterpret_cast<label_t*>(...) instead  [readability/casting] [4]
./src\objective\xentropy_objective.hpp:163:  Using C-style cast.  Use reinterpret_cast<label_t*>(...) instead  [readability/casting] [4]
./src\objective\xentropy_objective.hpp:254:  private: should be indented +1 space inside class CrossEntropyLambda  [whitespace/indent] [3]
./src\objective\xentropy_objective.hpp:124:  Add #include <algorithm> for max  [build/include_what_you_use] [4]
./src\objective\xentropy_objective.hpp:148:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
./src\objective\xentropy_objective.hpp:226:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./src\objective\xentropy_objective.hpp
./src\treelearner\feature_parallel_tree_learner.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\feature_parallel_tree_learner.cpp:1:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\treelearner\feature_parallel_tree_learner.cpp:3:  Found C++ system header after other header. Should be: feature_parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\feature_parallel_tree_learner.cpp:5:  Found C++ system header after other header. Should be: feature_parallel_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
Done processing ./src\treelearner\feature_parallel_tree_learner.cpp
./src\treelearner\serial_tree_learner.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\serial_tree_learner.cpp:1:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\treelearner\serial_tree_learner.cpp:272:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
./src\treelearner\serial_tree_learner.cpp:801:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\treelearner\serial_tree_learner.cpp:841:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\treelearner\serial_tree_learner.cpp:607:  Add #include <utility> for pair<>  [build/include_what_you_use] [4]
Done processing ./src\treelearner\serial_tree_learner.cpp
./include\LightGBM\utils\pipeline_reader.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\utils\pipeline_reader.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_UTILS_PIPELINE_READER_H_  [build/header_guard] [5]
./include\LightGBM\utils\pipeline_reader.h:67:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_UTILS_PIPELINE_READER_H_"  [build/header_guard] [5]
./include\LightGBM\utils\pipeline_reader.h:9:  <thread> is an unapproved C++11 header.  [build/c++11] [5]
./include\LightGBM\utils\pipeline_reader.h:13:  Include the directory when naming .h files  [build/include_subdir] [4]
./include\LightGBM\utils\pipeline_reader.h:58:  Add #include <utility> for swap  [build/include_what_you_use] [4]
Done processing ./include\LightGBM\utils\pipeline_reader.h
./src\lightgbm_R.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\lightgbm_R.cpp:34:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing ./src\lightgbm_R.cpp
./include\LightGBM\bin.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\bin.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_BIN_H_  [build/header_guard] [5]
./include\LightGBM\bin.h:492:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_BIN_H_"  [build/header_guard] [5]
./include\LightGBM\bin.h:176:  Add #include <string> for string  [build/include_what_you_use] [4]
./include\LightGBM\bin.h:181:  Add #include <limits> for numeric_limits<>  [build/include_what_you_use] [4]
Done processing ./include\LightGBM\bin.h
./src\boosting\gbdt.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\boosting\gbdt.h:1:  #ifndef header guard has wrong style, please use: SRC_BOOSTING_GBDT_H_  [build/header_guard] [5]
./src\boosting\gbdt.h:492:  #endif line should be "#endif  // SRC_BOOSTING_GBDT_H_"  [build/header_guard] [5]
./src\boosting\gbdt.h:11:  Found C++ system header after other header. Should be: gbdt.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\gbdt.h:12:  Found C++ system header after other header. Should be: gbdt.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\gbdt.h:13:  Found C++ system header after other header. Should be: gbdt.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\gbdt.h:14:  Found C++ system header after other header. Should be: gbdt.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\gbdt.h:15:  Found C++ system header after other header. Should be: gbdt.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\gbdt.h:16:  Found C++ system header after other header. Should be: gbdt.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\gbdt.h:16:  <mutex> is an unapproved C++11 header.  [build/c++11] [5]
./src\boosting\gbdt.h:17:  Found C++ system header after other header. Should be: gbdt.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\gbdt.h:19:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
./src\boosting\gbdt.h:137:  "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]
./src\boosting\gbdt.h:173:  "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]
./src\boosting\gbdt.h:180:  "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]
./src\boosting\gbdt.h:268:  "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]
./src\boosting\gbdt.h:276:  "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]
./src\boosting\gbdt.h:355:  "virtual" is redundant since function is already declared as "override"  [readability/inheritance] [4]
./src\boosting\gbdt.h:381:  Is this a non-const reference? If so, make const or use a pointer: Random& cur_rand  [runtime/references] [2]
./src\boosting\gbdt.h:87:  Add #include <utility> for swap  [build/include_what_you_use] [4]
./src\boosting\gbdt.h:330:  Add #include <algorithm> for min  [build/include_what_you_use] [4]
Done processing ./src\boosting\gbdt.h
./include\LightGBM\network.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\network.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_NETWORK_H_  [build/header_guard] [5]
./include\LightGBM\network.h:307:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_NETWORK_H_"  [build/header_guard] [5]
./include\LightGBM\network.h:166:  Is this a non-const reference? If so, make const or use a pointer: T& local  [runtime/references] [2]
./include\LightGBM\network.h:190:  Is this a non-const reference? If so, make const or use a pointer: T& local  [runtime/references] [2]
./include\LightGBM\network.h:214:  Is this a non-const reference? If so, make const or use a pointer: T& local  [runtime/references] [2]
./include\LightGBM\network.h:236:  Is this a non-const reference? If so, make const or use a pointer: std::vector<T>& local  [runtime/references] [2]
Done processing ./include\LightGBM\network.h
./src\boosting\boosting.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\boosting\boosting.cpp:2:  Include the directory when naming .h files  [build/include_subdir] [4]
Done processing ./src\boosting\boosting.cpp
./include\LightGBM\dataset.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\dataset.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_DATASET_H_  [build/header_guard] [5]
./include\LightGBM\dataset.h:625:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_DATASET_H_"  [build/header_guard] [5]
./include\LightGBM\dataset.h:17:  <mutex> is an unapproved C++11 header.  [build/c++11] [5]
./include\LightGBM\dataset.h:287:  Is this a non-const reference? If so, make const or use a pointer: std::vector<std::unique_ptr<BinMapper>>& bin_mappers  [runtime/references] [2]
./include\LightGBM\dataset.h:401:  Is this a non-const reference? If so, make const or use a pointer: std::vector<std::unique_ptr<OrderedBin>>& ordered_bins  [runtime/references] [2]
Done processing ./include\LightGBM\dataset.h
./src\treelearner\serial_tree_learner.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\serial_tree_learner.h:1:  #ifndef header guard has wrong style, please use: SRC_TREELEARNER_SERIAL_TREE_LEARNER_H_  [build/header_guard] [5]
./src\treelearner\serial_tree_learner.h:183:  #endif line should be "#endif  // SRC_TREELEARNER_SERIAL_TREE_LEARNER_H_"  [build/header_guard] [5]
./src\treelearner\serial_tree_learner.h:16:  Found C++ system header after other header. Should be: serial_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\serial_tree_learner.h:17:  Found C++ system header after other header. Should be: serial_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\serial_tree_learner.h:18:  Found C++ system header after other header. Should be: serial_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\serial_tree_learner.h:19:  Found C++ system header after other header. Should be: serial_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\serial_tree_learner.h:20:  Found C++ system header after other header. Should be: serial_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\serial_tree_learner.h:27:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
./src\treelearner\serial_tree_learner.h:105:  Is this a non-const reference? If so, make const or use a pointer: Json& forced_split_json  [runtime/references] [2]
Done processing ./src\treelearner\serial_tree_learner.h
./src\boosting\rf.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\boosting\rf.hpp:1:  #ifndef header guard has wrong style, please use: SRC_BOOSTING_RF_HPP_  [build/header_guard] [5]
./src\boosting\rf.hpp:209:  #endif line should be "#endif  // SRC_BOOSTING_RF_HPP_"  [build/header_guard] [5]
./src\boosting\rf.hpp:7:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\boosting\rf.hpp:9:  Found C++ system header after other header. Should be: rf.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\rf.hpp:10:  Found C++ system header after other header. Should be: rf.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\rf.hpp:11:  Found C++ system header after other header. Should be: rf.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\rf.hpp:12:  Found C++ system header after other header. Should be: rf.h, c system, c++ system, other.  [build/include_order] [4]
Done processing ./src\boosting\rf.hpp
./src\metric\map_metric.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\metric\map_metric.hpp:1:  #ifndef header guard has wrong style, please use: SRC_METRIC_MAP_METRIC_HPP_  [build/header_guard] [5]
./src\metric\map_metric.hpp:168:  #endif line should be "#endif  // SRC_METRIC_MAP_METRIC_HPP_"  [build/header_guard] [5]
./src\metric\map_metric.hpp:99:  Add #include <algorithm> for min  [build/include_what_you_use] [4]
./src\metric\map_metric.hpp:162:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./src\metric\map_metric.hpp
./include\LightGBM\feature_group.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\feature_group.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_FEATURE_GROUP_H_  [build/header_guard] [5]
./include\LightGBM\feature_group.h:234:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_FEATURE_GROUP_H_"  [build/header_guard] [5]
./include\LightGBM\feature_group.h:31:  Is this a non-const reference? If so, make const or use a pointer: std::vector<std::unique_ptr<BinMapper>>& bin_mappers  [runtime/references] [2]
./include\LightGBM\feature_group.h:54:  Is this a non-const reference? If so, make const or use a pointer: std::vector<std::unique_ptr<BinMapper>>& bin_mappers  [runtime/references] [2]
Done processing ./include\LightGBM\feature_group.h
./src\c_api.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\c_api.cpp:23:  <mutex> is an unapproved C++11 header.  [build/c++11] [5]
./src\c_api.cpp:343:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
./src\c_api.cpp:762:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing ./src\c_api.cpp
./src\io\tree.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\tree.cpp:345:  Using deprecated casting style.  Use static_cast<int>(...) instead  [readability/casting] [4]
Done processing ./src\io\tree.cpp
./include\LightGBM\application.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\application.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_APPLICATION_H_  [build/header_guard] [5]
./include\LightGBM\application.h:88:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_APPLICATION_H_"  [build/header_guard] [5]
Done processing ./include\LightGBM\application.h
./src\objective\rank_objective.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\objective\rank_objective.hpp:1:  #ifndef header guard has wrong style, please use: SRC_OBJECTIVE_RANK_OBJECTIVE_HPP_  [build/header_guard] [5]
./src\objective\rank_objective.hpp:240:  #endif line should be "#endif  // SRC_OBJECTIVE_RANK_OBJECTIVE_HPP_"  [build/header_guard] [5]
./src\objective\rank_objective.hpp:200:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./src\objective\rank_objective.hpp
./src\network\socket_wrapper.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\network\socket_wrapper.hpp:1:  #ifndef header guard has wrong style, please use: SRC_NETWORK_SOCKET_WRAPPER_HPP_  [build/header_guard] [5]
./src\network\socket_wrapper.hpp:300:  #endif line should be "#endif  // SRC_NETWORK_SOCKET_WRAPPER_HPP_"  [build/header_guard] [5]
./src\network\socket_wrapper.hpp:18:  Found C system header after C++ system header. Should be: socket_wrapper.h, c system, c++ system, other.  [build/include_order] [4]
./src\network\socket_wrapper.hpp:19:  Found C system header after C++ system header. Should be: socket_wrapper.h, c system, c++ system, other.  [build/include_order] [4]
./src\network\socket_wrapper.hpp:20:  Found C system header after C++ system header. Should be: socket_wrapper.h, c system, c++ system, other.  [build/include_order] [4]
./src\network\socket_wrapper.hpp:21:  Found C system header after C++ system header. Should be: socket_wrapper.h, c system, c++ system, other.  [build/include_order] [4]
./src\network\socket_wrapper.hpp:22:  Found C system header after C++ system header. Should be: socket_wrapper.h, c system, c++ system, other.  [build/include_order] [4]
./src\network\socket_wrapper.hpp:23:  Found C system header after C++ system header. Should be: socket_wrapper.h, c system, c++ system, other.  [build/include_order] [4]
./src\network\socket_wrapper.hpp:24:  Found C system header after C++ system header. Should be: socket_wrapper.h, c system, c++ system, other.  [build/include_order] [4]
./src\network\socket_wrapper.hpp:25:  Found C system header after C++ system header. Should be: socket_wrapper.h, c system, c++ system, other.  [build/include_order] [4]
./src\network\socket_wrapper.hpp:176:  Using C-style cast.  Use reinterpret_cast<IP_ADAPTER_INFO *>(...) instead  [readability/casting] [4]
./src\network\socket_wrapper.hpp:184:  Using C-style cast.  Use reinterpret_cast<IP_ADAPTER_INFO *>(...) instead  [readability/casting] [4]
./src\network\socket_wrapper.hpp:216:  Are you taking an address of a cast?  This is dangerous: could be a temp var.  Take the address before doing the cast, rather than after  [runtime/casting] [4]
Done processing ./src\network\socket_wrapper.hpp
./include\LightGBM\utils\random.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\utils\random.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_UTILS_RANDOM_H_  [build/header_guard] [5]
./include\LightGBM\utils\random.h:114:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_UTILS_RANDOM_H_"  [build/header_guard] [5]
./include\LightGBM\utils\random.h:29:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
Done processing ./include\LightGBM\utils\random.h
./src\io\file_io.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\file_io.cpp:51:  For a static/global string constant, use a C style string instead: "const char kHdfsProto[]".  [runtime/string] [4]
./src\io\file_io.cpp:95:  Using C-style cast.  Use reinterpret_cast<char *>(...) instead  [readability/casting] [4]
Done processing ./src\io\file_io.cpp
./src\network\linkers_mpi.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\network\linkers_mpi.cpp:2:  Include the directory when naming .h files  [build/include_subdir] [4]
Done processing ./src\network\linkers_mpi.cpp
./src\boosting\prediction_early_stop.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\boosting\prediction_early_stop.cpp:11:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing ./src\boosting\prediction_early_stop.cpp
./src\io\ordered_sparse_bin.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\ordered_sparse_bin.hpp:1:  #ifndef header guard has wrong style, please use: SRC_IO_ORDERED_SPARSE_BIN_HPP_  [build/header_guard] [5]
./src\io\ordered_sparse_bin.hpp:211:  #endif line should be "#endif  // SRC_IO_ORDERED_SPARSE_BIN_HPP_"  [build/header_guard] [5]
./src\io\ordered_sparse_bin.hpp:10:  <mutex> is an unapproved C++11 header.  [build/c++11] [5]
./src\io\ordered_sparse_bin.hpp:35:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
./src\io\ordered_sparse_bin.hpp:178:  Add #include <utility> for swap  [build/include_what_you_use] [4]
Done processing ./src\io\ordered_sparse_bin.hpp
./src\treelearner\feature_histogram.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\feature_histogram.hpp:1:  #ifndef header guard has wrong style, please use: SRC_TREELEARNER_FEATURE_HISTOGRAM_HPP_  [build/header_guard] [5]
./src\treelearner\feature_histogram.hpp:821:  #endif line should be "#endif  // SRC_TREELEARNER_FEATURE_HISTOGRAM_HPP_"  [build/header_guard] [5]
./src\treelearner\feature_histogram.hpp:6:  Found C system header after other header. Should be: feature_histogram.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\feature_histogram.hpp:7:  Found C system header after other header. Should be: feature_histogram.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\feature_histogram.hpp:9:  Found C++ system header after other header. Should be: feature_histogram.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\feature_histogram.hpp:10:  Found C++ system header after other header. Should be: feature_histogram.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\feature_histogram.hpp:668:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
./src\treelearner\feature_histogram.hpp:439:  Add #include <algorithm> for max  [build/include_what_you_use] [4]
./src\treelearner\feature_histogram.hpp:790:  Add #include <utility> for swap  [build/include_what_you_use] [4]
./src\treelearner\feature_histogram.hpp:816:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing ./src\treelearner\feature_histogram.hpp
./src\metric\dcg_calculator.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\metric\dcg_calculator.cpp:25:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing ./src\metric\dcg_calculator.cpp
./src\objective\multiclass_objective.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\objective\multiclass_objective.hpp:1:  #ifndef header guard has wrong style, please use: SRC_OBJECTIVE_MULTICLASS_OBJECTIVE_HPP_  [build/header_guard] [5]
./src\objective\multiclass_objective.hpp:259:  #endif line should be "#endif  // SRC_OBJECTIVE_MULTICLASS_OBJECTIVE_HPP_"  [build/header_guard] [5]
./src\objective\multiclass_objective.hpp:137:  Add #include <algorithm> for max  [build/include_what_you_use] [4]
./src\objective\multiclass_objective.hpp:225:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./src\objective\multiclass_objective.hpp
./src\network\linker_topo.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
Done processing ./src\network\linker_topo.cpp
./include\LightGBM\config.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\config.h:3:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_CONFIG_H_  [build/header_guard] [5]
./include\LightGBM\config.h:879:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_CONFIG_H_"  [build/header_guard] [5]
./include\LightGBM\config.h:74:  Is this a non-const reference? If so, make const or use a pointer: std::unordered_map<std::string, std::string>& params  [runtime/references] [2]
Done processing ./include\LightGBM\config.h
./src\treelearner\gpu_tree_learner.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\treelearner\gpu_tree_learner.h:1:  #ifndef header guard has wrong style, please use: SRC_TREELEARNER_GPU_TREE_LEARNER_H_  [build/header_guard] [5]
./src\treelearner\gpu_tree_learner.h:284:  #endif line should be "#endif  // SRC_TREELEARNER_GPU_TREE_LEARNER_H_"  [build/header_guard] [5]
./src\treelearner\gpu_tree_learner.h:10:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\treelearner\gpu_tree_learner.h:15:  Found C++ system header after other header. Should be: gpu_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\gpu_tree_learner.h:16:  Found C++ system header after other header. Should be: gpu_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\gpu_tree_learner.h:17:  Found C++ system header after other header. Should be: gpu_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\gpu_tree_learner.h:18:  Found C++ system header after other header. Should be: gpu_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\gpu_tree_learner.h:19:  Found C++ system header after other header. Should be: gpu_tree_learner.h, c system, c++ system, other.  [build/include_order] [4]
./src\treelearner\gpu_tree_learner.h:31:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
./src\treelearner\gpu_tree_learner.h:172:  Line contains only semicolon. If this should be an empty statement, use {} instead.  [whitespace/semicolon] [5]
./src\treelearner\gpu_tree_learner.h:176:  Line contains only semicolon. If this should be an empty statement, use {} instead.  [whitespace/semicolon] [5]
./src\treelearner\gpu_tree_learner.h:180:  Line contains only semicolon. If this should be an empty statement, use {} instead.  [whitespace/semicolon] [5]
./src\treelearner\gpu_tree_learner.h:184:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./src\treelearner\gpu_tree_learner.h
./include\LightGBM\metric.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\metric.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_METRIC_H_  [build/header_guard] [5]
./include\LightGBM\metric.h:139:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_METRIC_H_"  [build/header_guard] [5]
./include\LightGBM\metric.h:53:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./include\LightGBM\metric.h
./src\io\config_auto.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\config_auto.cpp:275:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
./src\io\config_auto.cpp:281:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:288:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
./src\io\config_auto.cpp:345:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:348:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:357:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:360:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:379:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:382:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:385:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:460:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:488:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:495:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:504:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:507:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:510:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\config_auto.cpp:521:  Redundant blank line at the end of a code block should be deleted.  [whitespace/blank_line] [3]
./src\io\config_auto.cpp:626:  Namespace should be terminated with "// namespace LightGBM"  [readability/namespace] [5]
Done processing ./src\io\config_auto.cpp
./src\network\linkers_socket.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\network\linkers_socket.cpp:2:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\network\linkers_socket.cpp:14:  <thread> is an unapproved C++11 header.  [build/c++11] [5]
./src\network\linkers_socket.cpp:15:  <chrono> is an unapproved C++11 header.  [build/c++11] [5]
Done processing ./src\network\linkers_socket.cpp
./src\boosting\dart.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\boosting\dart.hpp:1:  #ifndef header guard has wrong style, please use: SRC_BOOSTING_DART_HPP_  [build/header_guard] [5]
./src\boosting\dart.hpp:205:  #endif line should be "#endif  // SRC_BOOSTING_DART_HPP_"  [build/header_guard] [5]
./src\boosting\dart.hpp:6:  Include the directory when naming .h files  [build/include_subdir] [4]
./src\boosting\dart.hpp:8:  Found C++ system header after other header. Should be: dart.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\dart.hpp:9:  Found C++ system header after other header. Should be: dart.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\dart.hpp:10:  Found C++ system header after other header. Should be: dart.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\dart.hpp:11:  Found C++ system header after other header. Should be: dart.h, c system, c++ system, other.  [build/include_order] [4]
./src\boosting\dart.hpp:112:  Add #include <algorithm> for min  [build/include_what_you_use] [4]
Done processing ./src\boosting\dart.hpp
./src\io\json11.cpp:53:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
./src\io\json11.cpp:57:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
./src\io\json11.cpp:67:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
./src\io\json11.cpp:73:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
./src\io\json11.cpp:77:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
./src\io\json11.cpp:114:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
./src\io\json11.cpp:126:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
./src\io\json11.cpp:294:  Else clause should never be on same line as else (use 2 lines)  [whitespace/newline] [4]
./src\io\json11.cpp:337:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
./src\io\json11.cpp:349:  const string& members are dangerous. It is much better to use alternatives, such as pointers or simple constants.  [runtime/member_string_references] [2]
./src\io\json11.cpp:390:  At least two spaces is best between code and comments  [whitespace/comments] [2]
./src\io\json11.cpp:398:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\io\json11.cpp:398:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
./src\io\json11.cpp:411:  An else should appear on the same line as the preceding }  [whitespace/newline] [4]
./src\io\json11.cpp:430:  Empty loop bodies should use {} or continue  [whitespace/empty_loop_body] [5]
./src\io\json11.cpp:441:  Using C-style cast.  Use static_cast<char>(...) instead  [readability/casting] [4]
./src\io\json11.cpp:443:  Using C-style cast.  Use static_cast<char>(...) instead  [readability/casting] [4]
./src\io\json11.cpp:452:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
./src\io\json11.cpp:452:  Is this a non-const reference? If so, make const or use a pointer: string & out  [runtime/references] [2]
./src\io\json11.cpp:479:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
./src\io\json11.cpp:523:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
Done processing ./src\io\json11.cpp
./src\io\bin.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\bin.cpp:11:  Found C++ system header after other header. Should be: bin.h, c system, c++ system, other.  [build/include_order] [4]
./src\io\bin.cpp:12:  Found C++ system header after other header. Should be: bin.h, c system, c++ system, other.  [build/include_order] [4]
./src\io\bin.cpp:13:  Found C++ system header after other header. Should be: bin.h, c system, c++ system, other.  [build/include_order] [4]
./src\io\bin.cpp:15:  Found C++ system header after other header. Should be: bin.h, c system, c++ system, other.  [build/include_order] [4]
./src\io\bin.cpp:16:  Found C++ system header after other header. Should be: bin.h, c system, c++ system, other.  [build/include_order] [4]
./src\io\bin.cpp:17:  Found C++ system header after other header. Should be: bin.h, c system, c++ system, other.  [build/include_order] [4]
./src\io\bin.cpp:76:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\bin.cpp:196:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\bin.cpp:392:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing ./src\io\bin.cpp
./include\LightGBM\utils\array_args.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\utils\array_args.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_UTILS_ARRAY_ARGS_H_  [build/header_guard] [5]
./include\LightGBM\utils\array_args.h:191:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_UTILS_ARRAY_ARGS_H_"  [build/header_guard] [5]
./include\LightGBM\utils\array_args.h:6:  Found C system header after C++ system header. Should be: array_args.h, c system, c++ system, other.  [build/include_order] [4]
./include\LightGBM\utils\array_args.h:113:  Empty loop bodies should use {} or continue  [whitespace/empty_loop_body] [5]
./include\LightGBM\utils\array_args.h:124:  Add #include <utility> for swap  [build/include_what_you_use] [4]
Done processing ./include\LightGBM\utils\array_args.h
./src\io\dataset.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\io\dataset.cpp:7:  <chrono> is an unapproved C++11 header.  [build/c++11] [5]
./src\io\dataset.cpp:27:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
./src\io\dataset.cpp:60:  Is this a non-const reference? If so, make const or use a pointer: std::vector<bool>& mark  [runtime/references] [2]
./src\io\dataset.cpp:138:  Is this a non-const reference? If so, make const or use a pointer: std::vector<std::unique_ptr<BinMapper>>& bin_mappers  [runtime/references] [2]
./src\io\dataset.cpp:748:  Using C-style cast.  Use reinterpret_cast<void*>(...) instead  [readability/casting] [4]
./src\io\dataset.cpp:777:  Using C-style cast.  Use reinterpret_cast<void*>(...) instead  [readability/casting] [4]
./src\io\dataset.cpp:810:  Using C-style cast.  Use reinterpret_cast<void*>(...) instead  [readability/casting] [4]
./src\io\dataset.cpp:838:  Using C-style cast.  Use reinterpret_cast<void*>(...) instead  [readability/casting] [4]
Done processing ./src\io\dataset.cpp
./include\LightGBM\c_api.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./include\LightGBM\c_api.h:1:  #ifndef header guard has wrong style, please use: INCLUDE_LIGHTGBM_C_API_H_  [build/header_guard] [5]
./include\LightGBM\c_api.h:834:  #endif line should be "#endif  // INCLUDE_LIGHTGBM_C_API_H_"  [build/header_guard] [5]
./include\LightGBM\c_api.h:15:  Found C system header after C++ system header. Should be: c_api.h, c system, c++ system, other.  [build/include_order] [4]
./include\LightGBM\c_api.h:831:  Almost always, snprintf is better than strcpy  [runtime/printf] [4]
Done processing ./include\LightGBM\c_api.h
./src\metric\rank_metric.hpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
./src\metric\rank_metric.hpp:1:  #ifndef header guard has wrong style, please use: SRC_METRIC_RANK_METRIC_HPP_  [build/header_guard] [5]
./src\metric\rank_metric.hpp:171:  #endif line should be "#endif  // SRC_METRIC_RANK_METRIC_HPP_"  [build/header_guard] [5]
./src\metric\rank_metric.hpp:152:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing ./src\metric\rank_metric.hpp
Total errors found: 674
```

</details>
