### PR TITLE
[ci] added build/c++11 to cpplint filter

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -55,7 +55,7 @@ if [[ $TASK == "lint" ]]; then
     pip install --user cpplint
     pycodestyle --ignore=E501,W503 --exclude=./compute,./.nuget . || exit -1
     pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^compute|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1
-    cpplint --filter=-build/include_subdir,-build/header_guard,-whitespace/line_length --recursive ./src ./include || exit 0
+    cpplint --filter=-build/c++11,-build/include_subdir,-build/header_guard,-whitespace/line_length --recursive ./src ./include || exit 0
     exit 0
 fi
 


### PR DESCRIPTION
Refer to https://github.com/microsoft/LightGBM/issues/1990#issuecomment-533547900, https://chromium-cpp.appspot.com/.

Seem that the whole `build/c++11` group of error is very specific to Chromium development.
Here are errors in the `build/c++11` group:
https://github.com/google/styleguide/blob/5651966e0275572a9956199418d89c9ccc7b2b1a/cpplint/cpplint.py#L5842-L5855
https://github.com/google/styleguide/blob/5651966e0275572a9956199418d89c9ccc7b2b1a/cpplint/cpplint.py#L5861-L5873


@guolinke I'll be happy to replace the filter with multiple `NOLINT`s as we discussed earlier if you think that some errors in this group are useful for LightGBM.
