### PR TITLE
fixed cast error

### DIFF
--- a/src/io/file_io.cpp
+++ b/src/io/file_io.cpp
@@ -98,7 +98,7 @@ struct HDFSFile : VirtualFileReader, VirtualFileWriter {
 
   template <typename BufferType>
   inline size_t FileOperation(BufferType data, size_t bytes, fileOp<BufferType> op) const {
-    char* buffer = reinterpret_cast<char *>(data);
+    char* buffer = const_cast<char*>(static_cast<const char*>(data));
     size_t remain = bytes;
     while (remain != 0) {
       size_t nmax = static_cast<size_t>(std::numeric_limits<tSize>::max());


### PR DESCRIPTION
```
/opt/lightgbm/src/io/file_io.cpp:101:49: error: reinterpret_cast from type ‘const void*’ to type ‘char*’ casts away qualifiers
char* buffer = reinterpret_cast<char *>(data);
```

Fixed #2160, fixed #2185.