### PR TITLE
[docs] updated records of kaggle competitions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,10 +8,33 @@ Comments in configuration files might be outdated. Actual information about para
 Machine Learning Challenge Winning Solutions
 ============================================
 
-**LightGBM is used in the most winning solutions, so we do not update this table anymore.**
+**LightGBM is used in many winning solutions, but this table is updated very infrequently.**
 
 | Place         | Competition   | Solution  | Date |
 | ------------- |:------------- | --------- | -----|
+| 3rd     | [RSNA Intracranial Hemorrhage Detection](https://www.kaggle.com/c/rsna-intracranial-hemorrhage-detection) | [link](https://www.kaggle.com/c/rsna-intracranial-hemorrhage-detection/discussion/117223#latest-673643) | 2019.11 |
+| 1st     | [IEEE-CIS Fraud Detection](https://www.kaggle.com/c/ieee-fraud-detection) | [link](https://www.kaggle.com/c/ieee-fraud-detection/discussion/111308) | 2019.10 |
+| 2nd     | [IEEE-CIS Fraud Detection](https://www.kaggle.com/c/ieee-fraud-detection) | [link](https://www.kaggle.com/c/ieee-fraud-detection/discussion/111321) | 2019.10 |
+| 2nd     | [Kuzushiji Recognition](https://www.kaggle.com/c/kuzushiji-recognition) | [link](https://www.kaggle.com/c/kuzushiji-recognition/discussion/112712) | 2019.10 |
+| 1st     | [Los Alamos National Laboratory Earthquake Prediction](https://www.kaggle.com/c/LANL-Earthquake-Prediction) | [link](https://www.kaggle.com/c/LANL-Earthquake-Prediction/discussion/94390#latest-632778) | 2019.6 |
+| 3rd     | [Los Alamos National Laboratory Earthquake Prediction](https://www.kaggle.com/c/LANL-Earthquake-Prediction) | [link](https://www.kaggle.com/c/LANL-Earthquake-Prediction/discussion/94459) | 2019.6 |
+| 1st     | [Santander Customer Transaction Prediction](https://www.kaggle.com/c/santander-customer-transaction-prediction) | [link](https://www.kaggle.com/c/santander-customer-transaction-prediction/discussion/89003#latest-678843) | 2019.4 |
+| 2nd     | [Santander Customer Transaction Prediction](https://www.kaggle.com/c/santander-customer-transaction-prediction) | [link](https://www.kaggle.com/c/santander-customer-transaction-prediction/discussion/88939) | 2019.4 |
+| 3rd     | [Santander Customer Transaction Prediction](https://www.kaggle.com/c/santander-customer-transaction-prediction) | [link](https://www.kaggle.com/c/santander-customer-transaction-prediction/discussion/88902) | 2019.4 |
+| 2nd     | [PetFinder.my Adoption Prediction](https://www.kaggle.com/c/petfinder-adoption-prediction) | [link](https://www.kaggle.com/c/petfinder-adoption-prediction/discussion/88773#latest-512090) | 2019.4 |
+| 1st     | [Google Analytics Customer Revenue Prediction](https://www.kaggle.com/c/ga-customer-revenue-prediction) | [link](https://www.kaggle.com/c/ga-customer-revenue-prediction/discussion/82614#latest-482575) | 2019.3  |
+| 1st     | [VSB Power Line Fault Detection](https://www.kaggle.com/c/vsb-power-line-fault-detection) | [link](https://www.kaggle.com/c/vsb-power-line-fault-detection/discussion/87038#latest-521846) | 2019.3 |
+| 5th     | [Elo Merchant Category Recommendation](https://www.kaggle.com/c/elo-merchant-category-recommendation) | [link](https://www.kaggle.com/c/elo-merchant-category-recommendation/discussion/82314#latest-525737) | 2019.2 |
+| 2nd     | [PLAsTiCC Astronomical Classification](https://www.kaggle.com/c/PLAsTiCC-2018) | [link](https://www.kaggle.com/c/PLAsTiCC-2018/discussion/75059#latest-462457) | 2018.12 | 
+| 1st     | [Google Research Doodle Recognition Challenge](https://www.kaggle.com/c/quickdraw-doodle-recognition) | [link](https://www.kaggle.com/c/quickdraw-doodle-recognition/discussion/73738#latest-550028) | 2018.12 |
+| 1st     | [Home Credit Group Home Credit Default Risk](https://www.kaggle.com/c/home-credit-default-risk) | [link](https://www.kaggle.com/c/home-credit-default-risk/discussion/64480#latest-514514) | 2018.8 |
+| 2nd     | [Home Credit Group Home Credit Default Risk](https://www.kaggle.com/c/home-credit-default-risk) | [link](https://www.kaggle.com/c/home-credit-default-risk/discussion/64722#latest-394948) | 2018.8 |
+| 3rd     | [Home Credit Group Home Credit Default Risk](https://www.kaggle.com/c/home-credit-default-risk) | [link](https://www.kaggle.com/c/home-credit-default-risk/discussion/64596#latest-420333) | 2018.8 |
+| 2nd     | [Google AI Open Images - Visual Relationship Track](https://www.kaggle.com/c/google-ai-open-images-visual-relationship-track) | [link](https://www.kaggle.com/c/google-ai-open-images-visual-relationship-track/discussion/64651) | 2018.8 |
+| 2nd     | [Santander Value Prediction Challenge](https://www.kaggle.com/c/santander-value-prediction-challenge) | [link](https://www.kaggle.com/c/santander-value-prediction-challenge/discussion/63848#latest-374826) | 2018.8 |
+| 1st     | [Avito Demand Prediction Challenge](https://www.kaggle.com/c/avito-demand-prediction) | [link](https://www.kaggle.com/c/avito-demand-prediction/discussion/59880#latest-450523) | 2018.6 |
+| 2nd     | [Avito Demand Prediction Challenge](https://www.kaggle.com/c/avito-demand-prediction) | [link](https://www.kaggle.com/c/avito-demand-prediction/discussion/59871#latest-470807) | 2018.6 |
+| 3rd     | [Avito Demand Prediction Challenge](https://www.kaggle.com/c/avito-demand-prediction) | [link](https://www.kaggle.com/c/avito-demand-prediction/discussion/59885#latest-364403) | 2018.6 |
 | 1st     | [TalkingData AdTracking Fraud Detection Challenge](https://www.kaggle.com/c/talkingdata-adtracking-fraud-detection) | [link](https://www.kaggle.com/c/talkingdata-adtracking-fraud-detection/discussion/56475)| 2018.5 |
 | 1st     | [DonorsChoose.org Application Screening](https://www.kaggle.com/c/donorschoose-application-screening)| [link](https://www.kaggle.com/shadowwarrior/1st-place-solution/notebook) | 2018.4 | 
 | 1st     | [Toxic Comment Classification Challenge](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge)| [link](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/discussion/52557) | 2018.3 |


### PR DESCRIPTION
Have been meaning to do this for a while. I went back through the Kaggle competitions in the last year and did my best to identify top-3 solutions that used `LightGBM`. 

The only exception is the [Elo Merchant Category Recommendation](https://www.kaggle.com/c/elo-merchant-category-recommendation) competition. The 5th-place submission is the highest-ranked one with a public writeup / kernel available.