### PR TITLE
[java][mmlspark] fix lightgbm swig wrapper on windows

### DIFF
--- a/swig/lightgbmlib.i
+++ b/swig/lightgbmlib.i
@@ -17,6 +17,7 @@
 %include "various.i"
 %include "carrays.i"
 %include "cpointer.i"
+%include "stdint.i"
 
 /* Note: instead of using array_functions for string array we apply a typemap instead.
    Future char** parameter names should be added to the typemap.


### PR DESCRIPTION
part of fix for https://github.com/Azure/mmlspark/issues/483
specifically, we should be using int64_t directly instead of converting from long values as we are currently doing in some parts of the code