### PR TITLE
normalize the lambdas in lambdamart objective

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -802,7 +802,7 @@ Objective Parameters
 
    -  optimizes `NDCG <https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Normalized_DCG>`__ at this position
 
--  ``lambdamart_norm`` :raw-html:`<a id="lambdamart_norm" title="Permalink to this parameter" href="#lambdamart_norm">&#x1F517;&#xFE0E;</a>`, default = ``false``, type = bool
+-  ``lambdamart_norm`` :raw-html:`<a id="lambdamart_norm" title="Permalink to this parameter" href="#lambdamart_norm">&#x1F517;&#xFE0E;</a>`, default = ``true``, type = bool
 
    -  used only in ``lambdarank`` application
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -802,6 +802,12 @@ Objective Parameters
 
    -  optimizes `NDCG <https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Normalized_DCG>`__ at this position
 
+-  ``lambdamart_norm`` :raw-html:`<a id="lambdamart_norm" title="Permalink to this parameter" href="#lambdamart_norm">&#x1F517;&#xFE0E;</a>`, default = ``true``, type = bool
+
+   -  set this to ``true`` to normalize the lambdas for different queries, and improve the performance of unbalanced data
+
+   -  set this to ``false`` to enforce the original lambdamart algorithm
+
 -  ``label_gain`` :raw-html:`<a id="label_gain" title="Permalink to this parameter" href="#label_gain">&#x1F517;&#xFE0E;</a>`, default = ``0,1,3,7,15,31,63,...,2^30-1``, type = multi-double
 
    -  used only in ``lambdarank`` application

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -806,7 +806,7 @@ Objective Parameters
 
    -  used only in ``lambdarank`` application
 
-   -  set this to ``true`` to normalize the lambdas for different queries, and improve the performance of unbalanced data
+   -  set this to ``true`` to normalize the lambdas for different queries, and improve the performance for unbalanced data
 
    -  set this to ``false`` to enforce the original lambdamart algorithm
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -804,6 +804,8 @@ Objective Parameters
 
 -  ``lambdamart_norm`` :raw-html:`<a id="lambdamart_norm" title="Permalink to this parameter" href="#lambdamart_norm">&#x1F517;&#xFE0E;</a>`, default = ``false``, type = bool
 
+   -  used only in ``lambdarank`` application
+
    -  set this to ``true`` to normalize the lambdas for different queries, and improve the performance of unbalanced data
 
    -  set this to ``false`` to enforce the original lambdamart algorithm

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -802,7 +802,7 @@ Objective Parameters
 
    -  optimizes `NDCG <https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Normalized_DCG>`__ at this position
 
--  ``lambdamart_norm`` :raw-html:`<a id="lambdamart_norm" title="Permalink to this parameter" href="#lambdamart_norm">&#x1F517;&#xFE0E;</a>`, default = ``true``, type = bool
+-  ``lambdamart_norm`` :raw-html:`<a id="lambdamart_norm" title="Permalink to this parameter" href="#lambdamart_norm">&#x1F517;&#xFE0E;</a>`, default = ``false``, type = bool
 
    -  set this to ``true`` to normalize the lambdas for different queries, and improve the performance of unbalanced data
 

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -721,7 +721,7 @@ struct Config {
   // desc = used only in ``lambdarank`` application
   // desc = set this to ``true`` to normalize the lambdas for different queries, and improve the performance of unbalanced data
   // desc = set this to ``false`` to enforce the original lambdamart algorithm
-  bool lambdamart_norm = false;
+  bool lambdamart_norm = true;
 
   // type = multi-double
   // default = 0,1,3,7,15,31,63,...,2^30-1

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -719,7 +719,7 @@ struct Config {
   int max_position = 20;
 
   // desc = used only in ``lambdarank`` application
-  // desc = set this to ``true`` to normalize the lambdas for different queries, and improve the performance of unbalanced data
+  // desc = set this to ``true`` to normalize the lambdas for different queries, and improve the performance for unbalanced data
   // desc = set this to ``false`` to enforce the original lambdamart algorithm
   bool lambdamart_norm = true;
 

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -718,6 +718,10 @@ struct Config {
   // desc = optimizes `NDCG <https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Normalized_DCG>`__ at this position
   int max_position = 20;
 
+  // desc = set this to ``true`` to normalize the lambdas for different queries, and improve the performance of unbalanced data
+  // desc = set this to ``false`` to enforce the original lambdamart algorithm
+  bool lambdamart_norm = true;
+
   // type = multi-double
   // default = 0,1,3,7,15,31,63,...,2^30-1
   // desc = used only in ``lambdarank`` application

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -720,7 +720,7 @@ struct Config {
 
   // desc = set this to ``true`` to normalize the lambdas for different queries, and improve the performance of unbalanced data
   // desc = set this to ``false`` to enforce the original lambdamart algorithm
-  bool lambdamart_norm = true;
+  bool lambdamart_norm = false;
 
   // type = multi-double
   // default = 0,1,3,7,15,31,63,...,2^30-1

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -718,6 +718,7 @@ struct Config {
   // desc = optimizes `NDCG <https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Normalized_DCG>`__ at this position
   int max_position = 20;
 
+  // desc = used only in ``lambdarank`` application
   // desc = set this to ``true`` to normalize the lambdas for different queries, and improve the performance of unbalanced data
   // desc = set this to ``false`` to enforce the original lambdamart algorithm
   bool lambdamart_norm = false;

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -264,6 +264,7 @@ std::unordered_set<std::string> Config::parameter_set({
   "poisson_max_delta_step",
   "tweedie_variance_power",
   "max_position",
+  "lambdamart_norm",
   "label_gain",
   "metric",
   "metric_freq",
@@ -530,6 +531,8 @@ void Config::GetMembersFromString(const std::unordered_map<std::string, std::str
   GetInt(params, "max_position", &max_position);
   CHECK(max_position >0);
 
+  GetBool(params, "lambdamart_norm", &lambdamart_norm);
+
   if (GetString(params, "label_gain", &tmp_str)) {
     label_gain = Common::StringToArray<double>(tmp_str, ',');
   }
@@ -661,6 +664,7 @@ std::string Config::SaveMembersToString() const {
   str_buf << "[poisson_max_delta_step: " << poisson_max_delta_step << "]\n";
   str_buf << "[tweedie_variance_power: " << tweedie_variance_power << "]\n";
   str_buf << "[max_position: " << max_position << "]\n";
+  str_buf << "[lambdamart_norm: " << lambdamart_norm << "]\n";
   str_buf << "[label_gain: " << Common::Join(label_gain, ",") << "]\n";
   str_buf << "[metric_freq: " << metric_freq << "]\n";
   str_buf << "[is_provide_training_metric: " << is_provide_training_metric << "]\n";

--- a/src/objective/rank_objective.hpp
+++ b/src/objective/rank_objective.hpp
@@ -107,11 +107,11 @@ class LambdarankNDCG: public ObjectiveFunction {
                      [score](data_size_t a, data_size_t b) { return score[a] > score[b]; });
     // get best and worst score	
     const double best_score = score[sorted_idx[0]];
-    data_size_t wrost_idx = cnt - 1;
-    if (wrost_idx > 0 && score[sorted_idx[wrost_idx]] == kMinScore) {
-      wrost_idx -= 1;
+    data_size_t worst_idx = cnt - 1;
+    if (worst_idx > 0 && score[sorted_idx[worst_idx]] == kMinScore) {
+      worst_idx -= 1;
     }
-    const double wrost_score = score[sorted_idx[wrost_idx]];
+    const double worst_score = score[sorted_idx[worst_idx]];
     double sum_lambdas = 0.0;
     // start accmulate lambdas by pairs
     for (data_size_t i = 0; i < cnt; ++i) {
@@ -144,7 +144,7 @@ class LambdarankNDCG: public ObjectiveFunction {
         // get delta NDCG
         double delta_pair_NDCG = dcg_gap * paired_discount * inverse_max_dcg;
         // regular the delta_pair_NDCG by score distance	
-        if (norm_ && high_label != low_label && best_score != wrost_score) {
+        if (norm_ && high_label != low_label && best_score != worst_score) {
           delta_pair_NDCG /= (0.01f + fabs(delta_score));
         }
         // calculate lambda for this pair

--- a/src/objective/rank_objective.hpp
+++ b/src/objective/rank_objective.hpp
@@ -107,11 +107,11 @@ class LambdarankNDCG: public ObjectiveFunction {
                      [score](data_size_t a, data_size_t b) { return score[a] > score[b]; });
     // get best and worst score	
     const double best_score = score[sorted_idx[0]];
-    data_size_t worst_idx = cnt - 1;
-    if (worst_idx > 0 && score[sorted_idx[worst_idx]] == kMinScore) {
-      worst_idx -= 1;
+    data_size_t wrost_idx = cnt - 1;
+    if (wrost_idx > 0 && score[sorted_idx[wrost_idx]] == kMinScore) {
+      wrost_idx -= 1;
     }
-    const double wrost_score = score[sorted_idx[worst_idx]];
+    const double wrost_score = score[sorted_idx[wrost_idx]];
     double sum_lambdas = 0.0;
     // start accmulate lambdas by pairs
     for (data_size_t i = 0; i < cnt; ++i) {

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -82,7 +82,7 @@ class TestSklearn(unittest.TestCase):
                 eval_group=[q_test], eval_at=[1, 3], early_stopping_rounds=10, verbose=False,
                 callbacks=[lgb.reset_parameter(learning_rate=lambda x: max(0.01, 0.1 - 0.01 * x))])
         self.assertLessEqual(gbm.best_iteration_, 25)
-        self.assertGreater(gbm.best_score_['valid_0']['ndcg@1'], 0.65)
+        self.assertGreater(gbm.best_score_['valid_0']['ndcg@1'], 0.63)
         self.assertGreater(gbm.best_score_['valid_0']['ndcg@3'], 0.65)
 
     def test_regression_with_custom_objective(self):

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -80,7 +80,7 @@ class TestSklearn(unittest.TestCase):
         gbm = lgb.LGBMRanker()
         gbm.fit(X_train, y_train, group=q_train, eval_set=[(X_test, y_test)],
                 eval_group=[q_test], eval_at=[1, 3], early_stopping_rounds=10, verbose=False,
-                callbacks=[lgb.reset_parameter(learning_rate=lambda x: max(0.01, 0.1 - 0.01x))])
+                callbacks=[lgb.reset_parameter(learning_rate=lambda x: max(0.01, 0.1 - 0.01 * x))])
         self.assertLessEqual(gbm.best_iteration_, 12)
         self.assertGreater(gbm.best_score_['valid_0']['ndcg@1'], 0.6173)
         self.assertGreater(gbm.best_score_['valid_0']['ndcg@3'], 0.6479)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -82,8 +82,8 @@ class TestSklearn(unittest.TestCase):
                 eval_group=[q_test], eval_at=[1, 3], early_stopping_rounds=10, verbose=False,
                 callbacks=[lgb.reset_parameter(learning_rate=lambda x: max(0.01, 0.1 - 0.01 * x))])
         self.assertLessEqual(gbm.best_iteration_, 25)
-        self.assertGreater(gbm.best_score_['valid_0']['ndcg@1'], 0.63)
-        self.assertGreater(gbm.best_score_['valid_0']['ndcg@3'], 0.65)
+        self.assertGreater(gbm.best_score_['valid_0']['ndcg@1'], 0.6333)
+        self.assertGreater(gbm.best_score_['valid_0']['ndcg@3'], 0.6048)
 
     def test_regression_with_custom_objective(self):
         def objective_ls(y_true, y_pred):

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -82,8 +82,8 @@ class TestSklearn(unittest.TestCase):
                 eval_group=[q_test], eval_at=[1, 3], early_stopping_rounds=10, verbose=False,
                 callbacks=[lgb.reset_parameter(learning_rate=lambda x: max(0.01, 0.1 - 0.01 * x))])
         self.assertLessEqual(gbm.best_iteration_, 25)
-        self.assertGreater(gbm.best_score_['valid_0']['ndcg@1'], 0.6173)
-        self.assertGreater(gbm.best_score_['valid_0']['ndcg@3'], 0.6479)
+        self.assertGreater(gbm.best_score_['valid_0']['ndcg@1'], 0.60)
+        self.assertGreater(gbm.best_score_['valid_0']['ndcg@3'], 0.60)
 
     def test_regression_with_custom_objective(self):
         def objective_ls(y_true, y_pred):

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -81,7 +81,7 @@ class TestSklearn(unittest.TestCase):
         gbm.fit(X_train, y_train, group=q_train, eval_set=[(X_test, y_test)],
                 eval_group=[q_test], eval_at=[1, 3], early_stopping_rounds=10, verbose=False,
                 callbacks=[lgb.reset_parameter(learning_rate=lambda x: max(0.01, 0.1 - 0.01 * x))])
-        self.assertLessEqual(gbm.best_iteration_, 12)
+        self.assertLessEqual(gbm.best_iteration_, 25)
         self.assertGreater(gbm.best_score_['valid_0']['ndcg@1'], 0.6173)
         self.assertGreater(gbm.best_score_['valid_0']['ndcg@3'], 0.6479)
 

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -79,7 +79,7 @@ class TestSklearn(unittest.TestCase):
                                          '../../examples/lambdarank/rank.test.query'))
         gbm = lgb.LGBMRanker()
         gbm.fit(X_train, y_train, group=q_train, eval_set=[(X_test, y_test)],
-                eval_group=[q_test], eval_at=[1, 3], early_stopping_rounds=5, verbose=False,
+                eval_group=[q_test], eval_at=[1, 3], early_stopping_rounds=10, verbose=False,
                 callbacks=[lgb.reset_parameter(learning_rate=lambda x: 0.95 ** x * 0.1)])
         self.assertLessEqual(gbm.best_iteration_, 12)
         self.assertGreater(gbm.best_score_['valid_0']['ndcg@1'], 0.6173)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -80,7 +80,7 @@ class TestSklearn(unittest.TestCase):
         gbm = lgb.LGBMRanker()
         gbm.fit(X_train, y_train, group=q_train, eval_set=[(X_test, y_test)],
                 eval_group=[q_test], eval_at=[1, 3], early_stopping_rounds=10, verbose=False,
-                callbacks=[lgb.reset_parameter(learning_rate=lambda x: 0.95 ** x * 0.1)])
+                callbacks=[lgb.reset_parameter(learning_rate=lambda x: max(0.01, 0.1 - 0.01x))])
         self.assertLessEqual(gbm.best_iteration_, 12)
         self.assertGreater(gbm.best_score_['valid_0']['ndcg@1'], 0.6173)
         self.assertGreater(gbm.best_score_['valid_0']['ndcg@3'], 0.6479)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -82,8 +82,8 @@ class TestSklearn(unittest.TestCase):
                 eval_group=[q_test], eval_at=[1, 3], early_stopping_rounds=10, verbose=False,
                 callbacks=[lgb.reset_parameter(learning_rate=lambda x: max(0.01, 0.1 - 0.01 * x))])
         self.assertLessEqual(gbm.best_iteration_, 25)
-        self.assertGreater(gbm.best_score_['valid_0']['ndcg@1'], 0.60)
-        self.assertGreater(gbm.best_score_['valid_0']['ndcg@3'], 0.60)
+        self.assertGreater(gbm.best_score_['valid_0']['ndcg@1'], 0.65)
+        self.assertGreater(gbm.best_score_['valid_0']['ndcg@3'], 0.65)
 
     def test_regression_with_custom_objective(self):
         def objective_ls(y_true, y_pred):


### PR DESCRIPTION
- [x] benchmark

benchmark run by https://github.com/guolinke/boosting_tree_benchmarks

ndcg at Yahoo LTR:

| Metric      | original | norm |
|----|  ----| ---- | 
| ndcg@1|0.72757|0.732981|
| ndcg@3|0.731267|0.735689|
| ndcg@5|0.750774|0.75352|
| ndcg@10|0.791388|0.793498|

ndcg at Yahoo LTR:

| Metric      | original | norm |
|----|  ----| ---- | 
| ndcg@1|0.512893|0.519751|
| ndcg@3|0.50118|0.499677|
| ndcg@5|0.505995|0.5058|
| ndcg@10|0.524724|0.524123|

