### PR TITLE
[docs] fix version type in the R-package tooltip

### DIFF
--- a/R-package/_pkgdown.yml
+++ b/R-package/_pkgdown.yml
@@ -6,6 +6,9 @@ site:
   root: ''
   title: LightGBM, Light Gradient Boosting Machine
 
+development:
+  mode: unreleased
+
 authors:
   Guolin Ke:
     href: https://github.com/guolinke


### PR DESCRIPTION
Fix one issue from https://github.com/microsoft/LightGBM/issues/1143#issuecomment-526936690.

As we generate docs for the each commit to the `master` branch, version cannot be "released".

Before: 

![image](https://user-images.githubusercontent.com/25141164/64080206-47ccb880-ccfa-11e9-859c-e872521b4fc4.png)


After:

![image](https://user-images.githubusercontent.com/25141164/64080195-17851a00-ccfa-11e9-9e1a-ab5e6e1632c0.png)

Refer to https://pkgdown.r-lib.org/reference/build_site.html#development-mode.