### PR TITLE
[python] Deep copy params in _update_params of DataSet

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1115,7 +1115,7 @@ class Dataset(object):
         if self.handle is not None and params is not None:
             _safe_call(_LIB.LGBM_DatasetUpdateParam(self.handle, c_str(param_dict_to_str(params))))
         if not self.params:
-            self.params = params
+            self.params = copy.deepcopy(params)
         else:
             self.params_back_up = copy.deepcopy(self.params)
             self.params.update(params)


### PR DESCRIPTION
Otherwise, it would print `basic.py:762: UserWarning: categorical_feature in param dict is overridden` when you have pandas categorical features in your train dataset. Because when updating the params for a validation data, the updated params for the train data was being used which already contains `'categorical_column'` computed.