### PR TITLE
[python] error on nan in y for DataFrames

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -525,7 +525,7 @@ class LGBMModel(_LGBMModelBase):
             eval_metric = [eval_metric] if isinstance(eval_metric, (string_type, type(None))) else eval_metric
             params['metric'] = set(original_metric + eval_metric)
 
-        if not isinstance(X, (DataFrame, DataTable)):
+        if not isinstance(X, DataTable):
             _X, _y = _LGBMCheckXY(X, y, accept_sparse=True, force_all_finite=False, ensure_min_samples=2)
             _LGBMCheckConsistentLength(_X, _y, sample_weight)
         else:


### PR DESCRIPTION
I noticed that passing in a Pandas Series with a NaN will result in a model that only predicts 0s rather than an error or warning because CheckXY is only being run when X is a numpy array. The `sklearn.utils.validation.check_array` function being called is compatible with a DataFrame/Series as input, so it seemed reasonable to run the same check when X is a DataFrame as when X is an array.

Previous behavior:
```python
import numpy as np
import lightgbm as lgb
import pandas as pd

X = pd.DataFrame(np.array([0, np.nan, 0, 1, 1]).reshape(-1, 1))
y = pd.Series(np.array([0, np.nan, 0, 1, 1]))

gbdt = lgb.LGBMRegressor(n_estimators=1, min_child_samples=1)
print(gbdt.fit(X, y).predict(X))
```
>>> [0.0 0.0 0.0 0.0 0.0]

Now this throws a `ValueError`
