### PR TITLE
added LightGBM SWIG wrappers for macOS and updated docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,9 @@ if(USE_SWIG)
   if(WIN32)
       FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/com/microsoft/ml/lightgbm/windows/x86_64")
       include_directories($ENV{JAVA_HOME}/include/win32)
+  elseif(APPLE)
+      FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/com/microsoft/ml/lightgbm/osx/x86_64")
+      include_directories($ENV{JAVA_HOME}/include/darwin)
   else()
       FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/com/microsoft/ml/lightgbm/linux/x86_64")
       include_directories($ENV{JAVA_HOME}/include/linux)
@@ -196,6 +199,12 @@ if(USE_SWIG)
             COMMAND cp "${PROJECT_SOURCE_DIR}/Release/*.dll" com/microsoft/ml/lightgbm/windows/x86_64
             COMMAND "${Java_JAR_EXECUTABLE}" -cf lightgbmlib.jar com)
     endif()
+  elseif(APPLE)
+    add_custom_command(TARGET _lightgbm_swig POST_BUILD
+            COMMAND "${Java_JAVAC_EXECUTABLE}" -d . java/*.java
+            COMMAND cp "${PROJECT_SOURCE_DIR}/*.dylib" com/microsoft/ml/lightgbm/osx/x86_64
+            COMMAND cp "${PROJECT_SOURCE_DIR}/lib_lightgbm_swig.jnilib" com/microsoft/ml/lightgbm/osx/x86_64/lib_lightgbm_swig.dylib
+            COMMAND "${Java_JAR_EXECUTABLE}" -cf lightgbmlib.jar com)
   else()
     add_custom_command(TARGET _lightgbm_swig POST_BUILD
 	    COMMAND "${Java_JAVAC_EXECUTABLE}" -d . java/*.java

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -671,7 +671,7 @@ On Linux Java wrapper of LightGBM can be built using **Java**, **SWIG**, **CMake
      make -j4
 
 macOS
-~~~~~
+^^^^^
 
 On macOS Java wrapper of LightGBM can be built using **Java**, **SWIG**, **CMake** and **Apple Clang** or **gcc**.
 
@@ -679,7 +679,7 @@ First, install `SWIG`_ and **Java** (also make sure that ``JAVA_HOME`` is set pr
 Then, either follow the **Apple Clang** or **gcc** installation instructions below.
 
 Apple Clang
-^^^^^^^^^^^
+***********
 
 Only **Apple Clang** version 8.1 or higher is supported.
 
@@ -719,7 +719,7 @@ Only **Apple Clang** version 8.1 or higher is supported.
      make -j4
 
 gcc
-^^^
+***
 
 1. Install `CMake`_ (3.2 or higher):
 

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -670,6 +670,23 @@ On Linux Java wrapper of LightGBM can be built using **Java**, **SWIG**, **CMake
      cmake -DUSE_SWIG=ON ..
      make -j4
 
+macOS
+^^^^^
+
+On macOS Java wrapper of LightGBM can be build using **Java**, **SWIG**, **CMake** and **gcc** or **Apple Clang**
+
+1. Install `CMake`_, `SWIG`_ and **Java** (also make sure that ``JAVA_HOME`` is set properly).
+
+2. Run the following commands:
+
+   .. code::
+
+      git clone --recursive https://github.com/Microsoft/LightGBM ; cd LightGBM
+      mkdir build ; cd build
+      cmake -DUSE_SWIG=ON -DAPPLE_OUTPUT_DYLIB=ON ..
+      make -j4
+
+
 .. |download artifacts| image:: ./_static/images/artifacts-not-available.svg
    :target: https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html
 

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -671,20 +671,79 @@ On Linux Java wrapper of LightGBM can be built using **Java**, **SWIG**, **CMake
      make -j4
 
 macOS
-^^^^^
+~~~~~
 
-On macOS Java wrapper of LightGBM can be build using **Java**, **SWIG**, **CMake** and **gcc** or **Apple Clang**
+On macOS Java wrapper of LightGBM can be built using **Java**, **SWIG**, **CMake** and **Apple Clang** or **gcc**.
 
-1. Install `CMake`_, `SWIG`_ and **Java** (also make sure that ``JAVA_HOME`` is set properly).
+First, install `SWIG`_ and **Java** (also make sure that ``JAVA_HOME`` is set properly).
+Then, either follow the **Apple Clang** or **gcc** installation instructions below.
 
-2. Run the following commands:
+Apple Clang
+^^^^^^^^^^^
+
+Only **Apple Clang** version 8.1 or higher is supported.
+
+1. Install `CMake`_ (3.12 or higher):
 
    .. code::
 
-      git clone --recursive https://github.com/Microsoft/LightGBM ; cd LightGBM
-      mkdir build ; cd build
-      cmake -DUSE_SWIG=ON -DAPPLE_OUTPUT_DYLIB=ON ..
-      make -j4
+     brew install cmake
+
+2. Install **OpenMP**:
+
+   .. code::
+
+     brew install libomp
+
+3. Run the following commands:
+
+   .. code::
+
+     git clone --recursive https://github.com/Microsoft/LightGBM ; cd LightGBM
+     mkdir build ; cd build
+
+     # For Mojave (10.14)
+     cmake \
+       -DUSE_SWIG=ON \
+       -DAPPLE_OUTPUT_DYLIB=ON \
+       -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp -I$(brew --prefix libomp)/include" \
+       -DOpenMP_C_LIB_NAMES="omp" \
+       -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp -I$(brew --prefix libomp)/include" \
+       -DOpenMP_CXX_LIB_NAMES="omp" \
+       -DOpenMP_omp_LIBRARY=$(brew --prefix libomp)/lib/libomp.dylib \
+       ..
+
+     # For High Sierra or earlier (<= 10.13)
+     cmake -DUSE_SWIG=ON -DAPPLE_OUTPUT_DYLIB=ON ..
+
+     make -j4
+
+gcc
+^^^
+
+1. Install `CMake`_ (3.2 or higher):
+
+   .. code::
+
+     brew install cmake
+
+2. Install **gcc**:
+
+   .. code::
+
+     brew install gcc
+
+3. Run the following commands:
+
+   .. code::
+
+     git clone --recursive https://github.com/Microsoft/LightGBM ; cd LightGBM
+     export CXX=g++-7 CC=gcc-7  # replace "7" with version of gcc installed on your machine
+     mkdir build ; cd build
+     cmake -DUSE_SWIG=ON -DAPPLE_OUTPUT_DYLIB=ON ..
+     make -j4
+
+Also, you may want to read `gcc Tips <./gcc-Tips.rst>`__.
 
 
 .. |download artifacts| image:: ./_static/images/artifacts-not-available.svg


### PR DESCRIPTION
- Added support for Java SWIG wrapper in macOS
- Updated installation instructions in documentation
- Verified on mac machine I borrowed
This should resolve https://github.com/Microsoft/LightGBM/issues/1326