### PR TITLE
[docs] remove duplicated param in Python-Intro.rst

### DIFF
--- a/docs/Python-Intro.rst
+++ b/docs/Python-Intro.rst
@@ -141,7 +141,7 @@ For instance:
 
    .. code:: python
 
-       param = {'num_leaves': 31, 'num_trees': 100, 'objective': 'binary'}
+       param = {'num_leaves': 31, 'objective': 'binary'}
        param['metric'] = 'auc'
 
 -  You can also specify multiple eval metrics:
@@ -185,7 +185,6 @@ Training with 5-fold CV:
 
 .. code:: python
 
-    num_round = 10
     lgb.cv(param, train_data, num_round, nfold=5)
 
 Early Stopping
@@ -196,7 +195,7 @@ Early stopping requires at least one set in ``valid_sets``. If there is more tha
 
 .. code:: python
 
-    bst = lgb.train(param, train_data, num_round, valid_sets=valid_sets, early_stopping_rounds=10)
+    bst = lgb.train(param, train_data, num_round, valid_sets=valid_sets, early_stopping_rounds=5)
     bst.save_model('model.txt', num_iteration=bst.best_iteration)
 
 The model will train until the validation score stops improving.


### PR DESCRIPTION
`num_round` is redundant here because it will be overrideen by `num_trees` in the `param` dictionary.