### PR TITLE
[docs][python] fixed docstrings

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -357,9 +357,9 @@ class _InnerPredictor(object):
     Not exposed to user.
     Used only for prediction, usually used for continued training.
 
-    Note
-    ----
-    Can be converted from Booster, but cannot be converted to Booster.
+    .. note::
+
+        Can be converted from Booster, but cannot be converted to Booster.
     """
 
     def __init__(self, model_file=None, booster_handle=None, pred_parameter=None):
@@ -1939,11 +1939,11 @@ class Booster(object):
     def __boost(self, grad, hess):
         """Boost Booster for one iteration with customized gradient statistics.
 
-        Note
-        ----
-        For multi-class task, the score is group by class_id first, then group by row_id.
-        If you want to get i-th row score in j-th class, the access way is score[j * num_data + i]
-        and you should group grad and hess in this way as well.
+        .. note::
+
+            For multi-class task, the score is group by class_id first, then group by row_id.
+            If you want to get i-th row score in j-th class, the access way is score[j * num_data + i]
+            and you should group grad and hess in this way as well.
 
         Parameters
         ----------
@@ -2340,13 +2340,13 @@ class Booster(object):
         pred_contrib : bool, optional (default=False)
             Whether to predict feature contributions.
 
-            Note
-            ----
-            If you want to get more explanations for your model's predictions using SHAP values,
-            like SHAP interaction values,
-            you can install the shap package (https://github.com/slundberg/shap).
-            Note that unlike the shap package, with ``pred_contrib`` we return a matrix with an extra
-            column, where the last column is the expected value.
+            .. note::
+
+                If you want to get more explanations for your model's predictions using SHAP values,
+                like SHAP interaction values,
+                you can install the shap package (https://github.com/slundberg/shap).
+                Note that unlike the shap package, with ``pred_contrib`` we return a matrix with an extra
+                column, where the last column is the expected value.
 
         data_has_header : bool, optional (default=False)
             Whether the data has header.
@@ -2526,9 +2526,9 @@ class Booster(object):
             If int, interpreted as index.
             If string, interpreted as name.
 
-            Note
-            ----
-            Categorical features are not supported.
+            .. warning::
+
+                Categorical features are not supported.
 
         bins : int, string or None, optional (default=None)
             The maximum number of bins.

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -109,9 +109,9 @@ def record_evaluation(eval_result):
 def reset_parameter(**kwargs):
     """Create a callback that resets the parameter after the first iteration.
 
-    Note
-    ----
-    The initial parameter will still take in-effect on first iteration.
+    .. note::
+
+        The initial parameter will still take in-effect on first iteration.
 
     Parameters
     ----------
@@ -154,8 +154,6 @@ def reset_parameter(**kwargs):
 def early_stopping(stopping_rounds, first_metric_only=False, verbose=True):
     """Create a callback that activates early stopping.
 
-    Note
-    ----
     Activates early stopping.
     The model will train until the validation score stops improving.
     Validation score needs to improve at least every ``early_stopping_rounds`` round(s)

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -101,8 +101,8 @@ def train(params, train_set, num_boost_round=100,
     evals_result: dict or None, optional (default=None)
         This dictionary used to store all evaluation results of all the items in ``valid_sets``.
 
-        Example
-        -------
+        .. rubric:: Example
+
         With a ``valid_sets`` = [valid_set, train_set],
         ``valid_names`` = ['eval', 'train']
         and a ``params`` = {'metric': 'logloss'}
@@ -115,8 +115,8 @@ def train(params, train_set, num_boost_round=100,
         If int, the eval metric on the valid set is printed at every ``verbose_eval`` boosting stage.
         The last boosting stage or the boosting stage found by using ``early_stopping_rounds`` is also printed.
 
-        Example
-        -------
+        .. rubric:: Example
+
         With ``verbose_eval`` = 4 and at least one item in ``valid_sets``,
         an evaluation metric is printed every 4 (instead of 1) boosting stages.
 

--- a/python-package/lightgbm/plotting.py
+++ b/python-package/lightgbm/plotting.py
@@ -469,10 +469,10 @@ def create_tree_digraph(booster, tree_index=0, show_info=None, precision=3,
                         old_node_attr=None, old_edge_attr=None, old_body=None, old_strict=False, **kwargs):
     """Create a digraph representation of specified tree.
 
-    Note
-    ----
-    For more information please visit
-    https://graphviz.readthedocs.io/en/stable/api.html#digraph.
+    .. note::
+
+        For more information please visit
+        https://graphviz.readthedocs.io/en/stable/api.html#digraph.
 
     Parameters
     ----------
@@ -545,10 +545,10 @@ def plot_tree(booster, ax=None, tree_index=0, figsize=None,
               show_info=None, precision=3, **kwargs):
     """Plot specified tree.
 
-    Note
-    ----
-    It is preferable to use ``create_tree_digraph()`` because of its lossless quality
-    and returned objects can be also rendered and displayed directly inside a Jupyter notebook.
+    .. note::
+
+        It is preferable to use ``create_tree_digraph()`` because of its lossless quality
+        and returned objects can be also rendered and displayed directly inside a Jupyter notebook.
 
     Parameters
     ----------

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -40,11 +40,11 @@ class _ObjectiveFunctionWrapper(object):
                 hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                     The value of the second order derivative (Hessian) for each sample point.
 
-        Note
-        ----
-        For multi-class task, the y_pred is group by class_id first, then group by row_id.
-        If you want to get i-th row y_pred in j-th class, the access way is y_pred[j * num_data + i]
-        and you should group grad and hess in this way as well.
+        .. note::
+
+            For multi-class task, the y_pred is group by class_id first, then group by row_id.
+            If you want to get i-th row y_pred in j-th class, the access way is y_pred[j * num_data + i]
+            and you should group grad and hess in this way as well.
         """
         self.func = func
 
@@ -127,10 +127,10 @@ class _EvalFunctionWrapper(object):
                 is_higher_better : bool
                     Is eval result higher better, e.g. AUC is ``is_higher_better``.
 
-        Note
-        ----
-        For multi-class task, the y_pred is group by class_id first, then group by row_id.
-        If you want to get i-th row y_pred in j-th class, the access way is y_pred[j * num_data + i].
+        .. note::
+
+            For multi-class task, the y_pred is group by class_id first, then group by row_id.
+            If you want to get i-th row y_pred in j-th class, the access way is y_pred[j * num_data + i].
         """
         self.func = func
 
@@ -244,9 +244,9 @@ class LGBMModel(_LGBMModelBase):
             Other parameters for the model.
             Check http://lightgbm.readthedocs.io/en/latest/Parameters.html for more parameters.
 
-            Note
-            ----
-            \*\*kwargs is not supported in sklearn, it may cause unexpected issues.
+            .. warning::
+
+                \*\*kwargs is not supported in sklearn, it may cause unexpected issues.
 
         Attributes
         ----------
@@ -421,8 +421,8 @@ class LGBMModel(_LGBMModelBase):
             If int, the eval metric on the eval set is printed at every ``verbose`` boosting stage.
             The last boosting stage or the boosting stage found by using ``early_stopping_rounds`` is also printed.
 
-            Example
-            -------
+            .. rubric:: Example
+
             With ``verbose`` = 4 and at least one item in ``eval_set``,
             an evaluation metric is printed every 4 (instead of 1) boosting stages.
 
@@ -626,13 +626,13 @@ class LGBMModel(_LGBMModelBase):
         pred_contrib : bool, optional (default=False)
             Whether to predict feature contributions.
 
-            Note
-            ----
-            If you want to get more explanations for your model's predictions using SHAP values,
-            like SHAP interaction values,
-            you can install the shap package (https://github.com/slundberg/shap).
-            Note that unlike the shap package, with ``pred_contrib`` we return a matrix with an extra
-            column, where the last column is the expected value.
+            .. note::
+
+                If you want to get more explanations for your model's predictions using SHAP values,
+                like SHAP interaction values,
+                you can install the shap package (https://github.com/slundberg/shap).
+                Note that unlike the shap package, with ``pred_contrib`` we return a matrix with an extra
+                column, where the last column is the expected value.
 
         **kwargs
             Other parameters for the prediction.
@@ -705,12 +705,12 @@ class LGBMModel(_LGBMModelBase):
     def feature_importances_(self):
         """Get feature importances.
 
-        Note
-        ----
-        Feature importance in sklearn interface used to normalize to 1,
-        it's deprecated after 2.0.4 and is the same as Booster.feature_importance() now.
-        ``importance_type`` attribute is passed to the function
-        to configure the type of importance values to be extracted.
+        .. note::
+
+            Feature importance in sklearn interface used to normalize to 1,
+            it's deprecated after 2.0.4 and is the same as Booster.feature_importance() now.
+            ``importance_type`` attribute is passed to the function
+            to configure the type of importance values to be extracted.
         """
         if self._n_features is None:
             raise LGBMNotFittedError('No feature_importances found. Need to call fit beforehand.')
@@ -834,13 +834,13 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
         pred_contrib : bool, optional (default=False)
             Whether to predict feature contributions.
 
-            Note
-            ----
-            If you want to get more explanations for your model's predictions using SHAP values,
-            like SHAP interaction values,
-            you can install the shap package (https://github.com/slundberg/shap).
-            Note that unlike the shap package, with ``pred_contrib`` we return a matrix with an extra
-            column, where the last column is the expected value.
+            .. note::
+
+                If you want to get more explanations for your model's predictions using SHAP values,
+                like SHAP interaction values,
+                you can install the shap package (https://github.com/slundberg/shap).
+                Note that unlike the shap package, with ``pred_contrib`` we return a matrix with an extra
+                column, where the last column is the expected value.
 
         **kwargs
             Other parameters for the prediction.


### PR DESCRIPTION
Fix recently added in new version of `pydocstyle` errors `D214` and `D215`:

```
./python-package/lightgbm/basic.py:2321 in public method `predict`:
        D214: Section is over-indented ('Note')
./python-package/lightgbm/basic.py:2321 in public method `predict`:
        D215: Section underline is over-indented (in section 'Note')
./python-package/lightgbm/basic.py:2516 in public method `get_split_value_histogram`:
        D214: Section is over-indented ('Note')
./python-package/lightgbm/basic.py:2516 in public method `get_split_value_histogram`:
        D215: Section underline is over-indented (in section 'Note')
./python-package/lightgbm/sklearn.py:178 in public method `__init__`:
        D214: Section is over-indented ('Note')
./python-package/lightgbm/sklearn.py:178 in public method `__init__`:
        D215: Section underline is over-indented (in section 'Note')
./python-package/lightgbm/sklearn.py:379 in public method `fit`:
        D214: Section is over-indented ('Example')
./python-package/lightgbm/sklearn.py:379 in public method `fit`:
        D215: Section underline is over-indented (in section 'Example')
./python-package/lightgbm/sklearn.py:612 in public method `predict`:
        D214: Section is over-indented ('Note')
./python-package/lightgbm/sklearn.py:612 in public method `predict`:
        D215: Section underline is over-indented (in section 'Note')
./python-package/lightgbm/sklearn.py:820 in public method `predict_proba`:
        D214: Section is over-indented ('Note')
./python-package/lightgbm/sklearn.py:820 in public method `predict_proba`:
        D215: Section underline is over-indented (in section 'Note')
./python-package/lightgbm/engine.py:26 in public function `train`:
        D214: Section is over-indented ('Example')
./python-package/lightgbm/engine.py:26 in public function `train`:
        D215: Section underline is over-indented (in section 'Example')
./python-package/lightgbm/engine.py:26 in public function `train`:
        D214: Section is over-indented ('Example')
./python-package/lightgbm/engine.py:26 in public function `train`:
        D215: Section underline is over-indented (in section 'Example')
```

https://travis-ci.org/microsoft/LightGBM/jobs/589554300