### PR TITLE
[python] disabled split value histogram for categorical features

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2437,6 +2437,11 @@ class Booster(object):
             The feature name or index the histogram is calculated for.
             If int, interpreted as index.
             If string, interpreted as name.
+
+            Note
+            ----
+            Categorical features are not supported.
+
         bins : int, string or None, optional (default=None)
             The maximum number of bins.
             If None, or int and > number of unique split values and ``xgboost_style=True``,

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2465,7 +2465,7 @@ class Booster(object):
                     split_feature = root['split_feature']
                 if split_feature == feature:
                     if isinstance(root['threshold'], string_type):
-                        raise TypeError('Cannot compute split value histogram for the categorical feature')
+                        raise LightGBMError('Cannot compute split value histogram for the categorical feature')
                     else:
                         values.append(root['threshold'])
                 add(root['left_child'])

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2464,7 +2464,10 @@ class Booster(object):
                 else:
                     split_feature = root['split_feature']
                 if split_feature == feature:
-                    values.append(root['threshold'])
+                    if isinstance(root['threshold'], string_type):
+                        raise TypeError('Cannot compute split value histogram for the categorical feature')
+                    else:
+                        values.append(root['threshold'])
                 add(root['left_child'])
                 add(root['right_child'])
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1245,17 +1245,17 @@ class TestEngine(unittest.TestCase):
 
     def test_get_split_value_histogram(self):
         X, y = load_boston(True)
-        lgb_train = lgb.Dataset(X, y)
+        lgb_train = lgb.Dataset(X, y, categorical_feature=[2])
         gbm = lgb.train({'verbose': -1}, lgb_train, num_boost_round=20)
         # test XGBoost-style return value
         params = {'feature': 0, 'xgboost_style': True}
-        self.assertTupleEqual(gbm.get_split_value_histogram(**params).shape, (10, 2))
-        self.assertTupleEqual(gbm.get_split_value_histogram(bins=999, **params).shape, (10, 2))
+        self.assertTupleEqual(gbm.get_split_value_histogram(**params).shape, (9, 2))
+        self.assertTupleEqual(gbm.get_split_value_histogram(bins=999, **params).shape, (9, 2))
         self.assertTupleEqual(gbm.get_split_value_histogram(bins=-1, **params).shape, (1, 2))
         self.assertTupleEqual(gbm.get_split_value_histogram(bins=0, **params).shape, (1, 2))
         self.assertTupleEqual(gbm.get_split_value_histogram(bins=1, **params).shape, (1, 2))
         self.assertTupleEqual(gbm.get_split_value_histogram(bins=2, **params).shape, (2, 2))
-        self.assertTupleEqual(gbm.get_split_value_histogram(bins=6, **params).shape, (6, 2))
+        self.assertTupleEqual(gbm.get_split_value_histogram(bins=6, **params).shape, (5, 2))
         self.assertTupleEqual(gbm.get_split_value_histogram(bins=7, **params).shape, (6, 2))
         if lgb.compat.PANDAS_INSTALLED:
             np.testing.assert_almost_equal(
@@ -1277,8 +1277,8 @@ class TestEngine(unittest.TestCase):
             )
         # test numpy-style return value
         hist, bins = gbm.get_split_value_histogram(0)
-        self.assertEqual(len(hist), 22)
-        self.assertEqual(len(bins), 23)
+        self.assertEqual(len(hist), 23)
+        self.assertEqual(len(bins), 24)
         hist, bins = gbm.get_split_value_histogram(0, bins=999)
         self.assertEqual(len(hist), 999)
         self.assertEqual(len(bins), 1000)
@@ -1316,3 +1316,5 @@ class TestEngine(unittest.TestCase):
                 mask = hist_vals > 0
                 np.testing.assert_array_equal(hist_vals[mask], hist[:, 1])
                 np.testing.assert_almost_equal(bin_edges[1:][mask], hist[:, 0])
+        # test histogram is disabled for categorical features
+        self.assertRaises(lgb.basic.LightGBMError, gbm.get_split_value_histogram, 2)


### PR DESCRIPTION
Replace `TypeError` for categorical features with more understandable `LightGBMError`.
```
import lightgbm as lgb
from sklearn.datasets import load_boston

data = lgb.Dataset(*load_boston(True), categorical_feature=[2])
booster = lgb.train({'verbose': -1}, data, num_boost_round=20)
booster.get_split_value_histogram(2)
```

```
TypeError                                 Traceback (most recent call last)
<ipython-input-4-46f3fc73cd0a> in <module>
----> 1 booster.get_split_value_histogram(2)

C:\Program Files\Anaconda3\lib\site-packages\lightgbm\basic.py in get_split_value_histogram(self, feature, bins, xgboost_style)
   2480             bins = max(min(n_unique, bins) if bins is not None else n_unique, 1)
   2481         print(values)
-> 2482         hist, bin_edges = np.histogram(values, bins=bins)
   2483         if xgboost_style:
   2484             ret = np.column_stack((bin_edges[1:], hist))

C:\Program Files\Anaconda3\lib\site-packages\numpy\lib\histograms.py in histogram(a, bins, range, normed, weights, density)
    700     a, weights = _ravel_and_check_weights(a, weights)
    701 
--> 702     bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)
    703 
    704     # Histogram is an integer or a float array depending on the weights.

C:\Program Files\Anaconda3\lib\site-packages\numpy\lib\histograms.py in _get_bin_edges(a, bins, range, weights)
    353             raise ValueError('`bins` must be positive, when an integer')
    354 
--> 355         first_edge, last_edge = _get_outer_edges(a, range)
    356 
    357     elif np.ndim(bins) == 1:

C:\Program Files\Anaconda3\lib\site-packages\numpy\lib\histograms.py in _get_outer_edges(a, range)
    248         first_edge, last_edge = 0, 1
    249     else:
--> 250         first_edge, last_edge = a.min(), a.max()
    251         if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
    252             raise ValueError(

C:\Program Files\Anaconda3\lib\site-packages\numpy\core\_methods.py in _amin(a, axis, out, keepdims, initial)
     30 def _amin(a, axis=None, out=None, keepdims=False,
     31           initial=_NoValue):
---> 32     return umr_minimum(a, axis, None, out, keepdims, initial)
     33 
     34 def _sum(a, axis=None, dtype=None, out=None, keepdims=False,

TypeError: cannot perform reduce with flexible type
```
`values` here
https://github.com/Microsoft/LightGBM/blob/8d6666e0ffb7165096753dc392044af18ef2eae6/python-package/lightgbm/basic.py#L2481
`values = ['2||3||6||10||18', '2||3||6||10||18', '2||4||6||10||18', '2||3||6||10||18', '1||4||5||6', '1||2||4||10||21', '1||4||5||6', '10||18||19||21', '3||6||7||8||10||18||21', '3||5||6||9', '1||2||3||7||10||21', '1||2||3||8||10||21', '5||6||10||18', '5||6||9||18', '6||7||9||10||18', '2||4||6||7||9||18', '1||2||3||8||21']`