### PR TITLE
Improving monotone constraints ("Fast" method; linked to #2305, #2717) 

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -376,6 +376,13 @@ Learning Control Parameters
 
    -  dropout rate: a fraction of previous trees to drop during the dropout
 
+- ``monotone_constraints_method`` :raw-html:`<a id="monotone_constraints_method" title="Permalink to this parameter" href="#monotone_constraints_method">&#x1F517;&#xFE0E;</a>`, default = ``basic``, type = string, aliases: ``monotone_constraining_method``, constraints: ``0.0 <= monotone_penalty (< max_depth, if max_depth > 0)``
+
+   -  used only if ``monotone_constraints`` is set
+
+   -  monotone constraints method: if set to "basic", the most basic monotone constraints method will be used. It does not slow the library at all, but over-constrains the predictions. If set to "intermediate", a more advanced method will be used, which may very slightly slow the library. However, the intermediate method is much less constraining than the basic method and should significantly improve the results.
+
+
 -  ``max_drop`` :raw-html:`<a id="max_drop" title="Permalink to this parameter" href="#max_drop">&#x1F517;&#xFE0E;</a>`, default = ``50``, type = int
 
    -  used only in ``dart``

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -376,12 +376,6 @@ Learning Control Parameters
 
    -  dropout rate: a fraction of previous trees to drop during the dropout
 
--  ``monotone_constraints_method`` :raw-html:`<a id="monotone_constraints_method" title="Permalink to this parameter" href="#monotone_constraints_method">&#x1F517;&#xFE0E;</a>`, default = ``basic``, type = string, aliases: ``monotone_constraining_method``, ``mc_method``
-
-   -  used only if ``monotone_constraints`` is set
-
-   -  monotone constraints method: if set to "basic", the most basic monotone constraints method will be used. It does not slow the library at all, but over-constrains the predictions. If set to "intermediate", a more advanced method will be used, which may slow the library very slightly. However, the intermediate method is much less constraining than the basic method and should significantly improve the results.
-
 -  ``max_drop`` :raw-html:`<a id="max_drop" title="Permalink to this parameter" href="#max_drop">&#x1F517;&#xFE0E;</a>`, default = ``50``, type = int
 
    -  used only in ``dart``
@@ -465,6 +459,16 @@ Learning Control Parameters
    -  ``1`` means increasing, ``-1`` means decreasing, ``0`` means non-constraint
 
    -  you need to specify all features in order. For example, ``mc=-1,0,1`` means decreasing for 1st feature, non-constraint for 2nd feature and increasing for the 3rd feature
+
+-  ``monotone_constraints_method`` :raw-html:`<a id="monotone_constraints_method" title="Permalink to this parameter" href="#monotone_constraints_method">&#x1F517;&#xFE0E;</a>`, default = ``basic``, type = string, aliases: ``monotone_constraining_method``, ``mc_method``
+
+   -  used only if ``monotone_constraints`` is set
+
+   -  monotone constraints method
+
+      -  ``basic``, the most basic monotone constraints method. It does not slow the library at all, but over-constrains the predictions
+
+      -  ``intermediate``, a `more advanced method <https://github.com/microsoft/LightGBM/files/3457826/PR-monotone-constraints-report.pdf>`__, which may slow the library very slightly. However, this method is much less constraining than the basic method and should significantly improve the results
 
 -  ``feature_contri`` :raw-html:`<a id="feature_contri" title="Permalink to this parameter" href="#feature_contri">&#x1F517;&#xFE0E;</a>`, default = ``None``, type = multi-double, aliases: ``feature_contrib``, ``fc``, ``fp``, ``feature_penalty``
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -376,12 +376,11 @@ Learning Control Parameters
 
    -  dropout rate: a fraction of previous trees to drop during the dropout
 
-- ``monotone_constraints_method`` :raw-html:`<a id="monotone_constraints_method" title="Permalink to this parameter" href="#monotone_constraints_method">&#x1F517;&#xFE0E;</a>`, default = ``basic``, type = string, aliases: ``monotone_constraining_method``
+-  ``monotone_constraints_method`` :raw-html:`<a id="monotone_constraints_method" title="Permalink to this parameter" href="#monotone_constraints_method">&#x1F517;&#xFE0E;</a>`, default = ``basic``, type = string, aliases: ``monotone_constraining_method``
 
    -  used only if ``monotone_constraints`` is set
 
-   -  monotone constraints method: if set to "basic", the most basic monotone constraints method will be used. It does not slow the library at all, but over-constrains the predictions. If set to "intermediate", a more advanced method will be used, which may very slightly slow the library. However, the intermediate method is much less constraining than the basic method and should significantly improve the results.
-
+   -  monotone constraints method: if set to "basic", the most basic monotone constraints method will be used. It does not slow the library at all, but over-constrains the predictions. If set to "intermediate", a more advanced method will be used, which may slow the library very slightly. However, the intermediate method is much less constraining than the basic method and should significantly improve the results.
 
 -  ``max_drop`` :raw-html:`<a id="max_drop" title="Permalink to this parameter" href="#max_drop">&#x1F517;&#xFE0E;</a>`, default = ``50``, type = int
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -376,7 +376,7 @@ Learning Control Parameters
 
    -  dropout rate: a fraction of previous trees to drop during the dropout
 
-- ``monotone_constraints_method`` :raw-html:`<a id="monotone_constraints_method" title="Permalink to this parameter" href="#monotone_constraints_method">&#x1F517;&#xFE0E;</a>`, default = ``basic``, type = string, aliases: ``monotone_constraining_method``, constraints: ``0.0 <= monotone_penalty (< max_depth, if max_depth > 0)``
+- ``monotone_constraints_method`` :raw-html:`<a id="monotone_constraints_method" title="Permalink to this parameter" href="#monotone_constraints_method">&#x1F517;&#xFE0E;</a>`, default = ``basic``, type = string, aliases: ``monotone_constraining_method``
 
    -  used only if ``monotone_constraints`` is set
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -376,7 +376,7 @@ Learning Control Parameters
 
    -  dropout rate: a fraction of previous trees to drop during the dropout
 
--  ``monotone_constraints_method`` :raw-html:`<a id="monotone_constraints_method" title="Permalink to this parameter" href="#monotone_constraints_method">&#x1F517;&#xFE0E;</a>`, default = ``basic``, type = string, aliases: ``monotone_constraining_method``
+-  ``monotone_constraints_method`` :raw-html:`<a id="monotone_constraints_method" title="Permalink to this parameter" href="#monotone_constraints_method">&#x1F517;&#xFE0E;</a>`, default = ``basic``, type = string, aliases: ``monotone_constraining_method``, ``mc_method``
 
    -  used only if ``monotone_constraints`` is set
 

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -364,7 +364,7 @@ struct Config {
   // desc = dropout rate: a fraction of previous trees to drop during the dropout
   double drop_rate = 0.1;
 
-  // alias = monotone_constraining_method
+  // alias = monotone_constraining_method, mc_method
   // desc = used only if ``monotone_constraints`` is set
   // desc = monotone constraints method: if set to "basic", the most basic monotone constraints method will be used. It does not slow the library at all, but over-constrains the predictions. If set to "intermediate", a more advanced method will be used, which may slow the library very slightly. However, the intermediate method is much less constraining than the basic method and should significantly improve the results.
   std::string monotone_constraints_method = "basic";

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -364,11 +364,6 @@ struct Config {
   // desc = dropout rate: a fraction of previous trees to drop during the dropout
   double drop_rate = 0.1;
 
-  // alias = monotone_constraining_method, mc_method
-  // desc = used only if ``monotone_constraints`` is set
-  // desc = monotone constraints method: if set to "basic", the most basic monotone constraints method will be used. It does not slow the library at all, but over-constrains the predictions. If set to "intermediate", a more advanced method will be used, which may slow the library very slightly. However, the intermediate method is much less constraining than the basic method and should significantly improve the results.
-  std::string monotone_constraints_method = "basic";
-
   // desc = used only in ``dart``
   // desc = max number of dropped trees during one boosting iteration
   // desc = ``<=0`` means no limit
@@ -440,6 +435,13 @@ struct Config {
   // desc = ``1`` means increasing, ``-1`` means decreasing, ``0`` means non-constraint
   // desc = you need to specify all features in order. For example, ``mc=-1,0,1`` means decreasing for 1st feature, non-constraint for 2nd feature and increasing for the 3rd feature
   std::vector<int8_t> monotone_constraints;
+
+  // alias = monotone_constraining_method, mc_method
+  // desc = used only if ``monotone_constraints`` is set
+  // desc = monotone constraints method
+  // descl2 = ``basic``, the most basic monotone constraints method. It does not slow the library at all, but over-constrains the predictions
+  // descl2 = ``intermediate``, a `more advanced method <https://github.com/microsoft/LightGBM/files/3457826/PR-monotone-constraints-report.pdf>`__, which may slow the library very slightly. However, this method is much less constraining than the basic method and should significantly improve the results
+  std::string monotone_constraints_method = "basic";
 
   // type = multi-double
   // alias = feature_contrib, fc, fp, feature_penalty

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -364,6 +364,11 @@ struct Config {
   // desc = dropout rate: a fraction of previous trees to drop during the dropout
   double drop_rate = 0.1;
 
+  // alias = monotone_constraining_method
+  // desc = used only if ``monotone_constraints`` is set
+  // desc = monotone constraints method: if set to "basic", the most basic monotone constraints method will be used. It does not slow the library at all, but over-constrains the predictions. If set to "intermediate", a more advanced method will be used, which may slow the library very slightly. However, the intermediate method is much less constraining than the basic method and should significantly improve the results.
+  std::string monotone_constraints_method = "basic";
+
   // desc = used only in ``dart``
   // desc = max number of dropped trees during one boosting iteration
   // desc = ``<=0`` means no limit

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -134,18 +134,6 @@ class Tree {
   inline int PredictLeafIndex(const double* feature_values) const;
   inline int PredictLeafIndexByMap(const std::unordered_map<int, double>& feature_values) const;
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-  // Get node parent
-  inline int node_parent(int node_idx) const;
-  // Get leaf parent
-  inline int leaf_parent(int node_idx) const;
-=======
->>>>>>> more fixes
-
-
->>>>>>> Add util functions.
   inline void PredictContrib(const double* feature_values, int num_features, double* output);
 
   /*! \brief Get Number of leaves*/

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -159,7 +159,7 @@ class Tree {
 
   inline double split_gain(int split_idx) const { return split_gain_[split_idx]; }
 
-  inline double Tree::internal_value(int node_idx) const {
+  inline double internal_value(int node_idx) const {
     return internal_value_[node_idx];
   }
 

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -166,9 +166,6 @@ class Tree {
   inline int leaf_parent(int leaf_idx) const { return leaf_parent_[leaf_idx]; }
 
   inline uint32_t threshold_in_bin(int node_idx) const {
-#ifdef DEBUG
-    CHECK(node_idx >= 0);
-#endif
     return threshold_in_bin_[node_idx];
   }
 

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -322,6 +322,12 @@ void Config::CheckParamConflict() {
     Log::Warning("cannot use \"intermediate\" monotone constraints in parallel learning, auto set to \"basic\" method.");
     monotone_constraints_method = "basic";
   }
+  if (feature_fraction_bynode != 1.0 && monotone_constraints_method == std::string("intermediate")) {
+    // "intermediate" monotone constraints need to recompute splits. If the features are sampled when computing the
+    // split initially, then the sampling needs to be recorded or done once again, which is currently not supported
+    Log::Warning("cannot use \"intermediate\" monotone constraints with feature fraction different from 1, auto set monotone constraints to \"basic\" method.");
+    monotone_constraints_method = "basic";
+  }
 }
 
 std::string Config::ToString() const {

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -319,13 +319,13 @@ void Config::CheckParamConflict() {
   }
   if (is_parallel && monotone_constraints_method == std::string("intermediate")) {
     // In distributed mode, local node doesn't have histograms on all features, cannot perform "intermediate" monotone constraints.
-    Log::Warning("cannot use \"intermediate\" monotone constraints in parallel learning, auto set to \"basic\" method.");
+    Log::Warning("Cannot use \"intermediate\" monotone constraints in parallel learning, auto set to \"basic\" method.");
     monotone_constraints_method = "basic";
   }
   if (feature_fraction_bynode != 1.0 && monotone_constraints_method == std::string("intermediate")) {
     // "intermediate" monotone constraints need to recompute splits. If the features are sampled when computing the
     // split initially, then the sampling needs to be recorded or done once again, which is currently not supported
-    Log::Warning("cannot use \"intermediate\" monotone constraints with feature fraction different from 1, auto set monotone constraints to \"basic\" method.");
+    Log::Warning("Cannot use \"intermediate\" monotone constraints with feature fraction different from 1, auto set monotone constraints to \"basic\" method.");
     monotone_constraints_method = "basic";
   }
 }

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -320,7 +320,7 @@ void Config::CheckParamConflict() {
   if (is_parallel && monotone_constraints_method == std::string("intermediate")) {
     // In distributed mode, local node doesn't have histograms on all features, cannot perform "intermediate" monotone constraints.
     Log::Warning("cannot use \"intermediate\" monotone constraints in parallel learning, auto set to \"basic\" method.");
-    monotone_constraints_method == "basic";
+    monotone_constraints_method = "basic";
   }
 }
 

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -317,6 +317,11 @@ void Config::CheckParamConflict() {
     force_col_wise = true;
     force_row_wise = false;
   }
+  if (is_parallel && monotone_constraints_method == std::string("intermediate")) {
+    // In distributed mode, local node doesn't have histograms on all features, cannot perform "intermediate" monotone constraints.
+    Log::Warning("cannot use \"intermediate\" monotone constraints in parallel learning, auto set to \"basic\" method.");
+    monotone_constraints_method == "basic";
+  }
 }
 
 std::string Config::ToString() const {

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -83,6 +83,7 @@ const std::unordered_map<std::string, std::string>& Config::alias_table() {
   {"min_split_gain", "min_gain_to_split"},
   {"rate_drop", "drop_rate"},
   {"monotone_constraining_method", "monotone_constraints_method"},
+  {"mc_method", "monotone_constraints_method"},
   {"topk", "top_k"},
   {"mc", "monotone_constraints"},
   {"monotone_constraint", "monotone_constraints"},

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -82,11 +82,11 @@ const std::unordered_map<std::string, std::string>& Config::alias_table() {
   {"lambda", "lambda_l2"},
   {"min_split_gain", "min_gain_to_split"},
   {"rate_drop", "drop_rate"},
-  {"monotone_constraining_method", "monotone_constraints_method"},
-  {"mc_method", "monotone_constraints_method"},
   {"topk", "top_k"},
   {"mc", "monotone_constraints"},
   {"monotone_constraint", "monotone_constraints"},
+  {"monotone_constraining_method", "monotone_constraints_method"},
+  {"mc_method", "monotone_constraints_method"},
   {"feature_contrib", "feature_contri"},
   {"fc", "feature_contri"},
   {"fp", "feature_contri"},
@@ -203,7 +203,6 @@ const std::unordered_set<std::string>& Config::parameter_set() {
   "lambda_l2",
   "min_gain_to_split",
   "drop_rate",
-  "monotone_constraints_method",
   "max_drop",
   "skip_drop",
   "xgboost_dart_mode",
@@ -218,6 +217,7 @@ const std::unordered_set<std::string>& Config::parameter_set() {
   "max_cat_to_onehot",
   "top_k",
   "monotone_constraints",
+  "monotone_constraints_method",
   "feature_contri",
   "forcedsplits_filename",
   "refit_decay_rate",
@@ -375,8 +375,6 @@ void Config::GetMembersFromString(const std::unordered_map<std::string, std::str
   CHECK_GE(drop_rate, 0.0);
   CHECK_LE(drop_rate, 1.0);
 
-  GetString(params, "monotone_constraints_method", &monotone_constraints_method);
-
   GetInt(params, "max_drop", &max_drop);
 
   GetDouble(params, "skip_drop", &skip_drop);
@@ -418,6 +416,8 @@ void Config::GetMembersFromString(const std::unordered_map<std::string, std::str
   if (GetString(params, "monotone_constraints", &tmp_str)) {
     monotone_constraints = Common::StringToArray<int8_t>(tmp_str, ',');
   }
+
+  GetString(params, "monotone_constraints_method", &monotone_constraints_method);
 
   if (GetString(params, "feature_contri", &tmp_str)) {
     feature_contri = Common::StringToArray<double>(tmp_str, ',');
@@ -624,7 +624,6 @@ std::string Config::SaveMembersToString() const {
   str_buf << "[lambda_l2: " << lambda_l2 << "]\n";
   str_buf << "[min_gain_to_split: " << min_gain_to_split << "]\n";
   str_buf << "[drop_rate: " << drop_rate << "]\n";
-  str_buf << "[monotone_constraints_method: " << monotone_constraints_method << "]\n";
   str_buf << "[max_drop: " << max_drop << "]\n";
   str_buf << "[skip_drop: " << skip_drop << "]\n";
   str_buf << "[xgboost_dart_mode: " << xgboost_dart_mode << "]\n";
@@ -639,6 +638,7 @@ std::string Config::SaveMembersToString() const {
   str_buf << "[max_cat_to_onehot: " << max_cat_to_onehot << "]\n";
   str_buf << "[top_k: " << top_k << "]\n";
   str_buf << "[monotone_constraints: " << Common::Join(Common::ArrayCast<int8_t, int>(monotone_constraints), ",") << "]\n";
+  str_buf << "[monotone_constraints_method: " << monotone_constraints_method << "]\n";
   str_buf << "[feature_contri: " << Common::Join(feature_contri, ",") << "]\n";
   str_buf << "[forcedsplits_filename: " << forcedsplits_filename << "]\n";
   str_buf << "[refit_decay_rate: " << refit_decay_rate << "]\n";

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -622,8 +622,8 @@ std::string Config::SaveMembersToString() const {
   str_buf << "[lambda_l1: " << lambda_l1 << "]\n";
   str_buf << "[lambda_l2: " << lambda_l2 << "]\n";
   str_buf << "[min_gain_to_split: " << min_gain_to_split << "]\n";
-  str_buf << "[monotone_constraints_method: " << monotone_constraints_method << "]\n";
   str_buf << "[drop_rate: " << drop_rate << "]\n";
+  str_buf << "[monotone_constraints_method: " << monotone_constraints_method << "]\n";
   str_buf << "[max_drop: " << max_drop << "]\n";
   str_buf << "[skip_drop: " << skip_drop << "]\n";
   str_buf << "[xgboost_dart_mode: " << xgboost_dart_mode << "]\n";

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -82,6 +82,7 @@ const std::unordered_map<std::string, std::string>& Config::alias_table() {
   {"lambda", "lambda_l2"},
   {"min_split_gain", "min_gain_to_split"},
   {"rate_drop", "drop_rate"},
+  {"monotone_constraining_method", "monotone_constraints_method"},
   {"topk", "top_k"},
   {"mc", "monotone_constraints"},
   {"monotone_constraint", "monotone_constraints"},
@@ -201,6 +202,7 @@ const std::unordered_set<std::string>& Config::parameter_set() {
   "lambda_l2",
   "min_gain_to_split",
   "drop_rate",
+  "monotone_constraints_method",
   "max_drop",
   "skip_drop",
   "xgboost_dart_mode",
@@ -371,6 +373,8 @@ void Config::GetMembersFromString(const std::unordered_map<std::string, std::str
   GetDouble(params, "drop_rate", &drop_rate);
   CHECK_GE(drop_rate, 0.0);
   CHECK_LE(drop_rate, 1.0);
+
+  GetString(params, "monotone_constraints_method", &monotone_constraints_method);
 
   GetInt(params, "max_drop", &max_drop);
 
@@ -618,6 +622,7 @@ std::string Config::SaveMembersToString() const {
   str_buf << "[lambda_l1: " << lambda_l1 << "]\n";
   str_buf << "[lambda_l2: " << lambda_l2 << "]\n";
   str_buf << "[min_gain_to_split: " << min_gain_to_split << "]\n";
+  str_buf << "[monotone_constraints_method: " << monotone_constraints_method << "]\n";
   str_buf << "[drop_rate: " << drop_rate << "]\n";
   str_buf << "[max_drop: " << max_drop << "]\n";
   str_buf << "[skip_drop: " << skip_drop << "]\n";

--- a/src/io/tree.cpp
+++ b/src/io/tree.cpp
@@ -24,9 +24,7 @@ Tree::Tree(int max_leaves)
   threshold_.resize(max_leaves_ - 1);
   decision_type_.resize(max_leaves_ - 1, 0);
   split_gain_.resize(max_leaves_ - 1);
-  node_parent_.resize(max_leaves_ - 1);
   leaf_parent_.resize(max_leaves_);
-  leaf_is_in_monotone_subtree_.resize(max_leaves_);
   leaf_value_.resize(max_leaves_);
   leaf_weight_.resize(max_leaves_);
   leaf_count_.resize(max_leaves_);
@@ -40,7 +38,6 @@ Tree::Tree(int max_leaves)
   leaf_value_[0] = 0.0f;
   leaf_weight_[0] = 0.0f;
   leaf_parent_[0] = -1;
-  node_parent_.resize(max_leaves_ - 1);
   shrinkage_ = 1.0f;
   num_cat_ = 0;
   cat_boundaries_.push_back(0);
@@ -54,8 +51,8 @@ Tree::~Tree() {
 int Tree::Split(int leaf, int feature, int real_feature, uint32_t threshold_bin,
                 double threshold_double, double left_value, double right_value,
                 int left_cnt, int right_cnt, double left_weight, double right_weight, float gain,
-                MissingType missing_type, bool default_left, bool feature_was_monotone) {
-  Split(leaf, feature, real_feature, left_value, right_value, left_cnt, right_cnt, left_weight, right_weight, gain, feature_was_monotone);
+                MissingType missing_type, bool default_left) {
+  Split(leaf, feature, real_feature, left_value, right_value, left_cnt, right_cnt, left_weight, right_weight, gain);
   int new_node_idx = num_leaves_ - 1;
   decision_type_[new_node_idx] = 0;
   SetDecisionType(&decision_type_[new_node_idx], false, kCategoricalMask);
@@ -76,7 +73,7 @@ int Tree::Split(int leaf, int feature, int real_feature, uint32_t threshold_bin,
 int Tree::SplitCategorical(int leaf, int feature, int real_feature, const uint32_t* threshold_bin, int num_threshold_bin,
                            const uint32_t* threshold, int num_threshold, double left_value, double right_value,
                            data_size_t left_cnt, data_size_t right_cnt, double left_weight, double right_weight, float gain, MissingType missing_type) {
-  Split(leaf, feature, real_feature, left_value, right_value, left_cnt, right_cnt, left_weight, right_weight, gain, false);
+  Split(leaf, feature, real_feature, left_value, right_value, left_cnt, right_cnt, left_weight, right_weight, gain);
   int new_node_idx = num_leaves_ - 1;
   decision_type_[new_node_idx] = 0;
   SetDecisionType(&decision_type_[new_node_idx], true, kCategoricalMask);

--- a/src/io/tree.cpp
+++ b/src/io/tree.cpp
@@ -24,7 +24,9 @@ Tree::Tree(int max_leaves)
   threshold_.resize(max_leaves_ - 1);
   decision_type_.resize(max_leaves_ - 1, 0);
   split_gain_.resize(max_leaves_ - 1);
+  node_parent_.resize(max_leaves_ - 1);
   leaf_parent_.resize(max_leaves_);
+  leaf_is_in_monotone_subtree_.resize(max_leaves_);
   leaf_value_.resize(max_leaves_);
   leaf_weight_.resize(max_leaves_);
   leaf_count_.resize(max_leaves_);
@@ -38,6 +40,7 @@ Tree::Tree(int max_leaves)
   leaf_value_[0] = 0.0f;
   leaf_weight_[0] = 0.0f;
   leaf_parent_[0] = -1;
+  node_parent_.resize(max_leaves_ - 1);
   shrinkage_ = 1.0f;
   num_cat_ = 0;
   cat_boundaries_.push_back(0);
@@ -50,8 +53,9 @@ Tree::~Tree() {
 
 int Tree::Split(int leaf, int feature, int real_feature, uint32_t threshold_bin,
                 double threshold_double, double left_value, double right_value,
-                int left_cnt, int right_cnt, double left_weight, double right_weight, float gain, MissingType missing_type, bool default_left) {
-  Split(leaf, feature, real_feature, left_value, right_value, left_cnt, right_cnt, left_weight, right_weight, gain);
+                int left_cnt, int right_cnt, double left_weight, double right_weight, float gain,
+                MissingType missing_type, bool default_left, bool feature_was_monotone) {
+  Split(leaf, feature, real_feature, left_value, right_value, left_cnt, right_cnt, left_weight, right_weight, gain, feature_was_monotone);
   int new_node_idx = num_leaves_ - 1;
   decision_type_[new_node_idx] = 0;
   SetDecisionType(&decision_type_[new_node_idx], false, kCategoricalMask);
@@ -72,7 +76,7 @@ int Tree::Split(int leaf, int feature, int real_feature, uint32_t threshold_bin,
 int Tree::SplitCategorical(int leaf, int feature, int real_feature, const uint32_t* threshold_bin, int num_threshold_bin,
                            const uint32_t* threshold, int num_threshold, double left_value, double right_value,
                            data_size_t left_cnt, data_size_t right_cnt, double left_weight, double right_weight, float gain, MissingType missing_type) {
-  Split(leaf, feature, real_feature, left_value, right_value, left_cnt, right_cnt, left_weight, right_weight, gain);
+  Split(leaf, feature, real_feature, left_value, right_value, left_cnt, right_cnt, left_weight, right_weight, gain, false);
   int new_node_idx = num_leaves_ - 1;
   decision_type_[new_node_idx] = 0;
   SetDecisionType(&decision_type_[new_node_idx], true, kCategoricalMask);

--- a/src/treelearner/leaf_splits.hpp
+++ b/src/treelearner/leaf_splits.hpp
@@ -46,6 +46,19 @@ class LeafSplits {
   }
 
   /*!
+
+  * \brief Init split on current leaf on partial data.
+  * \param leaf Index of current leaf
+  * \param sum_gradients
+  * \param sum_hessians
+  */
+  void Init(int leaf, double sum_gradients, double sum_hessians) {
+    leaf_index_ = leaf;
+    sum_gradients_ = sum_gradients;
+    sum_hessians_ = sum_hessians;
+  }
+
+  /*!
   * \brief Init splits on current leaf, it will traverse all data to sum up the results
   * \param gradients
   * \param hessians

--- a/src/treelearner/leaf_splits.hpp
+++ b/src/treelearner/leaf_splits.hpp
@@ -31,7 +31,6 @@ class LeafSplits {
   }
 
   /*!
-
   * \brief Init split on current leaf on partial data. 
   * \param leaf Index of current leaf
   * \param data_partition current data partition
@@ -46,7 +45,6 @@ class LeafSplits {
   }
 
   /*!
-
   * \brief Init split on current leaf on partial data.
   * \param leaf Index of current leaf
   * \param sum_gradients

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -9,8 +9,23 @@
 #include <algorithm>
 #include <cstdint>
 #include <vector>
+#include "split_info.hpp"
 
 namespace LightGBM {
+
+struct CostEfficientGradientBoosting;
+
+struct LearnerState {
+  const Config *config_;
+  const Dataset *train_data_;
+  const Tree *tree;
+  std::unique_ptr<CostEfficientGradientBoosting> &cegb_;
+
+  LearnerState(const Config *config_, const Dataset *train_data_,
+               const Tree *tree,
+               std::unique_ptr<CostEfficientGradientBoosting> &cegb_)
+      : config_(config_), train_data_(train_data_), tree(tree), cegb_(cegb_) {};
+};
 
 struct ConstraintEntry {
   double min = -std::numeric_limits<double>::max();
@@ -26,6 +41,22 @@ struct ConstraintEntry {
   void UpdateMin(double new_min) { min = std::max(new_min, min); }
 
   void UpdateMax(double new_max) { max = std::min(new_max, max); }
+
+  bool UpdateMinAndReturnBoolIfChanged(double new_min) {
+    if (new_min > min) {
+      min = new_min;
+      return true;
+    }
+    return false;
+  }
+
+  bool UpdateMaxAndReturnBoolIfChanged(double new_max) {
+    if (new_max < max) {
+      max = new_max;
+      return true;
+    }
+    return false;
+  }
 };
 
 template <typename ConstraintEntry>
@@ -33,6 +64,7 @@ class LeafConstraints {
  public:
   explicit LeafConstraints(int num_leaves) : num_leaves_(num_leaves) {
     entries_.resize(num_leaves_);
+    leaves_to_update.reserve(num_leaves_);
   }
 
   void Reset() {
@@ -41,7 +73,7 @@ class LeafConstraints {
     }
   }
 
-  void UpdateConstraints(bool is_numerical_split, int leaf, int new_leaf,
+  void UpdateConstraintsWithMid(bool is_numerical_split, int leaf, int new_leaf,
                          int8_t monotone_type, double right_output,
                          double left_output) {
     entries_[new_leaf] = entries_[leaf];
@@ -57,7 +89,236 @@ class LeafConstraints {
     }
   }
 
+  void UpdateConstraintsWithOutputs(bool is_numerical_split, int leaf,
+                                    int new_leaf, int8_t monotone_type,
+                                    double right_output, double left_output) {
+    entries_[new_leaf] = entries_[leaf];
+    if (is_numerical_split) {
+      if (monotone_type < 0) {
+        entries_[leaf].UpdateMin(right_output);
+        entries_[new_leaf].UpdateMax(left_output);
+      } else if (monotone_type > 0) {
+        entries_[leaf].UpdateMax(right_output);
+        entries_[new_leaf].UpdateMin(left_output);
+      }
+    }
+  }
+
+  void GoUpToFindLeavesToUpdate(int node_idx, std::vector<int> &features,
+                                std::vector<uint32_t> &thresholds,
+                                std::vector<bool> &is_in_right_split,
+                                int split_feature, const SplitInfo &split_info,
+                                uint32_t split_threshold,
+                                std::vector<SplitInfo> &best_split_per_leaf_,
+                                LearnerState &learner_state) {
+
+    int parent_idx = learner_state.tree->node_parent(node_idx);
+    if (parent_idx != -1) {
+      int inner_feature = learner_state.tree->split_feature_inner(parent_idx);
+      int8_t monotone_type =
+          learner_state.train_data_->FeatureMonotone(inner_feature);
+      bool is_right_split =
+          learner_state.tree->right_child(parent_idx) == node_idx;
+      bool split_contains_new_information = true;
+      bool is_split_numerical =
+          learner_state.train_data_->FeatureBinMapper(inner_feature)
+              ->bin_type() == BinType::NumericalBin;
+
+      // only branches containing leaves that are contiguous to the original
+      // leaf need to be updated
+      for (unsigned int i = 0; i < features.size(); ++i) {
+        if ((features[i] == inner_feature && is_split_numerical) &&
+            (is_in_right_split[i] == is_right_split)) {
+          split_contains_new_information = false;
+          break;
+        }
+      }
+
+      if (split_contains_new_information) {
+        if (monotone_type != 0) {
+          int left_child_idx = learner_state.tree->left_child(parent_idx);
+          int right_child_idx = learner_state.tree->right_child(parent_idx);
+          bool left_child_is_curr_idx = (left_child_idx == node_idx);
+          int node_idx_to_pass =
+              (left_child_is_curr_idx) ? right_child_idx : left_child_idx;
+          bool take_min = (monotone_type < 0) ? left_child_is_curr_idx
+                                              : !left_child_is_curr_idx;
+
+          GoDownToFindLeavesToUpdate(
+              node_idx_to_pass, features, thresholds, is_in_right_split,
+              take_min, split_feature, split_info, true, true, split_threshold,
+              best_split_per_leaf_,
+              learner_state);
+        }
+
+        is_in_right_split.push_back(
+            learner_state.tree->right_child(parent_idx) == node_idx);
+        thresholds.push_back(learner_state.tree->threshold_in_bin(parent_idx));
+        features.push_back(learner_state.tree->split_feature_inner(parent_idx));
+      }
+
+      if (parent_idx != 0) {
+        LeafConstraints::GoUpToFindLeavesToUpdate(
+            parent_idx, features, thresholds, is_in_right_split, split_feature,
+            split_info, split_threshold, best_split_per_leaf_,
+            learner_state);
+      }
+    }
+  }
+
+  void GoDownToFindLeavesToUpdate(
+      int node_idx, const std::vector<int> &features,
+      const std::vector<uint32_t> &thresholds,
+      const std::vector<bool> &is_in_right_split, int maximum,
+      int split_feature, const SplitInfo &split_info, bool use_left_leaf,
+      bool use_right_leaf, uint32_t split_threshold,
+      std::vector<SplitInfo> &best_split_per_leaf_,
+      LearnerState &learner_state) {
+
+    if (node_idx < 0) {
+      int leaf_idx = ~node_idx;
+
+      // if a leaf is at max depth then there is no need to update it
+      int max_depth = learner_state.config_->max_depth;
+      if (learner_state.tree->leaf_depth(leaf_idx) >= max_depth &&
+          max_depth > 0) {
+        return;
+      }
+
+      // splits that are not to be used shall not be updated
+      if (best_split_per_leaf_[leaf_idx].gain == kMinScore) {
+        return;
+      }
+
+      std::pair<double, double> min_max_constraints;
+      bool something_changed;
+      if (use_right_leaf && use_left_leaf) {
+        min_max_constraints =
+            std::minmax(split_info.right_output, split_info.left_output);
+      } else if (use_right_leaf && !use_left_leaf) {
+        min_max_constraints = std::pair<double, double>(
+            split_info.right_output, split_info.right_output);
+      } else {
+        min_max_constraints = std::pair<double, double>(split_info.left_output,
+                                                        split_info.left_output);
+      }
+
+#ifdef DEBUG
+      if (maximum) {
+        CHECK(min_max_constraints.first >=
+              learner_state.tree->LeafOutput(leaf_idx));
+      } else {
+        CHECK(min_max_constraints.second <=
+              learner_state.tree->LeafOutput(leaf_idx));
+      }
+#endif
+
+      if (!maximum) {
+        something_changed = entries_[leaf_idx].UpdateMinAndReturnBoolIfChanged(
+            min_max_constraints.second);
+      } else {
+        something_changed = entries_[leaf_idx].UpdateMaxAndReturnBoolIfChanged(
+            min_max_constraints.first);
+      }
+      if (!something_changed) {
+        return;
+      }
+      leaves_to_update.push_back(leaf_idx);
+
+    } else {
+      // check if the children are contiguous with the original leaf
+      std::pair<bool, bool> keep_going_left_right = ShouldKeepGoingLeftRight(
+          learner_state.tree, node_idx, features, thresholds, is_in_right_split,
+          learner_state.train_data_);
+      int inner_feature = learner_state.tree->split_feature_inner(node_idx);
+      uint32_t threshold = learner_state.tree->threshold_in_bin(node_idx);
+      bool is_split_numerical =
+          learner_state.train_data_->FeatureBinMapper(inner_feature)
+              ->bin_type() == BinType::NumericalBin;
+      bool use_left_leaf_for_update = true;
+      bool use_right_leaf_for_update = true;
+      if (is_split_numerical && inner_feature == split_feature) {
+        if (threshold >= split_threshold) {
+          use_left_leaf_for_update = false;
+        }
+        if (threshold <= split_threshold) {
+          use_right_leaf_for_update = false;
+        }
+      }
+
+      if (keep_going_left_right.first) {
+        GoDownToFindLeavesToUpdate(
+            learner_state.tree->left_child(node_idx), features, thresholds,
+            is_in_right_split, maximum, split_feature, split_info,
+            use_left_leaf, use_right_leaf_for_update && use_right_leaf,
+            split_threshold, best_split_per_leaf_,
+            learner_state);
+      }
+      if (keep_going_left_right.second) {
+        GoDownToFindLeavesToUpdate(
+            learner_state.tree->right_child(node_idx), features, thresholds,
+            is_in_right_split, maximum, split_feature, split_info,
+            use_left_leaf_for_update && use_left_leaf, use_right_leaf,
+            split_threshold, best_split_per_leaf_,
+            learner_state);
+      }
+    }
+  }
+
+  void GoUpToFindLeavesToUpdate(int node_idx, int split_feature,
+                                const SplitInfo &split_info,
+                                uint32_t split_threshold,
+                                std::vector<SplitInfo> &best_split_per_leaf_,
+                                LearnerState &learner_state) {
+    int depth = learner_state.tree->leaf_depth(
+                    ~learner_state.tree->left_child(node_idx)) -
+                1;
+
+    std::vector<int> features;
+    std::vector<uint32_t> thresholds;
+    std::vector<bool> is_in_right_split;
+
+    features.reserve(depth);
+    thresholds.reserve(depth);
+    is_in_right_split.reserve(depth);
+
+    GoUpToFindLeavesToUpdate(
+        node_idx, features, thresholds, is_in_right_split, split_feature,
+        split_info, split_threshold, best_split_per_leaf_,
+        learner_state);
+  }
+
+  std::pair<bool, bool> ShouldKeepGoingLeftRight(
+      const Tree *tree, int node_idx, const std::vector<int> &features,
+      const std::vector<uint32_t> &thresholds,
+      const std::vector<bool> &is_in_right_split, const Dataset *train_data_) {
+    int inner_feature = tree->split_feature_inner(node_idx);
+    uint32_t threshold = tree->threshold_in_bin(node_idx);
+    bool is_split_numerical = train_data_->FeatureBinMapper(inner_feature)
+                                  ->bin_type() == BinType::NumericalBin;
+
+    bool keep_going_right = true;
+    bool keep_going_left = true;
+    // left and right nodes are checked to find out if they are contiguous with the original leaf
+    // if so the algorithm should keep going down these nodes to update constraints
+    for (unsigned int i = 0; i < features.size(); ++i) {
+      if (features[i] == inner_feature) {
+        if (is_split_numerical) {
+          if (threshold >= thresholds[i] && !is_in_right_split[i]) {
+            keep_going_right = false;
+          }
+          if (threshold <= thresholds[i] && is_in_right_split[i]) {
+            keep_going_left = false;
+          }
+        }
+      }
+    }
+    return std::pair<bool, bool>(keep_going_left, keep_going_right);
+  }
+
   const ConstraintEntry& Get(int leaf_idx) const { return entries_[leaf_idx]; }
+
+  std::vector<int> leaves_to_update;
 
  private:
   int num_leaves_;

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -115,8 +115,9 @@ class LeafConstraints {
     int parent_idx = learner_state.tree->node_parent(node_idx);
     if (parent_idx != -1) {
       int inner_feature = learner_state.tree->split_feature_inner(parent_idx);
+      int feature = learner_state.tree->split_feature(parent_idx);
       int8_t monotone_type =
-          learner_state.train_data_->FeatureMonotone(inner_feature);
+          learner_state.config_->monotone_constraints[feature];
       bool is_right_split =
           learner_state.tree->right_child(parent_idx) == node_idx;
       bool split_contains_new_information = true;

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -124,6 +124,10 @@ class FastLeafConstraints : public BasicLeafConstraints {
       leaf_is_in_monotone_subtree_[leaf] = true;
       leaf_is_in_monotone_subtree_[new_leaf] = true;
     }
+#ifdef DEBUG
+    CHECK(new_leaf - 1 >= 0);
+    CHECK(new_leaf - 1 < node_parent_.size());
+#endif
     node_parent_[new_leaf - 1] = tree->leaf_parent(leaf);
   }
 
@@ -162,6 +166,10 @@ class FastLeafConstraints : public BasicLeafConstraints {
       std::vector<uint32_t> &thresholds, std::vector<bool> &is_in_right_split,
       int split_feature, const SplitInfo &split_info, uint32_t split_threshold,
       const std::vector<SplitInfo> &best_split_per_leaf) {
+#ifdef DEBUG
+    CHECK(node_idx >= 0);
+    CHECK(node_idx < node_parent_.size());
+#endif
     int parent_idx = node_parent_[node_idx];
     if (parent_idx != -1) {
       int inner_feature = tree->split_feature_inner(parent_idx);

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -126,7 +126,7 @@ class FastLeafConstraints : public BasicLeafConstraints {
     }
 #ifdef DEBUG
     CHECK(new_leaf - 1 >= 0);
-    CHECK(new_leaf - 1 < node_parent_.size());
+    CHECK((unsigned int)(new_leaf - 1) < node_parent_.size());
 #endif
     node_parent_[new_leaf - 1] = tree->leaf_parent(leaf);
   }
@@ -168,7 +168,7 @@ class FastLeafConstraints : public BasicLeafConstraints {
       const std::vector<SplitInfo> &best_split_per_leaf) {
 #ifdef DEBUG
     CHECK(node_idx >= 0);
-    CHECK(node_idx < node_parent_.size());
+    CHECK((unsigned int) node_idx < node_parent_.size());
 #endif
     int parent_idx = node_parent_[node_idx];
     if (parent_idx != -1) {
@@ -252,10 +252,10 @@ class FastLeafConstraints : public BasicLeafConstraints {
 #ifdef DEBUG
       if (maximum) {
         CHECK(min_max_constraints.first >=
-              learner_state.tree->LeafOutput(leaf_idx));
+              tree->LeafOutput(leaf_idx));
       } else {
         CHECK(min_max_constraints.second <=
-              learner_state.tree->LeafOutput(leaf_idx));
+              tree->LeafOutput(leaf_idx));
       }
 #endif
 

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -49,17 +49,17 @@ struct ConstraintEntry {
 class LeafConstraintsBase {
  public:
   virtual ~LeafConstraintsBase(){};
-  virtual const ConstraintEntry &Get(int leaf_idx) const = 0;
+  virtual const ConstraintEntry& Get(int leaf_idx) const = 0;
   virtual void Reset() = 0;
-  virtual void BeforeSplit(const Tree *tree, int leaf, int new_leaf,
+  virtual void BeforeSplit(const Tree* tree, int leaf, int new_leaf,
                            int8_t monotone_type) = 0;
   virtual std::vector<int> Update(
-      const Tree *tree, bool is_numerical_split,
+      const Tree* tree, bool is_numerical_split,
       int leaf, int new_leaf, int8_t monotone_type, double right_output,
-      double left_output, int split_feature, const SplitInfo &split_info,
-      const std::vector<SplitInfo> &best_split_per_leaf) = 0;
+      double left_output, int split_feature, const SplitInfo& split_info,
+      const std::vector<SplitInfo>& best_split_per_leaf) = 0;
 
-  inline static LeafConstraintsBase *Create(const Config *config, int num_leaves);
+  inline static LeafConstraintsBase* Create(const Config* config, int num_leaves);
 };
 
 class BasicLeafConstraints : public LeafConstraintsBase {
@@ -69,18 +69,18 @@ class BasicLeafConstraints : public LeafConstraintsBase {
   }
 
   void Reset() override {
-    for (auto &entry : entries_) {
+    for (auto& entry : entries_) {
       entry.Reset();
     }
   }
 
-  void BeforeSplit(const Tree *, int, int, int8_t) override {}
+  void BeforeSplit(const Tree*, int, int, int8_t) override {}
 
-  std::vector<int> Update(const Tree *,
+  std::vector<int> Update(const Tree*,
                           bool is_numerical_split, int leaf, int new_leaf,
                           int8_t monotone_type, double right_output,
-                          double left_output, int, const SplitInfo &,
-                          const std::vector<SplitInfo> &) override {
+                          double left_output, int, const SplitInfo& ,
+                          const std::vector<SplitInfo>& ) override {
     entries_[new_leaf] = entries_[leaf];
     if (is_numerical_split) {
       double mid = (left_output + right_output) / 2.0f;
@@ -95,7 +95,7 @@ class BasicLeafConstraints : public LeafConstraintsBase {
     return std::vector<int>();
   }
 
-  const ConstraintEntry &Get(int leaf_idx) const override { return entries_[leaf_idx]; }
+  const ConstraintEntry& Get(int leaf_idx) const override { return entries_[leaf_idx]; }
 
  protected:
   int num_leaves_;
@@ -104,7 +104,7 @@ class BasicLeafConstraints : public LeafConstraintsBase {
 
 class FastLeafConstraints : public BasicLeafConstraints {
  public:
-  explicit FastLeafConstraints(const Config *config, int num_leaves)
+  explicit FastLeafConstraints(const Config* config, int num_leaves)
       : BasicLeafConstraints(num_leaves), config_(config) {
     leaf_is_in_monotone_subtree_.resize(num_leaves_, false);
     node_parent_.resize(num_leaves_ - 1, -1);
@@ -118,7 +118,7 @@ class FastLeafConstraints : public BasicLeafConstraints {
     leaves_to_update_.clear();
   }
 
-  void BeforeSplit(const Tree *tree, int leaf, int new_leaf,
+  void BeforeSplit(const Tree* tree, int leaf, int new_leaf,
                    int8_t monotone_type) override {
     if (monotone_type != 0 || leaf_is_in_monotone_subtree_[leaf]) {
       leaf_is_in_monotone_subtree_[leaf] = true;
@@ -146,11 +146,11 @@ class FastLeafConstraints : public BasicLeafConstraints {
     }
   }
 
-  std::vector<int> Update(const Tree *tree, bool is_numerical_split, int leaf,
+  std::vector<int> Update(const Tree* tree, bool is_numerical_split, int leaf,
                           int new_leaf, int8_t monotone_type,
                           double right_output, double left_output,
-                          int split_feature, const SplitInfo &split_info,
-                          const std::vector<SplitInfo> &best_split_per_leaf) override{
+                          int split_feature, const SplitInfo& split_info,
+                          const std::vector<SplitInfo>& best_split_per_leaf) override{
     leaves_to_update_.clear();
     if (leaf_is_in_monotone_subtree_[leaf]) {
       UpdateConstraintsWithOutputs(is_numerical_split, leaf, new_leaf,
@@ -165,9 +165,9 @@ class FastLeafConstraints : public BasicLeafConstraints {
 
   bool OppositeChildShouldBeUpdated(
       bool is_split_numerical,
-      const std::vector<int> &features_of_splits_going_up_from_original_leaf,
+      const std::vector<int>& features_of_splits_going_up_from_original_leaf,
       int inner_feature,
-      std::vector<bool> &was_original_leaf_right_child_of_split,
+      std::vector<bool>& was_original_leaf_right_child_of_split,
       bool is_in_right_child) {
     bool opposite_child_should_be_updated = true;
 
@@ -198,12 +198,12 @@ class FastLeafConstraints : public BasicLeafConstraints {
   // Recursive function that goes up the tree, and then down to find leaves that
   // have constraints to be updated
   void GoUpToFindLeavesToUpdate(
-      const Tree *tree, int node_idx,
-      std::vector<int> &features_of_splits_going_up_from_original_leaf,
-      std::vector<uint32_t> &thresholds_of_splits_going_up_from_original_leaf,
-      std::vector<bool> &was_original_leaf_right_child_of_split,
-      int split_feature, const SplitInfo &split_info, uint32_t split_threshold,
-      const std::vector<SplitInfo> &best_split_per_leaf) {
+      const Tree* tree, int node_idx,
+      std::vector<int>& features_of_splits_going_up_from_original_leaf,
+      std::vector<uint32_t>& thresholds_of_splits_going_up_from_original_leaf,
+      std::vector<bool>& was_original_leaf_right_child_of_split,
+      int split_feature, const SplitInfo& split_info, uint32_t split_threshold,
+      const std::vector<SplitInfo>& best_split_per_leaf) {
 #ifdef DEBUG
     CHECK(node_idx >= 0);
     CHECK((unsigned int)node_idx < node_parent_.size());
@@ -264,15 +264,15 @@ class FastLeafConstraints : public BasicLeafConstraints {
   }
 
   void GoDownToFindLeavesToUpdate(
-      const Tree *tree, int node_idx,
-      const std::vector<int> &features_of_splits_going_up_from_original_leaf,
-      const std::vector<uint32_t> &
+      const Tree* tree, int node_idx,
+      const std::vector<int>& features_of_splits_going_up_from_original_leaf,
+      const std::vector<uint32_t>&
           thresholds_of_splits_going_up_from_original_leaf,
-      const std::vector<bool> &was_original_leaf_right_child_of_split,
+      const std::vector<bool>& was_original_leaf_right_child_of_split,
       bool update_max_constraints, int split_feature,
-      const SplitInfo &split_info, bool use_left_leaf, bool use_right_leaf,
+      const SplitInfo& split_info, bool use_left_leaf, bool use_right_leaf,
       uint32_t split_threshold,
-      const std::vector<SplitInfo> &best_split_per_leaf) {
+      const std::vector<SplitInfo>& best_split_per_leaf) {
     if (node_idx < 0) {
       int leaf_idx = ~node_idx;
 
@@ -359,10 +359,10 @@ class FastLeafConstraints : public BasicLeafConstraints {
   }
 
   void
-  GoUpToFindLeavesToUpdate(const Tree *tree, int node_idx, int split_feature,
-                           const SplitInfo &split_info,
+  GoUpToFindLeavesToUpdate(const Tree* tree, int node_idx, int split_feature,
+                           const SplitInfo& split_info,
                            uint32_t split_threshold,
-                           const std::vector<SplitInfo> &best_split_per_leaf) {
+                           const std::vector<SplitInfo>& best_split_per_leaf) {
     int depth = tree->leaf_depth(~tree->left_child(node_idx)) - 1;
 
     std::vector<int> features_of_splits_going_up_from_original_leaf;
@@ -381,11 +381,11 @@ class FastLeafConstraints : public BasicLeafConstraints {
   }
 
   std::pair<bool, bool> ShouldKeepGoingLeftRight(
-      const Tree *tree, int node_idx,
-      const std::vector<int> &features_of_splits_going_up_from_original_leaf,
-      const std::vector<uint32_t> &
+      const Tree* tree, int node_idx,
+      const std::vector<int>& features_of_splits_going_up_from_original_leaf,
+      const std::vector<uint32_t>&
           thresholds_of_splits_going_up_from_original_leaf,
-      const std::vector<bool> &was_original_leaf_right_child_of_split) {
+      const std::vector<bool>& was_original_leaf_right_child_of_split) {
     int inner_feature = tree->split_feature_inner(node_idx);
     uint32_t threshold = tree->threshold_in_bin(node_idx);
     bool is_split_numerical = tree->IsNumericalSplit(node_idx);
@@ -417,7 +417,7 @@ class FastLeafConstraints : public BasicLeafConstraints {
   }
 
  private:
-  const Config *config_;
+  const Config* config_;
   std::vector<int> leaves_to_update_;
   // add parent node information
   std::vector<int> node_parent_;
@@ -425,7 +425,7 @@ class FastLeafConstraints : public BasicLeafConstraints {
   std::vector<bool> leaf_is_in_monotone_subtree_;
 };
 
-LeafConstraintsBase *LeafConstraintsBase::Create(const Config *config,
+LeafConstraintsBase* LeafConstraintsBase::Create(const Config* config,
                                                  int num_leaves) {
   if (config->monotone_constraints_method == "intermediate") {
     return new FastLeafConstraints(config, num_leaves);

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -199,9 +199,9 @@ class FastLeafConstraints : public BasicLeafConstraints {
   // have constraints to be updated
   void GoUpToFindLeavesToUpdate(
       const Tree* tree, int node_idx,
-      std::vector<int>& features_of_splits_going_up_from_original_leaf,
-      std::vector<uint32_t>& thresholds_of_splits_going_up_from_original_leaf,
-      std::vector<bool>& was_original_leaf_right_child_of_split,
+      std::vector<int>* features_of_splits_going_up_from_original_leaf,
+      std::vector<uint32_t>* thresholds_of_splits_going_up_from_original_leaf,
+      std::vector<bool>* was_original_leaf_right_child_of_split,
       int split_feature, const SplitInfo& split_info, uint32_t split_threshold,
       const std::vector<SplitInfo>& best_split_per_leaf) {
 #ifdef DEBUG
@@ -220,8 +220,8 @@ class FastLeafConstraints : public BasicLeafConstraints {
       // this is just an optimisation not to waste time going down in subtrees
       // where there won't be any leaf to update
       bool opposite_child_should_be_updated = OppositeChildShouldBeUpdated(
-          is_split_numerical, features_of_splits_going_up_from_original_leaf,
-          inner_feature, was_original_leaf_right_child_of_split,
+          is_split_numerical, *features_of_splits_going_up_from_original_leaf,
+          inner_feature, *was_original_leaf_right_child_of_split,
           is_in_right_child);
 
       if (opposite_child_should_be_updated) {
@@ -244,9 +244,9 @@ class FastLeafConstraints : public BasicLeafConstraints {
           // to see which leaves' constraints need to be updated
           GoDownToFindLeavesToUpdate(
               tree, opposite_child_idx,
-              features_of_splits_going_up_from_original_leaf,
-              thresholds_of_splits_going_up_from_original_leaf,
-              was_original_leaf_right_child_of_split,
+              *features_of_splits_going_up_from_original_leaf,
+              *thresholds_of_splits_going_up_from_original_leaf,
+              *was_original_leaf_right_child_of_split,
               update_max_constraints_in_opposite_child_leaves, split_feature,
               split_info, true, true, split_threshold, best_split_per_leaf);
         }
@@ -255,11 +255,11 @@ class FastLeafConstraints : public BasicLeafConstraints {
         // i.e. that it will be helpful going down to determine which leaf
         // is actually contiguous to the original 2 leaves and should be updated
         // so the variables associated with the split need to be recorded
-        was_original_leaf_right_child_of_split.push_back(
+        was_original_leaf_right_child_of_split->push_back(
             tree->right_child(parent_idx) == node_idx);
-        thresholds_of_splits_going_up_from_original_leaf.push_back(
+        thresholds_of_splits_going_up_from_original_leaf->push_back(
             tree->threshold_in_bin(parent_idx));
-        features_of_splits_going_up_from_original_leaf.push_back(
+        features_of_splits_going_up_from_original_leaf->push_back(
             tree->split_feature_inner(parent_idx));
       }
 
@@ -387,13 +387,13 @@ class FastLeafConstraints : public BasicLeafConstraints {
                            const std::vector<SplitInfo>& best_split_per_leaf) {
     int depth = tree->leaf_depth(~tree->left_child(node_idx)) - 1;
 
-    std::vector<int> features_of_splits_going_up_from_original_leaf;
-    std::vector<uint32_t> thresholds_of_splits_going_up_from_original_leaf;
-    std::vector<bool> was_original_leaf_right_child_of_split;
+    std::vector<int>* features_of_splits_going_up_from_original_leaf = new std::vector<int>();
+    std::vector<uint32_t>* thresholds_of_splits_going_up_from_original_leaf = new std::vector<uint32_t>();
+    std::vector<bool>* was_original_leaf_right_child_of_split = new std::vector<bool>();
 
-    features_of_splits_going_up_from_original_leaf.reserve(depth);
-    thresholds_of_splits_going_up_from_original_leaf.reserve(depth);
-    was_original_leaf_right_child_of_split.reserve(depth);
+    features_of_splits_going_up_from_original_leaf->reserve(depth);
+    thresholds_of_splits_going_up_from_original_leaf->reserve(depth);
+    was_original_leaf_right_child_of_split->reserve(depth);
 
     GoUpToFindLeavesToUpdate(
         tree, node_idx, features_of_splits_going_up_from_original_leaf,

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -11,6 +11,7 @@
 #include <limits>
 #include <utility>
 #include <vector>
+
 #include "split_info.hpp"
 
 namespace LightGBM {

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <limits>
+#include <utility>
 #include <vector>
 #include "split_info.hpp"
 
@@ -48,7 +49,7 @@ struct ConstraintEntry {
 
 class LeafConstraintsBase {
  public:
-  virtual ~LeafConstraintsBase(){};
+  virtual ~LeafConstraintsBase(){}
   virtual const ConstraintEntry& Get(int leaf_idx) const = 0;
   virtual void Reset() = 0;
   virtual void BeforeSplit(const Tree* tree, int leaf, int new_leaf,
@@ -80,7 +81,7 @@ class BasicLeafConstraints : public LeafConstraintsBase {
                           bool is_numerical_split, int leaf, int new_leaf,
                           int8_t monotone_type, double right_output,
                           double left_output, int, const SplitInfo& ,
-                          const std::vector<SplitInfo>& ) override {
+                          const std::vector<SplitInfo>&) override {
     entries_[new_leaf] = entries_[leaf];
     if (is_numerical_split) {
       double mid = (left_output + right_output) / 2.0f;
@@ -150,7 +151,7 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
                           int new_leaf, int8_t monotone_type,
                           double right_output, double left_output,
                           int split_feature, const SplitInfo& split_info,
-                          const std::vector<SplitInfo>& best_split_per_leaf) override{
+                          const std::vector<SplitInfo>& best_split_per_leaf) override {
     leaves_to_update_.clear();
     if (leaf_is_in_monotone_subtree_[leaf]) {
       UpdateConstraintsWithOutputs(is_numerical_split, leaf, new_leaf,
@@ -219,8 +220,8 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
       int split_feature, const SplitInfo& split_info, uint32_t split_threshold,
       const std::vector<SplitInfo>& best_split_per_leaf) {
 #ifdef DEBUG
-    CHECK(node_idx >= 0);
-    CHECK((unsigned int)node_idx < node_parent_.size());
+    CHECK_GE(node_idx >= 0);
+    CHECK_GE((unsigned int)node_idx < node_parent_.size());
 #endif
     int parent_idx = node_parent_[node_idx];
     // if not at the root
@@ -345,7 +346,7 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
       }
       leaves_to_update_.push_back(leaf_idx);
 
-    } else { // if node
+    } else {  // if node
       // check if the children are contiguous with the original leaf
       std::pair<bool, bool> keep_going_left_right = ShouldKeepGoingLeftRight(
           tree, node_idx, features_of_splits_going_up_from_original_leaf,

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -128,7 +128,7 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
     }
 #ifdef DEBUG
     CHECK_GE(new_leaf - 1, 0);
-    CHECK_LT((unsigned int)(new_leaf - 1), node_parent_.size());
+    CHECK_LT(static_cast<size_t>(new_leaf - 1), node_parent_.size());
 #endif
     node_parent_[new_leaf - 1] = tree->leaf_parent(leaf);
   }
@@ -196,7 +196,7 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
       // leaf need to be updated
       // therefore, for the same feature, there is no use going down from the
       // second time going up on the right (or on the left)
-      for (unsigned int split_idx = 0;
+      for (size_t split_idx = 0;
            split_idx < features_of_splits_going_up_from_original_leaf.size();
            ++split_idx) {
         if (features_of_splits_going_up_from_original_leaf[split_idx] ==
@@ -222,7 +222,7 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
       const std::vector<SplitInfo>& best_split_per_leaf) {
 #ifdef DEBUG
     CHECK_GE(node_idx, 0);
-    CHECK_LT((unsigned int)node_idx, node_parent_.size());
+    CHECK_LT(static_cast<size_t>(node_idx), node_parent_.size());
 #endif
     int parent_idx = node_parent_[node_idx];
     // if not at the root
@@ -412,7 +412,7 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
     // the original leaves if so the algorithm should keep going down these nodes
     // to update constraints
     if (is_split_numerical) {
-      for (unsigned int i = 0;
+      for (size_t i = 0;
            i < features_of_splits_going_up_from_original_leaf.size(); ++i) {
         if (features_of_splits_going_up_from_original_leaf[i] ==
             inner_feature) {

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -420,11 +420,17 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
                   thresholds_of_splits_going_up_from_original_leaf[i] &&
               !was_original_leaf_right_child_of_split[i]) {
             keep_going_right = false;
+            if (!keep_going_left) {
+              break;
+            }
           }
           if (threshold <=
                   thresholds_of_splits_going_up_from_original_leaf[i] &&
               was_original_leaf_right_child_of_split[i]) {
             keep_going_left = false;
+            if (!keep_going_right) {
+              break;
+            }
           }
         }
       }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -49,7 +49,7 @@ struct ConstraintEntry {
 
 class LeafConstraintsBase {
  public:
-  virtual ~LeafConstraintsBase(){}
+  virtual ~LeafConstraintsBase() {}
   virtual const ConstraintEntry& Get(int leaf_idx) const = 0;
   virtual void Reset() = 0;
   virtual void BeforeSplit(const Tree* tree, int leaf, int new_leaf,
@@ -126,8 +126,8 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
       leaf_is_in_monotone_subtree_[new_leaf] = true;
     }
 #ifdef DEBUG
-    CHECK(new_leaf - 1 >= 0);
-    CHECK((unsigned int)(new_leaf - 1) < node_parent_.size());
+    CHECK_GE(new_leaf - 1, 0);
+    CHECK_LT((unsigned int)(new_leaf - 1), node_parent_.size());
 #endif
     node_parent_[new_leaf - 1] = tree->leaf_parent(leaf);
   }
@@ -326,9 +326,9 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
 
 #ifdef DEBUG
       if (update_max_constraints) {
-        CHECK(min_max_constraints.first >= tree->LeafOutput(leaf_idx));
+        CHECK_GE(min_max_constraints.first, tree->LeafOutput(leaf_idx));
       } else {
-        CHECK(min_max_constraints.second <= tree->LeafOutput(leaf_idx));
+        CHECK_LE(min_max_constraints.second, tree->LeafOutput(leaf_idx));
       }
 #endif
       // depending on which split made the current leaf and the original leaves contiguous,

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -167,7 +167,7 @@ class FastLeafConstraints : public BasicLeafConstraints {
       bool is_split_numerical,
       const std::vector<int>& features_of_splits_going_up_from_original_leaf,
       int inner_feature,
-      std::vector<bool>& was_original_leaf_right_child_of_split,
+      const std::vector<bool>& was_original_leaf_right_child_of_split,
       bool is_in_right_child) {
     bool opposite_child_should_be_updated = true;
 

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -220,8 +220,8 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
       int split_feature, const SplitInfo& split_info, uint32_t split_threshold,
       const std::vector<SplitInfo>& best_split_per_leaf) {
 #ifdef DEBUG
-    CHECK_GE(node_idx >= 0);
-    CHECK_GE((unsigned int)node_idx < node_parent_.size());
+    CHECK_GE(node_idx, 0);
+    CHECK_LT((unsigned int)node_idx, node_parent_.size());
 #endif
     int parent_idx = node_parent_[node_idx];
     // if not at the root

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -159,21 +159,18 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
       // Initialize variables to store information while going up the tree
       int depth = tree->leaf_depth(new_leaf) - 1;
 
-      std::vector<int> *features_of_splits_going_up_from_original_leaf =
-          new std::vector<int>();
-      std::vector<uint32_t> *thresholds_of_splits_going_up_from_original_leaf =
-          new std::vector<uint32_t>();
-      std::vector<bool> *was_original_leaf_right_child_of_split =
-          new std::vector<bool>();
+      std::vector<int> features_of_splits_going_up_from_original_leaf;
+      std::vector<uint32_t> thresholds_of_splits_going_up_from_original_leaf;
+      std::vector<bool> was_original_leaf_right_child_of_split;
 
-      features_of_splits_going_up_from_original_leaf->reserve(depth);
-      thresholds_of_splits_going_up_from_original_leaf->reserve(depth);
-      was_original_leaf_right_child_of_split->reserve(depth);
+      features_of_splits_going_up_from_original_leaf.reserve(depth);
+      thresholds_of_splits_going_up_from_original_leaf.reserve(depth);
+      was_original_leaf_right_child_of_split.reserve(depth);
 
       GoUpToFindLeavesToUpdate(tree, tree->leaf_parent(new_leaf),
-                               features_of_splits_going_up_from_original_leaf,
-                               thresholds_of_splits_going_up_from_original_leaf,
-                               was_original_leaf_right_child_of_split,
+                               &features_of_splits_going_up_from_original_leaf,
+                               &thresholds_of_splits_going_up_from_original_leaf,
+                               &was_original_leaf_right_child_of_split,
                                split_feature, split_info, split_info.threshold,
                                best_split_per_leaf);
     }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -156,8 +156,25 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
       UpdateConstraintsWithOutputs(is_numerical_split, leaf, new_leaf,
                                    monotone_type, right_output, left_output);
 
-      GoUpToFindLeavesToUpdate(tree, tree->leaf_parent(new_leaf), split_feature,
-                               split_info, split_info.threshold,
+      // Initialize variables to store information while going up the tree
+      int depth = tree->leaf_depth(new_leaf) - 1;
+
+      std::vector<int> *features_of_splits_going_up_from_original_leaf =
+          new std::vector<int>();
+      std::vector<uint32_t> *thresholds_of_splits_going_up_from_original_leaf =
+          new std::vector<uint32_t>();
+      std::vector<bool> *was_original_leaf_right_child_of_split =
+          new std::vector<bool>();
+
+      features_of_splits_going_up_from_original_leaf->reserve(depth);
+      thresholds_of_splits_going_up_from_original_leaf->reserve(depth);
+      was_original_leaf_right_child_of_split->reserve(depth);
+
+      GoUpToFindLeavesToUpdate(tree, tree->leaf_parent(new_leaf),
+                               features_of_splits_going_up_from_original_leaf,
+                               thresholds_of_splits_going_up_from_original_leaf,
+                               was_original_leaf_right_child_of_split,
+                               split_feature, split_info, split_info.threshold,
                                best_split_per_leaf);
     }
     return leaves_to_update_;
@@ -378,28 +395,6 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
             split_threshold, best_split_per_leaf);
       }
     }
-  }
-
-  void
-  GoUpToFindLeavesToUpdate(const Tree* tree, int node_idx, int split_feature,
-                           const SplitInfo& split_info,
-                           uint32_t split_threshold,
-                           const std::vector<SplitInfo>& best_split_per_leaf) {
-    int depth = tree->leaf_depth(~tree->left_child(node_idx)) - 1;
-
-    std::vector<int>* features_of_splits_going_up_from_original_leaf = new std::vector<int>();
-    std::vector<uint32_t>* thresholds_of_splits_going_up_from_original_leaf = new std::vector<uint32_t>();
-    std::vector<bool>* was_original_leaf_right_child_of_split = new std::vector<bool>();
-
-    features_of_splits_going_up_from_original_leaf->reserve(depth);
-    thresholds_of_splits_going_up_from_original_leaf->reserve(depth);
-    was_original_leaf_right_child_of_split->reserve(depth);
-
-    GoUpToFindLeavesToUpdate(
-        tree, node_idx, features_of_splits_going_up_from_original_leaf,
-        thresholds_of_splits_going_up_from_original_leaf,
-        was_original_leaf_right_child_of_split, split_feature, split_info,
-        split_threshold, best_split_per_leaf);
   }
 
   std::pair<bool, bool> ShouldKeepGoingLeftRight(

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -152,12 +152,14 @@ class FastLeafConstraints : public BasicLeafConstraints {
                           int split_feature, const SplitInfo &split_info,
                           const std::vector<SplitInfo> &best_split_per_leaf) override{
     leaves_to_update_.clear();
-    UpdateConstraintsWithOutputs(is_numerical_split, leaf, new_leaf,
-                                 monotone_type, right_output, left_output);
+    if (leaf_is_in_monotone_subtree_[leaf]) {
+      UpdateConstraintsWithOutputs(is_numerical_split, leaf, new_leaf,
+                                   monotone_type, right_output, left_output);
 
-    GoUpToFindLeavesToUpdate(tree, tree->leaf_parent(new_leaf), split_feature,
-                             split_info, split_info.threshold,
-                             best_split_per_leaf);
+      GoUpToFindLeavesToUpdate(tree, tree->leaf_parent(new_leaf), split_feature,
+                               split_info, split_info.threshold,
+                               best_split_per_leaf);
+    }
     return leaves_to_update_;
   }
 

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -97,7 +97,7 @@ class BasicLeafConstraints : public LeafConstraintsBase {
 
   const ConstraintEntry &Get(int leaf_idx) const { return entries_[leaf_idx]; }
 
- private:
+ protected:
   int num_leaves_;
   std::vector<ConstraintEntry> entries_;
 };
@@ -107,14 +107,14 @@ class FastLeafConstraints : public BasicLeafConstraints {
   explicit FastLeafConstraints(const Config *config, int num_leaves)
       : BasicLeafConstraints(num_leaves), config_(config) {
     leaf_is_in_monotone_subtree_.resize(num_leaves_, false);
-    node_parent_.resize(num_leaves_, 0);
+    node_parent_.resize(num_leaves_ - 1, -1);
     leaves_to_update_.reserve(num_leaves_);
   }
 
   void Reset() override {
     BasicLeafConstraints::Reset();
     std::fill_n(leaf_is_in_monotone_subtree_.begin(), num_leaves_, false);
-    std::fill_n(node_parent_.begin(), num_leaves_, 0);
+    std::fill_n(node_parent_.begin(), num_leaves_ - 1, -1);
     leaves_to_update_.clear();
   }
 
@@ -349,8 +349,6 @@ class FastLeafConstraints : public BasicLeafConstraints {
 
  private:
   const Config *config_;
-  int num_leaves_;
-  std::vector<ConstraintEntry> entries_;
   std::vector<int> leaves_to_update_;
   // add parent node information
   std::vector<int> node_parent_;

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -102,9 +102,9 @@ class BasicLeafConstraints : public LeafConstraintsBase {
   std::vector<ConstraintEntry> entries_;
 };
 
-class FastLeafConstraints : public BasicLeafConstraints {
+class IntermediateLeafConstraints : public BasicLeafConstraints {
  public:
-  explicit FastLeafConstraints(const Config* config, int num_leaves)
+  explicit IntermediateLeafConstraints(const Config* config, int num_leaves)
       : BasicLeafConstraints(num_leaves), config_(config) {
     leaf_is_in_monotone_subtree_.resize(num_leaves_, false);
     node_parent_.resize(num_leaves_ - 1, -1);
@@ -450,7 +450,7 @@ class FastLeafConstraints : public BasicLeafConstraints {
 LeafConstraintsBase* LeafConstraintsBase::Create(const Config* config,
                                                  int num_leaves) {
   if (config->monotone_constraints_method == "intermediate") {
-    return new FastLeafConstraints(config, num_leaves);
+    return new IntermediateLeafConstraints(config, num_leaves);
   }
   return new BasicLeafConstraints(num_leaves);
 }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -95,7 +95,7 @@ class BasicLeafConstraints : public LeafConstraintsBase {
     return std::vector<int>();
   }
 
-  const ConstraintEntry &Get(int leaf_idx) const { return entries_[leaf_idx]; }
+  const ConstraintEntry &Get(int leaf_idx) const override { return entries_[leaf_idx]; }
 
  protected:
   int num_leaves_;
@@ -150,7 +150,7 @@ class FastLeafConstraints : public BasicLeafConstraints {
                           int new_leaf, int8_t monotone_type,
                           double right_output, double left_output,
                           int split_feature, const SplitInfo &split_info,
-                          const std::vector<SplitInfo> &best_split_per_leaf) {
+                          const std::vector<SplitInfo> &best_split_per_leaf) override{
     leaves_to_update_.clear();
     UpdateConstraintsWithOutputs(is_numerical_split, leaf, new_leaf,
                                  monotone_type, right_output, left_output);

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -345,8 +345,6 @@ class FastLeafConstraints : public BasicLeafConstraints {
     return std::pair<bool, bool>(keep_going_left, keep_going_right);
   }
 
-  const ConstraintEntry &Get(int leaf_idx) const { return entries_[leaf_idx]; }
-
  private:
   const Config *config_;
   std::vector<int> leaves_to_update_;

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -618,13 +618,47 @@ void SerialTreeLearner::SplitInner(Tree* tree, int best_leaf, int* left_leaf,
     larger_leaf_splits_->Init(*left_leaf, data_partition_.get(),
                               best_split_info.left_sum_gradient,
                               best_split_info.left_sum_hessian);
+
+  // constraints are updated differently depending on the method used
+  if (!config_->monotone_constraints.empty() &&
+      tree->leaf_is_in_monotone_subtree(*right_leaf)) {
+    if (config_->monotone_constraints_method == "basic") {
+      constraints_->UpdateConstraintsWithMid(
+          is_numerical_split, *left_leaf, *right_leaf,
+          best_split_info.monotone_type, best_split_info.right_output,
+          best_split_info.left_output);
+
+    } else if (config_->monotone_constraints_method == "intermediate") {
+      constraints_->UpdateConstraintsWithOutputs(
+          is_numerical_split, *left_leaf, *right_leaf,
+          best_split_info.monotone_type, best_split_info.right_output,
+          best_split_info.left_output);
+
+      LearnerState learner_state(config_, train_data_, tree, cegb_);
+
+      // if there is a monotone split above, new values should
+      // be checked not to clash with existing constraints in the subtree;
+      // if they do, the existing splits need to be updated
+      constraints_->GoUpToFindLeavesToUpdate(
+          tree->leaf_parent(*right_leaf), inner_feature_index, best_split_info,
+          best_split_info.threshold, best_split_per_leaf_, learner_state);
+
+      // Update splits that just got their constraints updated
+      while (!constraints_->leaves_to_update.empty()) {
+        int leaf_idx = constraints_->leaves_to_update.back();
+        UpdateBestSplitsFromHistograms(
+            &best_split_per_leaf_[leaf_idx], leaf_idx, is_feature_used_,
+            num_features_, histogram_pool_, learner_state);
+        constraints_->leaves_to_update.pop_back();
+      }
+    } else {
+      throw "monotone_constraints_methode has to be one of ('basic', "
+            "'intermediate')"; // FIXME improve how this exception is handled
+    }
   }
-  constraints_->UpdateConstraints(is_numerical_split, *left_leaf, *right_leaf,
-                                  best_split_info.monotone_type,
-                                  best_split_info.right_output,
-                                  best_split_info.left_output);
 }
 
+>>>>>>> Add the intermediate constraining method.
 void SerialTreeLearner::RenewTreeOutput(Tree* tree, const ObjectiveFunction* obj, std::function<double(const label_t*, int)> residual_getter,
                                         data_size_t total_num_data, const data_size_t* bag_indices, data_size_t bag_cnt) const {
   if (obj != nullptr && obj->IsRenewTreeOutput()) {
@@ -685,6 +719,53 @@ void SerialTreeLearner::ComputeBestSplitForFeature(
   if (new_split > *best_split) {
     *best_split = new_split;
   }
+}
+
+
+// this function updates the best split for a leaf
+// it is called only when monotone constraints exist
+void SerialTreeLearner::UpdateBestSplitsFromHistograms(
+    SplitInfo *split, int leaf,
+    const std::vector<int8_t> &is_feature_used_,
+    int num_features_, HistogramPool &histogram_pool_,
+    LearnerState &learner_state) {
+  // the feature histogram is retrieved
+  FeatureHistogram *histogram_array_;
+  histogram_pool_.Get(leaf, &histogram_array_);
+  double sum_gradients = split->left_sum_gradient + split->right_sum_gradient;
+  double sum_hessians = split->left_sum_hessian + split->right_sum_hessian;
+  int num_data = split->left_count + split->right_count;
+  split->gain = kMinScore;
+
+  OMP_INIT_EX();
+#pragma omp parallel for schedule(static, 1024) if (num_features_ >= 2048)
+  for (int feature_index = 0; feature_index < num_features_; ++feature_index) {
+    OMP_LOOP_EX_BEGIN();
+    // splits are computed for the feature that are to be used
+    if (!histogram_array_[feature_index].is_splittable()) {
+      continue;
+    }
+
+    // loop through the features to find the best one just like in the
+    // FindBestSplitsFromHistograms function
+    int real_fidx = learner_state.train_data_->RealFeatureIndex(feature_index);
+    LeafSplits *leaf_splits = new LeafSplits(0);
+    leaf_splits->Init(leaf, sum_gradients,
+                     sum_hessians);
+
+    // best split is updated
+    ComputeBestSplitForFeature(
+        histogram_array_,
+        feature_index,
+        real_fidx,
+        is_feature_used_[feature_index], // FIXME is this the right parameter to pass here?
+        num_data,
+        leaf_splits,
+        split);
+
+    OMP_LOOP_EX_END();
+  }
+  OMP_THROW_EX();
 }
 
 }  // namespace LightGBM

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -710,7 +710,7 @@ void SerialTreeLearner::RecomputeBestSplitForLeaf(int leaf, SplitInfo* split) {
   double sum_hessians = split->left_sum_hessian + split->right_sum_hessian;
   int num_data = split->left_count + split->right_count;
 
-  std::vector<SplitInfo> bests(num_threads_);
+  std::vector<SplitInfo> bests(share_state_->num_threads);
   LeafSplits leaf_splits(num_data);
   leaf_splits.Init(leaf, sum_gradients, sum_hessians);
 

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -630,7 +630,7 @@ void SerialTreeLearner::SplitInner(Tree* tree, int best_leaf, int* left_leaf,
       best_split_info.left_output, inner_feature_index, best_split_info,
       best_split_per_leaf_);
   // update leave outputs if needed
-  for (auto leaf: leaves_need_update) {
+  for (auto leaf : leaves_need_update) {
     RecomputeBestSplitForLeaf(leaf, &best_split_per_leaf_[leaf]);
   }
 }

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -725,7 +725,7 @@ void SerialTreeLearner::RecomputeBestSplitForLeaf(int leaf, SplitInfo* split) {
     const int tid = omp_get_thread_num();
     int real_fidx = train_data_->RealFeatureIndex(feature_index);
     ComputeBestSplitForFeature(
-        smaller_leaf_histogram_array_, feature_index, real_fidx,
+        histogram_array_, feature_index, real_fidx,
         true,  // fixme: this cannot work with colsample_bynode, but do we really need to compute all features? why not just the used features of `split->feature`?
         num_data, &leaf_splits, &bests[tid]);
 

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -722,6 +722,9 @@ void SerialTreeLearner::RecomputeBestSplitForLeaf(int leaf, SplitInfo* split) {
     if (!is_feature_used_[feature_index]) {
       continue;
     }
+    if (!histogram_array_[feature_index].is_splittable()) {
+      continue;
+    }
     const int tid = omp_get_thread_num();
     int real_fidx = train_data_->RealFeatureIndex(feature_index);
     ComputeBestSplitForFeature(

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -46,7 +46,7 @@ void SerialTreeLearner::Init(const Dataset* train_data, bool is_constant_hessian
 
   // push split information for all leaves
   best_split_per_leaf_.resize(config_->num_leaves);
-  constraints_.reset(new LeafConstraints<ConstraintEntry>(config_->num_leaves));
+  constraints_.reset(LeafConstraintsBase::Create(config_, config_->num_leaves));
 
   // initialize splits for leaf
   smaller_leaf_splits_.reset(new LeafSplits(train_data_->num_data()));
@@ -144,6 +144,7 @@ void SerialTreeLearner::ResetConfig(const Config* config) {
     cegb_.reset(new CostEfficientGradientBoosting(this));
     cegb_->Init();
   }
+  constraints_.reset(LeafConstraintsBase::Create(config_, config_->num_leaves));
 }
 
 Tree* SerialTreeLearner::Train(const score_t* gradients, const score_t *hessians) {
@@ -533,6 +534,10 @@ void SerialTreeLearner::SplitInner(Tree* tree, int best_leaf, int* left_leaf,
   *left_leaf = best_leaf;
   auto next_leaf_id = tree->NextLeafId();
 
+  // update before tree split
+  constraints_->BeforeSplit(tree, best_leaf, next_leaf_id,
+                            best_split_info.monotone_type);
+
   bool is_numerical_split =
       train_data_->FeatureBinMapper(inner_feature_index)->bin_type() ==
       BinType::NumericalBin;
@@ -618,47 +623,18 @@ void SerialTreeLearner::SplitInner(Tree* tree, int best_leaf, int* left_leaf,
     larger_leaf_splits_->Init(*left_leaf, data_partition_.get(),
                               best_split_info.left_sum_gradient,
                               best_split_info.left_sum_hessian);
-
-  // constraints are updated differently depending on the method used
-  if (!config_->monotone_constraints.empty() &&
-      tree->leaf_is_in_monotone_subtree(*right_leaf)) {
-    if (config_->monotone_constraints_method == "basic") {
-      constraints_->UpdateConstraintsWithMid(
-          is_numerical_split, *left_leaf, *right_leaf,
-          best_split_info.monotone_type, best_split_info.right_output,
-          best_split_info.left_output);
-
-    } else if (config_->monotone_constraints_method == "intermediate") {
-      constraints_->UpdateConstraintsWithOutputs(
-          is_numerical_split, *left_leaf, *right_leaf,
-          best_split_info.monotone_type, best_split_info.right_output,
-          best_split_info.left_output);
-
-      LearnerState learner_state(config_, train_data_, tree, cegb_);
-
-      // if there is a monotone split above, new values should
-      // be checked not to clash with existing constraints in the subtree;
-      // if they do, the existing splits need to be updated
-      constraints_->GoUpToFindLeavesToUpdate(
-          tree->leaf_parent(*right_leaf), inner_feature_index, best_split_info,
-          best_split_info.threshold, best_split_per_leaf_, learner_state);
-
-      // Update splits that just got their constraints updated
-      while (!constraints_->leaves_to_update.empty()) {
-        int leaf_idx = constraints_->leaves_to_update.back();
-        UpdateBestSplitsFromHistograms(
-            &best_split_per_leaf_[leaf_idx], leaf_idx, is_feature_used_,
-            num_features_, histogram_pool_, learner_state);
-        constraints_->leaves_to_update.pop_back();
-      }
-    } else {
-      throw "monotone_constraints_method has to be one of ('basic', "
-            "'intermediate')"; // FIXME improve how this exception is handled
-    }
+  }
+  auto leaves_need_update = constraints_->Update(
+      tree, is_numerical_split, *left_leaf, *right_leaf,
+      best_split_info.monotone_type, best_split_info.right_output,
+      best_split_info.left_output, inner_feature_index, best_split_info,
+      best_split_per_leaf_);
+  // update leave outputs if needed
+  for (auto leaf: leaves_need_update) {
+    RecomputeBestSplitForLeaf(leaf, &best_split_per_leaf_[leaf]);
   }
 }
 
->>>>>>> Add the intermediate constraining method.
 void SerialTreeLearner::RenewTreeOutput(Tree* tree, const ObjectiveFunction* obj, std::function<double(const label_t*, int)> residual_getter,
                                         data_size_t total_num_data, const data_size_t* bag_indices, data_size_t bag_cnt) const {
   if (obj != nullptr && obj->IsRenewTreeOutput()) {
@@ -721,51 +697,43 @@ void SerialTreeLearner::ComputeBestSplitForFeature(
   }
 }
 
-
-// this function updates the best split for a leaf
-// it is called only when monotone constraints exist
-void SerialTreeLearner::UpdateBestSplitsFromHistograms(
-    SplitInfo *split, int leaf,
-    const std::vector<int8_t> &is_feature_used_,
-    int num_features_, HistogramPool &histogram_pool_,
-    LearnerState &learner_state) {
-  // the feature histogram is retrieved
-  FeatureHistogram *histogram_array_;
-  histogram_pool_.Get(leaf, &histogram_array_);
+void SerialTreeLearner::RecomputeBestSplitForLeaf(int leaf, SplitInfo* split) {
+  FeatureHistogram* histogram_array_;
+  if (!histogram_pool_.Get(leaf, &histogram_array_)) {
+    Log::Warning(
+        "Get historical Histogram for leaf %d failed, will skip the "
+        "``RecomputeBestSplitForLeaf``",
+        leaf);
+    return;
+  }
   double sum_gradients = split->left_sum_gradient + split->right_sum_gradient;
   double sum_hessians = split->left_sum_hessian + split->right_sum_hessian;
   int num_data = split->left_count + split->right_count;
-  split->gain = kMinScore;
+
+  std::vector<SplitInfo> bests(num_threads_);
+  LeafSplits leaf_splits(num_data);
+  leaf_splits.Init(leaf, sum_gradients, sum_hessians);
 
   OMP_INIT_EX();
-#pragma omp parallel for schedule(static, 1024) if (num_features_ >= 2048)
+// find splits
+#pragma omp parallel for schedule(static)
   for (int feature_index = 0; feature_index < num_features_; ++feature_index) {
     OMP_LOOP_EX_BEGIN();
-    // splits are computed for the feature that are to be used
-    if (!histogram_array_[feature_index].is_splittable()) {
+    if (!is_feature_used_[feature_index]) {
       continue;
     }
-
-    // loop through the features to find the best one just like in the
-    // FindBestSplitsFromHistograms function
-    int real_fidx = learner_state.train_data_->RealFeatureIndex(feature_index);
-    LeafSplits *leaf_splits = new LeafSplits(0);
-    leaf_splits->Init(leaf, sum_gradients,
-                     sum_hessians);
-
-    // best split is updated
+    const int tid = omp_get_thread_num();
+    int real_fidx = train_data_->RealFeatureIndex(feature_index);
     ComputeBestSplitForFeature(
-        histogram_array_,
-        feature_index,
-        real_fidx,
-        is_feature_used_[feature_index], // FIXME is this the right parameter to pass here?
-        num_data,
-        leaf_splits,
-        split);
+        smaller_leaf_histogram_array_, feature_index, real_fidx,
+        true,  // fixme: this cannot work with colsample_bynode, but do we really need to compute all features? why not just the used features of `split->feature`?
+        num_data, &leaf_splits, &bests[tid]);
 
     OMP_LOOP_EX_END();
   }
   OMP_THROW_EX();
+  auto best_idx = ArrayArgs<SplitInfo>::ArgMax(bests);
+  *split = bests[best_idx];
 }
 
 }  // namespace LightGBM

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -726,7 +726,7 @@ void SerialTreeLearner::RecomputeBestSplitForLeaf(int leaf, SplitInfo* split) {
     int real_fidx = train_data_->RealFeatureIndex(feature_index);
     ComputeBestSplitForFeature(
         histogram_array_, feature_index, real_fidx,
-        true,  // fixme: this cannot work with colsample_bynode, but do we really need to compute all features? why not just the used features of `split->feature`?
+        true,
         num_data, &leaf_splits, &bests[tid]);
 
     OMP_LOOP_EX_END();

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -716,13 +716,11 @@ void SerialTreeLearner::RecomputeBestSplitForLeaf(int leaf, SplitInfo* split) {
 
   OMP_INIT_EX();
 // find splits
-#pragma omp parallel for schedule(static)
+#pragma omp parallel for schedule(static) num_threads(share_state_->num_threads)
   for (int feature_index = 0; feature_index < num_features_; ++feature_index) {
     OMP_LOOP_EX_BEGIN();
-    if (!col_sampler_.is_feature_used_bytree()[feature_index]) {
-      continue;
-    }
-    if (!histogram_array_[feature_index].is_splittable()) {
+    if (!col_sampler_.is_feature_used_bytree()[feature_index] |
+        !histogram_array_[feature_index].is_splittable()) {
       continue;
     }
     const int tid = omp_get_thread_num();

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -719,7 +719,7 @@ void SerialTreeLearner::RecomputeBestSplitForLeaf(int leaf, SplitInfo* split) {
 #pragma omp parallel for schedule(static) num_threads(share_state_->num_threads)
   for (int feature_index = 0; feature_index < num_features_; ++feature_index) {
     OMP_LOOP_EX_BEGIN();
-    if (!col_sampler_.is_feature_used_bytree()[feature_index] |
+    if (!col_sampler_.is_feature_used_bytree()[feature_index] ||
         !histogram_array_[feature_index].is_splittable()) {
       continue;
     }

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -652,7 +652,7 @@ void SerialTreeLearner::SplitInner(Tree* tree, int best_leaf, int* left_leaf,
         constraints_->leaves_to_update.pop_back();
       }
     } else {
-      throw "monotone_constraints_methode has to be one of ('basic', "
+      throw "monotone_constraints_method has to be one of ('basic', "
             "'intermediate')"; // FIXME improve how this exception is handled
     }
   }

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -719,7 +719,7 @@ void SerialTreeLearner::RecomputeBestSplitForLeaf(int leaf, SplitInfo* split) {
 #pragma omp parallel for schedule(static)
   for (int feature_index = 0; feature_index < num_features_; ++feature_index) {
     OMP_LOOP_EX_BEGIN();
-    if (!is_feature_used_[feature_index]) {
+    if (!col_sampler_.is_feature_used_bytree()[feature_index]) {
       continue;
     }
     if (!histogram_array_[feature_index].is_splittable()) {

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -122,12 +122,7 @@ class SerialTreeLearner: public TreeLearner {
 
   void GetShareStates(const Dataset* dataset, bool is_constant_hessian, bool is_first_time);
 
-
-  void UpdateBestSplitsFromHistograms(
-      SplitInfo *split, int leaf, const std::vector<int8_t> &is_feature_used_,
-      int num_features_, HistogramPool &histogram_pool_,
-      LearnerState &learner_state);
-
+  void RecomputeBestSplitForLeaf(int leaf, SplitInfo* split);
 
   /*!
   * \brief Some initial works before training
@@ -195,7 +190,7 @@ class SerialTreeLearner: public TreeLearner {
   /*! \brief store best split per feature for all leaves */
   std::vector<SplitInfo> splits_per_leaf_;
   /*! \brief stores minimum and maximum constraints for each leaf */
-  std::unique_ptr<LeafConstraints<ConstraintEntry>> constraints_;
+  std::unique_ptr<LeafConstraintsBase> constraints_;
 
   /*! \brief stores best thresholds for all feature for smaller leaf */
   std::unique_ptr<LeafSplits> smaller_leaf_splits_;

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -122,6 +122,13 @@ class SerialTreeLearner: public TreeLearner {
 
   void GetShareStates(const Dataset* dataset, bool is_constant_hessian, bool is_first_time);
 
+
+  void UpdateBestSplitsFromHistograms(
+      SplitInfo *split, int leaf, const std::vector<int8_t> &is_feature_used_,
+      int num_features_, HistogramPool &histogram_pool_,
+      LearnerState &learner_state);
+
+
   /*!
   * \brief Some initial works before training
   */

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1044,19 +1044,17 @@ class TestEngine(unittest.TestCase):
                     return False
             return True
 
-        number_of_trials = 1
-        for _ in range(number_of_trials):
-            for monotone_constraints_method in ["basic", "intermediate"]:
-                trainset = self.generate_trainset_for_monotone_constraints_tests()
-                params = {
-                    'min_data': 20,
-                    'num_leaves': 20,
-                    'monotone_constraints': [1, -1, 0],
-                    "monotone_constraints_method": monotone_constraints_method,
-                    "use_missing": False,
-                }
-                constrained_model = lgb.train(params, trainset)
-                self.assertTrue(is_correctly_constrained(constrained_model))
+        for monotone_constraints_method in ["basic", "intermediate"]:
+            trainset = self.generate_trainset_for_monotone_constraints_tests()
+            params = {
+                'min_data': 20,
+                'num_leaves': 20,
+                'monotone_constraints': [1, -1, 0],
+                "monotone_constraints_method": monotone_constraints_method,
+                "use_missing": False,
+            }
+            constrained_model = lgb.train(params, trainset)
+            self.assertTrue(is_correctly_constrained(constrained_model))
 
     def test_max_bin_by_feature(self):
         col1 = np.arange(0, 100)[:, np.newaxis]

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1038,9 +1038,9 @@ class TestEngine(unittest.TestCase):
                 monotonically_decreasing_y = learner.predict(monotonically_decreasing_x)
                 non_monotone_x = np.column_stack((fixed_x, fixed_x, variable_x))
                 non_monotone_y = learner.predict(non_monotone_x)
-                if not (is_increasing(monotonically_increasing_y) and
-                        is_decreasing(monotonically_decreasing_y) and
-                        is_non_monotone(non_monotone_y)):
+                if not (is_increasing(monotonically_increasing_y)
+                        and is_decreasing(monotonically_decreasing_y)
+                        and is_non_monotone(non_monotone_y)):
                     return False
             return True
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1044,7 +1044,7 @@ class TestEngine(unittest.TestCase):
                     return False
             return True
 
-        number_of_trials = 10
+        number_of_trials = 1
         for _ in range(number_of_trials):
             for monotone_constraints_method in ["basic", "intermediate"]:
                 trainset = self.generate_trainset_for_monotone_constraints_tests()

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -46,6 +46,7 @@ def constant_metric(preds, train_data):
 def decreasing_metric(preds, train_data):
     return ('decreasing_metric', next(decreasing_generator), False)
 
+
 def categorize(continuous_x):
     return np.digitize(continuous_x, bins=np.arange(0, 1, 0.01))
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1051,7 +1051,7 @@ class TestEngine(unittest.TestCase):
                 params = {
                     'min_data': 20,
                     'num_leaves': 20,
-                    'monotone_constraints': '1,-1,0',
+                    'monotone_constraints': [1, -1, 0],
                     "monotone_constraints_method": monotone_constraints_method,
                     "use_missing": False,
                 }


### PR DESCRIPTION
@aldanor @redditur

@guolinke @chivee @jameslamb @huanzhang12 @Laurae2 @StrikerRUS
You were all reviewers of the PRs #2305 and #2717. #2305 was judged to be not merge-able because it is too big. Therefore, in my ultimate comment (https://github.com/microsoft/LightGBM/pull/2305#issuecomment-574560469) I said I would split into smaller PRs easier to merge. This is the second PR in relation with #2305; the first one being #2717 and having been merged.

The goal of this PR is to introduce a new constraining method. This is the "Fast" method from #2305. I introduce a new parameter in the config called "monotone_constraints_method". When this is set to "basic", then the original constraining method is used. When it is set to "intermediate", the new constraining method of this PR is used. (And later, we would like to add an even better constraining method, called "Slow" method, for which this parameter will be set to "advanced").

Here are a few details about the changes I made:
- test_engine.py: improved test to make sure to catch any error and to test both methods;
- Parameters.rst, config.h, config_auto.cpp: added the new config parameter "monotone_constraints_method";
- tree.cpp, tree.h, leaf_splits.hpp: added new utility functions which should be fairly straightforward;
- monotone_constraints.hpp: added the methods to compute the new constraints;
- serial_tree_learner.h, serial_tree_learner.cpp: added code to switch between the new method + a new function to compute best splits, used only with the new fast method.

As I detailed in #2305, this new method yields significantly better results than the existing one, because it is not as constraining. Feel free to ask more details about that. The code in monotone_constraints.hpp may be complicated to understand because the new constraining method is an algorithm that goes through the tree from the split to the root and then from the root to all the leaves, and that updates constraints while trying ignore branches it does need to update to save as much time as possible. I am very happy to give more details or to explain the method further if needed.

I guess this PR is still pretty big, but I hope if is still manageable for you. Please @guolinke let me know if that is okay for you. Thank you very much.

EDIT: Here is the link to the report we made for the original PR. The method we implement in this PR is described in it. https://github.com/microsoft/LightGBM/files/3457826/PR-monotone-constraints-report.pdf