### PR TITLE
update lockbot

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -11,7 +11,7 @@ skipCreatedBefore: false
 exemptLabels: ['effectiveness', 'efficiency', 'feature request', 'help wanted']
 
 # Label to add before locking, such as `outdated`. Set to `false` to disable
-lockLabel: true
+lockLabel: false
 
 # Comment to post before locking. Set to `false` to disable
 lockComment: >

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -14,10 +14,7 @@ exemptLabels: ['effectiveness', 'efficiency', 'feature request', 'help wanted']
 lockLabel: false
 
 # Comment to post before locking. Set to `false` to disable
-lockComment: >
-  This thread has been automatically locked since there has not been
-  any recent activity after it was closed. Please open a new issue for
-  related bugs.
+lockComment: false
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
 setLockReason: true

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -8,7 +8,7 @@ daysUntilLock: 60
 skipCreatedBefore: false
 
 # Issues and pull requests with these labels will be ignored. Set to `[]` to disable
-exemptLabels: ['blocking', 'bug', 'effectiveness', 'efficiency', 'feature request', 'help wanted', 'in progress']
+exemptLabels: ['effectiveness', 'efficiency', 'feature request', 'help wanted']
 
 # Label to add before locking, such as `outdated`. Set to `false` to disable
 lockLabel: true


### PR DESCRIPTION
Seems that I misunderstood the way this bot locks issues [here](https://github.com/microsoft/LightGBM/pull/2815#issuecomment-590464219).
As it locks **only closed** issues, I think that removed in this PR labels can be allowed to be locked as we keep them **open** when they are actual.