### PR TITLE
[python][tests] fixed typo

### DIFF
--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -714,7 +714,7 @@ class TestEngine(unittest.TestCase):
                                "B": np.random.permutation([1, 3] * 30),
                                "C": np.random.permutation([0.1, -0.1, 0.2, 0.2] * 15),
                                "D": np.random.permutation([True, False] * 30),
-                               "E": pd.Categorical(pd.np.random.permutation(['z', 'y'] * 30),
+                               "E": pd.Categorical(np.random.permutation(['z', 'y'] * 30),
                                                    ordered=True)})
         np.random.seed()  # reset seed
         cat_cols_actual = ["A", "B", "C", "D"]

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -280,7 +280,7 @@ class TestSklearn(unittest.TestCase):
                                "B": np.random.permutation([1, 3] * 30),
                                "C": np.random.permutation([0.1, -0.1, 0.2, 0.2] * 15),
                                "D": np.random.permutation([True, False] * 30),
-                               "E": pd.Categorical(pd.np.random.permutation(['z', 'y'] * 30),
+                               "E": pd.Categorical(np.random.permutation(['z', 'y'] * 30),
                                                    ordered=True)})
         np.random.seed()  # reset seed
         cat_cols_actual = ["A", "B", "C", "D"]


### PR DESCRIPTION
I have no idea how `pd.np.random` occurred there 😃 

Fix warning:
```
  /Users/travis/build/microsoft/LightGBM/tests/python_package_test/test_engine.py:717: FutureWarning: The pandas.np module is deprecated and will be removed from pandas in a future version. Import numpy directly instead
    "E": pd.Categorical(pd.np.random.permutation(['z', 'y'] * 30),
```