### PR TITLE
[ci] fixed conda

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,8 +29,8 @@ install:
   - set PATH=%MINICONDA%;%MINICONDA%\Scripts;%PATH%
   - ps: $env:LGB_VER = (Get-Content VERSION.txt).trim()
   - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda create -q -n test-env python=%PYTHON_VERSION% matplotlib nose numpy pandas psutil pytest python-graphviz scikit-learn scipy
+  - conda update -q -y conda
+  - conda create -q -y -n test-env python=%PYTHON_VERSION% matplotlib nose numpy pandas psutil pytest python-graphviz scikit-learn scipy
   - activate test-env
 
 build_script:
@@ -53,5 +53,5 @@ test_script:
         if (!$?) { $host.SetShouldExit(-1) }
       }  # run all examples
   - cd %APPVEYOR_BUILD_FOLDER%\examples\python-guide\notebooks
-  - conda install -y -n test-env ipywidgets notebook
+  - conda install -q -y -n test-env ipywidgets notebook
   - jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb  # run all notebooks

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -20,9 +20,7 @@ if [[ $OS_NAME == "macos" ]]; then
     if [[ $TASK == "mpi" ]]; then
         brew install open-mpi
     fi
-    if [[ $TRAVIS == "true" ]]; then
-        wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION:0:1}-latest-MacOSX-x86_64.sh
-    fi
+    wget -q -O conda.sh https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION:0:1}-latest-MacOSX-x86_64.sh
 else  # Linux
     if [[ $AZURE == "true" ]] && [[ $COMPILER == "clang" ]]; then
         sudo apt-get update
@@ -49,13 +47,13 @@ else  # Linux
         mv $AMDAPPSDK_PATH/lib/x86_64/sdk/* $AMDAPPSDK_PATH/lib/x86_64/
         echo libamdocl64.so > $OPENCL_VENDOR_PATH/amdocl64.icd
     fi
-    if [[ $TRAVIS == "true" ]]; then
-        wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION:0:1}-latest-Linux-x86_64.sh
+    if [[ $TRAVIS == "true" ]] || [[ $TASK == "gpu" ]]; then
+        wget -q -O conda.sh https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION:0:1}-latest-Linux-x86_64.sh
     fi
 fi
 
-if [[ $TRAVIS == "true" ]]; then
-    sh conda.sh -b -p $HOME_DIRECTORY/miniconda
+if [[ $TRAVIS == "true" ]] || [[ $OS_NAME == "macos" ]] || [[ $TASK == "gpu" ]]; then
+    sh conda.sh -b -p $CONDA
 fi
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -15,9 +15,9 @@ cd $BUILD_DIRECTORY
 
 if [[ $TRAVIS == "true" ]] && [[ $TASK == "check-docs" ]]; then
     if [[ $PYTHON_VERSION == "2.7" ]]; then
-        conda -y -n $CONDA_ENV mock
+        conda -q -y -n $CONDA_ENV mock
     fi
-    conda install -y -n $CONDA_ENV sphinx "sphinx_rtd_theme>=0.3"
+    conda install -q -y -n $CONDA_ENV sphinx "sphinx_rtd_theme>=0.3"
     pip install --user rstcheck
     # check reStructuredText formatting
     cd $BUILD_DIRECTORY/python-package
@@ -43,14 +43,14 @@ if [[ $TRAVIS == "true" ]] && [[ $TASK == "check-docs" ]]; then
 fi
 
 if [[ $TASK == "pylint" ]]; then
-    conda install -y -n $CONDA_ENV pycodestyle pydocstyle
+    conda install -q -y -n $CONDA_ENV pycodestyle pydocstyle
     pycodestyle --ignore=E501,W503 --exclude=./compute,./.nuget . || exit -1
     pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^compute|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1
     exit 0
 fi
 
 if [[ $TASK == "if-else" ]]; then
-    conda install -y -n $CONDA_ENV numpy
+    conda install -q -y -n $CONDA_ENV numpy
     mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build && cmake .. && make lightgbm -j4 || exit -1
     cd $BUILD_DIRECTORY/tests/cpp_test && ../../lightgbm config=train.conf convert_model_language=cpp convert_model=../../src/boosting/gbdt_prediction.cpp && ../../lightgbm config=predict.conf output_result=origin.pred || exit -1
     cd $BUILD_DIRECTORY/build && make lightgbm -j4 || exit -1
@@ -139,6 +139,6 @@ matplotlib.use\(\"Agg\"\)\
     sed -i'.bak' 's/graph.render(view=True)/graph.render(view=False)/' plot_example.py
     for f in *.py; do python $f || exit -1; done  # run all examples
     cd $BUILD_DIRECTORY/examples/python-guide/notebooks
-    conda install -y -n $CONDA_ENV ipywidgets notebook
+    conda install -q -y -n $CONDA_ENV ipywidgets notebook
     jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb || exit -1  # run all notebooks
 fi

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -38,6 +38,6 @@ if ($env:TASK -eq "regular") {
     python $file ; Check-Output $?
   }  # run all examples
   cd $env:BUILD_SOURCESDIRECTORY/examples/python-guide/notebooks
-  conda install -y -n $env:CONDA_ENV ipywidgets notebook
+  conda install -q -y -n $env:CONDA_ENV ipywidgets notebook
   jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb ; Check-Output $?  # run all notebooks
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ before_install:
         export OS_NAME="linux";
         export COMPILER="clang";
     fi
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  - export CONDA="$HOME/miniconda"
+  - export PATH="$CONDA/bin:$PATH"
   - export CONDA_ENV="test-env"
   - export LGB_VER=$(head -n 1 VERSION.txt)
   - export AMDAPPSDK_PATH=$HOME/AMDAPPSDK

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -33,12 +33,12 @@ jobs:
         PYTHON_VERSION: 2.7
   steps:
   - script: |
-      echo "##vso[task.setvariable variable=PATH]$CONDA/bin:$PATH"
       echo "##vso[task.setvariable variable=HOME_DIRECTORY]$AGENT_HOMEDIRECTORY"
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
       echo "##vso[task.setvariable variable=OS_NAME]linux"
       echo "##vso[task.setvariable variable=AZURE]true"
       echo "##vso[task.setvariable variable=LGB_VER]$(head -n 1 VERSION.txt)"
+      echo "##vso[task.prependpath]$CONDA/bin"
     displayName: 'Set variables'
   - bash: $(Build.SourcesDirectory)/.ci/setup.sh
     displayName: Setup
@@ -65,9 +65,6 @@ jobs:
         METHOD: source
         PYTHON_VERSION: 3.6
   steps:
-  - task: CondaEnvironment@1
-    inputs:
-      updateConda: false
   - script: |
       echo "##vso[task.setvariable variable=HOME_DIRECTORY]$AGENT_HOMEDIRECTORY"
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
@@ -79,6 +76,9 @@ jobs:
       LD_LIBRARY_PATH=$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH
       echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$LD_LIBRARY_PATH"
       echo "##vso[task.setvariable variable=OPENCL_VENDOR_PATH]$AMDAPPSDK_PATH/etc/OpenCL/vendors"
+      CONDA=$AGENT_HOMEDIRECTORY/miniconda
+      echo "##vso[task.setvariable variable=CONDA]$CONDA"
+      echo "##vso[task.prependpath]$CONDA/bin"
     displayName: 'Set variables'
   - bash: $(Build.SourcesDirectory)/.ci/setup.sh
     displayName: Setup
@@ -103,15 +103,15 @@ jobs:
       bdist:
         TASK: bdist
   steps:
-  - task: CondaEnvironment@1
-    inputs:
-      updateConda: false
   - script: |
       echo "##vso[task.setvariable variable=HOME_DIRECTORY]$AGENT_HOMEDIRECTORY"
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
       echo "##vso[task.setvariable variable=OS_NAME]macos"
       echo "##vso[task.setvariable variable=AZURE]true"
       echo "##vso[task.setvariable variable=LGB_VER]$(head -n 1 VERSION.txt)"
+      CONDA=$AGENT_HOMEDIRECTORY/miniconda
+      echo "##vso[task.setvariable variable=CONDA]$CONDA"
+      echo "##vso[task.prependpath]$CONDA/bin"
     displayName: 'Set variables'
   - bash: $(Build.SourcesDirectory)/.ci/setup.sh
     displayName: Setup
@@ -141,14 +141,12 @@ jobs:
         TASK: bdist
         PYTHON_VERSION: 3.6
   steps:
-  - task: CondaEnvironment@1
-    inputs:
-      createCustomEnvironment: true
-      updateConda: true
-      environmentName: $(CONDA_ENV)
-      packageSpecs: 'python=$(PYTHON_VERSION) matplotlib nose numpy pandas psutil pytest python-graphviz scikit-learn scipy'
-      createOptions: '-q'
-  - powershell: $(Build.SourcesDirectory)/.ci/test_windows.ps1
+  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+    displayName: Enable conda
+  - script: |
+      conda update -q -y conda
+      conda create -q -y -n %CONDA_ENV% python=%PYTHON_VERSION% matplotlib nose numpy pandas psutil pytest python-graphviz scikit-learn scipy
+      cmd /c "activate %CONDA_ENV% & powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/test_windows.ps1"
     displayName: Test
   - task: PublishBuildArtifacts@1
     condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))


### PR DESCRIPTION
Fixed #2010. Refer to https://github.com/ContinuumIO/anaconda-issues/issues/10629.


Multiple minor additions of `-q` and `-y` options for `conda` and `wget` commands.


The main idea of this PR is about that `CondaEnvironment` task on Azure Pipelines [has been deprecated recently](https://github.com/Microsoft/azure-pipelines-tasks/pull/9573). Now users should manage `conda` environments by their own scripts. As it was discovered from the conversation in https://github.com/ContinuumIO/anaconda-issues/issues/10629, Azure Pipelines used their own ["activation"](https://github.com/Microsoft/azure-pipelines-tasks/blob/1873ad9bcf74fd7db3dde3f9c8d246610e71101b/Tasks/CondaEnvironmentV1/conda_internal.ts#L133-L147) of `conda` environments which is not correct and doesn't work with the latest `conda`'s  Python patch.

Also, we cannot rely on the **preinstalled** `conda` on Linux and macOS because it's installed in the folder which requires to execute every `conda`-command [with `sudo`](https://github.com/Microsoft/azure-pipelines-tasks/blob/1873ad9bcf74fd7db3dde3f9c8d246610e71101b/Tasks/CondaEnvironmentV1/conda_internal.ts#L95), what is strongly discouraged by `conda` itself (refer to our ordeals in #1849). So, this PR adds `conda` installation into `$AGENT_HOMEDIRECTORY/miniconda` folder and overwrites environmental variable `CONDA`.