### PR TITLE
[python] correctly handle full path to compiler in CC and CXX env vars

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -168,8 +168,8 @@ def compile_cpp(use_mingw=False, use_gpu=False, use_mpi=False,
     else:  # Linux, Darwin (macOS), etc.
         logger.info("Starting to compile with CMake.")
         # Apple Clang with OpenMP
-        if system() == 'Darwin' and not nomp and not (os.environ.get('CC', '').startswith('gcc')
-                                                      and os.environ.get('CXX', '').startswith('g++')):
+        if system() == 'Darwin' and not nomp and not (os.environ.get('CC', '').split('/')[-1].split('\\')[-1].startswith('gcc')
+                                                      and os.environ.get('CXX', '').split('/')[-1].split('\\')[-1].startswith('g++')):
             def get_cmake_opts(openmp_include_dir, openmp_library):
                 if openmp_include_dir and openmp_library:
                     return ['-DOpenMP_C_FLAGS=-Xpreprocessor -fopenmp -I{0}'.format(openmp_include_dir),


### PR DESCRIPTION
For instance, `CC` can be `/usr/bin/gcc`. Refer to #2339.



@jameslamb Seems that the regex from #2339 for R-package will produce false positive result for something like `C:/Users/gccharlee/pgcc-8` (any **intermediate folder name** which starts with `gcc`).