### PR TITLE
[docs] limit number of files to scan for autosummary generation and reorganize conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,12 +84,11 @@ autodoc_default_options = {
 # Generate autosummary pages. Output should be set with: `:toctree: pythonapi/`
 autosummary_generate = ['Python-API.rst']
 
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# Only the class' docstring is inserted.
+autoclass_content = 'class'
 
-# The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-# source_suffix = ['.rst', '.md']
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = False
 
 # The master toctree document.
 master_doc = 'index'
@@ -123,12 +122,6 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'default'
-
-# If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = False
-
-# Both the class' and the __init__ method's docstring are concatenated and inserted.
-autoclass_content = 'class'
 
 # -- Configuration for C API docs generation ------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,11 +81,11 @@ autodoc_default_options = {
     "show-inheritance": True,
 }
 
+# Generate autosummary pages. Output should be set with: `:toctree: pythonapi/`
+autosummary_generate = ['Python-API.rst']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
-
-# Generate autosummary pages. Output should be set with: `:toctree: pythonapi/`
-autosummary_generate = True
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:


### PR DESCRIPTION
Refer to https://github.com/microsoft/LightGBM/pull/2286#issuecomment-516373439.

Before:
```
D:\Users\nekit\Downloads\LightGBM\docs>make html
Running Sphinx v1.8.5
making output directory...
[autosummary] generating autosummary for: Advanced-Topics.rst, C-API.rst, Development-Guide.rst, Experiments.rst, FAQ.rst, Features.rst, GPU-Performance.rst, GPU-Targets.rst, GPU-Tutorial.rst, GPU-Windows.rst, Installation-Guide.rst, Parallel-Learning-Guide.rst, Parameters-Tuning.rst, Parameters.rst, Python-API.rst, Python-Intro.rst, Quick-Start.rst, README.rst, gcc-Tips.rst, index.rst

...
```

Now:
```
D:\Users\nekit\Downloads\LightGBM\docs>make html
Running Sphinx v1.8.5
making output directory...
[autosummary] generating autosummary for: Python-API.rst

...
```

@hayesall Can you please give your review?

**UPD:** Also, group options in `conf.py` logically.