### PR TITLE
[docs] refer to RTD site directly

### DIFF
--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -8,7 +8,6 @@ ignore=
   public.tableau.com
   https://www.open-mpi.org
   https://readthedocs.org
-  .*R/reference$
 ignorewarnings=http-robots-denied,https-certificate-error
 
 [output]

--- a/docs/R-API.rst
+++ b/docs/R-API.rst
@@ -1,4 +1,0 @@
-R API
-=====
-
-Refer to `R reference <./R/reference>`__.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ For more details, please refer to `Features <./Features.rst>`__.
    Parameters Tuning <Parameters-Tuning>
    C API <C-API>
    Python API <Python-API>
-   R API <R-API>
+   R API <https://lightgbm.readthedocs.io/en/latest/R/reference/>
    Parallel Learning Guide <Parallel-Learning-Guide>
    GPU Tutorial <GPU-Tutorial>
    Advanced Topics <Advanced-Topics>


### PR DESCRIPTION
Pros:
- -1 click for users to reach R-API reference;
- -1 broken link in GitHub repo (`./R/reference`).

Cons:
- language and version settings for RTD (`en/latest`, if we will make them in the future) will be reset in case users want to get back to index page.
  ![image](https://user-images.githubusercontent.com/25141164/64966394-5ba21e00-d8a7-11e9-9dc5-6a971db1e0fa.png)
