### PR TITLE
[ci] [R-package] Changed installation strategy to use binaries for data.table

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -70,7 +70,7 @@ Rscript -e "install.packages(c('jsonlite', 'Matrix', 'R6', 'testthat'))" || exit
 if [[ $OS_NAME == "macos" ]]; then
     Rscript -e "install.packages('data.table', type = 'mac.binary')" || exit -1
 else
-    Rscript -e "install.packages('data.table', type = 'both')" || exit -1
+    Rscript -e "install.packages('data.table', type = 'source')" || exit -1
 fi
 
 cd ${BUILD_DIRECTORY}

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -65,7 +65,13 @@ conda install \
 
 # Manually install Depends and Imports libraries + 'testthat'
 # to avoid a CI-time dependency on devtools (for devtools::install_deps())
-Rscript -e "install.packages(c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat'))" || exit -1
+Rscript -e "install.packages(c('jsonlite', 'Matrix', 'R6', 'testthat'))" || exit -1
+
+if [[ $OS_NAME == "macos" ]]; then
+    Rscript -e "install.packages('data.table', type = 'mac.binary')" || exit -1
+else
+    Rscript -e "install.packages('data.table', type = 'both')" || exit -1
+fi
 
 cd ${BUILD_DIRECTORY}
 Rscript build_r.R || exit -1


### PR DESCRIPTION
Sometimes the R builds on macOS fail, complaining about OpenMP issues in compiling `data.table`. See https://github.com/microsoft/LightGBM/pull/2748#issuecomment-583676147.

Per Matt Dowle's recommendation in https://github.com/Rdatatable/data.table/issues/2406, this PR changes our CI strategy to use the precompiled binaries for `data.table` available from CRAN. Those tend to only be a week or two between the source distribution, which I think is a reasonable price to pay in exchange for better stability in `LightGBM`'s CI.

For information on the change, see this detail from `?install.packages` in R:

![image](https://user-images.githubusercontent.com/7608904/74078078-9a1dae00-49eb-11ea-9d07-fe97dd79482b.png)
