### PR TITLE
[docs] fixed params description

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -730,7 +730,7 @@ Objective Parameters
 
 -  ``is_unbalance`` :raw-html:`<a id="is_unbalance" title="Permalink to this parameter" href="#is_unbalance">&#x1F517;&#xFE0E;</a>`, default = ``false``, type = bool, aliases: ``unbalance``, ``unbalanced_sets``
 
-   -  used only in ``binary`` and ``multiclassova``
+   -  used only in ``binary`` and ``multiclassova`` applications
 
    -  set this to ``true`` if training data are unbalanced
 
@@ -740,7 +740,7 @@ Objective Parameters
 
 -  ``scale_pos_weight`` :raw-html:`<a id="scale_pos_weight" title="Permalink to this parameter" href="#scale_pos_weight">&#x1F517;&#xFE0E;</a>`, default = ``1.0``, type = double, constraints: ``scale_pos_weight > 0.0``
 
-   -  used only in ``binary`` and ``multiclassova``
+   -  used only in ``binary`` and ``multiclassova`` applications
 
    -  weight of labels with positive class
 
@@ -756,7 +756,7 @@ Objective Parameters
 
 -  ``boost_from_average`` :raw-html:`<a id="boost_from_average" title="Permalink to this parameter" href="#boost_from_average">&#x1F517;&#xFE0E;</a>`, default = ``true``, type = bool
 
-   -  used only in ``regression``, ``binary`` and ``cross-entropy`` applications
+   -  used only in ``regression``, ``binary``, ``multiclassova`` and ``cross-entropy`` applications
 
    -  adjusts initial score to the mean of labels for faster convergence
 

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -663,14 +663,14 @@ struct Config {
   int num_class = 1;
 
   // alias = unbalance, unbalanced_sets
-  // desc = used only in ``binary`` and ``multiclassova``
+  // desc = used only in ``binary`` and ``multiclassova`` applications
   // desc = set this to ``true`` if training data are unbalanced
   // desc = **Note**: while enabling this should increase the overall performance metric of your model, it will also result in poor estimates of the individual class probabilities
   // desc = **Note**: this parameter cannot be used at the same time with ``scale_pos_weight``, choose only **one** of them
   bool is_unbalance = false;
 
   // check = >0.0
-  // desc = used only in ``binary`` and ``multiclassova``
+  // desc = used only in ``binary`` and ``multiclassova`` applications
   // desc = weight of labels with positive class
   // desc = **Note**: while enabling this should increase the overall performance metric of your model, it will also result in poor estimates of the individual class probabilities
   // desc = **Note**: this parameter cannot be used at the same time with ``is_unbalance``, choose only **one** of them
@@ -681,7 +681,7 @@ struct Config {
   // desc = parameter for the sigmoid function
   double sigmoid = 1.0;
 
-  // desc = used only in ``regression``, ``binary`` and ``cross-entropy`` applications
+  // desc = used only in ``regression``, ``binary``, ``multiclassova`` and ``cross-entropy`` applications
   // desc = adjusts initial score to the mean of labels for faster convergence
   bool boost_from_average = true;
 


### PR DESCRIPTION
Refer to https://github.com/microsoft/LightGBM/issues/2163#issuecomment-517393323.

@guolinke To be honest, I'm not sure that `pos_bagging_fraction` and `neg_bagging_fraction` are used in MultiClassOVA. It seems to me that according to the code below, `num_pos_data = 0` and `balance_bagging_cond = false` because MultiClassOVA objective doesn't override `NumPositiveData()`.
https://github.com/microsoft/LightGBM/blob/55656f27e13e35a634eb01a11493b10ca1c65c1c/src/boosting/gbdt.cpp#L728-L732

Please tell how it is actually working.