### PR TITLE
[python] add property: feature_name_ in lgb sklearn api

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -729,6 +729,14 @@ class LGBMModel(_LGBMModelBase):
             raise LGBMNotFittedError('No feature_importances found. Need to call fit beforehand.')
         return self._Booster.feature_importance(importance_type=self.importance_type)
 
+    @property
+    def feature_name_(self):
+        """Get feature name
+        """
+        if self._n_features is None:
+            raise LGBMNotFittedError('No feature_importances found. Need to call fit beforehand.')
+        return self._Booster.feature_name()
+
 
 class LGBMRegressor(LGBMModel, _LGBMRegressorBase):
     """LightGBM regressor."""

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -269,6 +269,8 @@ class LGBMModel(_LGBMModelBase):
             The evaluation results if ``early_stopping_rounds`` has been specified.
         feature_importances_ : array of shape = [n_features]
             The feature importances (the higher, the more important the feature).
+        feature_name_ : array of shape = [n_features]
+            The names of features.
 
         Note
         ----
@@ -731,8 +733,7 @@ class LGBMModel(_LGBMModelBase):
 
     @property
     def feature_name_(self):
-        """Get feature name
-        """
+        """Get feature name."""
         if self._n_features is None:
             raise LGBMNotFittedError('No feature_name found. Need to call fit beforehand.')
         return self._Booster.feature_name()

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -734,7 +734,7 @@ class LGBMModel(_LGBMModelBase):
         """Get feature name
         """
         if self._n_features is None:
-            raise LGBMNotFittedError('No feature_importances found. Need to call fit beforehand.')
+            raise LGBMNotFittedError('No feature_name found. Need to call fit beforehand.')
         return self._Booster.feature_name()
 
 


### PR DESCRIPTION
add property: `feature_name_` in lgb sklearn api, just like Catboost

It allows that the feature name could be retrieved with `self.feature_name_` in sklearn wrapper of lgb, which will be more convenient without duplicated invoking `self._Booster.feature_name()`.

