### PR TITLE
[R-package] added tests on lgb.plot.importance and clarified documentation

### DIFF
--- a/R-package/R/lgb.plot.importance.R
+++ b/R-package/R/lgb.plot.importance.R
@@ -6,7 +6,9 @@
 #' @param top_n maximal number of top features to include into the plot.
 #' @param measure the name of importance measure to plot, can be "Gain", "Cover" or "Frequency".
 #' @param left_margin (base R barplot) allows to adjust the left margin size to fit feature names.
-#' @param cex (base R barplot) passed as \code{cex.names} parameter to \code{barplot}.
+#' @param cex (base R barplot) passed as \code{cex.names} parameter to \code{\link[graphics]{barplot}}.
+#'            Set a number smaller than 1.0 to make the bar labels smaller than R's default and values
+#'            greater than 1.0 to make them larger.
 #'
 #' @details
 #' The graph represents each feature as a horizontal bar of length proportional to the defined importance of a feature.
@@ -30,7 +32,7 @@
 #'     , min_sum_hessian_in_leaf = 1.0
 #' )
 #'
-#' model <- lgb.train(params, dtrain, 10)
+#' model <- lgb.train(params, dtrain, 10L)
 #'
 #' tree_imp <- lgb.importance(model, percentage = TRUE)
 #' lgb.plot.importance(tree_imp, top_n = 10L, measure = "Gain")

--- a/R-package/man/lgb.plot.importance.Rd
+++ b/R-package/man/lgb.plot.importance.Rd
@@ -21,7 +21,9 @@ lgb.plot.importance(
 
 \item{left_margin}{(base R barplot) allows to adjust the left margin size to fit feature names.}
 
-\item{cex}{(base R barplot) passed as \code{cex.names} parameter to \code{barplot}.}
+\item{cex}{(base R barplot) passed as \code{cex.names} parameter to \code{\link[graphics]{barplot}}.
+Set a number smaller than 1.0 to make the bar labels smaller than R's default and values
+greater than 1.0 to make them larger.}
 }
 \value{
 The \code{lgb.plot.importance} function creates a \code{barplot}
@@ -48,7 +50,7 @@ params <- list(
     , min_sum_hessian_in_leaf = 1.0
 )
 
-model <- lgb.train(params, dtrain, 10)
+model <- lgb.train(params, dtrain, 10L)
 
 tree_imp <- lgb.importance(model, percentage = TRUE)
 lgb.plot.importance(tree_imp, top_n = 10L, measure = "Gain")

--- a/R-package/tests/testthat/test_lgb.plot.importance.R
+++ b/R-package/tests/testthat/test_lgb.plot.importance.R
@@ -1,0 +1,37 @@
+context("lgb.plot.importance()")
+
+test_that("lgb.plot.importance() should run without error for well-formed inputs", {
+    data(agaricus.train, package = "lightgbm")
+    train <- agaricus.train
+    dtrain <- lgb.Dataset(train$data, label = train$label)
+    params <- list(
+        objective = "binary"
+        , learning_rate = 0.01
+        , num_leaves = 63L
+        , max_depth = -1L
+        , min_data_in_leaf = 1L
+        , min_sum_hessian_in_leaf = 1.0
+    )
+    model <- lgb.train(params, dtrain, 10L)
+    tree_imp <- lgb.importance(model, percentage = TRUE)
+
+    # Check that there are no plots present before plotting
+    expect_null(dev.list())
+    resDT <- lgb.plot.importance(
+        tree_imp = tree_imp
+        , top_n = 10L
+        , measure = "Gain"
+        , cex = 0.75
+    )
+
+    # Check that lgb.plot.importance() returns the data.table of the plotted data
+    expect_true(data.table::is.data.table(resDT))
+    expect_named(resDT, c("Feature", "Gain", "Cover", "Frequency"))
+
+    # Check that a plot was produced
+    expect_false(is.null(dev.list()))
+
+    # remove all plots
+    dev.off()
+    expect_null(dev.list())
+})


### PR DESCRIPTION
`lgb.plot.importance()` in the R package is currently untested. In this PR, I propose a basic test that will cover all of the code in that function and at least help us catch some types of issues in CI.

This PR increases the R package's test coverage from `71.29%` to  `72.29%`.

I also clarified the documentation on the `cex` parameter so that it is easier for users  to identify valid values to pass.