### PR TITLE
[python] removed unused pylint directives

### DIFF
--- a/examples/python-guide/advanced_example.py
+++ b/examples/python-guide/advanced_example.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable = invalid-name, C0111
 import json
 import lightgbm as lgb
 import pandas as pd

--- a/examples/python-guide/logistic_regression.py
+++ b/examples/python-guide/logistic_regression.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable = invalid-name, C0111
 """Comparison of `binary` and `xentropy` objectives.
 
 BLUF: The `xentropy` objective does logistic regression and generalizes

--- a/examples/python-guide/plot_example.py
+++ b/examples/python-guide/plot_example.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable = invalid-name, C0111
 import lightgbm as lgb
 import pandas as pd
 

--- a/examples/python-guide/simple_example.py
+++ b/examples/python-guide/simple_example.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable = invalid-name, C0111
 import lightgbm as lgb
 import pandas as pd
 from sklearn.metrics import mean_squared_error

--- a/examples/python-guide/sklearn_example.py
+++ b/examples/python-guide/sklearn_example.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable = invalid-name, C0111
 import numpy as np
 import pandas as pd
 import lightgbm as lgb

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1,6 +1,4 @@
 # coding: utf-8
-# pylint: disable = invalid-name, C0111, C0301
-# pylint: disable = R0912, R0913, R0914, W0105, W0201, W0212
 """Wrapper for C API of LightGBM."""
 from __future__ import absolute_import
 

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable = invalid-name, W0105, C0301
 """Callbacks library."""
 from __future__ import absolute_import
 

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable = C0103
 """Compatibility library."""
 from __future__ import absolute_import
 

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable = invalid-name, W0105
 """Library with training routines of LightGBM."""
 from __future__ import absolute_import
 

--- a/python-package/lightgbm/plotting.py
+++ b/python-package/lightgbm/plotting.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable = C0103
 """Plotting library."""
 from __future__ import absolute_import, division
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable = invalid-name, W0105, C0111, C0301
 """Scikit-learn wrapper interface for LightGBM."""
 from __future__ import absolute_import
 

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable=invalid-name, exec-used, C0111
 """Setup lightgbm package."""
 from __future__ import absolute_import
 

--- a/tests/c_api_test/test_.py
+++ b/tests/c_api_test/test_.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: skip-file
 import ctypes
 import os
 import sys

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: skip-file
 import os
 import tempfile
 import unittest

--- a/tests/python_package_test/test_consistency.py
+++ b/tests/python_package_test/test_consistency.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: skip-file
 import os
 import unittest
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: skip-file
 import copy
 import itertools
 import math

--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: skip-file
 import unittest
 
 import lightgbm as lgb

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: skip-file
 import itertools
 import joblib
 import math


### PR DESCRIPTION
We use `pycodestyle`:
https://github.com/microsoft/LightGBM/blob/cc7a1e27398d86e9befdf6eb08141359882f3d49/.ci/test.sh#L56