### PR TITLE
refined order of includes

### DIFF
--- a/src/network/socket_wrapper.hpp
+++ b/src/network/socket_wrapper.hpp
@@ -19,9 +19,9 @@
 #define NOMINMAX
 #endif
 
-#include <iphlpapi.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <iphlpapi.h>
 
 #else
 

--- a/src/network/socket_wrapper.hpp
+++ b/src/network/socket_wrapper.hpp
@@ -8,35 +8,35 @@
 
 #include <LightGBM/utils/log.h>
 
+#include <string>
+#include <cerrno>
+#include <cstdlib>
+#include <unordered_set>
+
 #if defined(_WIN32)
 
 #ifdef _MSC_VER
 #define NOMINMAX
 #endif
 
+#include <iphlpapi.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#include <iphlpapi.h>
 
 #else
 
-#include <fcntl.h>
-#include <netdb.h>
-#include <unistd.h>
 #include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/ioctl.h>
-#include <sys/types.h>
+#include <fcntl.h>
 #include <ifaddrs.h>
+#include <netdb.h>
+#include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#endif
-
-#include <cerrno>
-#include <cstdlib>
-#include <string>
-#include <unordered_set>
+#endif  // defined(_WIN32)
 
 #ifdef _MSC_VER
 #pragma comment(lib, "Ws2_32.lib")


### PR DESCRIPTION
Refer to https://github.com/microsoft/LightGBM/pull/2407#issuecomment-531752226.

- Move block with system C/C++ headers upper;
- apply alphabetical order.

`#include <iphlpapi.h>` cannot be moved according to the alphabetical order:

<details>

<summary>
Error log
</summary>

```
    Directory: D:\a\1\s


Mode                LastWriteTime         Length Name                                                                  
----                -------------         ------ ----                                                                  
d-----        9/23/2019   1:37 PM                build                                                                 
-- Building for: Visual Studio 15 2017
-- The C compiler identification is MSVC 19.16.27032.1
-- The CXX compiler identification is MSVC 19.16.27032.1
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.16.27023/bin/Hostx86/x64/cl.exe
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.16.27023/bin/Hostx86/x64/cl.exe -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.16.27023/bin/Hostx86/x64/cl.exe
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.16.27023/bin/Hostx86/x64/cl.exe -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found OpenMP_C: -openmp (found version "2.0") 
-- Found OpenMP_CXX: -openmp (found version "2.0") 
-- Found OpenMP: TRUE (found version "2.0")  
-- Configuring done
-- Generating done
-- Build files have been written to: D:/a/1/s/build
Microsoft (R) Build Engine version 15.9.21+g9802d43bc3 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  Building Custom Rule D:/a/1/s/CMakeLists.txt
  c_api.cpp
  lightgbm_R.cpp
  application.cpp
  boosting.cpp
  gbdt.cpp
  gbdt_model_text.cpp
  gbdt_prediction.cpp
  prediction_early_stop.cpp
  bin.cpp
  config.cpp
  config_auto.cpp
  dataset.cpp
  dataset_loader.cpp
  file_io.cpp
  json11.cpp
  metadata.cpp
  parser.cpp
  tree.cpp
  dcg_calculator.cpp
  metric.cpp
  linker_topo.cpp
  linkers_mpi.cpp
  linkers_socket.cpp
  network.cpp
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ipifcons.h(252): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ipifcons.h(252): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ipifcons.h(252): error C2146: syntax error: missing ';' before identifier 'IFTYPE' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ipifcons.h(252): error C2146: syntax error: missing ';' before identifier 'IFTYPE' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(145): error C3646: 'dwVarId': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(145): error C3646: 'dwVarId': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(145): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(145): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C3646: 'rgdwVarIndex': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C3646: 'rgdwVarIndex': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(23): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(23): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(23): error C2146: syntax error: missing ';' before identifier 'NET_IF_COMPARTMENT_ID' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(23): error C2146: syntax error: missing ';' before identifier 'NET_IF_COMPARTMENT_ID' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(31): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(31): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(31): error C2146: syntax error: missing ';' before identifier 'NET_IF_NETWORK_GUID' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(31): error C2146: syntax error: missing ';' before identifier 'NET_IF_NETWORK_GUID' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(50): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(50): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(50): error C2146: syntax error: missing ';' before identifier 'NET_IF_OBJECT_ID' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(50): error C2146: syntax error: missing ';' before identifier 'NET_IF_OBJECT_ID' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(98): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(98): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(117): error C3646: 'ifRcvAddressLength': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(117): error C3646: 'ifRcvAddressLength': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(117): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(117): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(118): error C3646: 'ifRcvAddressOffset': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(118): error C3646: 'ifRcvAddressOffset': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(118): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(118): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(123): error C3646: 'ifAliasLength': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(123): error C3646: 'ifAliasLength': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(123): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(123): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(124): error C3646: 'ifAliasOffset': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(124): error C3646: 'ifAliasOffset': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(124): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(124): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(131): error C3646: 'Value': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(131): error C3646: 'Value': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(131): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(131): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(134): error C3646: 'Reserved': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(134): error C3646: 'Reserved': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(134): error C2059: syntax error: ':' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(134): error C2059: syntax error: ':' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(134): error C2334: unexpected token(s) preceding ':'; skipping apparent function body (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(134): error C2334: unexpected token(s) preceding ':'; skipping apparent function body (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(137): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(137): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(152): error C3646: 'NET_LUID': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(152): error C3646: 'NET_LUID': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(152): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(152): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(152): error C2378: '_NET_LUID_LH::NET_LUID_LH': redefinition; symbol cannot be overloaded with a typedef (compiling source file D:\a\1\s\src\network\linkers_socket.cpp)C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(152): error C2378: '_NET_LUID_LH::NET_LUID_LH': redefinition; symbol cannot be overloaded with a typedef (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(138): note: see declaration of '_NET_LUID_LH::NET_LUID_LH' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp)
  
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(153): error C2143: syntax error: missing ';' before '*' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp)C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(138): note: see declaration of '_NET_LUID_LH::NET_LUID_LH' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(153): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
  
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(153): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(153): error C2143: syntax error: missing ';' before '*' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(165): error C3646: 'NET_IFTYPE': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(153): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(165): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(153): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(165): error C3646: 'NET_IFTYPE': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(292): error C3646: 'Length': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(165): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(292): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C3646: 'String': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(292): error C3646: 'Length': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(292): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C3646: 'String': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(301): error C3646: 'Length': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(301): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C3646: 'Address': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(301): error C3646: 'Length': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(301): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C3646: 'Address': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(374): error C3646: 'ifPromiscuousMode': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(374): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(375): error C3646: 'ifDeviceWakeUpEnable': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(374): error C3646: 'ifPromiscuousMode': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(375): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(374): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(376): error C3646: 'XmitLinkSpeed': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(375): error C3646: 'ifDeviceWakeUpEnable': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(376): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(375): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(377): error C3646: 'RcvLinkSpeed': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(376): error C3646: 'XmitLinkSpeed': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(377): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(376): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(379): error C3646: 'ifLastChange': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(377): error C3646: 'RcvLinkSpeed': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(379): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(377): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(380): error C3646: 'ifCounterDiscontinuityTime': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(379): error C3646: 'ifLastChange': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(380): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(379): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(381): error C3646: 'ifInUnknownProtos': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(380): error C3646: 'ifCounterDiscontinuityTime': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(381): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(380): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(386): error C3646: 'ifInDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(381): error C3646: 'ifInUnknownProtos': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(386): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(381): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(387): error C3646: 'ifInErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(386): error C3646: 'ifInDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(387): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(386): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(388): error C3646: 'ifHCInOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(387): error C3646: 'ifInErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(388): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(387): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(389): error C3646: 'ifHCInUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(388): error C3646: 'ifHCInOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(389): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(388): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(390): error C3646: 'ifHCInMulticastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(389): error C3646: 'ifHCInUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(390): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(389): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(391): error C3646: 'ifHCInBroadcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(390): error C3646: 'ifHCInMulticastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(391): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(390): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(392): error C3646: 'ifHCOutOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(391): error C3646: 'ifHCInBroadcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(392): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(391): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(393): error C3646: 'ifHCOutUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(392): error C3646: 'ifHCOutOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(393): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(392): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(394): error C3646: 'ifHCOutMulticastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(393): error C3646: 'ifHCOutUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(394): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(393): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(395): error C3646: 'ifHCOutBroadcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(394): error C3646: 'ifHCOutMulticastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(395): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(394): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(396): error C3646: 'ifOutErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(395): error C3646: 'ifHCOutBroadcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(396): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(395): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(397): error C3646: 'ifOutDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(396): error C3646: 'ifOutErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(397): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(396): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(398): error C3646: 'ifHCInUcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(397): error C3646: 'ifOutDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(398): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(397): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(399): error C3646: 'ifHCInMulticastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(398): error C3646: 'ifHCInUcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(399): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(398): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(400): error C3646: 'ifHCInBroadcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(399): error C3646: 'ifHCInMulticastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(400): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(399): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(401): error C3646: 'ifHCOutUcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(400): error C3646: 'ifHCInBroadcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(401): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(400): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(402): error C3646: 'ifHCOutMulticastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(401): error C3646: 'ifHCOutUcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(402): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(401): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(403): error C3646: 'ifHCOutBroadcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(402): error C3646: 'ifHCOutMulticastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(403): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(402): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(404): error C3646: 'CompartmentId': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(403): error C3646: 'ifHCOutBroadcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(404): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(403): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(32): error C2159: more than one storage class specified (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(404): error C3646: 'CompartmentId': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(32): error C2236: unexpected token 'struct'. Did you forget a ';'? (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(404): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(33): error C2059: syntax error: '{' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(32): error C2159: more than one storage class specified (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(33): error C2143: syntax error: missing ';' before '{' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(32): error C2236: unexpected token 'struct'. Did you forget a ';'? (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(33): error C2447: '{': missing function header (old-style formal list?) (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(33): error C2059: syntax error: '{' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(35): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(33): error C2143: syntax error: missing ';' before '{' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(33): error C2447: '{': missing function header (old-style formal list?) (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C3646: 'wszName': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(35): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C3646: 'wszName': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(50): error C3646: 'dwIndex': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(50): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(51): error C3646: 'dwType': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(50): error C3646: 'dwIndex': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(51): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(50): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(52): error C3646: 'dwMtu': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(51): error C3646: 'dwType': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(52): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(51): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(53): error C3646: 'dwSpeed': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(52): error C3646: 'dwMtu': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(53): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(52): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(54): error C3646: 'dwPhysAddrLen': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(53): error C3646: 'dwSpeed': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(54): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(53): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C3646: 'bPhysAddr': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(54): error C3646: 'dwPhysAddrLen': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(54): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C3646: 'bPhysAddr': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(56): error C3646: 'dwAdminStatus': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(56): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(58): error C3646: 'dwLastChange': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(56): error C3646: 'dwAdminStatus': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(58): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(56): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(59): error C3646: 'dwInOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(58): error C3646: 'dwLastChange': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(59): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(58): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(60): error C3646: 'dwInUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(59): error C3646: 'dwInOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(60): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(59): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(61): error C3646: 'dwInNUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(60): error C3646: 'dwInUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(61): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(60): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(62): error C3646: 'dwInDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(61): error C3646: 'dwInNUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(62): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(61): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(63): error C3646: 'dwInErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(62): error C3646: 'dwInDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(63): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(62): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(64): error C3646: 'dwInUnknownProtos': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(63): error C3646: 'dwInErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(64): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(63): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(65): error C3646: 'dwOutOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(64): error C3646: 'dwInUnknownProtos': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(65): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(64): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(66): error C3646: 'dwOutUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(65): error C3646: 'dwOutOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(66): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(65): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(67): error C3646: 'dwOutNUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(66): error C3646: 'dwOutUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(67): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(66): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(68): error C3646: 'dwOutDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(67): error C3646: 'dwOutNUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(68): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(67): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(69): error C3646: 'dwOutErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(68): error C3646: 'dwOutDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(69): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(68): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(70): error C3646: 'dwOutQLen': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(69): error C3646: 'dwOutErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(70): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(69): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(71): error C3646: 'dwDescrLen': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(70): error C3646: 'dwOutQLen': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(71): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(70): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C3646: 'bDescr': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(71): error C3646: 'dwDescrLen': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(71): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C3646: 'bDescr': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(76): error C3646: 'dwNumEntries': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(76): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(76): error C3646: 'dwNumEntries': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(76): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(218): error C3646: 'NlChecksumSupported': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(218): error C3646: 'NlChecksumSupported': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(218): error C2059: syntax error: ':' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(218): error C2059: syntax error: ':' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(218): error C2334: unexpected token(s) preceding ':'; skipping apparent function body (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(218): error C2334: unexpected token(s) preceding ':'; skipping apparent function body (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(226): error C2059: syntax error: ',' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(226): error C2059: syntax error: ',' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(226): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(226): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(226): fatal error C1003: error count exceeds 100; stopping compilation (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(226): fatal error C1003: error count exceeds 100; stopping compilation (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\_lightgbm.vcxproj]
  objective_function.cpp
  data_parallel_tree_learner.cpp
  feature_parallel_tree_learner.cpp
  gpu_tree_learner.cpp
  serial_tree_learner.cpp
  tree_learner.cpp
  voting_parallel_tree_learner.cpp
  Building Custom Rule D:/a/1/s/CMakeLists.txt
  main.cpp
  application.cpp
  boosting.cpp
  gbdt.cpp
  gbdt_model_text.cpp
  gbdt_prediction.cpp
  prediction_early_stop.cpp
  bin.cpp
  config.cpp
  config_auto.cpp
  dataset.cpp
  dataset_loader.cpp
  file_io.cpp
  json11.cpp
  metadata.cpp
  parser.cpp
  tree.cpp
  dcg_calculator.cpp
  metric.cpp
  linker_topo.cpp
  linkers_mpi.cpp
  linkers_socket.cpp
  network.cpp
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ipifcons.h(252): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ipifcons.h(252): error C2146: syntax error: missing ';' before identifier 'IFTYPE' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(145): error C3646: 'dwVarId': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(145): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C3646: 'rgdwVarIndex': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(23): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(23): error C2146: syntax error: missing ';' before identifier 'NET_IF_COMPARTMENT_ID' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(31): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(31): error C2146: syntax error: missing ';' before identifier 'NET_IF_NETWORK_GUID' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(50): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(50): error C2146: syntax error: missing ';' before identifier 'NET_IF_OBJECT_ID' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(98): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(117): error C3646: 'ifRcvAddressLength': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(117): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(118): error C3646: 'ifRcvAddressOffset': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(118): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(123): error C3646: 'ifAliasLength': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(123): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(124): error C3646: 'ifAliasOffset': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(124): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(131): error C3646: 'Value': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(131): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(134): error C3646: 'Reserved': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(134): error C2059: syntax error: ':' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(134): error C2334: unexpected token(s) preceding ':'; skipping apparent function body (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(137): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(152): error C3646: 'NET_LUID': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(152): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(152): error C2378: '_NET_LUID_LH::NET_LUID_LH': redefinition; symbol cannot be overloaded with a typedef (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(138): note: see declaration of '_NET_LUID_LH::NET_LUID_LH' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp)
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(153): error C2143: syntax error: missing ';' before '*' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(153): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(153): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(165): error C3646: 'NET_IFTYPE': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(165): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(292): error C3646: 'Length': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(292): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C3646: 'String': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(301): error C3646: 'Length': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(301): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C3646: 'Address': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(374): error C3646: 'ifPromiscuousMode': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(374): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(375): error C3646: 'ifDeviceWakeUpEnable': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(375): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(376): error C3646: 'XmitLinkSpeed': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(376): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(377): error C3646: 'RcvLinkSpeed': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(377): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(379): error C3646: 'ifLastChange': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(379): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(380): error C3646: 'ifCounterDiscontinuityTime': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(380): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(381): error C3646: 'ifInUnknownProtos': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(381): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(386): error C3646: 'ifInDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(386): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(387): error C3646: 'ifInErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(387): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(388): error C3646: 'ifHCInOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(388): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(389): error C3646: 'ifHCInUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(389): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(390): error C3646: 'ifHCInMulticastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(390): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(391): error C3646: 'ifHCInBroadcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(391): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(392): error C3646: 'ifHCOutOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(392): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(393): error C3646: 'ifHCOutUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(393): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(394): error C3646: 'ifHCOutMulticastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(394): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(395): error C3646: 'ifHCOutBroadcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(395): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(396): error C3646: 'ifOutErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(396): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(397): error C3646: 'ifOutDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(397): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(398): error C3646: 'ifHCInUcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(398): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(399): error C3646: 'ifHCInMulticastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(399): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(400): error C3646: 'ifHCInBroadcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(400): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(401): error C3646: 'ifHCOutUcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(401): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(402): error C3646: 'ifHCOutMulticastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(402): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(403): error C3646: 'ifHCOutBroadcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(403): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(404): error C3646: 'CompartmentId': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(404): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(32): error C2159: more than one storage class specified (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(32): error C2236: unexpected token 'struct'. Did you forget a ';'? (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(33): error C2059: syntax error: '{' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(33): error C2143: syntax error: missing ';' before '{' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(33): error C2447: '{': missing function header (old-style formal list?) (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(35): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C3646: 'wszName': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(50): error C3646: 'dwIndex': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(50): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(51): error C3646: 'dwType': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(51): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(52): error C3646: 'dwMtu': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(52): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(53): error C3646: 'dwSpeed': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(53): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(54): error C3646: 'dwPhysAddrLen': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(54): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C3646: 'bPhysAddr': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(56): error C3646: 'dwAdminStatus': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(56): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(58): error C3646: 'dwLastChange': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(58): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(59): error C3646: 'dwInOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(59): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(60): error C3646: 'dwInUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(60): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(61): error C3646: 'dwInNUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(61): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(62): error C3646: 'dwInDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(62): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(63): error C3646: 'dwInErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(63): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(64): error C3646: 'dwInUnknownProtos': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(64): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(65): error C3646: 'dwOutOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(65): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(66): error C3646: 'dwOutUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(66): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(67): error C3646: 'dwOutNUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(67): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(68): error C3646: 'dwOutDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(68): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(69): error C3646: 'dwOutErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(69): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(70): error C3646: 'dwOutQLen': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(70): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(71): error C3646: 'dwDescrLen': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(71): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C3646: 'bDescr': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(76): error C3646: 'dwNumEntries': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(76): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(218): error C3646: 'NlChecksumSupported': unknown override specifier (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(218): error C2059: syntax error: ':' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(218): error C2334: unexpected token(s) preceding ':'; skipping apparent function body (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(226): error C2059: syntax error: ',' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(226): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(226): fatal error C1003: error count exceeds 100; stopping compilation (compiling source file D:\a\1\s\src\network\linkers_socket.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
  objective_function.cpp
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ipifcons.h(252): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ipifcons.h(252): error C2146: syntax error: missing ';' before identifier 'IFTYPE' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(145): error C3646: 'dwVarId': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(145): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C3646: 'rgdwVarIndex': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\iprtrmib.h(146): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(23): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(23): error C2146: syntax error: missing ';' before identifier 'NET_IF_COMPARTMENT_ID' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(31): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(31): error C2146: syntax error: missing ';' before identifier 'NET_IF_NETWORK_GUID' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(50): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(50): error C2146: syntax error: missing ';' before identifier 'NET_IF_OBJECT_ID' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(98): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(117): error C3646: 'ifRcvAddressLength': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(117): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(118): error C3646: 'ifRcvAddressOffset': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(118): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(123): error C3646: 'ifAliasLength': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(123): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(124): error C3646: 'ifAliasOffset': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(124): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(131): error C3646: 'Value': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(131): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(134): error C3646: 'Reserved': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(134): error C2059: syntax error: ':' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(134): error C2334: unexpected token(s) preceding ':'; skipping apparent function body (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(137): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(152): error C3646: 'NET_LUID': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(152): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(152): error C2378: '_NET_LUID_LH::NET_LUID_LH': redefinition; symbol cannot be overloaded with a typedef (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(138): note: see declaration of '_NET_LUID_LH::NET_LUID_LH' (compiling source file D:\a\1\s\src\network\network.cpp)
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(153): error C2143: syntax error: missing ';' before '*' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(153): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(153): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(165): error C3646: 'NET_IFTYPE': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(165): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(292): error C3646: 'Length': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(292): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C3646: 'String': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(293): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(301): error C3646: 'Length': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(301): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C3646: 'Address': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(302): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(374): error C3646: 'ifPromiscuousMode': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(374): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(375): error C3646: 'ifDeviceWakeUpEnable': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(375): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(376): error C3646: 'XmitLinkSpeed': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(376): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(377): error C3646: 'RcvLinkSpeed': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(377): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(379): error C3646: 'ifLastChange': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(379): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(380): error C3646: 'ifCounterDiscontinuityTime': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(380): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(381): error C3646: 'ifInUnknownProtos': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(381): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(386): error C3646: 'ifInDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(386): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(387): error C3646: 'ifInErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(387): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(388): error C3646: 'ifHCInOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(388): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(389): error C3646: 'ifHCInUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(389): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(390): error C3646: 'ifHCInMulticastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(390): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(391): error C3646: 'ifHCInBroadcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(391): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(392): error C3646: 'ifHCOutOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(392): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(393): error C3646: 'ifHCOutUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(393): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(394): error C3646: 'ifHCOutMulticastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(394): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(395): error C3646: 'ifHCOutBroadcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(395): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(396): error C3646: 'ifOutErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(396): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(397): error C3646: 'ifOutDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(397): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(398): error C3646: 'ifHCInUcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(398): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(399): error C3646: 'ifHCInMulticastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(399): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(400): error C3646: 'ifHCInBroadcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(400): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(401): error C3646: 'ifHCOutUcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(401): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(402): error C3646: 'ifHCOutMulticastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(402): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(403): error C3646: 'ifHCOutBroadcastOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(403): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(404): error C3646: 'CompartmentId': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifdef.h(404): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(32): error C2159: more than one storage class specified (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(32): error C2236: unexpected token 'struct'. Did you forget a ';'? (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(33): error C2059: syntax error: '{' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(33): error C2143: syntax error: missing ';' before '{' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(33): error C2447: '{': missing function header (old-style formal list?) (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(35): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C3646: 'wszName': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(49): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(50): error C3646: 'dwIndex': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(50): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(51): error C3646: 'dwType': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(51): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(52): error C3646: 'dwMtu': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(52): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(53): error C3646: 'dwSpeed': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(53): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(54): error C3646: 'dwPhysAddrLen': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(54): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C3646: 'bPhysAddr': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(55): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(56): error C3646: 'dwAdminStatus': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(56): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(58): error C3646: 'dwLastChange': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(58): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(59): error C3646: 'dwInOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(59): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(60): error C3646: 'dwInUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(60): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(61): error C3646: 'dwInNUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(61): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(62): error C3646: 'dwInDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(62): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(63): error C3646: 'dwInErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(63): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(64): error C3646: 'dwInUnknownProtos': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(64): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(65): error C3646: 'dwOutOctets': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(65): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(66): error C3646: 'dwOutUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(66): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(67): error C3646: 'dwOutNUcastPkts': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(67): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(68): error C3646: 'dwOutDiscards': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(68): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(69): error C3646: 'dwOutErrors': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(69): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(70): error C3646: 'dwOutQLen': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(70): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(71): error C3646: 'dwDescrLen': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(71): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C3646: 'bDescr': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C2143: syntax error: missing ',' before '[' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C2143: syntax error: missing ')' before ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(72): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(76): error C3646: 'dwNumEntries': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\ifmib.h(76): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(218): error C3646: 'NlChecksumSupported': unknown override specifier (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(218): error C2059: syntax error: ':' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(218): error C2334: unexpected token(s) preceding ':'; skipping apparent function body (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(226): error C2059: syntax error: ',' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(226): error C2238: unexpected token(s) preceding ';' (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\nldef.h(226): fatal error C1003: error count exceeds 100; stopping compilation (compiling source file D:\a\1\s\src\network\network.cpp) [D:\a\1\s\build\lightgbm.vcxproj]
  data_parallel_tree_learner.cpp
  feature_parallel_tree_learner.cpp
  gpu_tree_learner.cpp
  serial_tree_learner.cpp
  tree_learner.cpp
  voting_parallel_tree_learner.cpp
```

</details>