### PR TITLE
[ci] indicate support only for the last 3 macOS versions in wheel name

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -104,7 +104,7 @@ if [[ $TASK == "sdist" ]]; then
 elif [[ $TASK == "bdist" ]]; then
     if [[ $OS_NAME == "macos" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --plat-name=macosx --universal || exit -1
-        mv dist/lightgbm-$LGB_VER-py2.py3-none-macosx.whl dist/lightgbm-$LGB_VER-py2.py3-none-macosx_10_9_x86_64.macosx_10_10_x86_64.macosx_10_11_x86_64.macosx_10_12_x86_64.macosx_10_13_x86_64.macosx_10_14_x86_64.macosx_10_15_x86_64.whl
+        mv dist/lightgbm-$LGB_VER-py2.py3-none-macosx.whl dist/lightgbm-$LGB_VER-py2.py3-none-macosx_10_13_x86_64.macosx_10_14_x86_64.macosx_10_15_x86_64.whl
         if [[ $AZURE == "true" ]]; then
             cp dist/lightgbm-$LGB_VER-py2.py3-none-macosx*.whl $BUILD_ARTIFACTSTAGINGDIRECTORY
         fi

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -20,7 +20,7 @@ For **Windows** users, `VC runtime <https://support.microsoft.com/en-us/help/297
 
 For **Linux** users, **glibc** >= 2.14 is required.
 
-For **macOS** users:
+For **macOS** (we provide wheels for 3 newest macOS versions) users:
 
 - Starting from version 2.2.1, the library file in distribution wheels is built by the **Apple Clang** (Xcode_8.3.3) compiler. This means that you don't need to install the **gcc** compiler anymore. Instead of that you need to install the **OpenMP** library, which is required for running LightGBM on the system with the **Apple Clang** compiler. You can install the **OpenMP** library by the following command: ``brew install libomp``.
 


### PR DESCRIPTION
According to this article, it seems that Apple officially supports last 3 versions.
https://www.howtogeek.com/350901/which-releases-of-macos-are-supported-with-security-updates/

I think we can do the same and avoid super huge filename which can cause errors in some file systems.