### PR TITLE
[ci] downgrade conda

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ install:
   - set PATH=%MINICONDA%;%MINICONDA%\Scripts;%PATH%
   - ps: $env:LGB_VER = (Get-Content VERSION.txt).trim()
   - conda config --set always_yes yes --set changeps1 no
-  - conda update -q -y conda
+  - conda install -q -y conda=4.6.14  # temp fix, change to update later
   - conda create -q -y -n test-env python=%PYTHON_VERSION% matplotlib numpy pandas psutil pytest python-graphviz scikit-learn scipy
   - activate test-env
   - set PATH=%CONDA_PREFIX%\Library\bin\graphviz;%PATH%  # temp graphviz hotfix
@@ -44,7 +44,7 @@ test_script:
   - pytest %APPVEYOR_BUILD_FOLDER%\tests\python_package_test
   - cd %APPVEYOR_BUILD_FOLDER%\examples\python-guide
   - ps: >-
-      @("import matplotlib", "matplotlib.use('Agg')") + (Get-Content "plot_example.py") | Set-Content "plot_example.py"  # prevent interactive window mode
+      @("import matplotlib", "matplotlib.use('Agg')") +Â (Get-Content "plot_example.py") | Set-ContentÂ "plot_example.py"  # prevent interactive window mode
       (Get-Content "plot_example.py").replace('graph.render(view=True)', 'graph.render(view=False)') | Set-Content "plot_example.py"
   - ps: >-
       foreach ($file in @(Get-ChildItem *.py)) {

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -57,4 +57,4 @@ if [[ $TRAVIS == "true" ]] || [[ $OS_NAME == "macos" ]]; then
     sh conda.sh -b -p $CONDA
 fi
 conda config --set always_yes yes --set changeps1 no
-conda update -q conda
+conda install -q -y conda=4.6.14  # temp fix, change to update later

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -127,7 +127,7 @@ jobs:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Enable conda
   - script: |
-      conda update -q -y conda
+      conda install -q -y conda=4.6.14
       conda create -q -y -n %CONDA_ENV% python=%PYTHON_VERSION% matplotlib numpy pandas psutil pytest python-graphviz scikit-learn scipy
       cmd /c "activate %CONDA_ENV% & powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/test_windows.ps1"
     displayName: Test


### PR DESCRIPTION
conda 4.7 is broken completely on Windows:
```
Collecting package metadata: ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: C:\Miniconda

  added / updated specs:
    - conda


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    bzip2-1.0.6                |       hfa6e2cd_5         145 KB
    ca-certificates-2019.5.15  |                0         166 KB
    certifi-2019.6.16          |           py37_0         155 KB
    conda-4.7.5                |           py37_0         3.0 MB
    conda-package-handling-1.3.10|           py37_0         280 KB
    libarchive-3.3.3           |       h0643e63_5         1.4 MB
    libiconv-1.15              |       h1df5818_7         664 KB
    libxml2-2.9.9              |       h464c3ec_0         3.5 MB
    lz4-c-1.8.1.2              |       h2fa13f4_0         217 KB
    lzo-2.10                   |       h6df0209_2         154 KB
    openssl-1.1.1c             |       he774522_1         5.7 MB
    python-libarchive-c-2.8    |           py37_6          20 KB
    tqdm-4.32.1                |             py_0          48 KB
    xz-5.2.4                   |       h2fa13f4_4         812 KB
    zlib-1.2.11                |       h62dcd97_3         128 KB
    zstd-1.3.7                 |       h508b16e_0         536 KB
    ------------------------------------------------------------
                                           Total:        16.9 MB

The following NEW packages will be INSTALLED:

  bzip2              pkgs/main/win-64::bzip2-1.0.6-hfa6e2cd_5
  conda-package-han~ pkgs/main/win-64::conda-package-handling-1.3.10-py37_0
  libarchive         pkgs/main/win-64::libarchive-3.3.3-h0643e63_5
  libiconv           pkgs/main/win-64::libiconv-1.15-h1df5818_7
  libxml2            pkgs/main/win-64::libxml2-2.9.9-h464c3ec_0
  lz4-c              pkgs/main/win-64::lz4-c-1.8.1.2-h2fa13f4_0
  lzo                pkgs/main/win-64::lzo-2.10-h6df0209_2
  python-libarchive~ pkgs/main/win-64::python-libarchive-c-2.8-py37_6
  tqdm               pkgs/main/noarch::tqdm-4.32.1-py_0
  xz                 pkgs/main/win-64::xz-5.2.4-h2fa13f4_4
  zlib               pkgs/main/win-64::zlib-1.2.11-h62dcd97_3
  zstd               pkgs/main/win-64::zstd-1.3.7-h508b16e_0

The following packages will be UPDATED:

  ca-certificates                               2019.1.23-0 --> 2019.5.15-0
  certifi                                   2019.3.9-py37_0 --> 2019.6.16-py37_0
  conda                                       4.6.14-py37_0 --> 4.7.5-py37_0
  openssl                                 1.1.1b-he774522_1 --> 1.1.1c-he774522_1


Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
Traceback (most recent call last):
  File "C:\Miniconda\lib\site-packages\conda\exceptions.py", line 1043, in __call__
    return func(*args, **kwargs)
  File "C:\Miniconda\lib\site-packages\conda\cli\main.py", line 84, in _main
    exit_code = do_call(args, p)
  File "C:\Miniconda\lib\site-packages\conda\cli\conda_argparse.py", line 80, in do_call
    module = import_module(relative_mod, __name__.rsplit('.', 1)[0])
  File "C:\Miniconda\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "C:\Miniconda\lib\site-packages\conda\cli\main_create.py", line 10, in <module>
    from .install import install
  File "C:\Miniconda\lib\site-packages\conda\cli\install.py", line 19, in <module>
    from ..core.index import calculate_channel_urls, get_index
  File "C:\Miniconda\lib\site-packages\conda\core\index.py", line 9, in <module>
    from .package_cache_data import PackageCacheData
  File "C:\Miniconda\lib\site-packages\conda\core\package_cache_data.py", line 15, in <module>
    from conda_package_handling.api import InvalidArchiveError
  File "C:\Miniconda\lib\site-packages\conda_package_handling\api.py", line 3, in <module>
    from libarchive.exception import ArchiveError as _LibarchiveArchiveError
  File "C:\Miniconda\lib\site-packages\libarchive\__init__.py", line 1, in <module>
    from .entry import ArchiveEntry
  File "C:\Miniconda\lib\site-packages\libarchive\entry.py", line 6, in <module>
    from . import ffi
  File "C:\Miniconda\lib\site-packages\libarchive\ffi.py", line 27, in <module>
    libarchive = ctypes.cdll.LoadLibrary(libarchive_path)
  File "C:\Miniconda\lib\ctypes\__init__.py", line 434, in LoadLibrary
    return self._dlltype(name)
  File "C:\Miniconda\lib\ctypes\__init__.py", line 356, in __init__
    self._handle = _dlopen(self._name, mode)
TypeError: LoadLibrary() argument 1 must be str, not None

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Miniconda\Scripts\conda-script.py", line 12, in <module>
    sys.exit(main())
  File "C:\Miniconda\lib\site-packages\conda\cli\main.py", line 150, in main
    return conda_exception_handler(_main, *args, **kwargs)
  File "C:\Miniconda\lib\site-packages\conda\exceptions.py", line 1335, in conda_exception_handler
    return_value = exception_handler(func, *args, **kwargs)
  File "C:\Miniconda\lib\site-packages\conda\exceptions.py", line 1046, in __call__
    return self.handle_exception(exc_val, exc_tb)
  File "C:\Miniconda\lib\site-packages\conda\exceptions.py", line 1090, in handle_exception
    return self.handle_unexpected_exception(exc_val, exc_tb)
  File "C:\Miniconda\lib\site-packages\conda\exceptions.py", line 1101, in handle_unexpected_exception
    self.print_unexpected_error_report(error_report)
  File "C:\Miniconda\lib\site-packages\conda\exceptions.py", line 1171, in print_unexpected_error_report
    from .cli.main_info import get_env_vars_str, get_main_info_str
  File "C:\Miniconda\lib\site-packages\conda\cli\main_info.py", line 19, in <module>
    from ..core.index import _supplement_index_with_system
  File "C:\Miniconda\lib\site-packages\conda\core\index.py", line 9, in <module>
    from .package_cache_data import PackageCacheData
  File "C:\Miniconda\lib\site-packages\conda\core\package_cache_data.py", line 15, in <module>
    from conda_package_handling.api import InvalidArchiveError
  File "C:\Miniconda\lib\site-packages\conda_package_handling\api.py", line 7, in <module>
    from .tarball import CondaTarBZ2 as _CondaTarBZ2
  File "C:\Miniconda\lib\site-packages\conda_package_handling\tarball.py", line 7, in <module>
    import libarchive
  File "C:\Miniconda\lib\site-packages\libarchive\__init__.py", line 1, in <module>
    from .entry import ArchiveEntry
  File "C:\Miniconda\lib\site-packages\libarchive\entry.py", line 6, in <module>
    from . import ffi
  File "C:\Miniconda\lib\site-packages\libarchive\ffi.py", line 27, in <module>
    libarchive = ctypes.cdll.LoadLibrary(libarchive_path)
  File "C:\Miniconda\lib\ctypes\__init__.py", line 434, in LoadLibrary
    return self._dlltype(name)
  File "C:\Miniconda\lib\ctypes\__init__.py", line 356, in __init__
    self._handle = _dlopen(self._name, mode)
TypeError: LoadLibrary() argument 1 must be str, not None
Could not find conda environment: test-env
You can list all discoverable environments with `conda info --envs`.
```

and something related to file reading is broken on Linux:
```
=================================== FAILURES ===================================
________________________________ TestBasic.test ________________________________

self = <test_basic.TestBasic testMethod=test>
    def test(self):
>       X_train, X_test, y_train, y_test = train_test_split(*load_breast_cancer(True),
                                                            test_size=0.1, random_state=2)

../tests/python_package_test/test_basic.py:16: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../../miniconda/envs/test-env/lib/python3.6/site-packages/sklearn/datasets/base.py:456: in load_breast_cancer
    data, target, target_names = load_data(module_path, 'breast_cancer.csv')
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
module_path = '/home/travis/miniconda/envs/test-env/lib/python3.6/site-packages/sklearn/datasets'
data_file_name = 'breast_cancer.csv'

    def load_data(module_path, data_file_name):
        """Loads data from module_path/data/data_file_name.
    
        Parameters
        ----------
        module_path : string
            The module path.
    
        data_file_name : string
            Name of csv file to be loaded from
            module_path/data/data_file_name. For example 'wine_data.csv'.
    
        Returns
        -------
        data : Numpy array
            A 2D array with each row representing one sample and each column
            representing the features of a given sample.
    
        target : Numpy array
            A 1D array holding target variables for all the samples in `data.
            For example target[0] is the target varible for data[0].
    
        target_names : Numpy array
            A 1D array containing the names of the classifications. For example
            target_names[0] is the name of the target[0] class.
        """
        with open(join(module_path, 'data', data_file_name)) as csv_file:
            data_file = csv.reader(csv_file)
>           temp = next(data_file)
E           _csv.Error: line contains NULL byte
```

I have no better idea rather than pinning the last working version for all platforms.