### PR TITLE
Fix SingleRowPredictor::IsPredictorEqual comparison (invert)

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -77,13 +77,15 @@ class SingleRowPredictor {
     predict_function = predictor_->GetPredictFunction();
     num_total_model_ = boosting->NumberOfTotalModel();
   }
+
   ~SingleRowPredictor() {}
+
   bool IsPredictorEqual(const Config& config, int iter, Boosting* boosting) {
-    return early_stop_ != config.pred_early_stop ||
-      early_stop_freq_ != config.pred_early_stop_freq ||
-      early_stop_margin_ != config.pred_early_stop_margin ||
-      iter_ != iter ||
-      num_total_model_ != boosting->NumberOfTotalModel();
+    return early_stop_ == config.pred_early_stop &&
+      early_stop_freq_ == config.pred_early_stop_freq &&
+      early_stop_margin_ == config.pred_early_stop_margin &&
+      iter_ == iter &&
+      num_total_model_ == boosting->NumberOfTotalModel();
   }
 
  private:


### PR DESCRIPTION
This fixes the issue https://github.com/microsoft/LightGBM/issues/2798.

As stated in that issue, this should fix the bug in case the parameters change, and improve performance when they don't.

Please give me feedback if I'm doing anything in a less than desirable way.