### PR TITLE
fixed cpplint error about namespace using-directives

### DIFF
--- a/include/LightGBM/tree_learner.h
+++ b/include/LightGBM/tree_learner.h
@@ -13,9 +13,9 @@
 
 #include <LightGBM/json11.hpp>
 
-using namespace json11;
-
 namespace LightGBM {
+
+using json11::Json;
 
 /*! \brief forward declaration */
 class Tree;

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -24,9 +24,9 @@
 #include <LightGBM/json11.hpp>
 #include "score_updater.hpp"
 
-using namespace json11;
-
 namespace LightGBM {
+
+using json11::Json;
 
 /*!
 * \brief GBDT algorithm implementation. including Training, prediction, bagging.

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -13,9 +13,9 @@
 
 #include <LightGBM/json11.hpp>
 
-using namespace json11;
-
 namespace LightGBM {
+
+using json11::Json;
 
 DatasetLoader::DatasetLoader(const Config& io_config, const PredictFunction& predict_fun, int num_class, const char* filename)
   :config_(io_config), random_(config_.data_random_seed), predict_fun_(predict_fun), num_class_(num_class) {

--- a/src/treelearner/gpu_tree_learner.h
+++ b/src/treelearner/gpu_tree_learner.h
@@ -34,9 +34,9 @@
 #include <boost/compute/container/vector.hpp>
 #include <boost/align/aligned_allocator.hpp>
 
-using namespace json11;
-
 namespace LightGBM {
+
+using json11::Json;
 
 /*!
 * \brief GPU-based parallel learning algorithm.

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -30,9 +30,10 @@
 #include <boost/align/aligned_allocator.hpp>
 #endif
 
-using namespace json11;
-
 namespace LightGBM {
+
+using json11::Json;
+
 /*! \brief forward declaration */
 class CostEfficientGradientBoosting;
 /*!


### PR DESCRIPTION
Refer to #1990.

Fix error
```
Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
```

I don't know how to fix 2 remaining errors here:
https://github.com/microsoft/LightGBM/blob/e502ed01f67c878f2a24b6fdf6bc3958dd62e939/src/c_api.cpp#L546
https://github.com/microsoft/LightGBM/blob/e502ed01f67c878f2a24b6fdf6bc3958dd62e939/src/lightgbm_R.cpp#L36