### PR TITLE
Update LambdaRank example documentation

### DIFF
--- a/examples/lambdarank/README.md
+++ b/examples/lambdarank/README.md
@@ -3,15 +3,16 @@ LambdaRank Example
 
 Here is an example for LightGBM to run lambdarank task.
 
-***You should copy executable file to this folder first.***
+***You must follow the [installation instructions](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html)
+for the following commands to work. The `lightgbm` binary must be built and available at the root of this project.***
 
 Training
 --------
 
 Run the following command in this folder:
 
-```
-"./lightgbm" config=train.conf
+```bash
+"../../lightgbm" config=train.conf
 ```
 
 Prediction
@@ -21,6 +22,13 @@ You should finish training first.
 
 Run the following command in this folder:
 
+```bash
+"../../lightgbm" config=predict.conf
 ```
-"./lightgbm" config=predict.conf
-```
+
+Data Format
+-----------
+
+To learn more about the query format used in this example, check out the 
+[query data format](https://lightgbm.readthedocs.io/en/latest/Parameters.html#query-data).
+


### PR DESCRIPTION
- Add reference to documentation on the query data format.
- Refer readers to the official install instructions.
- Change command to use relative path to the `lightgbm` binary built at
the project's root when following build instructions.