### PR TITLE
[docs][python] allow usage and compilation of 32-bit library

### DIFF
--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -3,6 +3,10 @@ Installation Guide
 
 Here is the guide for the build of LightGBM CLI version.
 
+All instructions below are aimed to compile 64-bit version of LightGBM.
+It is worth to compile 32-bit version only in very rare special cases of environmental limitations.
+32-bit version is slow and untested, so use it on your own risk and don't forget to adjust some commands in this guide.
+
 For the build of Python-package and R-package, please refer to `Python-package`_ and `R-package`_ folders respectively.
 
 Also you can download artifacts of the latest successful build in master branch: |download artifacts|.

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -9,7 +9,7 @@ Installation
 Preparation
 '''''''''''
 
-32-bit Python is not supported. Please install 64-bit version.
+32-bit Python is not supported. Please install 64-bit version. If you have a strong need to install with 32-bit Python, refer to `Build 32-bit Version with 32-bit Python section <#build-32-bit-version-with-32-bit-python>`__.
 
 `setuptools <https://pypi.org/project/setuptools>`_ is needed.
 
@@ -134,6 +134,17 @@ Build with MinGW-w64 on Windows
 
 It is recommended to use **Visual Studio** for its better multithreading efficiency in **Windows** for many-core systems (see `FAQ <https://github.com/microsoft/LightGBM/blob/master/docs/FAQ.rst#lightgbm>`__ Question 4 and Question 8).
 
+Build 32-bit Version with 32-bit Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: sh
+
+    pip install lightgbm --install-option=--bit32
+
+By default, installation in environment with 32-bit Python is prohibited. However, you can remove this prohibition on your own risk by passing ``bit32`` option.
+
+It is **strongly not recommended** to use this version of LightGBM!
+
 Install from GitHub
 '''''''''''''''''''
 
@@ -161,6 +172,8 @@ Run ``python setup.py install --mingw``, if you want to use **MinGW-w64** on **W
 Run ``python setup.py install --gpu`` to enable GPU support. All remarks from `Build GPU Version section <#build-gpu-version>`__ are actual in this case. To pass additional options to **CMake** use the following syntax: ``python setup.py install --gpu --opencl-include-dir=/usr/local/cuda/include/``, see `Build GPU Version section <#build-gpu-version>`__ for the complete list of them.
 
 Run ``python setup.py install --hdfs`` to enable HDFS support. All remarks from `Build HDFS Version section <#build-hdfs-version>`__ are actual in this case.
+
+Run ``python setup.py install --bit32``, if you want to use 32-bit version. All remarks from `Build 32-bit Version with 32-bit Python section <#build-32-bit-version-with-32-bit-python>`__ are actual in this case.
 
 If you get any errors during installation or due to any other reasons, you may want to build dynamic library from sources by any method you prefer (see `Installation Guide <https://github.com/microsoft/LightGBM/blob/master/docs/Installation-Guide.rst>`__) and then just run ``python setup.py install --precompile``.
 


### PR DESCRIPTION
I think this PR should be merged **after** 2.2.4 release.

Refer to #1129. Closed #1864.

Description of advantages of `bit32` flag comparing to simple removal of exception can be found in https://github.com/microsoft/LightGBM/pull/1864#issuecomment-441091532.