### PR TITLE
fixed compiler check regex in install.libs.R

### DIFF
--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -48,11 +48,11 @@ if (!use_precompile) {
   # Using this kind-of complicated pattern to avoid matching to
   # things like "pgcc"
   using_gcc <- grepl(
-    pattern = '^gcc$|[/\\]+gcc|^gcc\\-[0-9]+$|[/\\]+gcc\\-[0-9]+$'
+    pattern = '^gcc$|[/\\]+gcc$|^gcc\\-[0-9]+$|[/\\]+gcc\\-[0-9]+$'
     , x = Sys.getenv('CC', '')
   )
   using_gpp <- grepl(
-    pattern = '^g\\+\\+$|[/\\]+g\\+\\+|^g\\+\\+\\-[0-9]+$|[/\\]+g\\+\\+\\-[0-9]+$'
+    pattern = '^g\\+\\+$|[/\\]+g\\+\\+$|^g\\+\\+\\-[0-9]+$|[/\\]+g\\+\\+\\-[0-9]+$'
     , x = Sys.getenv('CXX', '')
   )
   on_mac <- Sys.info()['sysname'] == 'Darwin'


### PR DESCRIPTION
As @StrikerRUS noted on #2345 , the regex change I made in #2339 misses cases where `gcc` or `g++` is matched in an intermediate directory name like `C:/Users/gccharlee/pgcc-8`.

This PR fixes that.