### PR TITLE
[ci] bump Azure image versions

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -4,7 +4,7 @@ if [[ $OS_NAME == "macos" ]]; then
     if  [[ $COMPILER == "clang" ]]; then
         brew install libomp
         if [[ $AZURE == "true" ]]; then
-            sudo xcode-select -s /Applications/Xcode_8.3.3.app/Contents/Developer
+            sudo xcode-select -s /Applications/Xcode_9.4.1.app/Contents/Developer
         fi
     else  # gcc
         if [[ $TASK != "mpi" ]]; then

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -115,7 +115,7 @@ jobs:
 - job: Windows
 ###########################################
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'vs2017-win2016'
   strategy:
     maxParallel: 3
     matrix:
@@ -151,7 +151,7 @@ jobs:
   - Windows
   condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'vs2017-win2016'
   steps:
   # Download all agent packages from all previous phases
   - task: DownloadBuildArtifacts@0

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -19,7 +19,7 @@ jobs:
   variables:
     COMPILER: gcc
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-latest'
   container: ubuntu1404
   strategy:
     maxParallel: 6
@@ -74,7 +74,7 @@ jobs:
   variables:
     COMPILER: clang
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   strategy:
     maxParallel: 3
     matrix:
@@ -115,7 +115,7 @@ jobs:
 - job: Windows
 ###########################################
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   strategy:
     maxParallel: 3
     matrix:
@@ -151,7 +151,7 @@ jobs:
   - Windows
   condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   steps:
   # Download all agent packages from all previous phases
   - task: DownloadBuildArtifacts@0

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -22,7 +22,7 @@ For **Linux** users, **glibc** >= 2.14 is required.
 
 For **macOS** (we provide wheels for 3 newest macOS versions) users:
 
-- Starting from version 2.2.1, the library file in distribution wheels is built by the **Apple Clang** (Xcode_8.3.3) compiler. This means that you don't need to install the **gcc** compiler anymore. Instead of that you need to install the **OpenMP** library, which is required for running LightGBM on the system with the **Apple Clang** compiler. You can install the **OpenMP** library by the following command: ``brew install libomp``.
+- Starting from version 2.2.1, the library file in distribution wheels is built by the **Apple Clang** (Xcode_8.3.3 for versions 2.2.1 - 2.3.1, and Xcode_9.4.1 from version 2.3.2) compiler. This means that you don't need to install the **gcc** compiler anymore. Instead of that you need to install the **OpenMP** library, which is required for running LightGBM on the system with the **Apple Clang** compiler. You can install the **OpenMP** library by the following command: ``brew install libomp``.
 
 - For version smaller than 2.2.1 and not smaller than 2.1.2, **gcc-8** with **OpenMP** support must be installed first. Refer to `Installation Guide <https://github.com/microsoft/LightGBM/blob/master/docs/Installation-Guide.rst#gcc>`__ for installation of **gcc-8** with **OpenMP** support.
 


### PR DESCRIPTION
Prepare for
```
##[warning]This pipeline uses a Microsoft-hosted agent image that will be removed on March 23, 2020 (MacOS-10.13). You must make changes to your pipeline before that date, or else your pipeline will fail. Learn more (https://aka.ms/removing-older-images-hosted-pools).
```

![image](https://user-images.githubusercontent.com/25141164/75296165-7fe22d80-583d-11ea-8abc-6ea3af218f5c.png)
