### PR TITLE
regression_metric.QuantileMetric loss bug

### DIFF
--- a/src/metric/regression_metric.hpp
+++ b/src/metric/regression_metric.hpp
@@ -148,7 +148,7 @@ class L2Metric: public RegressionMetric<L2Metric> {
   }
 };
 
-/*! \brief L2 loss for regression task */
+/*! \brief Quantile loss for regression task */
 class QuantileMetric : public RegressionMetric<QuantileMetric> {
  public:
   explicit QuantileMetric(const Config& config) :RegressionMetric<QuantileMetric>(config) {
@@ -157,7 +157,7 @@ class QuantileMetric : public RegressionMetric<QuantileMetric> {
   inline static double LossOnPoint(label_t label, double score, const Config& config) {
     double delta = label - score;
     if (delta < 0) {
-      return (config.alpha - 1.0f) * delta;
+      return (1.0f - config.alpha) * delta;
     } else {
       return config.alpha * delta;
     }


### PR DESCRIPTION
The quantile loss function had a bug where instead of returning (1-alpha) * diff it was returning (alpha - 1) * diff. See https://github.com/scikit-learn/scikit-learn/blob/7b136e9/sklearn/ensemble/gradient_boosting.py#L709 for an outside reference.

I also changed the comment on the line above (not really a bug fix, but it scratches my OCD itch)