### PR TITLE
[docs] updated js file attaching mechanism

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -220,4 +220,5 @@ def setup(app):
         app.connect("builder-inited", generate_doxygen_xml)
     else:
         app.add_directive('doxygenfile', IgnoredDirective)
-    app.add_javascript("js/script.js")
+    add_js_file = getattr(app, 'add_js_file', False) or app.add_javascript
+    add_js_file("js/script.js")


### PR DESCRIPTION
> Changed in version 1.8: Renamed from app.add_javascript(). And it allows keyword arguments as attributes of script tag.
  https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_js_file