### PR TITLE
[ci] compatibility hotfix for notebook execution

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,5 +53,5 @@ test_script:
         if (!$?) { $host.SetShouldExit(-1) }
       }  # run all examples
   - cd %APPVEYOR_BUILD_FOLDER%\examples\python-guide\notebooks
-  - conda install -q -y -n test-env ipywidgets notebook
+  - conda install -q -y -n test-env ipywidgets notebook "tornado=5.1.1"
   - jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb  # run all notebooks

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -139,6 +139,6 @@ matplotlib.use\(\"Agg\"\)\
     sed -i'.bak' 's/graph.render(view=True)/graph.render(view=False)/' plot_example.py
     for f in *.py; do python $f || exit -1; done  # run all examples
     cd $BUILD_DIRECTORY/examples/python-guide/notebooks
-    conda install -q -y -n $CONDA_ENV ipywidgets notebook
+    conda install -q -y -n $CONDA_ENV ipywidgets notebook "tornado=5.1.1"
     jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb || exit -1  # run all notebooks
 fi

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -38,6 +38,6 @@ if ($env:TASK -eq "regular") {
     python $file ; Check-Output $?
   }  # run all examples
   cd $env:BUILD_SOURCESDIRECTORY/examples/python-guide/notebooks
-  conda install -q -y -n $env:CONDA_ENV ipywidgets notebook
+  conda install -q -y -n $env:CONDA_ENV ipywidgets notebook "tornado=5.1.1"
   jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb ; Check-Output $?  # run all notebooks
 }


### PR DESCRIPTION
Pin `tornado` to previous version.

Issue can be observed in #2047 on all CI services.
```
Traceback (most recent call last):
  File "/home/travis/miniconda/envs/test-env/bin/jupyter-nbconvert", line 7, in <module>
    from nbconvert.nbconvertapp import main
  File "/home/travis/miniconda/envs/test-env/lib/python3.6/site-packages/nbconvert/__init__.py", line 7, in <module>
    from . import postprocessors
  File "/home/travis/miniconda/envs/test-env/lib/python3.6/site-packages/nbconvert/postprocessors/__init__.py", line 5, in <module>
    from .serve import ServePostProcessor
  File "/home/travis/miniconda/envs/test-env/lib/python3.6/site-packages/nbconvert/postprocessors/serve.py", line 19, in <module>
    class ProxyHandler(web.RequestHandler):
  File "/home/travis/miniconda/envs/test-env/lib/python3.6/site-packages/nbconvert/postprocessors/serve.py", line 21, in ProxyHandler
    @web.asynchronous
AttributeError: module 'tornado.web' has no attribute 'asynchronous'
```