### PR TITLE
[R-package] [docs] Added reference to unofficial R extensions (fixes #2640)

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -125,3 +125,10 @@ Please visit [demo](https://github.com/microsoft/LightGBM/tree/master/R-package/
 * [Multiclass Training/Prediction](https://github.com/microsoft/LightGBM/blob/master/R-package/demo/multiclass.R)
 * [Leaf (in)Stability](https://github.com/microsoft/LightGBM/blob/master/R-package/demo/leaf_stability.R)
 * [Weight-Parameter Adjustment Relationship](https://github.com/microsoft/LightGBM/blob/master/R-package/demo/weight_param.R)
+
+External (Unofficial) Repositories
+----------------------------------
+
+Projects listed here are not maintained or endorsed by the `LightGBM` development team, but may offer some features currently missing from the main R package.
+
+* [lightgbm.py](https://github.com/kapsner/lightgbm.py): This R package offers a wrapper built with `reticulate`, a package used to call Python code from R. If you are comfortable with the added installation complexity of installing `lightgbm`'s Python package and the performance cost of passing data between R and Python, you might find that this package offers some features that are not yet available in the native `lightgbm` R package.


### PR DESCRIPTION
This PR adds documentation of the unofficial `lightgbm` R extension described in #2640 . See [this comment](https://github.com/microsoft/LightGBM/issues/2640#issuecomment-568642105) for the reason that this is being added to `R-package/README.md` instead of `README.md`.