### PR TITLE
[R-package] removed function lgb.check.params

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -118,9 +118,6 @@ lgb.cv <- function(params = list()
     feval <- eval
   }
 
-  # Check for parameters
-  lgb.check.params(params)
-
   # Init predictor to empty
   predictor <- NULL
 

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -89,9 +89,6 @@ lgb.train <- function(params = list(),
     feval <- eval
   }
 
-  # Check for parameters
-  lgb.check.params(params)
-
   # Init predictor to empty
   predictor <- NULL
 

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -175,13 +175,6 @@ lgb.check.r6.class <- function(object, name) {
 
 }
 
-lgb.check.params <- function(params) {
-
-  # To-do
-  params # Currently return params because this is not finalized
-
-}
-
 lgb.check.obj <- function(params, obj) {
 
   # List known objectives in a vector


### PR DESCRIPTION
We have function `lgb.check.params()` in the R package. I'm not sure what it's original intent was, but it is [a few years old](https://github.com/microsoft/LightGBM/blame/master/R-package/R/utils.R) and currently just takes in a list called `params` and immediately returns it.

To simplify the R code slightly, in this PR I propose that we remove it. This function is not exported so removing it is not a user-facing breaking change.