### PR TITLE
[java][mmlspark] Fix cached predictor causing bad values for predicted probabilities

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -72,7 +72,7 @@ class SingleRowPredictor {
     early_stop_margin_ = config.pred_early_stop_margin;
     iter_ = iter;
     predictor_.reset(new Predictor(&boosting, iter_, is_raw_score, is_predict_leaf, predict_contrib,
-				   early_stop_, early_stop_freq_, early_stop_margin_));
+                                   early_stop_, early_stop_freq_, early_stop_margin_));
     num_pred_in_one_row = boosting.NumPredictOneRow(iter_, is_predict_leaf, predict_contrib);
     predict_function = predictor_->GetPredictFunction();
     num_total_model_ = boosting.NumberOfTotalModel();
@@ -255,9 +255,9 @@ class Booster {
                double* out_result, int64_t* out_len) {
     std::lock_guard<std::mutex> lock(mutex_);
     if (single_row_predictor_[predict_type].get() == nullptr ||
-	!single_row_predictor_[predict_type]->IsPredictorEqual(config, num_iteration, *boosting_.get())) {
+        !single_row_predictor_[predict_type]->IsPredictorEqual(config, num_iteration, *boosting_.get())) {
       single_row_predictor_[predict_type].reset(new SingleRowPredictor(predict_type, *boosting_.get(),
-								       config, num_iteration));
+                                                                       config, num_iteration));
     }
 
     auto one_row = get_row_fun(0);

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -48,6 +48,53 @@ return 0;
 
 const int PREDICTOR_TYPES = 4;
 
+// Single row predictor to abstract away caching logic
+class SingleRowPredictor {
+ public:
+  PredictFunction predict_function;
+  int64_t num_pred_in_one_row;
+
+  SingleRowPredictor(int predict_type, Boosting& boosting, const Config& config, int iter) {
+    bool is_predict_leaf = false;
+    bool is_raw_score = false;
+    bool predict_contrib = false;
+    if (predict_type == C_API_PREDICT_LEAF_INDEX) {
+      is_predict_leaf = true;
+    } else if (predict_type == C_API_PREDICT_RAW_SCORE) {
+      is_raw_score = true;
+    } else if (predict_type == C_API_PREDICT_CONTRIB) {
+      predict_contrib = true;
+    } else {
+      is_raw_score = false;
+    }
+    early_stop_ = config.pred_early_stop;
+    early_stop_freq_ = config.pred_early_stop_freq;
+    early_stop_margin_ = config.pred_early_stop_margin;
+    iter_ = iter;
+    predictor_.reset(new Predictor(&boosting, iter_, is_raw_score, is_predict_leaf, predict_contrib,
+				   early_stop_, early_stop_freq_, early_stop_margin_));
+    num_pred_in_one_row = boosting.NumPredictOneRow(iter_, is_predict_leaf, predict_contrib);
+    predict_function = predictor_->GetPredictFunction();
+    num_total_model_ = boosting.NumberOfTotalModel();
+  }
+  ~SingleRowPredictor() {}
+  bool IsPredictorEqual(const Config& config, int iter, Boosting& boosting) {
+    return early_stop_ != config.pred_early_stop ||
+      early_stop_freq_ != config.pred_early_stop_freq ||
+      early_stop_margin_ != config.pred_early_stop_margin ||
+      iter_ != iter ||
+      num_total_model_ != boosting.NumberOfTotalModel();
+  }
+  
+ private:
+  std::unique_ptr<Predictor> predictor_;
+  bool early_stop_;
+  int early_stop_freq_;
+  double early_stop_margin_;
+  int iter_;
+  int num_total_model_;
+};
+
 class Booster {
  public:
   explicit Booster(const char* filename) {
@@ -208,39 +255,16 @@ class Booster {
                double* out_result, int64_t* out_len) {
     std::lock_guard<std::mutex> lock(mutex_);
     if (single_row_predictor_[predict_type].get() == nullptr ||
-	single_row_predictor_pred_early_stop[predict_type] != config.pred_early_stop ||
-	single_row_predictor_pred_early_stop_freq[predict_type] != config.pred_early_stop_freq ||
-	single_row_predictor_pred_early_stop_margin[predict_type] != config.pred_early_stop_margin ||
-	single_row_predictor_iter_[predict_type] != num_iteration) {
-      single_row_predictor_iter_[predict_type] = num_iteration;
-      single_row_predictor_pred_early_stop[predict_type] = config.pred_early_stop;
-      single_row_predictor_pred_early_stop_freq[predict_type] = config.pred_early_stop_freq;
-      single_row_predictor_pred_early_stop_margin[predict_type] = config.pred_early_stop_margin;
-      bool is_predict_leaf = false;
-      bool is_raw_score = false;
-      bool predict_contrib = false;
-      if (predict_type == C_API_PREDICT_LEAF_INDEX) {
-        is_predict_leaf = true;
-      } else if (predict_type == C_API_PREDICT_RAW_SCORE) {
-        is_raw_score = true;
-      } else if (predict_type == C_API_PREDICT_CONTRIB) {
-        predict_contrib = true;
-      } else {
-        is_raw_score = false;
-      }
-
-      // TODO(eisber): config could be optimized away... (maybe using lambda callback?)
-      single_row_predictor_[predict_type].reset(new Predictor(boosting_.get(), num_iteration, is_raw_score, is_predict_leaf, predict_contrib,
-                                                config.pred_early_stop, config.pred_early_stop_freq, config.pred_early_stop_margin));
-      single_row_num_pred_in_one_row_[predict_type] = boosting_->NumPredictOneRow(num_iteration, is_predict_leaf, predict_contrib);
-      single_row_predict_function_[predict_type] = single_row_predictor_[predict_type]->GetPredictFunction();
+	!single_row_predictor_[predict_type]->IsPredictorEqual(config, num_iteration, *boosting_.get())) {
+      single_row_predictor_[predict_type].reset(new SingleRowPredictor(predict_type, *boosting_.get(),
+								       config, num_iteration));
     }
 
     auto one_row = get_row_fun(0);
     auto pred_wrt_ptr = out_result;
-    single_row_predict_function_[predict_type](one_row, pred_wrt_ptr);
+    single_row_predictor_[predict_type]->predict_function(one_row, pred_wrt_ptr);
 
-    *out_len = single_row_num_pred_in_one_row_[predict_type];
+    *out_len = single_row_predictor_[predict_type]->num_pred_in_one_row;
   }
 
 
@@ -373,13 +397,7 @@ class Booster {
  private:
   const Dataset* train_data_;
   std::unique_ptr<Boosting> boosting_;
-  std::unique_ptr<Predictor> single_row_predictor_[PREDICTOR_TYPES];
-  bool single_row_predictor_pred_early_stop[PREDICTOR_TYPES];
-  int single_row_predictor_pred_early_stop_freq[PREDICTOR_TYPES];
-  double single_row_predictor_pred_early_stop_margin[PREDICTOR_TYPES];
-  int single_row_predictor_iter_[PREDICTOR_TYPES];
-  PredictFunction single_row_predict_function_[PREDICTOR_TYPES];
-  int64_t single_row_num_pred_in_one_row_[PREDICTOR_TYPES];
+  std::unique_ptr<SingleRowPredictor> single_row_predictor_[PREDICTOR_TYPES];
 
   /*! \brief All configs */
   Config config_;


### PR DESCRIPTION
In mmlspark, the predictied probabilities column was appearing the same as raw predicted values when both columns were computed from the model.  This is due to a caching bug in the native code logic that was recently added.  I added an array of predictors, one for each type, to fix the caching bug - and also added some additional checks in case the cached predictor needs to be reinitialized (not used by mmlspark directly).