### PR TITLE
[ci] fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,31 +7,31 @@
 # offer a reasonable automatic best-guess
 
 # main C++ code
-include/*    @guolinke @chivee
-src/*    @guolinke @chivee
+include/    @guolinke @chivee
+src/    @guolinke @chivee
 CmakeLists.txt    @guolinke @chivee @Laurae2 @jameslamb @wxchan @henry0312 @StrikerRUS @huanzhang12
 
 # R code
 include/LightGBM/lightgbm_R.h    @Laurae2 @jameslamb
 include/LightGBM/R_object_helper.h    @Laurae2 @jameslamb
 src/lightgbm_R.cpp    @Laurae2 @jameslamb
-R-package/*    @Laurae2 @jameslamb
+R-package/    @Laurae2 @jameslamb
 *.R    @Laurae2 @jameslamb
 
 # Python code
-python-package/*    @StrikerRUS @chivee @wxchan @henry0312
+python-package/    @StrikerRUS @chivee @wxchan @henry0312
 
 # helpers
-helpers/*    @StrikerRUS @guolinke
+helpers/    @StrikerRUS @guolinke
 
 # CI administrative stuff
-.ci/*    @StrikerRUS @Laurae2 @jameslamb
-docs/*    @StrikerRUS @Laurae2 @jameslamb
+.ci/    @StrikerRUS @Laurae2 @jameslamb
+docs/    @StrikerRUS @Laurae2 @jameslamb
 *.yml    @StrikerRUS @Laurae2 @jameslamb
 .vsts-ci.yml    @Laurae2
 
 # GPU code
-docker/gpu/*    @huanzhang12
+docker/gpu/    @huanzhang12
 docs/GPU-*.rst    @huanzhang12
 src/treelearner/gpu_tree_learner.cpp    @huanzhang12 @guolinke @chivee
 src/treelearner/tree_learner.cpp    @huanzhang12 @guolinke @chivee


### PR DESCRIPTION
Allow recursion in CODEOWNERS.

From https://help.github.com/en/articles/about-code-owners:

```
# In this example, @doctocat owns any files in the build/logs
# directory at the root of the repository and any of its
# subdirectories.
/build/logs/ @doctocat

# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/*  docs@example.com
```

This is proved by #2406 when no codeowners triggered.