### PR TITLE
Bug fix: small values of max_bin cause program to crash

### DIFF
--- a/src/io/bin.cpp
+++ b/src/io/bin.cpp
@@ -192,7 +192,12 @@ namespace LightGBM {
     }
 
     if (bin_upper_bound.size() == 0) {
-      if (max_bin > 1) {
+      if (max_bin > 2) {
+        // create zero bin
+        bin_upper_bound.push_back(-kZeroThreshold);
+        bin_upper_bound.push_back(kZeroThreshold);
+      }
+      else if (max_bin > 1) {
         bin_upper_bound.push_back(kZeroThreshold);
       }
     } else {

--- a/src/io/bin.cpp
+++ b/src/io/bin.cpp
@@ -177,11 +177,10 @@ namespace LightGBM {
       left_cnt = num_distinct_values;
     }
 
-    if (left_cnt > 0) {
+    if ((left_cnt > 0) && (max_bin > 1)) {
       int left_max_bin = static_cast<int>(static_cast<double>(left_cnt_data) / (total_sample_cnt - cnt_zero) * (max_bin - 1));
       left_max_bin = std::max(1, left_max_bin);
       bin_upper_bound = GreedyFindBin(distinct_values, counts, left_cnt, left_max_bin, left_cnt_data, min_data_in_bin);
-      bin_upper_bound.back() = -kZeroThreshold;
     }
 
     int right_start = -1;
@@ -192,16 +191,27 @@ namespace LightGBM {
       }
     }
 
-    if (right_start >= 0) {
-      int right_max_bin = max_bin - 1 - static_cast<int>(bin_upper_bound.size());
-      CHECK(right_max_bin > 0);
+    if (bin_upper_bound.size() == 0) {
+      if (max_bin > 1) {
+        bin_upper_bound.push_back(kZeroThreshold);
+      }
+    } else {
+      bin_upper_bound.back() = -kZeroThreshold;
+      if (max_bin > 2) {
+        // create zero bin
+        bin_upper_bound.push_back(kZeroThreshold);
+      }
+    }
+
+    int right_max_bin = max_bin - static_cast<int>(bin_upper_bound.size());
+    if ((right_start >= 0) && (right_max_bin > 0)) {
       auto right_bounds = GreedyFindBin(distinct_values + right_start, counts + right_start,
         num_distinct_values - right_start, right_max_bin, right_cnt_data, min_data_in_bin);
-      bin_upper_bound.push_back(kZeroThreshold);
       bin_upper_bound.insert(bin_upper_bound.end(), right_bounds.begin(), right_bounds.end());
     } else {
       bin_upper_bound.push_back(std::numeric_limits<double>::infinity());
     }
+    CHECK(bin_upper_bound.size() <= max_bin);
     return bin_upper_bound;
   }
 
@@ -280,6 +290,7 @@ namespace LightGBM {
         }
       } else if (missing_type_ == MissingType::None) {
         bin_upper_bound_ = FindBinWithZeroAsOneBin(distinct_values.data(), counts.data(), num_distinct_values, max_bin, total_sample_cnt, min_data_in_bin);
+
       } else {
         bin_upper_bound_ = FindBinWithZeroAsOneBin(distinct_values.data(), counts.data(), num_distinct_values, max_bin - 1, total_sample_cnt - na_cnt, min_data_in_bin);
         bin_upper_bound_.push_back(NaN);

--- a/src/io/bin.cpp
+++ b/src/io/bin.cpp
@@ -290,7 +290,6 @@ namespace LightGBM {
         }
       } else if (missing_type_ == MissingType::None) {
         bin_upper_bound_ = FindBinWithZeroAsOneBin(distinct_values.data(), counts.data(), num_distinct_values, max_bin, total_sample_cnt, min_data_in_bin);
-
       } else {
         bin_upper_bound_ = FindBinWithZeroAsOneBin(distinct_values.data(), counts.data(), num_distinct_values, max_bin - 1, total_sample_cnt - na_cnt, min_data_in_bin);
         bin_upper_bound_.push_back(NaN);

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -921,7 +921,6 @@ class TestEngine(unittest.TestCase):
         est = lgb.train(params, lgb_x, num_boost_round=5)
         np.random.seed()  # reset seed
 
-
     def test_refit(self):
         X, y = load_breast_cancer(True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -901,6 +901,25 @@ class TestEngine(unittest.TestCase):
         est = lgb.train(params, lgb_data, num_boost_round=1)
         self.assertEqual(len(np.unique(est.predict(X))), 3)
 
+    def test_small_max_bin(self):
+        np.random.seed(0)
+        y = np.random.choice([0, 1], 100)
+        x = np.zeros((100, 1))
+        x[:30, 0] = -1
+        x[30:60, 0] = 1
+        x[60:, 0] = 2
+        params = {'objective': 'binary',
+                  'seed': 0,
+                  'min_data_in_leaf': 1,
+                  'verbose': -1,
+                  'max_bin': 2}
+        lgb_x = lgb.Dataset(x, label=y)
+        est = lgb.train(params, lgb_x, num_boost_round=5)
+        x[0, 0] = np.nan
+        params['max_bin'] = 3
+        lgb_x = lgb.Dataset(x, label=y)
+        est = lgb.train(params, lgb_x, num_boost_round=5)
+
     def test_refit(self):
         X, y = load_breast_cancer(True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -919,6 +919,8 @@ class TestEngine(unittest.TestCase):
         params['max_bin'] = 3
         lgb_x = lgb.Dataset(x, label=y)
         est = lgb.train(params, lgb_x, num_boost_round=5)
+        np.random.seed()  # reset seed
+
 
     def test_refit(self):
         X, y = load_breast_cancer(True)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -895,7 +895,7 @@ class TestEngine(unittest.TestCase):
         }
         lgb_data = lgb.Dataset(X, label=y)
         est = lgb.train(params, lgb_data, num_boost_round=1)
-        self.assertEqual(len(np.unique(est.predict(X))), 100)
+        self.assertEqual(len(np.unique(est.predict(X))), 99)
         params['max_bin_by_feature'] = [2, 100]
         lgb_data = lgb.Dataset(X, label=y)
         est = lgb.train(params, lgb_data, num_boost_round=1)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -901,25 +901,6 @@ class TestEngine(unittest.TestCase):
         est = lgb.train(params, lgb_data, num_boost_round=1)
         self.assertEqual(len(np.unique(est.predict(X))), 3)
 
-    def test_small_max_bin(self):
-        np.random.seed(0)
-        y = np.random.choice([0, 1], 100)
-        x = np.zeros((100, 1))
-        x[:30, 0] = -1
-        x[30:60, 0] = 1
-        x[60:, 0] = 2
-        params = {'objective': 'binary',
-                  'seed': 0,
-                  'min_data_in_leaf': 1,
-                  'verbose': -1,
-                  'max_bin': 2}
-        lgb_x = lgb.Dataset(x, label=y)
-        est = lgb.train(params, lgb_x, num_boost_round=5)
-        x[0, 0] = np.nan
-        params['max_bin'] = 3
-        lgb_x = lgb.Dataset(x, label=y)
-        est = lgb.train(params, lgb_x, num_boost_round=5)
-
     def test_refit(self):
         X, y = load_breast_cancer(True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)


### PR DESCRIPTION
Fixes a minor bug where setting `max_bin < 4` can cause lightgbm to crash. Below is an example to reproduce the bug. I think the problem is that in `bin.cpp`, the method `FindMaxBinWithZeroAsOneBin` sometimes attempts to create more bins than allowed by `max_bin`.

```
import numpy as np
import lightgbm as lgb

np.random.seed(0)
y = np.random.choice([0, 1], 100)
X = np.zeros((100, 1))
X[:30, 0] = -1
X[30:60, 0] = 1
X[60:, 0] = 2
X[0] = np.nan
params = {'objective': 'binary', 'seed': 0, 'min_data_in_leaf': 1, 'max_bin': 2}  # causes crash in training
#params = {'objective': 'binary', 'seed': 0, 'min_data_in_leaf': 1, 'max_bin': 3}  # works normally
lgb_x = lgb.Dataset(X, label=y)
est = lgb.train(params, lgb_x)

# another example, max_bin is 3 and X contains nan
X[0, 0] = np.nan
params = {'objective': 'binary', 'seed': 0, 'min_data_in_leaf': 1, 'max_bin': 3}  # causes crash
#params = {'objective': 'binary', 'seed': 0, 'min_data_in_leaf': 1, 'max_bin': 4}  # works
lgb_x = lgb.Dataset(X, label=y)
est = lgb.train(params, lgb_x)
```