### PR TITLE
[R-package] Fixed R implementation of upper_bound() and lower_bound() for lgb.Booster

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -324,7 +324,7 @@ Booster <- R6::R6Class(
     # Get upper bound
     upper_bound = function() {
 
-      upper_bound <- 0L
+      upper_bound <- 0.0
       lgb.call(
         "LGBM_BoosterGetUpperBoundValue_R"
         , ret = upper_bound
@@ -336,7 +336,7 @@ Booster <- R6::R6Class(
     # Get lower bound
     lower_bound = function() {
 
-      lower_bound <- 0L
+      lower_bound <- 0.0
       lgb.call(
         "LGBM_BoosterGetLowerBoundValue_R"
         , ret = lower_bound

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -322,7 +322,7 @@ Booster <- R6::R6Class(
     },
 
     # Get upper bound
-    upper_bound_ = function() {
+    upper_bound = function() {
 
       upper_bound <- 0L
       lgb.call(
@@ -334,12 +334,12 @@ Booster <- R6::R6Class(
     },
 
     # Get lower bound
-    lower_bound_ = function() {
+    lower_bound = function() {
 
       lower_bound <- 0L
       lgb.call(
         "LGBM_BoosterGetLowerBoundValue_R"
-        , ret = upper_bound
+        , ret = lower_bound
         , private$handle
       )
 

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -71,7 +71,7 @@ test_that("use of multiple eval metrics works", {
 })
 
 test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expected for binary classification", {
-  set.seed(708)
+  set.seed(708L)
   nrounds <- 10L
   bst <- lightgbm(
     data = train$data
@@ -87,7 +87,7 @@ test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expec
 })
 
 test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expected for regression", {
-  set.seed(708)
+  set.seed(708L)
   nrounds <- 10L
   bst <- lightgbm(
     data = train$data

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -7,6 +7,8 @@ test <- agaricus.test
 
 windows_flag <- grepl("Windows", Sys.info()[["sysname"]])
 
+TOLERANCE <- 1e-6
+
 test_that("train and predict binary classification", {
   nrounds <- 10L
   bst <- lightgbm(
@@ -28,7 +30,7 @@ test_that("train and predict binary classification", {
   expect_equal(length(pred1), 6513L)
   err_pred1 <- sum((pred1 > 0.5) != train$label) / length(train$label)
   err_log <- record_results[1L]
-  expect_lt(abs(err_pred1 - err_log), 10e-6)
+  expect_lt(abs(err_pred1 - err_log), TOLERANCE)
 })
 
 
@@ -81,7 +83,6 @@ test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expec
     , objective = "binary"
     , metric = "binary_error"
   )
-  TOLERANCE <- 1e-06
   expect_true(abs(bst$lower_bound() - -1.590853) < TOLERANCE)
   expect_true(abs(bst$upper_bound() - 1.871015) <  TOLERANCE)
 })
@@ -97,7 +98,6 @@ test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expec
     , objective = "regression"
     , metric = "l2"
   )
-  TOLERANCE <- 1e-06
   expect_true(abs(bst$lower_bound() - 0.1513859) < TOLERANCE)
   expect_true(abs(bst$upper_bound() - 0.9080349) < TOLERANCE)
 })

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -70,6 +70,33 @@ test_that("use of multiple eval metrics works", {
   expect_false(is.null(bst$record_evals))
 })
 
+test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expected for binary classification", {
+  nrounds <- 10L
+  bst <- lightgbm(
+    data = train$data
+    , label = train$label
+    , num_leaves = 5L
+    , nrounds = nrounds
+    , objective = "binary"
+    , metric = "binary_error"
+  )
+  expect_true(bst$lower_bound() == 0)
+  expect_true(bst$upper_bound() == 1)
+})
+
+test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expected for regression", {
+  bst <- lightgbm(
+    data = train$data
+    , label = train$label
+    , num_leaves = 5L
+    , nrounds = nrounds
+    , objective = "regression"
+    , metric = "l2"
+  )
+  expect_true(bst$lower_bound() >= 0.0)
+  expect_true(bst$upper_bound() <= 1.0)
+})
+
 test_that("lightgbm() rejects negative or 0 value passed to nrounds", {
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression", metric = "l2,l1")

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -71,6 +71,7 @@ test_that("use of multiple eval metrics works", {
 })
 
 test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expected for binary classification", {
+  set.seed(708)
   nrounds <- 10L
   bst <- lightgbm(
     data = train$data
@@ -80,11 +81,14 @@ test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expec
     , objective = "binary"
     , metric = "binary_error"
   )
-  expect_true(bst$lower_bound() == 0)
-  expect_true(bst$upper_bound() == 1)
+  TOLERANCE <- 1e-06
+  expect_true(abs(bst$lower_bound() - -1.590853) < TOLERANCE)
+  expect_true(abs(bst$upper_bound() - 1.871015) <  TOLERANCE)
 })
 
 test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expected for regression", {
+  set.seed(708)
+  nrounds <- 10L
   bst <- lightgbm(
     data = train$data
     , label = train$label
@@ -93,8 +97,9 @@ test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expec
     , objective = "regression"
     , metric = "l2"
   )
-  expect_true(bst$lower_bound() >= 0.0)
-  expect_true(bst$upper_bound() <= 1.0)
+  TOLERANCE <- 1e-06
+  expect_true(abs(bst$lower_bound() - 0.1513859) < TOLERANCE)
+  expect_true(abs(bst$upper_bound() - 0.9080349) < TOLERANCE)
 })
 
 test_that("lightgbm() rejects negative or 0 value passed to nrounds", {

--- a/include/LightGBM/lightgbm_R.h
+++ b/include/LightGBM/lightgbm_R.h
@@ -337,6 +337,30 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetCurrentIteration_R(LGBM_SE handle,
   LGBM_SE call_state);
 
 /*!
+* \brief Get model upper bound value.
+* \param handle Handle of booster
+* \param[out] out_results Result pointing to max value
+* \return 0 when succeed, -1 when failure happens
+*/
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetUpperBoundValue_R(
+    LGBM_SE handle,
+    LGBM_SE out_result,
+    LGBM_SE call_state
+);
+
+/*!
+* \brief Get model lower bound value.
+* \param handle Handle of booster
+* \param[out] out_results Result pointing to min value
+* \return 0 when succeed, -1 when failure happens
+*/
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetLowerBoundValue_R(
+    LGBM_SE handle,
+    LGBM_SE out_result,
+    LGBM_SE call_state
+);
+
+/*!
 * \brief Get Name of eval
 * \param eval_names eval names
 * \return 0 when succeed, -1 when failure happens


### PR DESCRIPTION
@JoanFM thanks for contributing #2737 ! Unfortunately, there were some issues in the R side. This PR attempts to address them:

* removes trailing  `_` from method names
* fixes bug where `lower_bound()` method was storing its return value in variable `upper_bound`
* adds unit tests to ensure the implementation is working
* added new functions to `lightgbm_R.h` (without that, `LGBM_BoosterGetUpperBoundValue_R` and  `LGBM_BoosterGetLowerBoundValue_R` are not callable from R)

I still need some help though @guolinke @JoanFM @StrikerRUS .... I am not getting the answers  I'd expect. For example, I would expect lower bound to be 0 and upper bound to be 1  for binary classification, but running this:

```r
data(agaricus.train, package = "lightgbm")
data(agaricus.test, package = "lightgbm")
train <- agaricus.train
test <- agaricus.test
nrounds <- 10L
  bst <- lightgbm(
    data = train$data
    , label = train$label
    , num_leaves = 5L
    , nrounds = nrounds
    , objective = "binary"
    , metric = "binary_error"
  )
```

I'm confused by the results:

> > bst$lower_bound()
[1] -1950774382
> bst$upper_bound()
[1] 1196082214

I'll look back through #2737 , but maybe there is just something fundamental that I've misunderstood?