### PR TITLE
[python] add sparsity support for new version of pandas and check Series for bad dtypes

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -78,7 +78,12 @@ def list_to_1d_numpy(data, dtype=np.float32, name='list'):
     elif is_1d_list(data):
         return np.array(data, dtype=dtype, copy=False)
     elif isinstance(data, Series):
-        return data.values.astype(dtype)
+        if _get_bad_pandas_dtypes([data.dtypes]):
+            raise ValueError('Series.dtypes must be int, float or bool')
+        if hasattr(data.values, 'values'):  # SparseArray
+            return data.values.values.astype(dtype)
+        else:
+            return data.values.astype(dtype)
     else:
         raise TypeError("Wrong type({0}) for {1}.\n"
                         "It should be list, numpy 1-D array or pandas Series".format(type(data).__name__, name))

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -257,9 +257,9 @@ def _get_bad_pandas_dtypes(dtypes):
                            'int64': 'int', 'uint8': 'int', 'uint16': 'int',
                            'uint32': 'int', 'uint64': 'int', 'bool': 'int',
                            'float16': 'float', 'float32': 'float', 'float64': 'float'}
-    bad_indices = [i for i, dtype in enumerate(dtypes) if dtype.name not in pandas_dtype_mapper
-                                                       and (not is_dtype_sparse(dtype)
-                                                            or dtype.subtype.name not in pandas_dtype_mapper)]
+    bad_indices = [i for i, dtype in enumerate(dtypes) if (dtype.name not in pandas_dtype_mapper
+                                                           and (not is_dtype_sparse(dtype)
+                                                                or dtype.subtype.name not in pandas_dtype_mapper))]
     return bad_indices
 
 

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -13,7 +13,7 @@ from tempfile import NamedTemporaryFile
 import numpy as np
 import scipy.sparse
 
-from .compat import (PANDAS_INSTALLED, DataFrame, Series,
+from .compat import (PANDAS_INSTALLED, DataFrame, Series, is_dtype_sparse,
                      DataTable,
                      decode_string, string_type,
                      integer_types, numeric_types,
@@ -252,7 +252,9 @@ def _get_bad_pandas_dtypes(dtypes):
                            'int64': 'int', 'uint8': 'int', 'uint16': 'int',
                            'uint32': 'int', 'uint64': 'int', 'bool': 'int',
                            'float16': 'float', 'float32': 'float', 'float64': 'float'}
-    bad_indices = [i for i, dtype in enumerate(dtypes) if dtype.name not in pandas_dtype_mapper]
+    bad_indices = [i for i, dtype in enumerate(dtypes) if dtype.name not in pandas_dtype_mapper
+                                                       and (not is_dtype_sparse(dtype)
+                                                            or dtype.subtype.name not in pandas_dtype_mapper)]
     return bad_indices
 
 

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -62,6 +62,7 @@ def json_default_with_numpy(obj):
 """pandas"""
 try:
     from pandas import Series, DataFrame
+    from pandas.api.types import is_sparse as is_dtype_sparse
     PANDAS_INSTALLED = True
 except ImportError:
     PANDAS_INSTALLED = False
@@ -75,6 +76,8 @@ except ImportError:
         """Dummy class for pandas.DataFrame."""
 
         pass
+
+    is_dtype_sparse = None
 
 """matplotlib"""
 try:

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -738,7 +738,12 @@ class TestEngine(unittest.TestCase):
         }
         lgb_train = lgb.Dataset(X, y)
         gbm = lgb.train(params, lgb_train, num_boost_round=10)
-        pred = gbm.predict(X_test)
+        pred_sparse = gbm.predict(X_test, raw_score=True)
+        if hasattr(X_test, 'sparse'):
+            pred_dense = gbm.predict(X_test.sparse.to_dense(), raw_score=True)
+        else:
+            pred_dense = gbm.predict(X_test.to_dense(), raw_score=True)
+        np.testing.assert_allclose(pred_sparse, pred_dense)
 
     def test_reference_chain(self):
         X = np.random.normal(size=(100, 2))

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -729,8 +729,9 @@ class TestEngine(unittest.TestCase):
         X_test = pd.DataFrame({"A": pd.SparseArray(np.random.permutation([0, 2] * 30)),
                                "B": pd.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
                                "C": pd.SparseArray(np.random.permutation([True, False] * 30))})
-        for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
-            self.assertTrue(pd.api.types.is_sparse(dtype))
+        if pd.__version__ >= '0.24.0':
+            for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
+                self.assertTrue(pd.api.types.is_sparse(dtype))
         params = {
             'objective': 'binary',
             'verbose': -1

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -719,6 +719,26 @@ class TestEngine(unittest.TestCase):
         self.assertListEqual(gbm6.pandas_categorical, cat_values)
         self.assertListEqual(gbm7.pandas_categorical, cat_values)
 
+    @unittest.skipIf(not lgb.compat.PANDAS_INSTALLED, 'pandas is not installed')
+    def test_pandas_sparse(self):
+        import pandas as pd
+        X = pd.DataFrame({"A": pd.SparseArray(np.random.permutation([0, 1, 2] * 100)),
+                          "B": pd.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
+                          "C": pd.SparseArray(np.random.permutation([True, False] * 150))})
+        y = pd.Series(pd.SparseArray(np.random.permutation([0, 1] * 150)))
+        X_test = pd.DataFrame({"A": pd.SparseArray(np.random.permutation([0, 2] * 30)),
+                               "B": pd.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
+                               "C": pd.SparseArray(np.random.permutation([True, False] * 30))})
+        for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
+            self.assertTrue(pd.api.types.is_sparse(dtype))
+        params = {
+            'objective': 'binary',
+            'verbose': -1
+        }
+        lgb_train = lgb.Dataset(X, y)
+        gbm = lgb.train(params, lgb_train, num_boost_round=10)
+        pred = gbm.predict(X_test)
+
     def test_reference_chain(self):
         X = np.random.normal(size=(100, 2))
         y = np.random.normal(size=100)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -277,6 +277,21 @@ class TestSklearn(unittest.TestCase):
         self.assertListEqual(gbm5.booster_.pandas_categorical, cat_values)
         self.assertListEqual(gbm6.booster_.pandas_categorical, cat_values)
 
+    @unittest.skipIf(not lgb.compat.PANDAS_INSTALLED, 'pandas is not installed')
+    def test_pandas_sparse(self):
+        import pandas as pd
+        X = pd.DataFrame({"A": pd.SparseArray(np.random.permutation([0, 1, 2] * 100)),
+                          "B": pd.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
+                          "C": pd.SparseArray(np.random.permutation([True, False] * 150))})
+        y = pd.Series(pd.SparseArray(np.random.permutation([0, 1] * 150)))
+        X_test = pd.DataFrame({"A": pd.SparseArray(np.random.permutation([0, 2] * 30)),
+                               "B": pd.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
+                               "C": pd.SparseArray(np.random.permutation([True, False] * 30))})
+        for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
+            self.assertTrue(pd.api.types.is_sparse(dtype))
+        gbm = lgb.sklearn.LGBMClassifier().fit(X, y)
+        pred = gbm.predict(X_test)
+
     def test_predict(self):
         iris = load_iris()
         X_train, X_test, y_train, y_test = train_test_split(iris.data, iris.target,

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -287,8 +287,9 @@ class TestSklearn(unittest.TestCase):
         X_test = pd.DataFrame({"A": pd.SparseArray(np.random.permutation([0, 2] * 30)),
                                "B": pd.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
                                "C": pd.SparseArray(np.random.permutation([True, False] * 30))})
-        for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
-            self.assertTrue(pd.api.types.is_sparse(dtype))
+        if pd.__version__ >= '0.24.0':
+            for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
+                self.assertTrue(pd.api.types.is_sparse(dtype))
         gbm = lgb.sklearn.LGBMClassifier().fit(X, y)
         pred = gbm.predict(X_test)
 

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -291,7 +291,12 @@ class TestSklearn(unittest.TestCase):
             for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
                 self.assertTrue(pd.api.types.is_sparse(dtype))
         gbm = lgb.sklearn.LGBMClassifier().fit(X, y)
-        pred = gbm.predict(X_test)
+        pred_sparse = gbm.predict(X_test, raw_score=True)
+        if hasattr(X_test, 'sparse'):
+            pred_dense = gbm.predict(X_test.sparse.to_dense(), raw_score=True)
+        else:
+            pred_dense = gbm.predict(X_test.to_dense(), raw_score=True)
+        np.testing.assert_allclose(pred_sparse, pred_dense)
 
     def test_predict(self):
         iris = load_iris()


### PR DESCRIPTION
Fixed #2143.

I guess there are more smart and efficient solutions, like converting to scipy, but according to that https://github.com/pandas-dev/pandas/issues/21978 was closed on Oct 13 2018 and @drkarthi raised the issue only on May 1 2019 (and the lack of comments for more than 2 months), pandas sparse features seems to be not very popular and it's not worth to implement something more smart.