### PR TITLE
[ci] ignore failing Yahoo URL

### DIFF
--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -7,6 +7,7 @@ sslverify=0
 ignore=
   public.tableau.com
   http://www.intel.com/software/products/support
+  https://webscope.sandbox.yahoo.com
 ignorewarnings=http-robots-denied,https-certificate-error
 
 [output]


### PR DESCRIPTION
OK, seems Yahoo are not in a hurry fixing their servers. But we have to merge too many PRs.

Since I haven't found any mirrors for this dataset, let's stub corresponding URL for a while. Then we'll remove this URL from ignoring list when Yahoo will wake up.

@guolinke Are you OK with this solution?