### PR TITLE
[docs] 🎨 Sphinx Autosummary for generating Python-API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,6 +339,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/pythonapi/
 
 # Doxygen documentation
 docs/doxyoutput/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,4 +1,0 @@
-# docs-specific .gitignore
-
-# `sphinx.ext.autosummary` should output to `pythonapi/` using :toctree:
-pythonapi/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+# docs-specific .gitignore
+
+# `sphinx.ext.autosummary` should output to `pythonapi/` using :toctree:
+pythonapi/

--- a/docs/Python-API.rst
+++ b/docs/Python-API.rst
@@ -1,71 +1,56 @@
 Python API
 ==========
 
+.. currentmodule:: lightgbm
+
 Data Structure API
 ------------------
 
-.. autoclass:: lightgbm.Dataset
-    :members:
-    :show-inheritance:
+.. autosummary::
+    :toctree: pythonapi/
 
-.. autoclass:: lightgbm.Booster
-    :members:
-    :show-inheritance:
-
+    Dataset
+    Booster
 
 Training API
 ------------
 
-.. autofunction:: lightgbm.train
+.. autosummary::
+    :toctree: pythonapi/
 
-.. autofunction:: lightgbm.cv
-
+    train
+    cv
 
 Scikit-learn API
 ----------------
 
-.. autoclass:: lightgbm.LGBMModel
-    :members:
-    :inherited-members:
-    :show-inheritance:
+.. autosummary::
+    :toctree: pythonapi/
 
-.. autoclass:: lightgbm.LGBMClassifier
-    :members:
-    :inherited-members:
-    :show-inheritance:
-
-.. autoclass:: lightgbm.LGBMRegressor
-    :members:
-    :inherited-members:
-    :show-inheritance:
-
-.. autoclass:: lightgbm.LGBMRanker
-    :members:
-    :inherited-members:
-    :show-inheritance:
-
+    LGBMModel
+    LGBMClassifier
+    LGBMRegressor
+    LGBMRanker
 
 Callbacks
 ---------
 
-.. autofunction:: lightgbm.early_stopping
+.. autosummary::
+    :toctree: pythonapi/
 
-.. autofunction:: lightgbm.print_evaluation
-
-.. autofunction:: lightgbm.record_evaluation
-
-.. autofunction:: lightgbm.reset_parameter
-
+    early_stopping
+    print_evaluation
+    record_evaluation
+    reset_parameter
 
 Plotting
 --------
 
-.. autofunction:: lightgbm.plot_importance
+.. autosummary::
+    :toctree: pythonapi/
 
-.. autofunction:: lightgbm.plot_split_value_histogram
-
-.. autofunction:: lightgbm.plot_metric
-
-.. autofunction:: lightgbm.plot_tree
-
-.. autofunction:: lightgbm.create_tree_digraph
+    plot_importance
+    plot_split_value_histogram
+    plot_metric
+    plot_tree
+    create_tree_digraph

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ extensions = [
     'sphinx.ext.napoleon',
 ]
 
-autodoc_default_flags = ['members', 'inherited-members']
+autodoc_default_flags = ['members', 'inherited-members', 'show-inheritance']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -123,7 +123,7 @@ pygments_style = 'default'
 todo_include_todos = False
 
 # Both the class' and the __init__ method's docstring are concatenated and inserted.
-autoclass_content = 'both'
+autoclass_content = 'class'
 
 # -- Configuration for C API docs generation ------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ extensions = [
     'sphinx.ext.napoleon',
 ]
 
+autodoc_default_flags = ['members', 'inherited-members', 'show-inheritance']
 autodoc_default_options = {
     "members": True,
     "inherited-members": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,11 @@ extensions = [
     'sphinx.ext.napoleon',
 ]
 
-autodoc_default_flags = ['members', 'inherited-members', 'show-inheritance']
+autodoc_default_options = {
+    "members": True,
+    "inherited-members": True,
+    "show-inheritance": True,
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,13 +68,19 @@ if needs_sphinx > sphinx.__version__:
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
 ]
 
+autodoc_default_flags = ['members', 'inherited-members']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
+
+# Generate autosummary pages. Output should be set with: `:toctree: pythonapi/`
+autosummary_generate = True
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:


### PR DESCRIPTION
### Executive Summary

This replaces `autoclass/autofunction` with [sphinx autosummary](https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html) to create and paginate the Python API.

### Summary of Changes

- Add `docs/.gitignore` to not track autosummary stubs
- Add `sphinx.ext.autosummary` in `docs/conf.py`
  - Add 'members' and 'inherited-members' as default parameters
  - Add 'autosummary = True' for setting output with `:toctree:`
- Add `.. autosummary::` tags to replace `.. autoclass::` and `.. autofunction::`

### Pull Request Motivation 📝

Previously the `Python-API.rst` dumped all of the Python API onto a single page when `sphinx-build` generated html pages.

This replaces the Python-API documentation with an index listing all modules, and paginates all functions and classes onto separate pages.

In summary, this pull request:

- Requires less scrolling on the [Python-API](https://lightgbm.readthedocs.io/en/latest/Python-API.html) page
- Makes it easier to find specific pieces of the full Python documentation

### Alternatives

This could also be accomplished by creating individual pages by hand and putting `autoclass` and `autofunction` on each. Autosummary simply makes this process more scalable.

Any feedback would be appreciated. **Thank you developers!**

--- 

## Screenshots

**Before (left) and After (right) of the `Python-API.html` landing page**

<img width="2542" alt="before_after" src="https://user-images.githubusercontent.com/11916674/61896501-20a4ef00-aee3-11e9-85f5-bfa2959c5780.png">

**Training API**: `lightgbm.cv`. The `lightgbm.cv` function has its own page.

<img width="1255" alt="Screen Shot 2019-07-25 at 1 49 09 PM" src="https://user-images.githubusercontent.com/11916674/61896571-48945280-aee3-11e9-9880-0bbb4b6f33d4.png">
