### PR TITLE
[tests][python] fixed pandas deprecation warning in tests

### DIFF
--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -813,13 +813,17 @@ class TestEngine(unittest.TestCase):
     @unittest.skipIf(not lgb.compat.PANDAS_INSTALLED, 'pandas is not installed')
     def test_pandas_sparse(self):
         import pandas as pd
-        X = pd.DataFrame({"A": pd.arrays.SparseArray(np.random.permutation([0, 1, 2] * 100)),
-                          "B": pd.arrays.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
-                          "C": pd.arrays.SparseArray(np.random.permutation([True, False] * 150))})
-        y = pd.Series(pd.arrays.SparseArray(np.random.permutation([0, 1] * 150)))
-        X_test = pd.DataFrame({"A": pd.arrays.SparseArray(np.random.permutation([0, 2] * 30)),
-                               "B": pd.arrays.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
-                               "C": pd.arrays.SparseArray(np.random.permutation([True, False] * 30))})
+        try:
+            from pandas.arrays import SparseArray
+        except ImportError:  # support old versions
+            from pandas import SparseArray
+        X = pd.DataFrame({"A": SparseArray(np.random.permutation([0, 1, 2] * 100)),
+                          "B": SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
+                          "C": SparseArray(np.random.permutation([True, False] * 150))})
+        y = pd.Series(SparseArray(np.random.permutation([0, 1] * 150)))
+        X_test = pd.DataFrame({"A": SparseArray(np.random.permutation([0, 2] * 30)),
+                               "B": SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
+                               "C": SparseArray(np.random.permutation([True, False] * 30))})
         if pd.__version__ >= '0.24.0':
             for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
                 self.assertTrue(pd.api.types.is_sparse(dtype))

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -813,13 +813,13 @@ class TestEngine(unittest.TestCase):
     @unittest.skipIf(not lgb.compat.PANDAS_INSTALLED, 'pandas is not installed')
     def test_pandas_sparse(self):
         import pandas as pd
-        X = pd.DataFrame({"A": pd.SparseArray(np.random.permutation([0, 1, 2] * 100)),
-                          "B": pd.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
-                          "C": pd.SparseArray(np.random.permutation([True, False] * 150))})
-        y = pd.Series(pd.SparseArray(np.random.permutation([0, 1] * 150)))
-        X_test = pd.DataFrame({"A": pd.SparseArray(np.random.permutation([0, 2] * 30)),
-                               "B": pd.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
-                               "C": pd.SparseArray(np.random.permutation([True, False] * 30))})
+        X = pd.DataFrame({"A": pd.arrays.SparseArray(np.random.permutation([0, 1, 2] * 100)),
+                          "B": pd.arrays.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
+                          "C": pd.arrays.SparseArray(np.random.permutation([True, False] * 150))})
+        y = pd.Series(pd.arrays.SparseArray(np.random.permutation([0, 1] * 150)))
+        X_test = pd.DataFrame({"A": pd.arrays.SparseArray(np.random.permutation([0, 2] * 30)),
+                               "B": pd.arrays.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
+                               "C": pd.arrays.SparseArray(np.random.permutation([True, False] * 30))})
         if pd.__version__ >= '0.24.0':
             for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
                 self.assertTrue(pd.api.types.is_sparse(dtype))

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -330,13 +330,17 @@ class TestSklearn(unittest.TestCase):
     @unittest.skipIf(not lgb.compat.PANDAS_INSTALLED, 'pandas is not installed')
     def test_pandas_sparse(self):
         import pandas as pd
-        X = pd.DataFrame({"A": pd.arrays.SparseArray(np.random.permutation([0, 1, 2] * 100)),
-                          "B": pd.arrays.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
-                          "C": pd.arrays.SparseArray(np.random.permutation([True, False] * 150))})
-        y = pd.Series(pd.arrays.SparseArray(np.random.permutation([0, 1] * 150)))
-        X_test = pd.DataFrame({"A": pd.arrays.SparseArray(np.random.permutation([0, 2] * 30)),
-                               "B": pd.arrays.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
-                               "C": pd.arrays.SparseArray(np.random.permutation([True, False] * 30))})
+        try:
+            from pandas.arrays import SparseArray
+        except ImportError:  # support old versions
+            from pandas import SparseArray
+        X = pd.DataFrame({"A": SparseArray(np.random.permutation([0, 1, 2] * 100)),
+                          "B": SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
+                          "C": SparseArray(np.random.permutation([True, False] * 150))})
+        y = pd.Series(SparseArray(np.random.permutation([0, 1] * 150)))
+        X_test = pd.DataFrame({"A": SparseArray(np.random.permutation([0, 2] * 30)),
+                               "B": SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
+                               "C": SparseArray(np.random.permutation([True, False] * 30))})
         if pd.__version__ >= '0.24.0':
             for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
                 self.assertTrue(pd.api.types.is_sparse(dtype))

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -330,13 +330,13 @@ class TestSklearn(unittest.TestCase):
     @unittest.skipIf(not lgb.compat.PANDAS_INSTALLED, 'pandas is not installed')
     def test_pandas_sparse(self):
         import pandas as pd
-        X = pd.DataFrame({"A": pd.SparseArray(np.random.permutation([0, 1, 2] * 100)),
-                          "B": pd.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
-                          "C": pd.SparseArray(np.random.permutation([True, False] * 150))})
-        y = pd.Series(pd.SparseArray(np.random.permutation([0, 1] * 150)))
-        X_test = pd.DataFrame({"A": pd.SparseArray(np.random.permutation([0, 2] * 30)),
-                               "B": pd.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
-                               "C": pd.SparseArray(np.random.permutation([True, False] * 30))})
+        X = pd.DataFrame({"A": pd.arrays.SparseArray(np.random.permutation([0, 1, 2] * 100)),
+                          "B": pd.arrays.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
+                          "C": pd.arrays.SparseArray(np.random.permutation([True, False] * 150))})
+        y = pd.Series(pd.arrays.SparseArray(np.random.permutation([0, 1] * 150)))
+        X_test = pd.DataFrame({"A": pd.arrays.SparseArray(np.random.permutation([0, 2] * 30)),
+                               "B": pd.arrays.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
+                               "C": pd.arrays.SparseArray(np.random.permutation([True, False] * 30))})
         if pd.__version__ >= '0.24.0':
             for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
                 self.assertTrue(pd.api.types.is_sparse(dtype))


### PR DESCRIPTION
```
The pandas.SparseArray class is deprecated and will be removed from pandas in a future version. Use pandas.arrays.SparseArray instead.
```