### PR TITLE
[R-package] fixed minor issues with tests and documentation

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -360,7 +360,7 @@ lgb.cv <- function(params = list()
       # Store temporarily model data elsewhere
       booster_old <- list(
         best_iter = fd$booster$best_iter
-        , best_score = fd$booster$best_score,
+        , best_score = fd$booster$best_score
         , record_evals = fd$booster$record_evals
       )
       # Reload model

--- a/R-package/R/lgb.prepare_rules2.R
+++ b/R-package/R/lgb.prepare_rules2.R
@@ -46,7 +46,7 @@
 #'   Species = c(
 #'     "setosa" = 3L
 #'     , "versicolor" = 2L
-#'     , virginica" = 1L
+#'     , "virginica" = 1L
 #'   )
 #' )
 #' newest_iris <- lgb.prepare_rules2(data = iris, rules = personal_rules)

--- a/R-package/R/lightgbm.R
+++ b/R-package/R/lightgbm.R
@@ -181,6 +181,7 @@ globalVariables(c(
     "."
     , ".N"
     , ".SD"
+    , "abs_contribution"
     , "Contribution"
     , "Cover"
     , "Feature"

--- a/R-package/tests/testthat/test_parameters.R
+++ b/R-package/tests/testthat/test_parameters.R
@@ -44,7 +44,7 @@ test_that("Feature penalties work properly", {
   expect_length(var_gain[[length(var_gain)]], 0L)
 })
 
-expect_true(".PARAMETER_ALIASES() returns a named list", {
+test_that(".PARAMETER_ALIASES() returns a named list", {
   param_aliases <- .PARAMETER_ALIASES()
   expect_true(is.list(param_aliases))
   expect_true(is.character(names(param_aliases)))
@@ -55,7 +55,7 @@ expect_true(".PARAMETER_ALIASES() returns a named list", {
   expect_true(is.character(param_aliases[["num_iterations"]]))
 })
 
-expect_true("training should warn if you use 'dart' boosting, specified with 'boosting' or aliases", {
+test_that("training should warn if you use 'dart' boosting, specified with 'boosting' or aliases", {
   for (boosting_param in .PARAMETER_ALIASES()[["boosting"]]) {
     expect_warning({
       result <- lightgbm(


### PR DESCRIPTION
This PR addresses a few issues found during #2530 . Splitting them out into a separate PR because I think they can go through a much quicker review, and we need to fix them regardless of what is decided in #2530 .

1.  extra comma in `lgb.cv.R`. fixes:

```
lgb.cv : <anonymous>: missing arguments not allowed in calls to ‘list’
```

2. missing quote in documentation in `lgb.prepare_rules2.R`. fixes:

```
Error: LaTeX error. Mismatched quote or braces
```

3. two uses of `expect_true()` where `test_that()` should have been used in `test_parameters.R`
4. fix to avoid warning from `R CMD check`

```
multiple.tree.interprete: no visible binding for global variable
  ‘abs_contribution’
Undefined global functions or variables:
  abs_contribution
```

None of these changes impact the `roxygen` documentation, so there are no `man/` file changes in the diff.