### PR TITLE
Bug fix in voting parallel learner

### DIFF
--- a/src/treelearner/voting_parallel_tree_learner.cpp
+++ b/src/treelearner/voting_parallel_tree_learner.cpp
@@ -190,6 +190,7 @@ void VotingParallelTreeLearner<TREELEARNER_T>::GlobalVoting(int leaf_idx, const 
   // get top k
   std::vector<LightSplitInfo> top_k_splits;
   ArrayArgs<LightSplitInfo>::MaxK(feature_best_split, top_k_, &top_k_splits);
+  std::sort(top_k_splits.begin(), top_k_splits.end(), std::greater<LightSplitInfo>());
   for (auto& split : top_k_splits) {
     if (split.gain == kMinScore || split.feature == -1) {
       continue;


### PR DESCRIPTION
In our environment, we met a bug that when process `GlobalVoting` function in voting parallel learner,
if the training data is very sparse and cause `train_data_->num_total_features()` to be different between workers,  the local calculated top_k_splits (from MaxK function) can result in different order between workers, thus cause the upcoming ReduceScatter to hang permanently for incorrect send/recv data size.

Sort the calculated top_k_splits seems a quick solution for this.

