### PR TITLE
[docs][docker] cleaned up CODEOWNERS and fixed build warning in dockerfile-python

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 # offer a reasonable automatic best-guess
 
 # catch-all rule (this only gets matched if no rules below match)
-*    @guolinke @StrikeRUS @jameslamb @Laurae2
+*    @guolinke @StrikerRUS @jameslamb @Laurae2
 
 # main C++ code
 include/    @guolinke @chivee

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,9 @@
 # setting reviewers on PRs manually, but this file should
 # offer a reasonable automatic best-guess
 
+# catch-all rule (this only gets matched if no rules below match)
+*    @guolinke @StrikeRUS @jameslamb @Laurae2
+
 # main C++ code
 include/    @guolinke @chivee
 src/    @guolinke @chivee
@@ -27,11 +30,18 @@ helpers/    @StrikerRUS @guolinke
 # CI administrative stuff
 .ci/    @StrikerRUS @Laurae2 @jameslamb
 docs/    @StrikerRUS @Laurae2 @jameslamb
+examples/     @StrikerRUS @jameslamb @guolinke
 *.yml    @StrikerRUS @Laurae2 @jameslamb
 .vsts-ci.yml    @Laurae2
 
-# GPU code
+# docker setup
+docker/    @StrikerRUS @jameslamb
+docker/dockerfile-cli    @guolinke @chivee
 docker/gpu/    @huanzhang12
+docker/dockerfile-python    @StrikerRUS @chivee @wxchan @henry0312
+docker/dockerfile-r    @Laurae2 @jameslamb
+
+# GPU code
 docs/GPU-*.rst    @huanzhang12
 src/treelearner/gpu_tree_learner.cpp    @huanzhang12 @guolinke @chivee
 src/treelearner/tree_learner.cpp    @huanzhang12 @guolinke @chivee

--- a/docker/dockerfile-python
+++ b/docker/dockerfile-python
@@ -11,9 +11,7 @@ RUN apt-get update && \
         g++ \
         git \
         wget && \
-
-# python-package
-    # miniconda
+    # python environment
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     /bin/bash Miniconda3-latest-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
     export PATH="$CONDA_DIR/bin:$PATH" && \
@@ -22,8 +20,7 @@ RUN apt-get update && \
     conda install -q -y numpy scipy scikit-learn pandas && \
     git clone --recursive --branch stable --depth 1 https://github.com/Microsoft/LightGBM && \
     cd LightGBM/python-package && python setup.py install && \
-
-# clean
+    # clean
     apt-get autoremove -y && apt-get clean && \
     conda clean -a -y && \
     rm -rf /usr/local/src/*

--- a/docker/dockerfile-r
+++ b/docker/dockerfile-r
@@ -2,7 +2,6 @@ FROM rocker/verse:latest
 
 WORKDIR /lgbm
 
-# R
 RUN apt-get update && \
     apt-get install -y build-essential && \
     git clone --recursive --branch stable --depth 1 https://github.com/Microsoft/LightGBM && \


### PR DESCRIPTION
I noticed two things while reviewing #2554 

1. No maintainers were automatically added as reviewers for that PR
2. When I tried to build `dockerfile-python` with `docker build -t lgbpy -f dockerfile-python .`, I got this warning

```
[WARNING]: Empty continuation line found in:
    RUN apt-get update &&     apt-get install -y --no-install-recommends         cmake         build-essential         gcc         g++         git         wget &&     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh &&     /bin/bash Miniconda3-latest-Linux-x86_64.sh -f -b -p $CONDA_DIR &&     export PATH="$CONDA_DIR/bin:$PATH" &&     conda config --set always_yes yes --set changeps1 no &&     conda install -q -y numpy scipy scikit-learn pandas &&     git clone --recursive --branch stable --depth 1 https://github.com/Microsoft/LightGBM &&     cd LightGBM/python-package && python setup.py install &&     apt-get autoremove -y && apt-get clean &&     conda clean -a -y &&     rm -rf /usr/local/src/*
[WARNING]: Empty continuation lines will become errors in a future release.
```

This PR fixes that warning in `docker/dockerfile-python` and adds rules to `CODEOWNERS` to ensure the proper reviewers are auto-assigned for future docker PRs.

This PR also removes an unnecessary comment in `docker/dockerfile-r`