### PR TITLE
LightGBM would hang on MPI run if only some nodes have a fatal error.…

### DIFF
--- a/include/LightGBM/application.h
+++ b/include/LightGBM/application.h
@@ -36,6 +36,9 @@ class Application {
   /*! \brief To call this function to run application*/
   inline void Run();
 
+  /*! \brief Returns whether we are running in parallel mode*/
+  inline bool IsParallel();
+
  private:
   /*! \brief Load parameters from command line and config file*/
   void LoadParameters(int argc, char** argv);
@@ -74,6 +77,9 @@ class Application {
   std::unique_ptr<ObjectiveFunction> objective_fun_;
 };
 
+inline bool Application::IsParallel() {
+  return (config_.is_parallel);
+}
 
 inline void Application::Run() {
   if (config_.task == TaskType::kPredict || config_.task == TaskType::KRefitTree) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,38 @@
 int main(int argc, char** argv) {
   try {
     LightGBM::Application app(argc, argv);
-    app.Run();
+
+    std::string exception_str;
+    try
+    {
+      app.Run();
+    }
+    catch (const std::exception& ex) {
+      exception_str = ex.what();
+    }
+    catch (const std::string& ex) {
+      exception_str = ex;
+    }
+    catch (...) {
+      exception_str = "Unknown Exceptions";
+    }
+
+    if (!exception_str.empty())
+    {
+#ifdef USE_MPI
+      // In the MPI mode, if there is an exception and you try to exit this block, the destructor for "app" is called,
+      // which in turn calls MPI_Finalize(). But that causes this process to hang and the whole MPI job can hang as a result.
+      // Instead we may want to call MPI_Abort(). However that right now doesn't do much more call abort(). So we just do it here.
+      if (app.IsParallel())
+      {
+        std::cerr << "Aborting because of exception in MPI mode:" << std::endl;
+        std::cerr << exception_str << std::endl;
+        std::cerr.flush();
+        abort();
+      }
+#endif
+      throw exception_str;
+    }
   }
   catch (const std::exception& ex) {
     std::cerr << "Met Exceptions:" << std::endl;


### PR DESCRIPTION
… The issue is that the destructor of Application calls MPI_Finalize(), which will cause the program to hand and prevent from exiting. We could call MPI_Abort(), but it appears to have the same affect as abort(). So we just use abort() in MPI mode if there is an unhandled exception.