### PR TITLE
Fix build error when HDFS is enabled.

### DIFF
--- a/src/io/file_io.cpp
+++ b/src/io/file_io.cpp
@@ -54,7 +54,7 @@ struct LocalFile : VirtualFileReader, VirtualFileWriter {
   const std::string mode_;
 };
 
-const char* kHdfsProto = "hdfs://";
+const std::string kHdfsProto = "hdfs://";
 
 #ifdef USE_HDFS
 struct HDFSFile : VirtualFileReader, VirtualFileWriter {

--- a/src/io/file_io.cpp
+++ b/src/io/file_io.cpp
@@ -54,7 +54,8 @@ struct LocalFile : VirtualFileReader, VirtualFileWriter {
   const std::string mode_;
 };
 
-const std::string kHdfsProto = "hdfs://";
+const char* kHdfsProto = "hdfs://";
+const size_t kHdfsProtoLength = strlen(kHdfsProto);
 
 #ifdef USE_HDFS
 struct HDFSFile : VirtualFileReader, VirtualFileWriter {
@@ -117,12 +118,12 @@ struct HDFSFile : VirtualFileReader, VirtualFileWriter {
   }
 
   static hdfsFS GetHDFSFileSystem(const std::string& uri) {
-    size_t end = uri.find("/", kHdfsProto.length());
+    size_t end = uri.find("/", kHdfsProtoLength);
     if (uri.find(kHdfsProto) != 0 || end == std::string::npos) {
       Log::Warning("Bad HDFS uri, no namenode found [%s]", uri.c_str());
       return NULL;
     }
-    std::string hostport = uri.substr(kHdfsProto.length(), end - kHdfsProto.length());
+    std::string hostport = uri.substr(kHdfsProtoLength, end - kHdfsProtoLength);
     if (fs_cache_.count(hostport) == 0) {
       fs_cache_[hostport] = MakeHDFSFileSystem(hostport);
     }


### PR DESCRIPTION
Without this revert, error messages come like:
```
/data00/home/shishaochen/github-repos/microsoft/LightGBM/src/io/file_io.cpp: In static member function ‘static hdfs_internal* LightGBM::HDFSFile::GetHDFSFileSystem(const string&)’:
/data00/home/shishaochen/github-repos/microsoft/LightGBM/src/io/file_io.cpp:120:43: error: request for member ‘length’ in ‘LightGBM::kHdfsProto’, which is of non-class type ‘const char*’
     size_t end = uri.find("/", kHdfsProto.length());
                                           ^
/data00/home/shishaochen/github-repos/microsoft/LightGBM/src/io/file_io.cpp:125:50: error: request for member ‘length’ in ‘LightGBM::kHdfsProto’, which is of non-class type ‘const char*’
     std::string hostport = uri.substr(kHdfsProto.length(), end - kHdfsProto.length());
                                                  ^
/data00/home/shishaochen/github-repos/microsoft/LightGBM/src/io/file_io.cpp:125:77: error: request for member ‘length’ in ‘LightGBM::kHdfsProto’, which is of non-class type ‘const char*’
     std::string hostport = uri.substr(kHdfsProto.length(), end - kHdfsProto.length());
                                                                             ^
At global scope:
cc1plus: warning: unrecognized command line option "-Wno-ignored-attributes"
CMakeFiles/_lightgbm.dir/build.make:231: recipe for target 'CMakeFiles/_lightgbm.dir/src/io/file_io.cpp.o' failed
```
This build error is brought from #2426.