### PR TITLE
[ci][docs] add OpenMPI link to ignore list

### DIFF
--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -7,6 +7,7 @@ sslverify=0
 ignore=
   public.tableau.com
   http://www.intel.com/software/products/support
+  https://www.open-mpi.org
 ignorewarnings=http-robots-denied,https-certificate-error
 
 [output]


### PR DESCRIPTION
(Temporary ?) hotfix for handshake failure for OpenMPI site.

If I'm not mistaken, `public.tableau.com` is in the list for the same reason.