### PR TITLE
[ci] avoid Appveyor failures

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@
 image: Visual Studio 2015
 platform: x64
 configuration:  # a trick to construct a build matrix with multiple Python versions
-  - 3.6
+  - 3.7
 
 environment:
   matrix:


### PR DESCRIPTION
Change Python version for Appveyor to avoid conda packaging errors described in https://github.com/microsoft/LightGBM/pull/2747#issuecomment-583685751 and make `master` branch builds green.

BTW, this is a part of #2713.