### PR TITLE
[docs] fixed metric_freq param description

### DIFF
--- a/R-package/tests/testthat/test_learning_to_rank.R
+++ b/R-package/tests/testthat/test_learning_to_rank.R
@@ -20,7 +20,6 @@ test_that("learning-to-rank with lgb.train() works as expected", {
         objective = "lambdarank"
         , metric = "ndcg"
         , ndcg_at = ndcg_at
-        , metric_freq = 1L
         , max_position = 3L
         , learning_rate = 0.001
     )
@@ -68,7 +67,6 @@ test_that("learning-to-rank with lgb.cv() works as expected", {
         objective = "lambdarank"
         , metric = "ndcg"
         , ndcg_at = ndcg_at
-        , metric_freq = 1L
         , max_position = 3L
         , label_gain = "0,1,3"
     )

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -969,6 +969,8 @@ Metric Parameters
 
    -  frequency for metric output
 
+   -  **Note**: can be used only in CLI version
+
 -  ``is_provide_training_metric`` :raw-html:`<a id="is_provide_training_metric" title="Permalink to this parameter" href="#is_provide_training_metric">&#x1F517;&#xFE0E;</a>`, default = ``false``, type = bool, aliases: ``training_metric``, ``is_training_metric``, ``train_metric``
 
    -  set this to ``true`` to output metric result over training dataset

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -822,6 +822,7 @@ struct Config {
   // check = >0
   // alias = output_freq
   // desc = frequency for metric output
+  // desc = **Note**: can be used only in CLI version
   int metric_freq = 1;
 
   // alias = training_metric, is_training_metric, train_metric


### PR DESCRIPTION
For Python we use `verbose_eval` and for R - `eval_freq`.