### PR TITLE
 [ci] removed temp fix for missing package 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.3.1.{build}
+﻿version: 2.3.1.{build}
 
 image: Visual Studio 2015
 platform: x64
@@ -54,5 +54,5 @@ test_script:
         if (!$?) { $host.SetShouldExit(-1) }
       }  # run all examples
   - cd %APPVEYOR_BUILD_FOLDER%\examples\python-guide\notebooks
-  - conda install -q -y -n test-env ipywidgets notebook pywin32
+  - conda install -q -y -n test-env ipywidgets notebook
   - jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb  # run all notebooks

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -49,6 +49,6 @@ if ($env:TASK -eq "regular") {
     python $file ; Check-Output $?
   }  # run all examples
   cd $env:BUILD_SOURCESDIRECTORY/examples/python-guide/notebooks
-  conda install -q -y -n $env:CONDA_ENV ipywidgets notebook pywin32
+  conda install -q -y -n $env:CONDA_ENV ipywidgets notebook
   jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb ; Check-Output $?  # run all notebooks
 }

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -116,13 +116,13 @@ jobs:
     matrix:
       regular:
         TASK: regular
-        PYTHON_VERSION: 2.7
+        PYTHON_VERSION: 3.7
       sdist:
         TASK: sdist
-        PYTHON_VERSION: 3.5
+        PYTHON_VERSION: 2.7
       bdist:
         TASK: bdist
-        PYTHON_VERSION: 3.6
+        PYTHON_VERSION: 3.5
   steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Enable conda

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -116,10 +116,10 @@ jobs:
     matrix:
       regular:
         TASK: regular
-        PYTHON_VERSION: 3.5
+        PYTHON_VERSION: 2.7
       sdist:
         TASK: sdist
-        PYTHON_VERSION: 2.7
+        PYTHON_VERSION: 3.5
       bdist:
         TASK: bdist
         PYTHON_VERSION: 3.6


### PR DESCRIPTION
They [will not fix package dependencies for Python 3.5](https://github.com/ContinuumIO/anaconda-issues/issues/11315#issuecomment-537964924), so use Python 3.5 for a job where that package is not needed. Python 3.6 is tested at Appveyor, so I replaced 3.6 -> 3.7 for Azure Pipelines as well.