### PR TITLE
LightGBM would hang on MPI run if only some nodes have a fatal error.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,26 +3,41 @@
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
 #include <LightGBM/application.h>
+#include "network/linkers.h"
 
 #include <iostream>
 
+
+
 int main(int argc, char** argv) {
+  bool success = false;
   try {
     LightGBM::Application app(argc, argv);
     app.Run();
+
+#ifdef USE_MPI
+    LightGBM::Linkers::MpiFinalizeIfIsParallel();
+#endif
+
+    success = true;
   }
   catch (const std::exception& ex) {
     std::cerr << "Met Exceptions:" << std::endl;
     std::cerr << ex.what() << std::endl;
-    exit(-1);
   }
   catch (const std::string& ex) {
     std::cerr << "Met Exceptions:" << std::endl;
     std::cerr << ex << std::endl;
-    exit(-1);
   }
   catch (...) {
     std::cerr << "Unknown Exceptions" << std::endl;
+  }
+
+  if (!success) {
+#ifdef USE_MPI
+    LightGBM::Linkers::MpiAbortIfIsParallel();
+#endif
+
     exit(-1);
   }
-}
+ }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,8 +7,6 @@
 
 #include <iostream>
 
-
-
 int main(int argc, char** argv) {
   bool success = false;
   try {

--- a/src/network/linkers.h
+++ b/src/network/linkers.h
@@ -138,7 +138,15 @@ class Linkers {
 
   #endif  // USE_SOCKET
 
+  #ifdef USE_MPI
 
+  static bool IsMpiInitialized();
+
+  static void MpiFinalizeIfIsParallel();
+
+  static void MpiAbortIfIsParallel();
+
+  #endif
  private:
   /*! \brief Rank of local machine */
   int rank_;

--- a/src/network/linkers.h
+++ b/src/network/linkers.h
@@ -140,10 +140,19 @@ class Linkers {
 
   #ifdef USE_MPI
 
+  /*!
+  * \brief Check if MPI has been initialized
+  */
   static bool IsMpiInitialized();
 
+  /*!
+  * \brief Finalize the MPI session if it was initialized
+  */
   static void MpiFinalizeIfIsParallel();
 
+  /*!
+  * \brief Abort the MPI session if it was initialized (called in case there was a error that needs abrupt ending)
+  */
   static void MpiAbortIfIsParallel();
 
   #endif

--- a/src/network/linkers_mpi.cpp
+++ b/src/network/linkers_mpi.cpp
@@ -27,11 +27,41 @@ Linkers::Linkers(Config) {
 }
 
 Linkers::~Linkers() {
-  if (is_init_) {
+  // Don't call MPI_Finalize() here: If the destructor was called because only this node had an exception, calling MPI_Finalize() will cause all nodes to hang.
+  // Instead we will handle finalize/abort for MPI in main().
+}
+
+bool Linkers::IsMpiInitialized() {
+  int is_mpi_init;
+  MPI_SAFE_CALL(MPI_Initialized(&is_mpi_init));
+  return is_mpi_init;
+}
+
+void Linkers::MpiFinalizeIfIsParallel() {
+  if (IsMpiInitialized()) {
+    Log::Debug("Finalizing MPI session.");
     MPI_SAFE_CALL(MPI_Finalize());
+  }
+  else {
+    Log::Debug("MPI was not initialized.");
   }
 }
 
+void Linkers::MpiAbortIfIsParallel() {
+  try {
+    if (IsMpiInitialized()) {
+      std::cerr << "Aborting MPI communication." << std::endl << std::flush;
+      MPI_SAFE_CALL(MPI_Abort(MPI_COMM_WORLD, -1));;
+    }
+    else {
+      Log::Debug("MPI was not initialized.");
+    }
+  }
+  catch (...) {
+    std::cerr << "Exception was raised before aborting MPI. Aborting process..." << std::endl << std::flush;
+    abort();
+  }
+}
 
 }  // namespace LightGBM
 #endif  // USE_MPI

--- a/src/network/linkers_mpi.cpp
+++ b/src/network/linkers_mpi.cpp
@@ -42,9 +42,6 @@ void Linkers::MpiFinalizeIfIsParallel() {
     Log::Debug("Finalizing MPI session.");
     MPI_SAFE_CALL(MPI_Finalize());
   }
-  else {
-    Log::Debug("MPI was not initialized.");
-  }
 }
 
 void Linkers::MpiAbortIfIsParallel() {
@@ -52,9 +49,6 @@ void Linkers::MpiAbortIfIsParallel() {
     if (IsMpiInitialized()) {
       std::cerr << "Aborting MPI communication." << std::endl << std::flush;
       MPI_SAFE_CALL(MPI_Abort(MPI_COMM_WORLD, -1));;
-    }
-    else {
-      Log::Debug("MPI was not initialized.");
     }
   }
   catch (...) {


### PR DESCRIPTION
The issue is that the destructor of Application calls MPI_Finalize(), which will cause the program to hand and prevent from exiting. As a solution, we remove MPI_Finalize() from the destructor and let main() decide whether to call MPI_Finalize() or MPI_Abort() based on the reason it is ending.