### PR TITLE
[R-package] [docker] Added ability to build LightGBM in an R container with different R versions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -81,6 +81,18 @@ wget https://raw.githubusercontent.com/Microsoft/LightGBM/master/docker/dockerfi
 docker build -t lightgbm-r -f dockerfile-r .
 ```
 
+This will default to the latest version of R. If you want to try with an older `rocker` container to run a particular version of R, pass in a build arg with [a valid tag](https://hub.docker.com/r/rocker/verse/tags).
+
+For example, to test with R 3.5:
+
+```
+docker build \
+    -t lightgbm-r-35 \
+    -f dockerfile-r \
+    --build-arg R_VERSION=3.5 \
+    .
+```
+
 After the build is finished you have two options to run the container:
 
 1. Start [RStudio](https://www.rstudio.com/products/rstudio/), an interactive development environment, so that you can develop your analysis using LightGBM or simply try out the R package. You can open RStudio in your web browser.

--- a/docker/dockerfile-r
+++ b/docker/dockerfile-r
@@ -1,9 +1,10 @@
-FROM rocker/verse:latest
+ARG R_VERSION=latest
+FROM rocker/verse:${R_VERSION}
 
 WORKDIR /lgbm
 
 RUN apt-get update && \
-    apt-get install -y build-essential && \
+    apt-get install -y build-essential cmake && \
     git clone --recursive --branch stable --depth 1 https://github.com/Microsoft/LightGBM && \
     cd LightGBM && \
     Rscript build_r.R


### PR DESCRIPTION
While working on #2715 , I found myself wanting a way to test multiple R versions locally. This PR changes the R Dockerfile to make it easy to switch R versions. I had to add an `apt-get install cmake` since it seems  `cmake` is not included in older `rocker/verse`  images.

I've tested and confirmed this works as expected. You can test with:

```shell
docker build \
    -t lightgbm-r-35 \
    -f dockerfile-r \
    --build-arg R_VERSION=3.5 \
    .

docker run -it lightgbm-r-35 /bin/bash

R --version
```