### PR TITLE
reworked GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,3 +1,9 @@
+---
+name: Bug Report 🐞
+about: Something isn't working as expected? Here is the right place to report.
+labels: bug
+---
+
 <!--
 Please search your question on previous issues, Stack Overflow (https://stackoverflow.com/questions/tagged/lightgbm) or other search engines before you open a new one.
 -->

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request 💡
+about: Suggest a new idea for the project.
+labels: enhancement, feature-request
+---
+
+<!--
+Please search your feature on previous issues and our feature requests consolidation hub (https://github.com/microsoft/LightGBM/issues/2302) before you open a new one.
+-->
+
+## Summary
+
+<!-- Briefly explain your feature proposal. -->
+
+## Motivation
+
+<!-- Why is it useful to have this feature in the LightGBM project? -->
+
+## Description
+
+<!-- Detailed description of the new feature. -->
+
+## References
+
+<!-- Any useful references, for instance, papers, implementations in other projects, draft code snippets, etc. -->


### PR DESCRIPTION
Fix deprecation warning from GitHub:

![image](https://user-images.githubusercontent.com/25141164/66255294-a3231800-e78a-11e9-8dff-ab5337824f63.png)


Refer to https://help.github.com/en/articles/about-issue-and-pull-request-templates.