### PR TITLE
Add ability to move features from one data set to another in memory

### DIFF
--- a/include/LightGBM/bin.h
+++ b/include/LightGBM/bin.h
@@ -447,6 +447,11 @@ class Bin {
   * \return The bin data object
   */
   static Bin* CreateSparseBin(data_size_t num_data, int num_bin);
+
+  /*!
+  * \brief Deep copy the bin
+  */
+  virtual Bin* Clone() = 0;
 };
 
 inline uint32_t BinMapper::ValueToBin(double value) const {

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -270,7 +270,7 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetGetFeatureNames(
 LIGHTGBM_C_EXPORT int LGBM_DatasetFree(DatasetHandle handle);
 
 /*!
-* \brief save dateset to binary file
+* \brief save dataset to binary file
 * \param handle a instance of dataset
 * \param filename file name
 * \return 0 when succeed, -1 when failure happens
@@ -278,6 +278,12 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetFree(DatasetHandle handle);
 LIGHTGBM_C_EXPORT int LGBM_DatasetSaveBinary(DatasetHandle handle,
                                              const char* filename);
 
+/*!
+* \brief save dataset to text file, intended for debugging use only
+* \param handle a instance of dataset
+* \param filename file name
+* \return 0 when succeed, -1 when failure happens
+*/
 LIGHTGBM_C_EXPORT int LGBM_DatasetDumpText(DatasetHandle handle,
 					   const char* filename);
 
@@ -339,6 +345,12 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetGetNumData(DatasetHandle handle,
 LIGHTGBM_C_EXPORT int LGBM_DatasetGetNumFeature(DatasetHandle handle,
                                                 int* out);
 
+/*!
+* \brief Add features from source to target, then free source
+* \param target The handle of the dataset to add features to
+* \param source The handle of the dataset to take features from
+* \return 0 when succeed, -1 when failure happens
+*/
 LIGHTGBM_C_EXPORT int LGBM_DatasetAddFeaturesFrom(DatasetHandle target,
 						  DatasetHandle source);
 

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -277,6 +277,9 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetFree(DatasetHandle handle);
 LIGHTGBM_C_EXPORT int LGBM_DatasetSaveBinary(DatasetHandle handle,
                                              const char* filename);
 
+LIGHTGBM_C_EXPORT int LGBM_DatasetDumpText(DatasetHandle handle,
+					   const char* filename);
+
 /*!
 * \brief set vector to a content in info
 *        Note: group and group only work for C_API_DTYPE_INT32

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -285,7 +285,7 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetSaveBinary(DatasetHandle handle,
 * \return 0 when succeed, -1 when failure happens
 */
 LIGHTGBM_C_EXPORT int LGBM_DatasetDumpText(DatasetHandle handle,
-					   const char* filename);
+                                           const char* filename);
 
 /*!
 * \brief set vector to a content in info
@@ -352,7 +352,7 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetGetNumFeature(DatasetHandle handle,
 * \return 0 when succeed, -1 when failure happens
 */
 LIGHTGBM_C_EXPORT int LGBM_DatasetAddFeaturesFrom(DatasetHandle target,
-						  DatasetHandle source);
+                                                  DatasetHandle source);
 
 // --- start Booster interfaces
 

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -21,6 +21,7 @@ typedef void* BoosterHandle;
 #define C_API_DTYPE_FLOAT64 (1)
 #define C_API_DTYPE_INT32   (2)
 #define C_API_DTYPE_INT64   (3)
+#define C_API_DTYPE_INT8    (4)
 
 #define C_API_PREDICT_NORMAL     (0)
 #define C_API_PREDICT_RAW_SCORE  (1)

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -335,6 +335,9 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetGetNumData(DatasetHandle handle,
 LIGHTGBM_C_EXPORT int LGBM_DatasetGetNumFeature(DatasetHandle handle,
                                                 int* out);
 
+LIGHTGBM_C_EXPORT int LGBM_DatasetAddFeaturesFrom(DatasetHandle target,
+						  DatasetHandle source);
+
 // --- start Booster interfaces
 
 /*!

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -581,6 +581,8 @@ public:
   /*! \brief Disable copy */
   Dataset(const Dataset&) = delete;
 
+  void addFeaturesFrom(Dataset* other);
+
 private:
   std::string data_filename_;
   /*! \brief Store used features */

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -386,6 +386,8 @@ public:
 
   LIGHTGBM_EXPORT bool GetIntField(const char* field_name, data_size_t* out_len, const int** out_ptr);
 
+  LIGHTGBM_EXPORT bool GetInt8Field(const char* field_name, data_size_t* out_len, const int8_t** out_ptr);
+
   /*!
   * \brief Save current dataset into binary file, will save to "filename.bin"
   */

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -391,6 +391,8 @@ public:
   */
   LIGHTGBM_EXPORT void SaveBinaryFile(const char* bin_filename);
 
+  LIGHTGBM_EXPORT void DumpTextFile(const char* text_filename);
+
   LIGHTGBM_EXPORT void CopyFeatureMapperFrom(const Dataset* dataset);
 
   LIGHTGBM_EXPORT void CreateValid(const Dataset* dataset);

--- a/include/LightGBM/feature_group.h
+++ b/include/LightGBM/feature_group.h
@@ -211,8 +211,21 @@ class FeatureGroup {
   }
   /*! \brief Disable copy */
   FeatureGroup& operator=(const FeatureGroup&) = delete;
-  /*! \brief Disable copy */
-  FeatureGroup(const FeatureGroup&) = delete;
+  /*! \brief Deep copy */
+  FeatureGroup(const FeatureGroup& other){
+    num_feature_ = other.num_feature_;
+    is_sparse_ = other.is_sparse_;
+    num_total_bin_ = other.num_total_bin_;
+    bin_offsets_ = other.bin_offsets_;
+
+    bin_mappers_.reserve(other.bin_mappers_.size());
+    for(auto& bin_mapper : other.bin_mappers_){
+      std::unique_ptr<BinMapper> p(new BinMapper(*bin_mapper));
+      bin_mappers_.push_back(std::move(p));
+    }
+
+    bin_data_.reset(bin_data_->Clone());
+  }
 
  private:
   /*! \brief Number of features */

--- a/include/LightGBM/feature_group.h
+++ b/include/LightGBM/feature_group.h
@@ -220,11 +220,10 @@ class FeatureGroup {
 
     bin_mappers_.reserve(other.bin_mappers_.size());
     for(auto& bin_mapper : other.bin_mappers_){
-      std::unique_ptr<BinMapper> p(new BinMapper(*bin_mapper));
-      bin_mappers_.push_back(std::move(p));
+      bin_mappers_.emplace_back(new BinMapper(*bin_mapper));
     }
 
-    bin_data_.reset(bin_data_->Clone());
+    bin_data_.reset(other.bin_data_->Clone());
   }
 
  private:

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1494,6 +1494,11 @@ class Dataset(object):
                 break
         return ref_chain
 
+    def add_features_from(self, other):
+        if self.handle is None or other.handle is None:
+            raise ArgumentError('Both source and target datasets must be constructed before adding features')
+        _safe_call(_LIB.LGBM_DatasetAddFeaturesFrom(self.handle, other.handle))
+        #TODO: Ensure other is properly de-initialised.
 
 class Booster(object):
     """Booster in LightGBM."""

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1552,7 +1552,6 @@ class Dataset(object):
         if self.handle is None or other.handle is None:
             raise ValueError('Both source and target datasets must be constructed before adding features')
         _safe_call(_LIB.LGBM_DatasetAddFeaturesFrom(self.handle, other.handle))
-        other.handle = None
 
     def dump_text(self, fname):
         """Save this dataset to a text file.

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -191,7 +191,7 @@ FIELD_TYPE_MAPPER = {"label": C_API_DTYPE_FLOAT32,
                      "init_score": C_API_DTYPE_FLOAT64,
                      "group": C_API_DTYPE_INT32,
                      "feature_penalty": C_API_DTYPE_FLOAT64,
-                     "monotone_types": C_API_DTYPE_INT8}
+                     "monotone_constraints": C_API_DTYPE_INT8}
 
 PANDAS_DTYPE_MAPPER = {'int8': 'int', 'int16': 'int', 'int32': 'int',
                        'int64': 'int', 'uint8': 'int', 'uint16': 'int',
@@ -1398,27 +1398,27 @@ class Dataset(object):
         return self.weight
 
     def get_feature_penalty(self):
-        """Get the feature penalty of the data set.
+        """Get the feature penalty of the Dataset.
 
         Returns
         -------
         feature_penalty : numpy array or None
-            Feature penalty for each feature in the data set.
+            Feature penalty for each feature in the Dataset.
         """
         if self.feature_penalty is None:
             self.feature_penalty = self.get_field('feature_penalty')
         return self.feature_penalty
 
-    def get_monotone_types(self):
-        """Get the monotone types of the data set.
+    def get_monotone_constraints(self):
+        """Get the monotone constraints of the Dataset.
 
         Returns
         -------
-        monotone types : numpy array or None
-            monotone types, -1, 0 or 1, for each feature in the data set
+        monotone_constraints : numpy array or None
+            Monotone constraints, -1, 0 or 1, for each feature in the Dataset
         """
         if self.monotone_types is None:
-            self.monotone_types = self.get_field('monotone_types')
+            self.monotone_types = self.get_field('monotone_constraints')
         return self.monotone_types
 
     def get_init_score(self):
@@ -1534,40 +1534,40 @@ class Dataset(object):
         return ref_chain
 
     def add_features_from(self, other):
-        """Add features from other to self.
+        """Add features from other Dataset to the current Dataset.
 
-        This will add every feature from other to self and free other.
-        Other must not be used after this method returns.
-        Both datasets must have been constructed before calling this method.
+        This will add every feature to the current dataset.
+        Both datasets must be constructed before calling this method.
 
         Parameters
         ----------
         other : Dataset
-            The dataset to take features from
+            The Dataset to take features from.
 
         Returns
         -------
-        self : The Dataset with the new features added
+        self : Dataset with the new features added
         """
         if self.handle is None or other.handle is None:
-            raise ValueError('Both source and target datasets must be constructed before adding features')
+            raise ValueError('Both source and target Datasets must be constructed before adding features')
         _safe_call(_LIB.LGBM_DatasetAddFeaturesFrom(self.handle, other.handle))
+        return self
 
-    def dump_text(self, fname):
-        """Save this dataset to a text file.
+    def dump_text(self, filename):
+        """Save Dataset to a text file.
 
-        This format cannot be loaded back in by LightGBM, but is useful to debug data set
-        manipulations.
+        This format cannot be loaded back in by LightGBM, but is useful for debugging purposes.
 
         Parameters
         ----------
-        fname : string
-            The file to dump the data set to
+        filename : string
+            Name of the output file.
 
         """
         _safe_call(_LIB.LGBM_DatasetDumpText(
             self.construct().handle,
-            c_str(fname)))
+            c_str(filename)))
+        return self
 
 
 class Booster(object):

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -106,12 +106,13 @@ def cint32_array_to_numpy(cptr, length):
     else:
         raise RuntimeError('Expected int pointer')
 
+
 def cint8_array_to_numpy(cptr, length):
     """Convert a ctypes int pointer array to a numpy array."""
     if isinstance(cptr, ctypes.POINTER(ctypes.c_int8)):
         return np.fromiter(cptr, dtype=np.int8, count=length)
     else:
-        raise RuntimeError('Expected int pointer')    
+        raise RuntimeError('Expected int pointer')
 
 
 def c_str(string):
@@ -1557,7 +1558,7 @@ class Dataset(object):
         """Save this dataset to a text file.
 
         This format cannot be loaded back in by LightGBM, but is useful to debug data set
-        manipulations. 
+        manipulations.
 
         Parameters
         ----------
@@ -1568,6 +1569,7 @@ class Dataset(object):
         _safe_call(_LIB.LGBM_DatasetDumpText(
             self.construct().handle,
             c_str(fname)))
+
 
 class Booster(object):
     """Booster in LightGBM."""

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1533,16 +1533,41 @@ class Dataset(object):
         return ref_chain
 
     def add_features_from(self, other):
+        """Add features from other to self.
+
+        This will add every feature from other to self and free other.
+        Other must not be used after this method returns.
+        Both datasets must have been constructed before calling this method.
+
+        Parameters
+        ----------
+        other : Dataset
+            The dataset to take features from
+
+        Returns
+        -------
+        self : The Dataset with the new features added
+        """
         if self.handle is None or other.handle is None:
             raise ValueError('Both source and target datasets must be constructed before adding features')
         _safe_call(_LIB.LGBM_DatasetAddFeaturesFrom(self.handle, other.handle))
         other.handle = None
 
     def dump_text(self, fname):
+        """Save this dataset to a text file.
+
+        This format cannot be loaded back in by LightGBM, but is useful to debug data set
+        manipulations. 
+
+        Parameters
+        ----------
+        fname : string
+            The file to dump the data set to
+
+        """
         _safe_call(_LIB.LGBM_DatasetDumpText(
             self.construct().handle,
             c_str(fname)))
-        return self
 
 class Booster(object):
     """Booster in LightGBM."""

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1500,6 +1500,12 @@ class Dataset(object):
         _safe_call(_LIB.LGBM_DatasetAddFeaturesFrom(self.handle, other.handle))
         #TODO: Ensure other is properly de-initialised.
 
+    def dump_text(self, fname):
+        _safe_call(_LIB.LGBM_DatasetDumpText(
+            self.construct().handle,
+            c_str(fname)))
+        return self
+
 class Booster(object):
     """Booster in LightGBM."""
 

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1536,7 +1536,7 @@ class Dataset(object):
         if self.handle is None or other.handle is None:
             raise ValueError('Both source and target datasets must be constructed before adding features')
         _safe_call(_LIB.LGBM_DatasetAddFeaturesFrom(self.handle, other.handle))
-        #TODO: Ensure other is properly de-initialised.
+        other.handle = None
 
     def dump_text(self, fname):
         _safe_call(_LIB.LGBM_DatasetDumpText(

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -712,7 +712,7 @@ class Dataset(object):
         self.pandas_categorical = None
         self.params_back_up = None
         self.feature_penalty = None
-        self.monotone_types = None
+        self.monotone_constraints = None
 
     def __del__(self):
         try:
@@ -1415,11 +1415,11 @@ class Dataset(object):
         Returns
         -------
         monotone_constraints : numpy array or None
-            Monotone constraints, -1, 0 or 1, for each feature in the Dataset
+            Monotone constraints: -1, 0 or 1, for each feature in the Dataset.
         """
-        if self.monotone_types is None:
-            self.monotone_types = self.get_field('monotone_constraints')
-        return self.monotone_types
+        if self.monotone_constraints is None:
+            self.monotone_constraints = self.get_field('monotone_constraints')
+        return self.monotone_constraints
 
     def get_init_score(self):
         """Get the initial score of the Dataset.
@@ -1536,8 +1536,7 @@ class Dataset(object):
     def add_features_from(self, other):
         """Add features from other Dataset to the current Dataset.
 
-        This will add every feature to the current dataset.
-        Both datasets must be constructed before calling this method.
+        Both Datasets must be constructed before calling this method.
 
         Parameters
         ----------
@@ -1546,7 +1545,8 @@ class Dataset(object):
 
         Returns
         -------
-        self : Dataset with the new features added
+        self : Dataset
+            Dataset with the new features added.
         """
         if self.handle is None or other.handle is None:
             raise ValueError('Both source and target Datasets must be constructed before adding features')
@@ -1562,6 +1562,11 @@ class Dataset(object):
         ----------
         filename : string
             Name of the output file.
+
+        Returns
+        -------
+        self : Dataset
+            Returns self.
 
         """
         _safe_call(_LIB.LGBM_DatasetDumpText(

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1567,7 +1567,6 @@ class Dataset(object):
         -------
         self : Dataset
             Returns self.
-
         """
         _safe_call(_LIB.LGBM_DatasetDumpText(
             self.construct().handle,

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1398,7 +1398,7 @@ class Dataset(object):
         return self.weight
 
     def get_feature_penalty(self):
-        """Get the feature penalty of the Dataset
+        """Get the feature penalty of the data set.
 
         Returns
         -------
@@ -1410,7 +1410,7 @@ class Dataset(object):
         return self.feature_penalty
 
     def get_monotone_types(self):
-        """Get the monotone types of the data set
+        """Get the monotone types of the data set.
 
         Returns
         -------

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1496,7 +1496,7 @@ class Dataset(object):
 
     def add_features_from(self, other):
         if self.handle is None or other.handle is None:
-            raise ArgumentError('Both source and target datasets must be constructed before adding features')
+            raise ValueError('Both source and target datasets must be constructed before adding features')
         _safe_call(_LIB.LGBM_DatasetAddFeaturesFrom(self.handle, other.handle))
         #TODO: Ensure other is properly de-initialised.
 

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -877,6 +877,15 @@ int LGBM_DatasetGetNumFeature(DatasetHandle handle,
   API_END();
 }
 
+int LGBM_DatasetAddFeaturesFrom(DatasetHandle target,
+				 DatasetHandle source) {
+  API_BEGIN();
+  auto target_d = reinterpret_cast<Dataset*>(target);
+  auto source_d = reinterpret_cast<Dataset*>(source);
+  target_d->addFeaturesFrom(source_d);
+  API_END();
+}
+
 // ---- start of booster
 
 int LGBM_BoosterCreate(const DatasetHandle train_data,

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -894,6 +894,7 @@ int LGBM_DatasetAddFeaturesFrom(DatasetHandle target,
   auto target_d = reinterpret_cast<Dataset*>(target);
   auto source_d = reinterpret_cast<Dataset*>(source);
   target_d->addFeaturesFrom(source_d);
+  LGBM_DatasetFree(source_d);
   API_END();
 }
 

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -814,7 +814,7 @@ int LGBM_DatasetSaveBinary(DatasetHandle handle,
 }
 
 int LGBM_DatasetDumpText(DatasetHandle handle,
-                           const char* filename) {
+                         const char* filename) {
   API_BEGIN();
   auto dataset = reinterpret_cast<Dataset*>(handle);
   dataset->DumpTextFile(filename);
@@ -890,7 +890,7 @@ int LGBM_DatasetGetNumFeature(DatasetHandle handle,
 }
 
 int LGBM_DatasetAddFeaturesFrom(DatasetHandle target,
-				 DatasetHandle source) {
+                                DatasetHandle source) {
   API_BEGIN();
   auto target_d = reinterpret_cast<Dataset*>(target);
   auto source_d = reinterpret_cast<Dataset*>(source);

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -895,7 +895,6 @@ int LGBM_DatasetAddFeaturesFrom(DatasetHandle target,
   auto target_d = reinterpret_cast<Dataset*>(target);
   auto source_d = reinterpret_cast<Dataset*>(source);
   target_d->addFeaturesFrom(source_d);
-  LGBM_DatasetFree(source_d);
   API_END();
 }
 

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -856,6 +856,9 @@ int LGBM_DatasetGetField(DatasetHandle handle,
   } else if (dataset->GetDoubleField(field_name, out_len, reinterpret_cast<const double**>(out_ptr))) {
     *out_type = C_API_DTYPE_FLOAT64;
     is_success = true;
+  } else if(dataset->GetInt8Field(field_name, out_len, reinterpret_cast<const int8_t**>(out_ptr))){
+    *out_type = C_API_DTYPE_INT8;
+    is_success = true;
   }
   if (!is_success) { throw std::runtime_error("Field not found"); }
   if (*out_ptr == nullptr) { *out_len = 0; }

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -812,6 +812,14 @@ int LGBM_DatasetSaveBinary(DatasetHandle handle,
   API_END();
 }
 
+int LGBM_DatasetDumpText(DatasetHandle handle,
+                           const char* filename) {
+  API_BEGIN();
+  auto dataset = reinterpret_cast<Dataset*>(handle);
+  dataset->DumpTextFile(filename);
+  API_END();
+}
+
 int LGBM_DatasetSetField(DatasetHandle handle,
                          const char* field_name,
                          const void* field_data,

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -577,7 +577,11 @@ bool Dataset::GetDoubleField(const char* field_name, data_size_t* out_len, const
   if (name == std::string("init_score")) {
     *out_ptr = metadata_.init_score();
     *out_len = static_cast<data_size_t>(metadata_.num_init_score());
-  } else {
+  } else if (name == std::string("feature_penalty")){
+    *out_ptr = feature_penalty_.data();
+    *out_len = feature_penalty_.size();
+  }
+  else {
     return false;
   }
   return true;
@@ -589,6 +593,18 @@ bool Dataset::GetIntField(const char* field_name, data_size_t* out_len, const in
   if (name == std::string("query") || name == std::string("group")) {
     *out_ptr = metadata_.query_boundaries();
     *out_len = metadata_.num_queries() + 1;
+  } else {
+    return false;
+  }
+  return true;
+}
+
+bool Dataset::GetInt8Field(const char* field_name, data_size_t* out_len, const int8_t** out_ptr) {
+  std::string name(field_name);
+  name = Common::Trim(name);
+  if (name == std::string("monotone_types")) {
+    *out_ptr = monotone_types_.data();
+    *out_len = monotone_types_.size();
   } else {
     return false;
   }

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -943,6 +943,7 @@ void Dataset::FixHistogram(int feature_idx, double sum_gradient, double sum_hess
 
 template<typename T>
 void PushVector(std::vector<T>& dest, const std::vector<T>& src){
+  dest.reserve(dest.size() + src.size());
   for(auto i : src){
     dest.push_back(i);
   }
@@ -950,6 +951,7 @@ void PushVector(std::vector<T>& dest, const std::vector<T>& src){
 
 template<typename T>
 void PushOffset(std::vector<T>& dest, const std::vector<T>& src, const T& offset){
+  dest.reserve(dest.size() + src.size());
   for(auto i : src){
     dest.push_back(i + offset);
   }

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -951,6 +951,13 @@ void PushVector(std::vector<T>& dest, const std::vector<T>& src){
 }
 
 template<typename T>
+void PushOffset(std::vector<T>& dest, const std::vector<T>& src, const T& offset){
+  for(auto i : src){
+    dest.push_back(i + offset);
+  }
+}
+
+template<typename T>
 void PushClearIfEmpty(std::vector<T>& dest, const size_t dest_len, const std::vector<T>& src, const size_t src_len, const T& deflt){
   if(!dest.empty() && !src.empty()){
     PushVector(dest, src);
@@ -984,20 +991,14 @@ void Dataset::addFeaturesFrom(Dataset* other){
       used_feature_map_.push_back(-1); //Unused feature.
     }
   }
-  for(auto real_feature_idx : other->real_feature_idx_){
-    real_feature_idx_.push_back(real_feature_idx + num_total_features_);
-  }
-  for(auto group : other->feature2group_){
-    feature2group_.push_back(group + num_groups_);
-  }
+  PushOffset(real_feature_idx_, other->real_feature_idx_, num_total_features_);
+  PushOffset(feature2group_, other->feature2group_, num_groups_);
   auto bin_offset = group_bin_boundaries_.back();
   //Skip the leading 0 when copying group_bin_boundaries.
   for(auto i = other->group_bin_boundaries_.begin()+1; i < other->group_bin_boundaries_.end(); i++){
     group_bin_boundaries_.push_back(*i + bin_offset);
   }
-  for(auto group_start : other->group_feature_start_){
-    group_feature_start_.push_back(group_start + num_features_);
-  }
+  PushOffset(group_feature_start_, other->group_feature_start_, num_features_);
 
   PushClearIfEmpty(monotone_types_, num_total_features_, other->monotone_types_, other->num_total_features_, (int8_t)0);
   PushClearIfEmpty(feature_penalty_, num_total_features_, other->feature_penalty_, other->num_total_features_, 1.0);

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -707,16 +707,11 @@ void Dataset::SaveBinaryFile(const char* bin_filename) {
 }
 
 void Dataset::DumpTextFile(const char* text_filename){
-  //TODO: Just use standard stdio for now, but consider VirtualFileWriter later.
-  //TODO: Error handling of any kind
   auto file = fopen(text_filename, "wt");
   fprintf(file, "num_features: %d\n", num_features_);
   fprintf(file, "num_total_features: %d\n", num_total_features_);
   fprintf(file, "num_groups: %d\n", num_groups_);
   fprintf(file, "num_data: %d\n", num_data_);
-  //TODO: Metadata
-  //Label_idx?
-  //Sparse_threshold???
   fprintf(file, "feature_names: ");
   for(auto n : feature_names_){
     fprintf(file, "%s, ", n.c_str());

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -705,30 +705,6 @@ void Dataset::DumpTextFile(const char* text_filename){
   for(auto n : feature_names_){
     fprintf(file, "%s, ", n.c_str());
   }
-  fprintf(file, "\nreal_feature_idx: ");
-  for(auto i : real_feature_idx_){
-    fprintf(file, "%d, ", i);
-  }
-  fprintf(file, "\nfeature2group: ");
-  for(auto i : feature2group_){
-    fprintf(file, "%d, ", i);
-  }
-  fprintf(file, "\nfeature2subfeature: ");
-  for(auto i : feature2subfeature_){
-    fprintf(file, "%d, ", i);
-  }
-  fprintf(file, "\ngroup_bin_boundaries: ");
-  for(auto i : group_bin_boundaries_){
-    fprintf(file, "%lu, ", i);
-  }
-  fprintf(file, "\ngroup_feature_start: ");
-  for(auto i : group_feature_start_){
-    fprintf(file, "%d, ", i);
-  }
-  fprintf(file, "\ngroup_feature_cnt: ");
-  for(auto i : group_feature_cnt_){
-    fprintf(file, "%d, ", i);
-  }
   fprintf(file, "\nmonotone_types: ");
   for(auto i : monotone_types_){
     fprintf(file, "%d, ", i);

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -983,7 +983,6 @@ void Dataset::addFeaturesFrom(Dataset* other){
   for(auto& fg : other->feature_groups_){
     feature_groups_.push_back(std::move(fg));
   }
-  //TODO: Much of this is just offsetting logic, factor it out.
   for(auto feature_idx : other->used_feature_map_){
     if(feature_idx >= 0){
       used_feature_map_.push_back(feature_idx + num_features_);

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -729,23 +729,21 @@ void Dataset::DumpTextFile(const char* text_filename){
   for(auto n : feature_names_){
     fprintf(file, "%s, ", n.c_str());
   }
-  std::vector<std::unique_ptr<BinIterator>> iterators(num_total_features_);
-  for(int j = 0; j < num_total_features_; j++){
-    if(used_feature_map_[j] >= 0){
-	auto real_feature_idx = used_feature_map_[j];
-	auto group_idx = feature2group_[real_feature_idx];
-	auto sub_idx = feature2subfeature_[real_feature_idx];
-	std::unique_ptr<BinIterator> sub_iter(feature_groups_[group_idx]->SubFeatureIterator(sub_idx));
-	iterators[j] = std::move(sub_iter);
-    }
+  std::vector<std::unique_ptr<BinIterator>> iterators;
+  iterators.reserve(num_features_);
+  for(int j = 0; j < num_features_; j++){
+    auto group_idx = feature2group_[j];
+    auto sub_idx = feature2subfeature_[j];
+    iterators.emplace_back(feature_groups_[group_idx]->SubFeatureIterator(sub_idx));
   }
   for(data_size_t i = 0; i < num_data_; i++){
     fprintf(file, "\n");
     for(int j = 0; j < num_total_features_; j++){
-      if(used_feature_map_[j] < 0){
+      auto inner_feature_idx = used_feature_map_[j];
+      if(inner_feature_idx < 0){
 	fprintf(file, "NA, ");
       } else {
-	fprintf(file, "%d, ", iterators[j]->RawGet(i));
+	fprintf(file, "%d, ", iterators[inner_feature_idx]->RawGet(i));
       }
     }
   }

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <unordered_map>
 #include <limits>
+#include <memory>
 #include <vector>
 #include <utility>
 #include <string>
@@ -728,18 +729,23 @@ void Dataset::DumpTextFile(const char* text_filename){
   for(auto n : feature_names_){
     fprintf(file, "%s, ", n.c_str());
   }
+  std::vector<std::unique_ptr<BinIterator>> iterators(num_total_features_);
+  for(int j = 0; j < num_total_features_; j++){
+    if(used_feature_map_[j] >= 0){
+	auto real_feature_idx = used_feature_map_[j];
+	auto group_idx = feature2group_[real_feature_idx];
+	auto sub_idx = feature2subfeature_[real_feature_idx];
+	std::unique_ptr<BinIterator> sub_iter(feature_groups_[group_idx]->SubFeatureIterator(sub_idx));
+	iterators[j] = std::move(sub_iter);
+    }
+  }
   for(data_size_t i = 0; i < num_data_; i++){
     fprintf(file, "\n");
     for(int j = 0; j < num_total_features_; j++){
       if(used_feature_map_[j] < 0){
 	fprintf(file, "NA, ");
       } else {
-	//Ludicrously inefficient, yay.
-	auto real_feature_idx = used_feature_map_[j];
-	auto group_idx = feature2group_[real_feature_idx];
-	auto sub_idx = feature2subfeature_[real_feature_idx];
-	auto sub_iter = feature_groups_[group_idx]->SubFeatureIterator(sub_idx);
-	fprintf(file, "%d, ", sub_iter->RawGet(i));
+	fprintf(file, "%d, ", iterators[j]->RawGet(i));
       }
     }
   }

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -962,11 +962,11 @@ void PushClearIfEmpty(std::vector<T>& dest, const size_t dest_len, const std::ve
   if(!dest.empty() && !src.empty()){
     PushVector(dest, src);
   } else if(!dest.empty() && src.empty()){
-    for(size_t i = 0; i < src_len; i++){
+    for(size_t i = 0; i < src_len; ++i){
       dest.push_back(deflt);
     }
   } else if(dest.empty() && !src.empty()){
-    for(size_t i = 0; i < dest_len; i++){
+    for(size_t i = 0; i < dest_len; ++i){
       dest.push_back(deflt);
     }
     PushVector(dest, src);

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -603,7 +603,7 @@ bool Dataset::GetIntField(const char* field_name, data_size_t* out_len, const in
 bool Dataset::GetInt8Field(const char* field_name, data_size_t* out_len, const int8_t** out_ptr) {
   std::string name(field_name);
   name = Common::Trim(name);
-  if (name == std::string("monotone_types")) {
+  if (name == std::string("monotone_constraints")) {
     *out_ptr = monotone_types_.data();
     *out_len = monotone_types_.size();
   } else {
@@ -717,7 +717,7 @@ void Dataset::DumpTextFile(const char* text_filename){
   for(auto n : feature_names_){
     fprintf(file, "%s, ", n.c_str());
   }
-  fprintf(file, "\nmonotone_types: ");
+  fprintf(file, "\nmonotone_constraints: ");
   for(auto i : monotone_types_){
     fprintf(file, "%d, ", i);
   }
@@ -731,14 +731,14 @@ void Dataset::DumpTextFile(const char* text_filename){
   }
   std::vector<std::unique_ptr<BinIterator>> iterators;
   iterators.reserve(num_features_);
-  for(int j = 0; j < num_features_; j++){
+  for(int j = 0; j < num_features_; ++j){
     auto group_idx = feature2group_[j];
     auto sub_idx = feature2subfeature_[j];
     iterators.emplace_back(feature_groups_[group_idx]->SubFeatureIterator(sub_idx));
   }
-  for(data_size_t i = 0; i < num_data_; i++){
+  for(data_size_t i = 0; i < num_data_; ++i){
     fprintf(file, "\n");
-    for(int j = 0; j < num_total_features_; j++){
+    for(int j = 0; j < num_total_features_; ++j){
       auto inner_feature_idx = used_feature_map_[j];
       if(inner_feature_idx < 0){
 	fprintf(file, "NA, ");
@@ -975,7 +975,7 @@ void PushClearIfEmpty(std::vector<T>& dest, const size_t dest_len, const std::ve
 
 void Dataset::addFeaturesFrom(Dataset* other){
   if(other->num_data_ != num_data_){
-    throw std::runtime_error("Cannot add features from other dataset with a different number of rows");
+    throw std::runtime_error("Cannot add features from other Dataset with a different number of rows");
   }
   PushVector(feature_names_, other->feature_names_);
   PushVector(feature2subfeature_, other->feature2subfeature_);
@@ -988,14 +988,14 @@ void Dataset::addFeaturesFrom(Dataset* other){
     if(feature_idx >= 0){
       used_feature_map_.push_back(feature_idx + num_features_);
     } else {
-      used_feature_map_.push_back(-1); //Unused feature.
+      used_feature_map_.push_back(-1);  // Unused feature.
     }
   }
   PushOffset(real_feature_idx_, other->real_feature_idx_, num_total_features_);
   PushOffset(feature2group_, other->feature2group_, num_groups_);
   auto bin_offset = group_bin_boundaries_.back();
-  //Skip the leading 0 when copying group_bin_boundaries.
-  for(auto i = other->group_bin_boundaries_.begin()+1; i < other->group_bin_boundaries_.end(); i++){
+  // Skip the leading 0 when copying group_bin_boundaries.
+  for(auto i = other->group_bin_boundaries_.begin()+1; i < other->group_bin_boundaries_.end(); ++i){
     group_bin_boundaries_.push_back(*i + bin_offset);
   }
   PushOffset(group_feature_start_, other->group_feature_start_, num_features_);

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -978,8 +978,9 @@ void Dataset::addFeaturesFrom(Dataset* other){
   PushVector(feature_names_, other->feature_names_);
   PushVector(feature2subfeature_, other->feature2subfeature_);
   PushVector(group_feature_cnt_, other->group_feature_cnt_);
+  feature_groups_.reserve(other->feature_groups_.size());
   for(auto& fg : other->feature_groups_){
-    feature_groups_.push_back(std::move(fg));
+    feature_groups_.emplace_back(new FeatureGroup(*fg));
   }
   for(auto feature_idx : other->used_feature_map_){
     if(feature_idx >= 0){

--- a/src/io/dense_bin.hpp
+++ b/src/io/dense_bin.hpp
@@ -311,10 +311,20 @@ class DenseBin: public Bin {
     return sizeof(VAL_T) * num_data_;
   }
 
- protected:
+  DenseBin<VAL_T>* Clone() override;
+
+ private:
   data_size_t num_data_;
   std::vector<VAL_T> data_;
+
+  DenseBin<VAL_T>(const DenseBin<VAL_T>& other)
+    : num_data_(other.num_data_), data_(other.data_){}
 };
+
+template<typename VAL_T>
+DenseBin<VAL_T>* DenseBin<VAL_T>::Clone(){
+  return new DenseBin<VAL_T>(*this);
+}
 
 template <typename VAL_T>
 uint32_t DenseBinIterator<VAL_T>::Get(data_size_t idx) {

--- a/src/io/dense_nbits_bin.hpp
+++ b/src/io/dense_nbits_bin.hpp
@@ -363,7 +363,9 @@ class Dense4bitsBin : public Bin {
     return sizeof(uint8_t) * data_.size();
   }
 
-  Dense4bitsBin* Clone() override;
+  Dense4bitsBin* Clone() override {
+    return new Dense4bitsBin(*this);
+  }
 
  protected:
   Dense4bitsBin(const Dense4bitsBin& other)
@@ -373,10 +375,6 @@ class Dense4bitsBin : public Bin {
   std::vector<uint8_t> data_;
   std::vector<uint8_t> buf_;
 };
-
-Dense4bitsBin* Dense4bitsBin::Clone(){
-  return new Dense4bitsBin(*this);
-}
 
 uint32_t Dense4bitsBinIterator::Get(data_size_t idx) {
   const auto bin = (bin_data_->data_[idx >> 1] >> ((idx & 1) << 2)) & 0xf;

--- a/src/io/dense_nbits_bin.hpp
+++ b/src/io/dense_nbits_bin.hpp
@@ -363,11 +363,20 @@ class Dense4bitsBin : public Bin {
     return sizeof(uint8_t) * data_.size();
   }
 
+  Dense4bitsBin* Clone() override;
+
  protected:
+  Dense4bitsBin(const Dense4bitsBin& other)
+    : num_data_(other.num_data_), data_(other.data_), buf_(other.buf_){}
+    
   data_size_t num_data_;
   std::vector<uint8_t> data_;
   std::vector<uint8_t> buf_;
 };
+
+Dense4bitsBin* Dense4bitsBin::Clone(){
+  return new Dense4bitsBin(*this);
+}
 
 uint32_t Dense4bitsBinIterator::Get(data_size_t idx) {
   const auto bin = (bin_data_->data_[idx >> 1] >> ((idx & 1) << 2)) & 0xf;

--- a/src/io/sparse_bin.hpp
+++ b/src/io/sparse_bin.hpp
@@ -407,7 +407,14 @@ class SparseBin: public Bin {
     GetFastIndex();
   }
 
+  SparseBin<VAL_T>* Clone() override;
+
  protected:
+  SparseBin<VAL_T>(const SparseBin<VAL_T>& other)
+    : num_data_(other.num_data_), deltas_(other.deltas_), vals_(other.vals_),
+      num_vals_(other.num_vals_), push_buffers_(other.push_buffers_),
+      fast_index_(other.fast_index_), fast_index_shift_(other.fast_index_shift_){}
+
   data_size_t num_data_;
   std::vector<uint8_t> deltas_;
   std::vector<VAL_T> vals_;
@@ -416,6 +423,11 @@ class SparseBin: public Bin {
   std::vector<std::pair<data_size_t, data_size_t>> fast_index_;
   data_size_t fast_index_shift_;
 };
+
+template<typename VAL_T>
+SparseBin<VAL_T>* SparseBin<VAL_T>::Clone(){
+  return new SparseBin(*this);
+}
 
 template <typename VAL_T>
 inline uint32_t SparseBinIterator<VAL_T>::RawGet(data_size_t idx) {

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -185,3 +185,51 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(np.asarray([1]), d.get_monotone_types())
         d = lgb.Dataset(X).construct()
         self.assertEqual(None, d.get_monotone_types())
+
+    def test_add_features_feature_penalty(self):
+        X = np.random.random((1000,2))
+        test_cases = [
+            (None, None, None),
+            ([0.5], None, [0.5, 1]),
+            (None, [0.5], [1, 0.5]),
+            ([0.5], [0.5], [0.5, 0.5])]
+        for (p1, p2, expected) in test_cases:
+            if p1 is not None:
+                params1 = {'feature_penalty': p1}
+            else:
+                params1 = {}
+            d1 = lgb.Dataset(X[:,0].reshape((-1,1)), params=params1).construct()
+            if p2 is not None:
+                params2 = {'feature_penalty': p2}
+            else:
+                params2 = {}
+            d2 = lgb.Dataset(X[:,1].reshape((-1,1)), params=params2).construct()
+            d1.add_features_from(d2)
+            actual = d1.get_feature_penalty()
+            if isinstance(actual, np.ndarray):
+                actual = list(actual)
+            self.assertEqual(expected, actual)
+
+    def test_add_features_monotone_types(self):
+        X = np.random.random((1000,2))
+        test_cases = [
+            (None, None, None),
+            ([1], None, [1, 0]),
+            (None, [1], [0, 1]),
+            ([1], [-1], [1, -1])]
+        for (p1, p2, expected) in test_cases:
+            if p1 is not None:
+                params1 = {'monotone_constraints': p1}
+            else:
+                params1 = {}
+            d1 = lgb.Dataset(X[:,0].reshape((-1,1)), params=params1).construct()
+            if p2 is not None:
+                params2 = {'monotone_constraints': p2}
+            else:
+                params2 = {}
+            d2 = lgb.Dataset(X[:,1].reshape((-1,1)), params=params2).construct()
+            d1.add_features_from(d2)
+            actual = d1.get_monotone_types()
+            if isinstance(actual, np.ndarray):
+                actual = list(actual)
+            self.assertEqual(expected, actual)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -116,41 +116,41 @@ class TestBasic(unittest.TestCase):
             d1.add_features_from(d2)
         with self.assertRaises(ValueError):
             d1 = lgb.Dataset(X1)
-            d2 = lgb.Dataset(X2).construct()            
+            d2 = lgb.Dataset(X2).construct()
             d1.add_features_from(d2)
 
     def test_add_features_equal_data_on_alternating_used_unused(self):
-        X = np.random.random((1000,5))
-        X[:,[1,3]] = 0
+        X = np.random.random((1000, 5))
+        X[:, [1, 3]] = 0
         names = ['col_%d' % (i,) for i in range(5)]
-        for j in range(1,5):
-            d1 = lgb.Dataset(X[:,:j],feature_name=names[:j]).construct()
-            d2 = lgb.Dataset(X[:,j:],feature_name=names[j:]).construct()
+        for j in range(1, 5):
+            d1 = lgb.Dataset(X[:, :j],feature_name=names[:j]).construct()
+            d2 = lgb.Dataset(X[:, j:],feature_name=names[j:]).construct()
             d1.add_features_from(d2)
             with tempfile.NamedTemporaryFile() as f:
                 d1name = f.name
             d1.dump_text(d1name)
-            d = lgb.Dataset(X,feature_name=names).construct()
+            d = lgb.Dataset(X, feature_name=names).construct()
             with tempfile.NamedTemporaryFile() as f:
                 dname = f.name
             d.dump_text(dname)
-            with open(d1name,'rt') as d1f:
-                 d1txt = d1f.read()
+            with open(d1name, 'rt') as d1f:
+                d1txt = d1f.read()
             with open(dname, 'rt') as df:
-                 dtxt = df.read()
+                dtxt = df.read()
             os.remove(dname)
             os.remove(d1name)
             self.assertEqual(dtxt, d1txt)
 
     def test_add_features_same_booster_behaviour(self):
-        X = np.random.random((1000,5))
-        X[:,[1,3]] = 0
+        X = np.random.random((1000, 5))
+        X[:, [1, 3]] = 0
         names = ['col_%d' % (i,) for i in range(5)]
-        for j in range(1,5):
-            d1 = lgb.Dataset(X[:,:j],feature_name=names[:j]).construct()
-            d2 = lgb.Dataset(X[:,j:],feature_name=names[j:]).construct()
+        for j in range(1, 5):
+            d1 = lgb.Dataset(X[:, :j], feature_name=names[:j]).construct()
+            d2 = lgb.Dataset(X[:, j:], feature_name=names[j:]).construct()
             d1.add_features_from(d2)
-            d = lgb.Dataset(X,feature_name=names).construct()
+            d = lgb.Dataset(X, feature_name=names).construct()
             y = np.random.random(1000)
             d1.set_label(y)
             d.set_label(y)
@@ -172,21 +172,21 @@ class TestBasic(unittest.TestCase):
             self.assertEqual(dtxt, d1txt)
 
     def test_get_feature_penalty(self):
-        X = np.random.random((1000,1))
+        X = np.random.random((1000, 1))
         d = lgb.Dataset(X, params={'feature_penalty': [0.5]}).construct()
         self.assertEqual(np.asarray([0.5]), d.get_feature_penalty())
         d = lgb.Dataset(X).construct()
         self.assertEqual(None, d.get_feature_penalty())
 
     def test_get_monotone_types(self):
-        X = np.random.random((1000,1))
+        X = np.random.random((1000, 1))
         d = lgb.Dataset(X, params={'monotone_constraints': [1]}).construct()
         self.assertEqual(np.asarray([1]), d.get_monotone_types())
         d = lgb.Dataset(X).construct()
         self.assertEqual(None, d.get_monotone_types())
 
     def test_add_features_feature_penalty(self):
-        X = np.random.random((1000,2))
+        X = np.random.random((1000, 2))
         test_cases = [
             (None, None, None),
             ([0.5], None, [0.5, 1]),
@@ -197,12 +197,12 @@ class TestBasic(unittest.TestCase):
                 params1 = {'feature_penalty': p1}
             else:
                 params1 = {}
-            d1 = lgb.Dataset(X[:,0].reshape((-1,1)), params=params1).construct()
+            d1 = lgb.Dataset(X[:, 0].reshape((-1, 1)), params=params1).construct()
             if p2 is not None:
                 params2 = {'feature_penalty': p2}
             else:
                 params2 = {}
-            d2 = lgb.Dataset(X[:,1].reshape((-1,1)), params=params2).construct()
+            d2 = lgb.Dataset(X[:, 1].reshape((-1, 1)), params=params2).construct()
             d1.add_features_from(d2)
             actual = d1.get_feature_penalty()
             if isinstance(actual, np.ndarray):
@@ -210,7 +210,7 @@ class TestBasic(unittest.TestCase):
             self.assertEqual(expected, actual)
 
     def test_add_features_monotone_types(self):
-        X = np.random.random((1000,2))
+        X = np.random.random((1000, 2))
         test_cases = [
             (None, None, None),
             ([1], None, [1, 0]),
@@ -221,12 +221,12 @@ class TestBasic(unittest.TestCase):
                 params1 = {'monotone_constraints': p1}
             else:
                 params1 = {}
-            d1 = lgb.Dataset(X[:,0].reshape((-1,1)), params=params1).construct()
+            d1 = lgb.Dataset(X[:, 0].reshape((-1, 1)), params=params1).construct()
             if p2 is not None:
                 params2 = {'monotone_constraints': p2}
             else:
                 params2 = {}
-            d2 = lgb.Dataset(X[:,1].reshape((-1,1)), params=params2).construct()
+            d2 = lgb.Dataset(X[:, 1].reshape((-1, 1)), params=params2).construct()
             d1.add_features_from(d2)
             actual = d1.get_monotone_types()
             if isinstance(actual, np.ndarray):
@@ -234,8 +234,8 @@ class TestBasic(unittest.TestCase):
             self.assertEqual(expected, actual)
 
     def test_add_features_frees_added_set(self):
-        X = np.random.random((1000,2))
-        d1 = lgb.Dataset(X[:,0].reshape((-1,1))).construct()
-        d2 = lgb.Dataset(X[:,1].reshape((-1,1))).construct()
+        X = np.random.random((1000, 2))
+        d1 = lgb.Dataset(X[:, 0].reshape((-1, 1))).construct()
+        d2 = lgb.Dataset(X[:, 1].reshape((-1, 1))).construct()
         d1.add_features_from(d2)
         self.assertEqual(None, d2.handle)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -92,3 +92,31 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(len(subset_group), 2)
         self.assertEqual(subset_group[0], 1)
         self.assertEqual(subset_group[1], 9)
+
+    def test_add_features_throws_if_num_data_unequal(self):
+        X1 = np.random.random((1000, 1))
+        X2 = np.random.random((100, 1))
+        d1 = lgb.Dataset(X1).construct()
+        d2 = lgb.Dataset(X2).construct()
+        with self.assertRaises(lgb.basic.LightGBMError):
+            d1.add_features_from(d2)
+
+    #TODO: Bit messy.
+    def test_add_features_throws_if_datasets_unconstructed(self):
+        X1 = np.random.random((1000, 1))
+        X2 = np.random.random((100, 1))
+        d1 = lgb.Dataset(X1)
+        d2 = lgb.Dataset(X2)
+        with self.assertRaises(ValueError):
+            d1 = lgb.Dataset(X1)
+            d2 = lgb.Dataset(X2)
+            d1.add_features_from(d2)
+        with self.assertRaises(ValueError):
+            d1 = lgb.Dataset(X1).construct()
+            d2 = lgb.Dataset(X2)
+            d1.add_features_from(d2)
+        with self.assertRaises(ValueError):
+            d1 = lgb.Dataset(X1)
+            d2 = lgb.Dataset(X2).construct()            
+            d1.add_features_from(d2)
+

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -232,10 +232,3 @@ class TestBasic(unittest.TestCase):
             if isinstance(actual, np.ndarray):
                 actual = list(actual)
             self.assertEqual(expected, actual)
-
-    def test_add_features_frees_added_set(self):
-        X = np.random.random((1000, 2))
-        d1 = lgb.Dataset(X[:, 0].reshape((-1, 1))).construct()
-        d2 = lgb.Dataset(X[:, 1].reshape((-1, 1))).construct()
-        d1.add_features_from(d2)
-        self.assertEqual(None, d2.handle)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -120,3 +120,25 @@ class TestBasic(unittest.TestCase):
             d2 = lgb.Dataset(X2).construct()            
             d1.add_features_from(d2)
 
+    def test_add_features_equal_data_on_alternating_used_unused(self):
+        X = np.random.random((1000,5))
+        X[:,[1,3]] = 0
+        names = ['col_%d' % (i,) for i in range(5)]
+        for j in range(1,5):
+            d1 = lgb.Dataset(X[:,:j],feature_name=names[:j]).construct()
+            d2 = lgb.Dataset(X[:,j:],feature_name=names[j:]).construct()
+            d1.add_features_from(d2)
+            with tempfile.NamedTemporaryFile() as f:
+                d1name = f.name
+            d1.dump_text(d1name)
+            d = lgb.Dataset(X,feature_name=names).construct()
+            with tempfile.NamedTemporaryFile() as f:
+                dname = f.name
+            d.dump_text(dname)
+            with open(d1name,'rt') as d1f:
+                 d1txt = d1f.read()
+            with open(dname, 'rt') as df:
+                 dtxt = df.read()
+            os.remove(dname)
+            os.remove(d1name)
+            self.assertEqual(dtxt, d1txt)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -178,12 +178,12 @@ class TestBasic(unittest.TestCase):
         d = lgb.Dataset(X).construct()
         self.assertEqual(None, d.get_feature_penalty())
 
-    def test_get_monotone_types(self):
+    def test_get_monotone_constraints(self):
         X = np.random.random((1000, 1))
         d = lgb.Dataset(X, params={'monotone_constraints': [1]}).construct()
-        self.assertEqual(np.asarray([1]), d.get_monotone_types())
+        self.assertEqual(np.asarray([1]), d.get_monotone_constraints())
         d = lgb.Dataset(X).construct()
-        self.assertEqual(None, d.get_monotone_types())
+        self.assertEqual(None, d.get_monotone_constraints())
 
     def test_add_features_feature_penalty(self):
         X = np.random.random((1000, 2))

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -171,3 +171,17 @@ class TestBasic(unittest.TestCase):
             with open(d1name, 'rt') as d1f:
                 d1txt = d1f.read()
             self.assertEqual(dtxt, d1txt)
+
+    def test_get_feature_penalty(self):
+        X = np.random.random((1000,1))
+        d = lgb.Dataset(X, params={'feature_penalty': [0.5]}).construct()
+        self.assertEqual(np.asarray([0.5]), d.get_feature_penalty())
+        d = lgb.Dataset(X).construct()
+        self.assertEqual(None, d.get_feature_penalty())
+
+    def test_get_monotone_types(self):
+        X = np.random.random((1000,1))
+        d = lgb.Dataset(X, params={'monotone_constraints': [1]}).construct()
+        self.assertEqual(np.asarray([1]), d.get_monotone_types())
+        d = lgb.Dataset(X).construct()
+        self.assertEqual(None, d.get_monotone_types())

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -233,3 +233,10 @@ class TestBasic(unittest.TestCase):
             if isinstance(actual, np.ndarray):
                 actual = list(actual)
             self.assertEqual(expected, actual)
+
+    def test_add_features_frees_added_set(self):
+        X = np.random.random((1000,2))
+        d1 = lgb.Dataset(X[:,0].reshape((-1,1))).construct()
+        d2 = lgb.Dataset(X[:,1].reshape((-1,1))).construct()
+        d1.add_features_from(d2)
+        self.assertEqual(None, d2.handle)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -101,7 +101,6 @@ class TestBasic(unittest.TestCase):
         with self.assertRaises(lgb.basic.LightGBMError):
             d1.add_features_from(d2)
 
-    #TODO: Bit messy.
     def test_add_features_throws_if_datasets_unconstructed(self):
         X1 = np.random.random((1000, 1))
         X2 = np.random.random((100, 1))

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -228,7 +228,7 @@ class TestBasic(unittest.TestCase):
                 params2 = {}
             d2 = lgb.Dataset(X[:, 1].reshape((-1, 1)), params=params2).construct()
             d1.add_features_from(d2)
-            actual = d1.get_monotone_types()
+            actual = d1.get_monotone_constraints()
             if isinstance(actual, np.ndarray):
                 actual = list(actual)
             self.assertEqual(expected, actual)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -124,8 +124,8 @@ class TestBasic(unittest.TestCase):
         X[:, [1, 3]] = 0
         names = ['col_%d' % (i,) for i in range(5)]
         for j in range(1, 5):
-            d1 = lgb.Dataset(X[:, :j],feature_name=names[:j]).construct()
-            d2 = lgb.Dataset(X[:, j:],feature_name=names[j:]).construct()
+            d1 = lgb.Dataset(X[:, :j], feature_name=names[:j]).construct()
+            d2 = lgb.Dataset(X[:, j:], feature_name=names[j:]).construct()
             d1.add_features_from(d2)
             with tempfile.NamedTemporaryFile() as f:
                 d1name = f.name


### PR DESCRIPTION
This is useful if features have been previously written out to different binary files.
A usage example is:
```
d1 = Dataset('d1.bin')
d2 = Dataset('d2.bin')
d1.add_features_from(d2)
```
The PR includes the functionality itself (add_features_from in the Python package and the underlying C API call LGBM_DatasetAddFeaturesFrom), as well as unit tests for it.