### PR TITLE
[docs] pin roxygen2 version for RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,7 +233,8 @@ def generate_r_docs(app):
         r-testthat=2.0.0=r351h29659fb_0 \
         cmake=3.14.0=h52cb24c_0
     /home/docs/.conda/bin/conda install -q -y -n r_env -c conda-forge \
-        r-pkgdown=1.3.0=r351h6115d3f_1000
+        r-pkgdown=1.3.0=r351h6115d3f_1000 \
+        r-roxygen2=6.1.1=r35h0357c0b_1001
     source /home/docs/.conda/bin/activate r_env
     export TAR=/bin/tar
     cd {0}


### PR DESCRIPTION
Our docs builds for `master` fails. Pinning `roxygen2` version for the one from the latest successful build solves the problem.

```

* installing *source* package ‘lightgbm’ ...
** libs
installing via 'install.libs.R' to /tmp/RtmprKIQ2D/devtools_install_537456a8988/lightgbm
* DONE (lightgbm)
Loading required package: R6
Updating roxygen version in /home/docs/checkouts/readthedocs.org/user_builds/lightgbm/checkouts/latest/lightgbm_r/DESCRIPTION
Error in env_get(roxy_meta, key, default = default) : 
  unused argument (default = default)
Calls: <Anonymous> ... .f -> parse_tags -> markdown_activate -> roxy_meta_get
Execution halted


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/lightgbm/envs/latest/lib/python3.7/site-packages/sphinx/cmd/build.py", line 303, in build_main
    args.tags, args.verbosity, args.jobs, args.keep_going)
  File "/home/docs/checkouts/readthedocs.org/user_builds/lightgbm/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 263, in __init__
    self._init_builder()
  File "/home/docs/checkouts/readthedocs.org/user_builds/lightgbm/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 325, in _init_builder
    self.emit('builder-inited')
  File "/home/docs/checkouts/readthedocs.org/user_builds/lightgbm/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 510, in emit
    return self.events.emit(event, self, *args)
  File "/home/docs/checkouts/readthedocs.org/user_builds/lightgbm/envs/latest/lib/python3.7/site-packages/sphinx/events.py", line 80, in emit
    results.append(callback(*args))
  File "/home/docs/checkouts/readthedocs.org/user_builds/lightgbm/checkouts/latest/docs/conf.py", line 259, in generate_r_docs
    raise Exception("An error has occurred while generating documentation for R-package\n" + str(e))
Exception: An error has occurred while generating documentation for R-package
```

Corrupted version is `r-roxygen2-7.0.0           |    r35h0357c0b_0         627 KB  conda-forge`

![image](https://user-images.githubusercontent.com/25141164/68868485-aa81fd80-0708-11ea-87d7-179908376c73.png)
