### PR TITLE
[ci] added CODEOWNERS (fixes #2194)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# This file controls default reviewers for LightGBM code.
+# See https://help.github.com/en/articles/about-code-owners
+# for details
+#
+# Maintainers are encouraged to use their best discretion in
+# setting reviewers on PRs manually, but this file should
+# offer a reasonable automatic best-guess
+
+# main C++ code
+include/*    @guolinke @chivee
+CmakeLists.txt    @guolinke @chivee @Laurae2 @jameslamb @wxchan @henry0312 @StrikerRUS @huanzhang12
+
+# R code
+R-package/*    @Laurae2 @jameslamb
+*.R    @Laurae2 @jameslamb
+
+# Python code
+python-package/*    @StrikerRUS @chivee
+*.py    @StrikerRUS @wxchan @henry0312
+
+# CI administrative stuff
+.ci/*    @StrikerRUS @Laurae2 @jameslamb
+docs/*    @StrikerRUS @Laurae2 @jameslamb
+.travis.yml    @StrikerRUS @Laurae2 @jameslamb
+.appveyor.yml    @StrikerRUS @Laurae2 @jameslamb
+.vsts-ci.yml    @Laurae2
+
+# GPU code
+docker/gpu/*    @huanzhang12
+docs/GPU-Windows.rst    @huanzhang12
+src/treelearner/gpu_tree_learner.cpp    @huanzhang12 @guolinke @chivee
+src/treelearner/tree_learner.cpp    @huanzhang12 @guolinke @chivee

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,6 @@ docs/*    @StrikerRUS @Laurae2 @jameslamb
 
 # GPU code
 docker/gpu/*    @huanzhang12
-docs/GPU-Windows.rst    @huanzhang12
+docs/GPU-*.rst    @huanzhang12
 src/treelearner/gpu_tree_learner.cpp    @huanzhang12 @guolinke @chivee
 src/treelearner/tree_learner.cpp    @huanzhang12 @guolinke @chivee

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,21 +8,26 @@
 
 # main C++ code
 include/*    @guolinke @chivee
+src/*    @guolinke @chivee
 CmakeLists.txt    @guolinke @chivee @Laurae2 @jameslamb @wxchan @henry0312 @StrikerRUS @huanzhang12
 
 # R code
+include/LightGBM/lightgbm_R.h    @Laurae2 @jameslamb
+include/LightGBM/R_object_helper.h    @Laurae2 @jameslamb
+src/lightgbm_R.cpp    @Laurae2 @jameslamb
 R-package/*    @Laurae2 @jameslamb
 *.R    @Laurae2 @jameslamb
 
 # Python code
-python-package/*    @StrikerRUS @chivee
-*.py    @StrikerRUS @wxchan @henry0312
+python-package/*    @StrikerRUS @chivee @wxchan @henry0312
+
+# helpers
+helpers/*    @StrikerRUS @guolinke
 
 # CI administrative stuff
 .ci/*    @StrikerRUS @Laurae2 @jameslamb
 docs/*    @StrikerRUS @Laurae2 @jameslamb
-.travis.yml    @StrikerRUS @Laurae2 @jameslamb
-.appveyor.yml    @StrikerRUS @Laurae2 @jameslamb
+*.yml    @StrikerRUS @Laurae2 @jameslamb
 .vsts-ci.yml    @Laurae2
 
 # GPU code


### PR DESCRIPTION
See #2194 for details. Please suggest if I've misinterpreted https://github.com/microsoft/LightGBM/blob/76170788c4bd6239334408f88cf51183ec791fa2/docs/FAQ.rst#critical...I did my best to make this file consistent with the conventions I've observed in PRs in this project. It's very likely I have made some mistakes.

My hope is that using `CODEOWNERS` will turn something being done by convention into something being done by automation. It will, I hope, also improve the contributor experience.