### PR TITLE
[R-package] fixed overly-strict compiler check in install.libs.R (fixes #2259)

### DIFF
--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -45,8 +45,16 @@ if (!use_precompile) {
   }
 
   # Could NOT find OpenMP_C on Mojave workaround
-  using_gcc <- grepl('gcc', Sys.getenv('CC', ''))
-  using_gpp <- grepl('g\\+\\+', Sys.getenv('CXX', ''))
+  # Using this kind-of complicated pattern to avoid matching to
+  # things like "pgcc"
+  using_gcc <- grepl(
+    pattern = '^gcc$|[/\\]+gcc|^gcc\\-[0-9]+$|[/\\]+gcc\\-[0-9]+$'
+    , x = Sys.getenv('CC', '')
+  )
+  using_gpp <- grepl(
+    pattern = '^g\\+\\+$|[/\\]+g\\+\\+|^g\\+\\+\\-[0-9]+$|[/\\]+g\\+\\+\\-[0-9]+$'
+    , x = Sys.getenv('CXX', '')
+  )
   on_mac <- Sys.info()['sysname'] == 'Darwin'
   if (on_mac && !(using_gcc & using_gpp)) {
     cmake_cmd <- paste(cmake_cmd, ' -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp -I$(brew --prefix libomp)/include" ')

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -45,7 +45,10 @@ if (!use_precompile) {
   }
 
   # Could NOT find OpenMP_C on Mojave workaround
-  if (Sys.info()['sysname'] == 'Darwin' && !(grepl('^gcc', Sys.getenv('CC', '')) & grepl('^g\\+\\+', Sys.getenv('CXX', '')))) {
+  using_gcc <- grepl('gcc', Sys.getenv('CC', ''))
+  using_gpp <- grepl('g\\+\\+', Sys.getenv('CXX', ''))
+  on_mac <- Sys.info()['sysname'] == 'Darwin'
+  if (on_mac && !(using_gcc & using_gpp)) {
     cmake_cmd <- paste(cmake_cmd, ' -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp -I$(brew --prefix libomp)/include" ')
     cmake_cmd <- paste(cmake_cmd, ' -DOpenMP_C_LIB_NAMES="omp" ')
     cmake_cmd <- paste(cmake_cmd, ' -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp -I$(brew --prefix libomp)/include" ')


### PR DESCRIPTION
As of #2164 , the R package picked up a fix in `install.libs.R` that handles difficulty finding OpenMP stuff when building on Mac OS Mojave.

Per discussion on #2259 , we found that that fix only works if environment variable `CC` is set to something that literally starts with `gcc` (and the same with `CXX` and `g++`). That could cause build failures if you pass a fully-qualified path like `CXX=/usr/local/bin/g++-8`. Thanks to @brandenkmurray for the help identifying that as the problem!

In this PR, I relax that check so that both `g++-8`, `g++`, and `/some/path/to/g++-8` will all work. I did not take an opinion on the versions of `g++` that are known to work with `lightgbm` (as suggested in [this comment](https://github.com/microsoft/LightGBM/issues/2259#issuecomment-522330822))  as I think that would increase our maintenance burden by duplicating the number of places that is specified.

I tested that this works (lucky for us I'm running Mojave 10.14.5 on my laptop) and can confirm it's fixed. Code to test that it worked:

```bash
export CC=gcc-8 CXX=g++-8
Rscript build_r.R
```

```bash
export CXX=/usr/local/bin/g++-8 CC=/usr/local/bin/gcc-8
Rscript build_r.R
```