### PR TITLE
[ci] use the latest versions of OSes at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,10 @@ before_install:
   - export BUILD_DIRECTORY="$TRAVIS_BUILD_DIR"
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
         export OS_NAME="macos";
-        export COMPILER="gcc";
+        export COMPILER="clang";
     else
         export OS_NAME="linux";
-        export COMPILER="clang";
+        export COMPILER="gcc";
     fi
   - export CONDA="$HOME/miniconda"
   - export PATH="$CONDA/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ git:
 os:
   - linux
   - osx
-dist: trusty
-osx_image: xcode10.2
+dist: bionic
+osx_image: xcode11
 
 env:
   global:  # default values

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,10 @@ before_install:
   - export BUILD_DIRECTORY="$TRAVIS_BUILD_DIR"
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
         export OS_NAME="macos";
-        export COMPILER="clang";
+        export COMPILER="gcc";
     else
         export OS_NAME="linux";
-        export COMPILER="gcc";
+        export COMPILER="clang";
     fi
   - export CONDA="$HOME/miniconda"
   - export PATH="$CONDA/bin:$PATH"

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -17,7 +17,7 @@ jobs:
 - job: Linux
 ###########################################
   variables:
-    COMPILER: gcc
+    COMPILER: clang
   pool:
     vmImage: 'ubuntu-16.04'
   container: ubuntu1404
@@ -70,7 +70,7 @@ jobs:
 - job: MacOS
 ###########################################
   variables:
-    COMPILER: clang
+    COMPILER: gcc
   pool:
     vmImage: 'macOS-10.13'
   strategy:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -17,7 +17,7 @@ jobs:
 - job: Linux
 ###########################################
   variables:
-    COMPILER: clang
+    COMPILER: gcc
   pool:
     vmImage: 'ubuntu-16.04'
   container: ubuntu1404
@@ -70,7 +70,7 @@ jobs:
 - job: MacOS
 ###########################################
   variables:
-    COMPILER: gcc
+    COMPILER: clang
   pool:
     vmImage: 'macOS-10.13'
   strategy:

--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -5,10 +5,9 @@ sslverify=0
 
 [filtering]
 ignore=
-  public.tableau.com
-  https://www.open-mpi.org
-  https://readthedocs.org
+  pythonapi/lightgbm\..*\.html.*
 ignorewarnings=http-robots-denied,https-certificate-error
+checkextern=1
 
 [output]
 # Set to 1 if you want see the full output, not only warnings and errors


### PR DESCRIPTION
Bump Linux to `Bionic` and Xcode to `11` at Travis. I think it's a good point to test the oldest supported versions at Azure Pipelines for the most compatibility of produced artifacts, while use the newest ones at Travis.

New version of linkchecker has some issues with anchors detection, so just ignore internal Python API refs (with the hope that Sphinx does everything correctly and they are not broken). Refer to https://github.com/microsoft/LightGBM/pull/1497#discussion_r200812795.

All checks are green for the testing commit with swapped compilers 2757b3f8b9dcd3d901485f2f14d99e7bfbbfdb7a:

![image](https://user-images.githubusercontent.com/25141164/65824436-dee14d80-e271-11e9-9f4c-b07ac2ebd926.png)
