### PR TITLE
[python] Drop Python 3.4 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,6 @@ install:
   - ps: >-
       switch ($env:PYTHON_VERSION) {
           "2.7" {$env:MINICONDA = """C:\Miniconda-x64"""}
-          "3.4" {$env:MINICONDA = """C:\Miniconda34-x64"""}
           "3.5" {$env:MINICONDA = """C:\Miniconda35-x64"""}
           "3.6" {$env:MINICONDA = """C:\Miniconda36-x64"""}
           "3.7" {$env:MINICONDA = """C:\Miniconda37-x64"""}

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -331,7 +331,6 @@ if __name__ == "__main__":
                        'Programming Language :: Python :: 2',
                        'Programming Language :: Python :: 2.7',
                        'Programming Language :: Python :: 3',
-                       'Programming Language :: Python :: 3.4',
                        'Programming Language :: Python :: 3.5',
                        'Programming Language :: Python :: 3.6',
                        'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Python 3.4 is reaching its End of Life today and no need to support it anymore.
https://devguide.python.org/#branchstatus