### PR TITLE
prefetch hint (1.3x speed-up)

### DIFF
--- a/include/LightGBM/bin.h
+++ b/include/LightGBM/bin.h
@@ -343,17 +343,18 @@ class Bin {
   *        ordered_gradients and ordered_hessians are preprocessed, and they are re-ordered by data_indices.
   *        Ordered_gradients[i] is aligned with data_indices[i]'s gradients (same for ordered_hessians).
   * \param data_indices Used data indices in current leaf
-  * \param num_data Number of used data
+  * \param start start index in data_indices
+  * \param end end index in data_indices
   * \param ordered_gradients Pointer to gradients, the data_indices[i]-th data's gradient is ordered_gradients[i]
   * \param ordered_hessians Pointer to hessians, the data_indices[i]-th data's hessian is ordered_hessians[i]
   * \param out Output Result
   */
   virtual void ConstructHistogram(
-    const data_size_t* data_indices, data_size_t num_data,
+    const data_size_t* data_indices, data_size_t start, data_size_t end,
     const score_t* ordered_gradients, const score_t* ordered_hessians,
     HistogramBinEntry* out) const = 0;
 
-  virtual void ConstructHistogram(data_size_t num_data,
+  virtual void ConstructHistogram(data_size_t start, data_size_t end,
     const score_t* ordered_gradients, const score_t* ordered_hessians,
     HistogramBinEntry* out) const = 0;
 
@@ -365,14 +366,15 @@ class Bin {
   *        ordered_gradients and ordered_hessians are preprocessed, and they are re-ordered by data_indices.
   *        Ordered_gradients[i] is aligned with data_indices[i]'s gradients (same for ordered_hessians).
   * \param data_indices Used data indices in current leaf
-  * \param num_data Number of used data
+  * \param start start index in data_indices
+  * \param end end index in data_indices
   * \param ordered_gradients Pointer to gradients, the data_indices[i]-th data's gradient is ordered_gradients[i]
   * \param out Output Result
   */
-  virtual void ConstructHistogram(const data_size_t* data_indices, data_size_t num_data,
+  virtual void ConstructHistogram(const data_size_t* data_indices, data_size_t start, data_size_t end,
                                   const score_t* ordered_gradients, HistogramBinEntry* out) const = 0;
 
-  virtual void ConstructHistogram(data_size_t num_data,
+  virtual void ConstructHistogram(data_size_t start, data_size_t end,
                                   const score_t* ordered_gradients, HistogramBinEntry* out) const = 0;
 
   /*!

--- a/include/LightGBM/meta.h
+++ b/include/LightGBM/meta.h
@@ -13,10 +13,13 @@
 #include <vector>
 
 #if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64))) || defined(__INTEL_COMPILER)
-#include <xmmintrin.h>
-#define PREFETCH_T0(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
+  #include <xmmintrin.h>
+  #define PREFETCH_T0(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
 #elif defined(__GNUC__)
-#define PREFETCH_T0(addr) __builtin_prefetch(reinterpret_cast<const char*>(addr), 0, 3)
+  #define PREFETCH_T0(addr) __builtin_prefetch(reinterpret_cast<const char*>(addr), 0, 3)
+#else
+  #define PREFETCH_T0(addr) do {} while (0)
+#endif
 #endif
 
 namespace LightGBM {

--- a/include/LightGBM/meta.h
+++ b/include/LightGBM/meta.h
@@ -12,6 +12,13 @@
 #include <utility>
 #include <vector>
 
+#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64))) || defined(__INTEL_COMPILER)
+#include <xmmintrin.h>
+#define PREFETCH_T0(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
+#elif defined(__GNUC__)
+#define PREFETCH_T0(addr) __builtin_prefetch(reinterpret_cast<const char*>(addr), 0, 3)
+#endif
+
 namespace LightGBM {
 
 /*! \brief Type of data size, it is better to use signed type*/

--- a/include/LightGBM/meta.h
+++ b/include/LightGBM/meta.h
@@ -20,7 +20,6 @@
 #else
   #define PREFETCH_T0(addr) do {} while (0)
 #endif
-#endif
 
 namespace LightGBM {
 

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -881,6 +881,7 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
           // if not use ordered bin
           feature_groups_[group]->bin_data_->ConstructHistogram(
             data_indices,
+            0,
             num_data,
             ptr_ordered_grad,
             ptr_ordered_hess,
@@ -910,6 +911,7 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
           // if not use ordered bin
           feature_groups_[group]->bin_data_->ConstructHistogram(
             data_indices,
+            0,
             num_data,
             ptr_ordered_grad,
             data_ptr);
@@ -942,6 +944,7 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
         if (ref_ordered_bins[group] == nullptr) {
           // if not use ordered bin
           feature_groups_[group]->bin_data_->ConstructHistogram(
+            0,
             num_data,
             ptr_ordered_grad,
             ptr_ordered_hess,
@@ -970,6 +973,7 @@ void Dataset::ConstructHistograms(const std::vector<int8_t>& is_feature_used,
         if (ref_ordered_bins[group] == nullptr) {
           // if not use ordered bin
           feature_groups_[group]->bin_data_->ConstructHistogram(
+            0,
             num_data,
             ptr_ordered_grad,
             data_ptr);

--- a/src/io/dense_bin.hpp
+++ b/src/io/dense_bin.hpp
@@ -77,10 +77,10 @@ class DenseBin: public Bin {
       if (i + prefetch_size < end) {
         PREFETCH_T0(data_.data() + data_indices[i + prefetch_size]);
       }
-      const VAL_T bin0 = data_[data_indices[i]];
-      out[bin0].sum_gradients += ordered_gradients[i];
-      out[bin0].sum_hessians += ordered_hessians[i];
-      ++out[bin0].cnt;
+      const VAL_T bin = data_[data_indices[i]];
+      out[bin].sum_gradients += ordered_gradients[i];
+      out[bin].sum_hessians += ordered_hessians[i];
+      ++out[bin].cnt;
     }
   }
 

--- a/src/io/ordered_sparse_bin.hpp
+++ b/src/io/ordered_sparse_bin.hpp
@@ -84,46 +84,17 @@ class OrderedSparseBin: public OrderedBin {
 
   void ConstructHistogram(int leaf, const score_t* gradient, const score_t* hessian,
                           HistogramBinEntry* out) const override {
+    const data_size_t prefetch_size = 4;
     // get current leaf boundary
     const data_size_t start = leaf_start_[leaf];
     const data_size_t end = start + leaf_cnt_[leaf];
-    const int rest = (end - start) % 4;
-    data_size_t i = start;
-    // use data on current leaf to construct histogram
-    for (; i < end - rest; i += 4) {
+    for (data_size_t i = start; i < end; ++i) {
+      if (i + prefetch_size < end) {
+        PREFETCH_T0(ordered_pair_.data() + i + prefetch_size);
+        PREFETCH_T0(gradient + ordered_pair_[i + prefetch_size].ridx);
+        PREFETCH_T0(hessian + ordered_pair_[i + prefetch_size].ridx);
+      }
       const VAL_T bin0 = ordered_pair_[i].bin;
-      const VAL_T bin1 = ordered_pair_[i + 1].bin;
-      const VAL_T bin2 = ordered_pair_[i + 2].bin;
-      const VAL_T bin3 = ordered_pair_[i + 3].bin;
-
-      const auto g0 = gradient[ordered_pair_[i].ridx];
-      const auto h0 = hessian[ordered_pair_[i].ridx];
-      const auto g1 = gradient[ordered_pair_[i + 1].ridx];
-      const auto h1 = hessian[ordered_pair_[i + 1].ridx];
-      const auto g2 = gradient[ordered_pair_[i + 2].ridx];
-      const auto h2 = hessian[ordered_pair_[i + 2].ridx];
-      const auto g3 = gradient[ordered_pair_[i + 3].ridx];
-      const auto h3 = hessian[ordered_pair_[i + 3].ridx];
-
-      out[bin0].sum_gradients += g0;
-      out[bin1].sum_gradients += g1;
-      out[bin2].sum_gradients += g2;
-      out[bin3].sum_gradients += g3;
-
-      out[bin0].sum_hessians += h0;
-      out[bin1].sum_hessians += h1;
-      out[bin2].sum_hessians += h2;
-      out[bin3].sum_hessians += h3;
-
-      ++out[bin0].cnt;
-      ++out[bin1].cnt;
-      ++out[bin2].cnt;
-      ++out[bin3].cnt;
-    }
-
-    for (; i < end; ++i) {
-      const VAL_T bin0 = ordered_pair_[i].bin;
-
       const auto g0 = gradient[ordered_pair_[i].ridx];
       const auto h0 = hessian[ordered_pair_[i].ridx];
 
@@ -135,34 +106,15 @@ class OrderedSparseBin: public OrderedBin {
 
   void ConstructHistogram(int leaf, const score_t* gradient,
                           HistogramBinEntry* out) const override {
+    const data_size_t prefetch_size = 4;
     // get current leaf boundary
     const data_size_t start = leaf_start_[leaf];
     const data_size_t end = start + leaf_cnt_[leaf];
-    const int rest = (end - start) % 4;
-    data_size_t i = start;
-    // use data on current leaf to construct histogram
-    for (; i < end - rest; i += 4) {
-      const VAL_T bin0 = ordered_pair_[i].bin;
-      const VAL_T bin1 = ordered_pair_[i + 1].bin;
-      const VAL_T bin2 = ordered_pair_[i + 2].bin;
-      const VAL_T bin3 = ordered_pair_[i + 3].bin;
-
-      const auto g0 = gradient[ordered_pair_[i].ridx];
-      const auto g1 = gradient[ordered_pair_[i + 1].ridx];
-      const auto g2 = gradient[ordered_pair_[i + 2].ridx];
-      const auto g3 = gradient[ordered_pair_[i + 3].ridx];
-
-      out[bin0].sum_gradients += g0;
-      out[bin1].sum_gradients += g1;
-      out[bin2].sum_gradients += g2;
-      out[bin3].sum_gradients += g3;
-
-      ++out[bin0].cnt;
-      ++out[bin1].cnt;
-      ++out[bin2].cnt;
-      ++out[bin3].cnt;
-    }
-    for (; i < end; ++i) {
+    for (data_size_t i = start; i < end; ++i) {
+      if (i + prefetch_size < end) {
+        PREFETCH_T0(ordered_pair_.data() + i + prefetch_size);
+        PREFETCH_T0(gradient + ordered_pair_[i + prefetch_size].ridx);
+      }
       const VAL_T bin0 = ordered_pair_[i].bin;
       const auto g0 = gradient[ordered_pair_[i].ridx];
       out[bin0].sum_gradients += g0;

--- a/src/io/sparse_bin.hpp
+++ b/src/io/sparse_bin.hpp
@@ -102,25 +102,25 @@ class SparseBin: public Bin {
 
   BinIterator* GetIterator(uint32_t min_bin, uint32_t max_bin, uint32_t default_bin) const override;
 
-  void ConstructHistogram(const data_size_t*, data_size_t, const score_t*,
+  void ConstructHistogram(const data_size_t*, data_size_t, data_size_t, const score_t*,
     const score_t*, HistogramBinEntry*) const override {
     // Will use OrderedSparseBin->ConstructHistogram() instead
     Log::Fatal("Using OrderedSparseBin->ConstructHistogram() instead");
   }
 
-  void ConstructHistogram(data_size_t, const score_t*,
+  void ConstructHistogram(data_size_t, data_size_t, const score_t*,
                           const score_t*, HistogramBinEntry*) const override {
     // Will use OrderedSparseBin->ConstructHistogram() instead
     Log::Fatal("Using OrderedSparseBin->ConstructHistogram() instead");
   }
 
-  void ConstructHistogram(const data_size_t*, data_size_t, const score_t*,
+  void ConstructHistogram(const data_size_t*, data_size_t, data_size_t, const score_t*,
                           HistogramBinEntry*) const override {
     // Will use OrderedSparseBin->ConstructHistogram() instead
     Log::Fatal("Using OrderedSparseBin->ConstructHistogram() instead");
   }
 
-  void ConstructHistogram(data_size_t, const score_t*,
+  void ConstructHistogram(data_size_t, data_size_t, const score_t*,
                           HistogramBinEntry*) const override {
     // Will use OrderedSparseBin->ConstructHistogram() instead
     Log::Fatal("Using OrderedSparseBin->ConstructHistogram() instead");


### PR DESCRIPTION
set prefetch hint to increase cache hit chance.

benchmark:

| Data      | Master|  This PR | Improvement |  
|----|  ----| ----- | ----|
| Higgs|252.526271  |192.186991 s | 1.31x |
| Yahoo LTR|158.277699 s |129.526579 s | 1.22x |
| MS LTR|357.12529 s|251.736296 s | 1.42x |