### PR TITLE
[docs] updated problem link

### DIFF
--- a/docs/Features.rst
+++ b/docs/Features.rst
@@ -281,7 +281,7 @@ References
 
 .. _LightGBM\: A Highly Efficient Gradient Boosting Decision Tree: https://papers.nips.cc/paper/6907-lightgbm-a-highly-efficient-gradient-boosting-decision-tree.pdf
 
-.. _On Grouping for Maximum Homogeneity: https://www.researchgate.net/publication/242580910_On_Grouping_for_Maximum_Homogeneity
+.. _On Grouping for Maximum Homogeneity: http://www.csiss.org/SPACE/workshops/2004/SAC/files/fisher.pdf
 
 .. _Optimization of collective communication operations in MPICH: https://www.mcs.anl.gov/~thakur/papers/ijhpca-coll.pdf
 


### PR DESCRIPTION
After upgrading linkchecker in #2467 this link started producing a lot of annoying `Error: 429 Too Many Requests`, which results in the need to manually re-run docs test many times.
```
URL        `https://www.researchgate.net/publication/242580910_On_Grouping_for_Maximum_Homogeneity'
Name       `On Grouping for Maximum Homogeneity'
Parent URL file:///home/travis/build/microsoft/LightGBM/docs/_build/html/Features.html, line 399, col 29
Real URL   https://www.researchgate.net/publication/242580910_On_Grouping_for_Maximum_Homogeneity
Check time 0.936 seconds
Result     Error: 429 Too Many Requests
```

Also, we already use the new link in `Advanced-Topics` document: `Fisher (1958)`  https://github.com/microsoft/LightGBM/blob/master/docs/Advanced-Topics.rst#categorical-feature-support.