### PR TITLE
[python] make dump_text() private

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1588,7 +1588,7 @@ class Dataset(object):
         _safe_call(_LIB.LGBM_DatasetAddFeaturesFrom(self.handle, other.handle))
         return self
 
-    def dump_text(self, filename):
+    def _dump_text(self, filename):
         """Save Dataset to a text file.
 
         This format cannot be loaded back in by LightGBM, but is useful for debugging purposes.

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -127,11 +127,11 @@ class TestBasic(unittest.TestCase):
             d1.add_features_from(d2)
             with tempfile.NamedTemporaryFile() as f:
                 d1name = f.name
-            d1.dump_text(d1name)
+            d1._dump_text(d1name)
             d = lgb.Dataset(X, feature_name=names).construct()
             with tempfile.NamedTemporaryFile() as f:
                 dname = f.name
-            d.dump_text(dname)
+            d._dump_text(dname)
             with open(d1name, 'rt') as d1f:
                 d1txt = d1f.read()
             with open(dname, 'rt') as df:


### PR DESCRIPTION
Make debugging function private.

As this format in contrast to `Booster`'s method cannot be used for storing datasets, many users may be confused about it, because of inattentive reading.

I think this method is not needed to ordinary users. However, there is no problems for advanced users to find it.