### PR TITLE
[python] Variable Typo: redictor -> predictor

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -803,7 +803,7 @@ class Dataset(object):
                 assert num_data == len(used_indices)
                 for i in range_(len(used_indices)):
                     for j in range_(predictor.num_class):
-                        sub_init_score[i * redictor.num_class + j] = init_score[used_indices[i] * redictor.num_class + j]
+                        sub_init_score[i * predictor.num_class + j] = init_score[used_indices[i] * predictor.num_class + j]
                 init_score = sub_init_score
         if predictor.num_class > 1:
             # need to regroup init_score


### PR DESCRIPTION
I believe that this should be a typo, right? It was strange that it could even compile, because it was clearly red in my Pycharm.

By the way, the continuous-integration has 1 test failing because of 'too many requests', so it should be related to some kind of server problem rather than this commit.