### PR TITLE
[R-package] [ci] removed TODOs in code

### DIFF
--- a/.ci/lint_r_code.R
+++ b/.ci/lint_r_code.R
@@ -34,7 +34,7 @@ LINTERS_TO_USE <- list(
     , "single_quotes" = lintr::single_quotes_linter
     , "spaces_inside" = lintr::spaces_inside_linter
     , "spaces_left_parens" = lintr::spaces_left_parentheses_linter
-    , "todo_comments" = lintr::todo_comment_linter
+    , "todo_comments" = lintr::todo_comment_linter(c("todo", "fixme", "to-do"))
     , "trailing_blank" = lintr::trailing_blank_lines_linter
     , "trailing_white" = lintr::trailing_whitespace_linter
     , "true_false" = lintr::T_and_F_symbol_linter

--- a/R-package/R/callback.R
+++ b/R-package/R/callback.R
@@ -100,7 +100,6 @@ cb.reset.parameters <- function(new_params) {
       p[i]
     })
 
-    # To-do check pars
     if (!is.null(env$model)) {
       env$model$reset_parameter(pars)
     }

--- a/R-package/R/lgb.Predictor.R
+++ b/R-package/R/lgb.Predictor.R
@@ -180,7 +180,6 @@ Predictor <- R6::R6Class(
         } else {
 
           # Cannot predict on unknown class
-          # to-do: predict from lgb.Dataset
           stop("predict: cannot predict on data of class ", sQuote(class(data)))
 
         }


### PR DESCRIPTION
In this PR, I propose removing two TODOs in the R package's code. I think that issues is a better home for feature requests than TODO comments.

This wasn't caught by our linting because the default for `lintr::todo_comment_linter` is to check only `'todo'` and `fixme`. In this PR, I've also added `'to-do'` to the linting for this project.

I've described these TODOs in #2665 and #2666 , and added those to #2302 .