### PR TITLE
[R-package] Added instructions for generating R test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -322,6 +322,8 @@ coverage.xml
 *,cover
 .hypothesis/
 **/coverage.html
+**/coverage.html.zip
+R-package/tests/testthat/Rplots.pdf
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -321,6 +321,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+**/coverage.html
 
 # Translations
 *.mo

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -133,7 +133,7 @@ The R package's unit tests are run automatically on every commit, via integratio
 
 When adding tests, you may want to use test coverage to identify untested areas and to check if the tests you've added are covering all branches of the intended code.
 
-The example below shows how to generate code coverage for the R package on a Mac or Linux setup. To adjust for your environment, swap out the 'Install' step with [the relevant code from the instructions above](#install).
+The example below shows how to generate code coverage for the R package on a macOS or Linux setup, using `gcc-8` to compile `LightGBM`. To adjust for your environment, swap out the 'Install' step with [the relevant code from the instructions above](#install).
 
 ```shell
 # Install

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -31,7 +31,7 @@ You can perform installation either with **Apple Clang** or **gcc**. In case you
 export CXX=/usr/local/bin/g++-8 CC=/usr/local/bin/gcc-8
 ```
 
-### Install
+### Install <a name="install-source"></a>
 
 Build and install R-package with the following commands:
 
@@ -125,6 +125,30 @@ Please visit [demo](https://github.com/microsoft/LightGBM/tree/master/R-package/
 * [Multiclass Training/Prediction](https://github.com/microsoft/LightGBM/blob/master/R-package/demo/multiclass.R)
 * [Leaf (in)Stability](https://github.com/microsoft/LightGBM/blob/master/R-package/demo/leaf_stability.R)
 * [Weight-Parameter Adjustment Relationship](https://github.com/microsoft/LightGBM/blob/master/R-package/demo/weight_param.R)
+
+Testing
+-------
+
+The R package's unit tests are run automatically on every commit, via integrations like [Travis CI](https://travis-ci.org/microsoft/LightGBM/) and [Azure DevOps](https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build). Adding new tests in `R-package/tests/testthat` is a valuable way to improve the reliability of the R package.
+
+When adding tests, you may want to use test coverage to identify untested areas and to check if the tests you've added are covering all branches of the intended code.
+
+The example below shows how to generate code coverage for the R package on a Mac or Linux setup. To adjust for your environment, swap out the 'Install' step with [the relevant code from the instructions above](#install-source).
+
+```shell
+# Install
+export CXX=/usr/local/bin/g++-8
+export CC=/usr/local/bin/gcc-8
+Rscript build_r.R
+
+# Get coverage
+rm -rf lightgbm_r/build
+Rscript -e " \
+    coverage  <- covr::package_coverage('./lightgbm_r', quiet=FALSE);
+    print(coverage);
+    covr::report(coverage, file = file.path(getwd(), 'coverage.html'), browse = TRUE);
+    "
+```
 
 External (Unofficial) Repositories
 ----------------------------------

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -31,7 +31,7 @@ You can perform installation either with **Apple Clang** or **gcc**. In case you
 export CXX=/usr/local/bin/g++-8 CC=/usr/local/bin/gcc-8
 ```
 
-### Install <a name="install-source"></a>
+### Install
 
 Build and install R-package with the following commands:
 
@@ -133,7 +133,7 @@ The R package's unit tests are run automatically on every commit, via integratio
 
 When adding tests, you may want to use test coverage to identify untested areas and to check if the tests you've added are covering all branches of the intended code.
 
-The example below shows how to generate code coverage for the R package on a Mac or Linux setup. To adjust for your environment, swap out the 'Install' step with [the relevant code from the instructions above](#install-source).
+The example below shows how to generate code coverage for the R package on a Mac or Linux setup. To adjust for your environment, swap out the 'Install' step with [the relevant code from the instructions above](#install).
 
 ```shell
 # Install


### PR DESCRIPTION
Really excited to say that I've discovered that `covr` (the most popular library for generating test coverage for R projects) now works well with `lightgbm`'s R package! I had created [jameslamb/lightgbm-r-coverage](https://github.com/jameslamb/lightgbm-r-coverage)  to work around the previous issues I had and I am VERY excited to archive that repo.

In this PR, I propose adding instructions to the R package's README explaining how contributors can generate coverage reports. I think this will be a valuable way for us to catch edge cases that are not covered by our current tests, and all the other good things you can do with code coverage.

At the time of creating this PR, the R package is `64.48%` covered.

```
lightgbm Coverage: 64.48%
R/lgb.plot.importance.R: 0.00%
R/lgb.prepare_rules.R: 0.00%
R/lgb.prepare_rules2.R: 0.00%
R/lgb.prepare.R: 0.00%
R/lgb.prepare2.R: 0.00%
R/lgb.unloader.R: 0.00%
R/readRDS.lgb.Booster.R: 0.00%
R/saveRDS.lgb.Booster.R: 0.00%
R/lgb.cv.R: 57.14%
R/lgb.Predictor.R: 57.66%
R/lgb.Booster.R: 62.58%
R/callback.R: 67.48%
R/utils.R: 70.63%
R/lgb.Dataset.R: 72.02%
R/lgb.train.R: 75.94%
R/lightgbm.R: 95.45%
R/aliases.R: 100.00%
R/lgb.importance.R: 100.00%
R/lgb.interprete.R: 100.00%
R/lgb.model.dt.tree.R: 100.00%
R/lgb.plot.interpretation.R: 100.00%
```

I've attached a detailed coverage report for those who are curious (GitHub will not let you attach a `.html` file, so had to zip it).

[coverage.html.zip](https://github.com/microsoft/LightGBM/files/4022587/coverage.html.zip)
