### PR TITLE
fixed cpplint warning about parenthesis placement

### DIFF
--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -411,7 +411,8 @@ struct __TToStringHelperFast<T, true, false> {
                   #ifdef _MSC_VER
                   buf_len
                   #endif
-                  ) const {
+                  )
+  const {
     #ifdef _MSC_VER
     sprintf_s(buffer, buf_len, "%g", value);
     #else


### PR DESCRIPTION
This is to address the following cpplint warning (#1990), taking us from 88 warnings to 87.

```
include/LightGBM/utils/common.h:414:  Closing ) should be moved to the previous line  [whitespace/parens] [2]  
```

This warning is raised because other common headers sometimes include `max`, but it is safer to include it explicitly.

<details><summary>cpplint log</summary>

```
Done processing src/treelearner/data_partition.hpp
Done processing include/LightGBM/network.h
Done processing src/boosting/prediction_early_stop.cpp
Done processing include/LightGBM/utils/file_io.h
Done processing include/LightGBM/application.h
include/LightGBM/json11.hpp:80:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:81:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:82:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:83:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:84:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:85:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:86:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:87:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:88:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:89:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:90:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:94:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:101:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:107:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:111:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:144:  Is this a non-const reference? If so, make const or use a pointer: std::string &out  [runtime/references] [2]
include/LightGBM/json11.hpp:153:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/json11.hpp:156:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/json11.hpp:168:  Is this a non-const reference? If so, make const or use a pointer: std::string::size_type & parser_stop_pos  [runtime/references] [2]
include/LightGBM/json11.hpp:169:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/json11.hpp:174:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/json11.hpp:193:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/json11.hpp:208:  Is this a non-const reference? If so, make const or use a pointer: std::string &out  [runtime/references] [2]
Done processing include/LightGBM/json11.hpp
Done processing src/io/dense_nbits_bin.hpp
include/LightGBM/tree.h:487:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
Done processing include/LightGBM/tree.h
Done processing src/treelearner/cost_effective_gradient_boosting.hpp
Done processing include/LightGBM/utils/openmp_wrapper.h
Done processing src/treelearner/tree_learner.cpp
Done processing src/boosting/dart.hpp
src/c_api.cpp:421:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
src/c_api.cpp:920:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/c_api.cpp
Done processing include/LightGBM/dataset.h
Done processing src/network/linkers.h
Done processing src/boosting/boosting.cpp
Done processing src/application/application.cpp
src/io/dataset.cpp:30:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/dataset.cpp:341:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/io/dataset.cpp
Done processing include/LightGBM/utils/pipeline_reader.h
Done processing src/metric/map_metric.hpp
include/LightGBM/utils/common.h:303:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
include/LightGBM/utils/common.h:374:  Never use sprintf. Use snprintf instead.  [runtime/printf] [5]
include/LightGBM/utils/common.h:413:  Uncommented text after #endif is non-standard.  Use a comment.  [build/endif_comment] [5]
include/LightGBM/utils/common.h:418:  Never use sprintf. Use snprintf instead.  [runtime/printf] [5]
Done processing include/LightGBM/utils/common.h
src/io/dataset_loader.cpp:16:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
src/io/dataset_loader.cpp:439:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/dataset_loader.cpp:591:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/dataset_loader.cpp:902:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/io/dataset_loader.cpp
Done processing include/LightGBM/objective_function.h
Done processing src/metric/metric.cpp
Done processing src/io/file_io.cpp
src/application/predictor.hpp:45:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/application/predictor.hpp:46:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
Done processing src/application/predictor.hpp
Done processing include/LightGBM/R_object_helper.h
Done processing src/treelearner/leaf_splits.hpp
Done processing include/LightGBM/utils/array_args.h
Done processing src/treelearner/parallel_tree_learner.h
Done processing src/objective/xentropy_objective.hpp
Done processing src/metric/binary_metric.hpp
Done processing include/LightGBM/dataset_loader.h
Done processing src/treelearner/feature_parallel_tree_learner.cpp
Done processing src/network/linkers_mpi.cpp
include/LightGBM/tree_learner.h:16:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing include/LightGBM/tree_learner.h
Done processing src/objective/multiclass_objective.hpp
Done processing include/LightGBM/feature_group.h
Done processing src/io/ordered_sparse_bin.hpp
src/metric/dcg_calculator.cpp:27:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/metric/dcg_calculator.cpp
src/io/config_auto.cpp:298:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
src/io/config_auto.cpp:304:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:305:  Consider using CHECK_LE instead of CHECK(a <= b)  [readability/check] [2]
src/io/config_auto.cpp:312:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
src/io/config_auto.cpp:383:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:386:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:395:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:398:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:433:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:440:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:443:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:516:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:544:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:553:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:562:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:565:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:568:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:571:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/io/config_auto.cpp
src/io/bin.cpp:80:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/bin.cpp:511:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/io/bin.cpp
Done processing src/io/parser.hpp
src/metric/regression_metric.hpp:274:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/metric/regression_metric.hpp:296:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/metric/regression_metric.hpp
Done processing include/LightGBM/utils/random.h
src/io/json11.cpp:53:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:57:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:67:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:73:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:77:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:114:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:126:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:339:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
src/io/json11.cpp:351:  const string& members are dangerous. It is much better to use alternatives, such as pointers or simple constants.  [runtime/member_string_references] [2]
src/io/json11.cpp:452:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
src/io/json11.cpp:452:  Is this a non-const reference? If so, make const or use a pointer: string & out  [runtime/references] [2]
src/io/json11.cpp:479:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
src/io/json11.cpp:523:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
Done processing src/io/json11.cpp
Done processing src/treelearner/voting_parallel_tree_learner.cpp
Done processing src/metric/xentropy_metric.hpp
Done processing src/io/dense_bin.hpp
src/treelearner/serial_tree_learner.h:32:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing src/treelearner/serial_tree_learner.h
Done processing src/io/metadata.cpp
Done processing src/network/network.cpp
Done processing src/objective/objective_function.cpp
Done processing include/LightGBM/utils/threading.h
src/treelearner/feature_histogram.hpp:676:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
Done processing src/treelearner/feature_histogram.hpp
src/network/socket_wrapper.hpp:221:  Are you taking an address of a cast?  This is dangerous: could be a temp var.  Take the address before doing the cast, rather than after  [runtime/casting] [4]
Done processing src/network/socket_wrapper.hpp
Done processing src/treelearner/gpu_tree_learner.cpp
Done processing src/metric/multiclass_metric.hpp
include/LightGBM/c_api.h:1041:  Almost always, snprintf is better than strcpy  [runtime/printf] [4]
Done processing include/LightGBM/c_api.h
Done processing src/boosting/gbdt_prediction.cpp
Done processing src/treelearner/data_parallel_tree_learner.cpp
Done processing src/treelearner/split_info.hpp
Done processing include/LightGBM/prediction_early_stop.h
Done processing src/boosting/goss.hpp
Done processing src/boosting/score_updater.hpp
Done processing include/LightGBM/metric.h
Done processing include/LightGBM/utils/log.h
src/treelearner/serial_tree_learner.cpp:290:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
src/treelearner/serial_tree_learner.cpp:302:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
src/treelearner/serial_tree_learner.cpp:314:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
src/treelearner/serial_tree_learner.cpp:876:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/treelearner/serial_tree_learner.cpp
Done processing include/LightGBM/config.h
Done processing include/LightGBM/boosting.h
src/treelearner/gpu_tree_learner.h:37:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing src/treelearner/gpu_tree_learner.h
Done processing src/objective/regression_objective.hpp
src/boosting/gbdt.cpp:299:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/boosting/gbdt.cpp
Done processing include/LightGBM/export.h
Done processing src/network/linker_topo.cpp
Done processing src/metric/rank_metric.hpp
Done processing src/io/tree.cpp
Done processing include/LightGBM/meta.h
Done processing include/LightGBM/utils/text_reader.h
Done processing src/main.cpp
Done processing include/LightGBM/bin.h
src/io/parser.cpp:183:  Add #include <algorithm> for max  [build/include_what_you_use] [4]
Done processing src/io/parser.cpp
Done processing include/LightGBM/lightgbm_R.h
Done processing src/objective/rank_objective.hpp
src/lightgbm_R.cpp:36:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing src/lightgbm_R.cpp
Done processing src/boosting/gbdt_model_text.cpp
Done processing src/io/sparse_bin.hpp
Done processing src/network/linkers_socket.cpp
Done processing src/boosting/rf.hpp
Done processing src/io/config.cpp
src/boosting/gbdt.h:26:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing src/boosting/gbdt.h
Done processing src/objective/binary_objective.hpp
Total errors found: 88
Jamess-MacBook-Pro:LightGBM jlamb$
Jamess-MacBook-Pro:LightGBM jlamb$ cpplint     --filter=-build/c++11,-build/include_subdir,-build/header_guard,-whitespace/line_length     --recursive     ./src     ./include
Done processing include/LightGBM/R_object_helper.h
Done processing src/io/parser.hpp
Done processing src/network/linker_topo.cpp
Done processing src/io/tree.cpp
Done processing src/objective/multiclass_objective.hpp
include/LightGBM/json11.hpp:80:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:81:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:82:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:83:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:84:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:85:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:86:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:87:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:88:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:89:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:90:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:94:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:101:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:107:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:111:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/json11.hpp:144:  Is this a non-const reference? If so, make const or use a pointer: std::string &out  [runtime/references] [2]
include/LightGBM/json11.hpp:153:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/json11.hpp:156:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/json11.hpp:168:  Is this a non-const reference? If so, make const or use a pointer: std::string::size_type & parser_stop_pos  [runtime/references] [2]
include/LightGBM/json11.hpp:169:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/json11.hpp:174:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/json11.hpp:193:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/json11.hpp:208:  Is this a non-const reference? If so, make const or use a pointer: std::string &out  [runtime/references] [2]
Done processing include/LightGBM/json11.hpp
include/LightGBM/utils/common.h:303:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
include/LightGBM/utils/common.h:374:  Never use sprintf. Use snprintf instead.  [runtime/printf] [5]
include/LightGBM/utils/common.h:419:  Never use sprintf. Use snprintf instead.  [runtime/printf] [5]
Done processing include/LightGBM/utils/common.h
Done processing src/boosting/prediction_early_stop.cpp
Done processing src/boosting/gbdt_prediction.cpp
Done processing src/main.cpp
Done processing include/LightGBM/network.h
Done processing src/treelearner/gpu_tree_learner.cpp
src/c_api.cpp:421:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
src/c_api.cpp:920:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/c_api.cpp
src/network/socket_wrapper.hpp:221:  Are you taking an address of a cast?  This is dangerous: could be a temp var.  Take the address before doing the cast, rather than after  [runtime/casting] [4]
Done processing src/network/socket_wrapper.hpp
Done processing src/network/linkers_socket.cpp
Done processing src/io/file_io.cpp
src/treelearner/serial_tree_learner.cpp:290:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
src/treelearner/serial_tree_learner.cpp:302:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
src/treelearner/serial_tree_learner.cpp:314:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
src/treelearner/serial_tree_learner.cpp:876:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/treelearner/serial_tree_learner.cpp
Done processing src/io/dense_nbits_bin.hpp
src/metric/regression_metric.hpp:274:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/metric/regression_metric.hpp:296:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/metric/regression_metric.hpp
Done processing include/LightGBM/utils/array_args.h
Done processing include/LightGBM/utils/file_io.h
Done processing src/metric/binary_metric.hpp
src/io/config_auto.cpp:298:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
src/io/config_auto.cpp:304:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:305:  Consider using CHECK_LE instead of CHECK(a <= b)  [readability/check] [2]
src/io/config_auto.cpp:312:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
src/io/config_auto.cpp:383:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:386:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:395:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:398:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:433:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:440:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:443:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:516:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:544:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:553:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:562:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:565:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:568:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/config_auto.cpp:571:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/io/config_auto.cpp
src/boosting/gbdt.cpp:299:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/boosting/gbdt.cpp
Done processing src/treelearner/cost_effective_gradient_boosting.hpp
Done processing include/LightGBM/bin.h
Done processing include/LightGBM/boosting.h
Done processing src/boosting/score_updater.hpp
src/io/json11.cpp:53:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:57:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:67:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:73:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:77:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:114:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:126:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:339:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
src/io/json11.cpp:351:  const string& members are dangerous. It is much better to use alternatives, such as pointers or simple constants.  [runtime/member_string_references] [2]
src/io/json11.cpp:452:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
src/io/json11.cpp:452:  Is this a non-const reference? If so, make const or use a pointer: string & out  [runtime/references] [2]
src/io/json11.cpp:479:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
src/io/json11.cpp:523:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
Done processing src/io/json11.cpp
Done processing include/LightGBM/objective_function.h
Done processing src/metric/metric.cpp
Done processing src/treelearner/parallel_tree_learner.h
Done processing include/LightGBM/lightgbm_R.h
Done processing include/LightGBM/utils/random.h
Done processing include/LightGBM/meta.h
Done processing include/LightGBM/dataset_loader.h
Done processing src/metric/multiclass_metric.hpp
src/treelearner/gpu_tree_learner.h:37:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing src/treelearner/gpu_tree_learner.h
Done processing include/LightGBM/utils/openmp_wrapper.h
Done processing src/treelearner/split_info.hpp
src/io/dataset.cpp:30:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/dataset.cpp:341:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/io/dataset.cpp
src/metric/dcg_calculator.cpp:27:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/metric/dcg_calculator.cpp
Done processing include/LightGBM/utils/text_reader.h
Done processing src/network/network.cpp
Done processing src/metric/map_metric.hpp
Done processing src/boosting/gbdt_model_text.cpp
src/treelearner/feature_histogram.hpp:676:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
Done processing src/treelearner/feature_histogram.hpp
Done processing src/boosting/rf.hpp
Done processing include/LightGBM/utils/threading.h
Done processing src/objective/binary_objective.hpp
Done processing src/io/dense_bin.hpp
Done processing src/boosting/boosting.cpp
Done processing include/LightGBM/metric.h
src/application/predictor.hpp:45:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/application/predictor.hpp:46:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
Done processing src/application/predictor.hpp
Done processing include/LightGBM/feature_group.h
Done processing include/LightGBM/application.h
Done processing src/objective/objective_function.cpp
Done processing src/network/linkers_mpi.cpp
Done processing include/LightGBM/dataset.h
Done processing src/objective/regression_objective.hpp
Done processing src/io/config.cpp
Done processing src/boosting/dart.hpp
Done processing include/LightGBM/export.h
include/LightGBM/c_api.h:1041:  Almost always, snprintf is better than strcpy  [runtime/printf] [4]
Done processing include/LightGBM/c_api.h
include/LightGBM/tree.h:487:  Consider using CHECK_GE instead of CHECK(a >= b)  [readability/check] [2]
Done processing include/LightGBM/tree.h
src/boosting/gbdt.h:26:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing src/boosting/gbdt.h
Done processing src/application/application.cpp
Done processing src/objective/rank_objective.hpp
Done processing src/treelearner/voting_parallel_tree_learner.cpp
Done processing src/io/ordered_sparse_bin.hpp
Done processing src/boosting/goss.hpp
Done processing include/LightGBM/prediction_early_stop.h
Done processing src/metric/xentropy_metric.hpp
Done processing include/LightGBM/config.h
Done processing src/treelearner/leaf_splits.hpp
src/io/dataset_loader.cpp:16:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
src/io/dataset_loader.cpp:439:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/dataset_loader.cpp:591:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/dataset_loader.cpp:902:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/io/dataset_loader.cpp
Done processing src/objective/xentropy_objective.hpp
Done processing include/LightGBM/utils/pipeline_reader.h
Done processing src/treelearner/data_partition.hpp
src/lightgbm_R.cpp:36:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing src/lightgbm_R.cpp
include/LightGBM/tree_learner.h:16:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing include/LightGBM/tree_learner.h
Done processing src/io/metadata.cpp
Done processing src/network/linkers.h
Done processing include/LightGBM/utils/log.h
Done processing src/io/sparse_bin.hpp
Done processing src/treelearner/data_parallel_tree_learner.cpp
Done processing src/metric/rank_metric.hpp
src/io/parser.cpp:183:  Add #include <algorithm> for max  [build/include_what_you_use] [4]
Done processing src/io/parser.cpp
src/treelearner/serial_tree_learner.h:32:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing src/treelearner/serial_tree_learner.h
src/io/bin.cpp:80:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
src/io/bin.cpp:511:  Consider using CHECK_GT instead of CHECK(a > b)  [readability/check] [2]
Done processing src/io/bin.cpp
Done processing src/treelearner/tree_learner.cpp
Done processing src/treelearner/feature_parallel_tree_learner.cpp
Total errors found: 87
```
</details>