### PR TITLE
[SWIG] fix swig build warnings/errors on windows

### DIFF
--- a/swig/lightgbmlib.i
+++ b/swig/lightgbmlib.i
@@ -160,7 +160,7 @@
       // int* indices0 = (int*)jenv->GetPrimitiveArrayCritical(indices, 0);
       // double* values0 = (double*)jenv->GetPrimitiveArrayCritical(values, 0);
       // in test-usecase an alternative to GetPrimitiveArrayCritical as it performs copies
-      int* indices0 = jenv->GetIntArrayElements(indices, 0);
+      int* indices0 = (int *)jenv->GetIntArrayElements(indices, 0);
       double* values0 = jenv->GetDoubleArrayElements(values, 0);
       
       jniCache.push_back({indices, values, indices0, values0, size});
@@ -187,7 +187,7 @@
       // jenv->ReleasePrimitiveArrayCritical(jc.values, jc.values0, JNI_ABORT);
       // jenv->ReleasePrimitiveArrayCritical(jc.indices, jc.indices0, JNI_ABORT);
       jenv->ReleaseDoubleArrayElements(jc.values, jc.values0, JNI_ABORT);
-      jenv->ReleaseIntArrayElements(jc.indices, jc.indices0, JNI_ABORT);
+      jenv->ReleaseIntArrayElements(jc.indices, (jint *)jc.indices0, JNI_ABORT);
    }
    
    return ret;


### PR DESCRIPTION
Getting errors on windows build:

"C:\LightGBM\LightGBM\build\ALL_BUILD.vcxproj" (default target) (1) ->
"C:\LightGBM\LightGBM\build\_lightgbm_swig.vcxproj" (default target) (4) ->
(ClCompile target) ->
  c:\lightgbm\lightgbm\build\java\lightgbmlibjava_wrap.cxx(372): error C2440: 'initializing': cannot convert from 'jint *' to 'int *' [C:\LightGBM\LightGBM\build\_lightgbm_swig.vcxproj]
  c:\lightgbm\lightgbm\build\java\lightgbmlibjava_wrap.cxx(399): error C2664: 'void JNIEnv_::ReleaseIntArrayElements(jintArray,jint *,jint)': cannot convert argument 2 from 'int *' to 'jint *' [C:\LightGBM\LightGBM\build\_lightgbm_swig.vcxproj]

    0 Warning(s)
    2 Error(s)