### PR TITLE
[R-package] removed unnecessary Suggests dependencies

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -23,15 +23,10 @@ License: MIT + file LICENSE
 URL: https://github.com/Microsoft/LightGBM
 BugReports: https://github.com/Microsoft/LightGBM/issues
 Suggests:
-    Ckmeans.1d.dp (>= 3.3.1),
-    DiagrammeR (>= 0.8.1),
     ggplot2 (>= 1.0.1),
-    igraph (>= 1.0.1),
     knitr,
     rmarkdown,
-    stringi (>= 0.5.2),
-    testthat,
-    vcd (>= 1.3)
+    testthat
 Depends:
     R (>= 3.4),
     R6 (>= 2.0)


### PR DESCRIPTION
Noticed while working on #2530 that we have some packages listed as `Suggests` dependencies for the R package which do not show up anywhere in the examples, tests, or package code (as far as I can tell). We can remove:

* `Ckmeans.1d.dp`
* `DiagrammeR`
* `igraph`
* `stringi`
* `vcd`

I think we should remove these suggested dependencies to reduce the cost of building this library. In some cases R will install Suggests of all packages recursively (e.g. with `devtools::install()`). Also when using `R CMD check`, you will get an error if any `Suggests` dependencies are not found, unless you explicitly express it with an environment variable.