### PR TITLE
[docs] switch name and alias of rmse metric

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -819,7 +819,7 @@ Metric Parameters
 
       -  ``l2``, square loss, aliases: ``mean_squared_error``, ``mse``, ``regression_l2``, ``regression``
 
-      -  ``l2_root``, root square loss, aliases: ``root_mean_squared_error``, ``rmse``
+      -  ``rmse``, root square loss, aliases: ``root_mean_squared_error``, ``l2_root``
 
       -  ``quantile``, `Quantile regression <https://en.wikipedia.org/wiki/Quantile_regression>`__
 

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -732,7 +732,7 @@ struct Config {
   // descl2 = ``"None"`` (string, **not** a ``None`` value) means that no metric will be registered, aliases: ``na``, ``null``, ``custom``
   // descl2 = ``l1``, absolute loss, aliases: ``mean_absolute_error``, ``mae``, ``regression_l1``
   // descl2 = ``l2``, square loss, aliases: ``mean_squared_error``, ``mse``, ``regression_l2``, ``regression``
-  // descl2 = ``l2_root``, root square loss, aliases: ``root_mean_squared_error``, ``rmse``
+  // descl2 = ``rmse``, root square loss, aliases: ``root_mean_squared_error``, ``l2_root``
   // descl2 = ``quantile``, `Quantile regression <https://en.wikipedia.org/wiki/Quantile_regression>`__
   // descl2 = ``mape``, `MAPE loss <https://en.wikipedia.org/wiki/Mean_absolute_percentage_error>`__, aliases: ``mean_absolute_percentage_error``
   // descl2 = ``huber``, `Huber loss <https://en.wikipedia.org/wiki/Huber_loss>`__


### PR DESCRIPTION
Fix real name and alias of RMSE metric in docs.
https://github.com/microsoft/LightGBM/blob/16751b3803e847592dba3bab876c4f052507e45d/src/metric/regression_metric.hpp#L132-L134

I guess this should fix this https://github.com/microsoft/LightGBM/pull/2209#discussion_r300841937.