### PR TITLE
[python] fix trees_to_dataframe and enhance test

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1898,7 +1898,7 @@ class Booster(object):
                 return feature_name
 
             def _is_single_node_tree(tree):
-                return tree.keys() == {'leaf_value'}
+                return set(tree.keys()) == {'leaf_value'}
 
             # Create the node record, and populate universal data members
             node = OrderedDict()


### PR DESCRIPTION
- transfer `test_trees_to_dataframe` test from `test_basic` to `test_engine` with `skipIf` guard as we use `lgb.train()` there;
- add test for the edge case described in https://github.com/microsoft/LightGBM/pull/2592#discussion_r364435337;
- it turned out that dictionary keys are `list` in Python 2, so it's needed to convert them into a `set`