### PR TITLE
[R-package] cleaned up formatting in R C/C++ files

### DIFF
--- a/include/LightGBM/R_object_helper.h
+++ b/include/LightGBM/R_object_helper.h
@@ -5,8 +5,10 @@
  * \brief A simple wrapper for accessing data in R object.
  *
  * \note
- * Due to license issue, we cannot include R's header file, so use this simple wrapper instead.
- * However, if R changes the way it defines objects, this file will need to be updated as well.
+ * We previously did not want to use R's headers because of license concerns. This is no longer a concern:
+ * https://github.com/microsoft/LightGBM/issues/629#issuecomment-474995635
+ * For now, this wrapper is lightgbm's interface from R to C.
+ * If R changes the way it defines objects, this file will need to be updated as well.
  */
 #ifndef R_OBJECT_HELPER_H_
 #define R_OBJECT_HELPER_H_
@@ -17,48 +19,47 @@
 // use .Internal(internalsID()) to uuid
 #define R_INTERNALS_UUID "2fdf6c18-697a-4ba7-b8ef-11c0d92f1327"
 
-
 #ifdef R_VER_ABOVE_35
-#define NAMED_BITS 16
-struct lgbm_sxpinfo {
-  unsigned int type : 5;
-  unsigned int scalar : 1;
-  unsigned int obj : 1;
-  unsigned int alt : 1;
-  unsigned int gp : 16;
-  unsigned int mark : 1;
-  unsigned int debug : 1;
-  unsigned int trace : 1;
-  unsigned int spare : 1;
-  unsigned int gcgen : 1;
-  unsigned int gccls : 3;
-  unsigned int named : NAMED_BITS;
-  unsigned int extra : 32 - NAMED_BITS;
-};
+  #define NAMED_BITS 16
+  struct lgbm_sxpinfo {
+    unsigned int type : 5;
+    unsigned int scalar : 1;
+    unsigned int obj : 1;
+    unsigned int alt : 1;
+    unsigned int gp : 16;
+    unsigned int mark : 1;
+    unsigned int debug : 1;
+    unsigned int trace : 1;
+    unsigned int spare : 1;
+    unsigned int gcgen : 1;
+    unsigned int gccls : 3;
+    unsigned int named : NAMED_BITS;
+    unsigned int extra : 32 - NAMED_BITS;
+  };
 
-// 64bit pointer
-#if INTPTR_MAX == INT64_MAX
-typedef int64_t R_xlen_t;
+  // 64bit pointer
+  #if INTPTR_MAX == INT64_MAX
+    typedef int64_t R_xlen_t;
+  #else
+    typedef int R_xlen_t;
+  #endif
+
 #else
-typedef int R_xlen_t;
-#endif
+  struct lgbm_sxpinfo {
+    unsigned int type : 5;
+    unsigned int obj : 1;
+    unsigned int named : 2;
+    unsigned int gp : 16;
+    unsigned int mark : 1;
+    unsigned int debug : 1;
+    unsigned int trace : 1;
+    unsigned int spare : 1;
+    unsigned int gcgen : 1;
+    unsigned int gccls : 3;
+  };
 
-#else
-struct lgbm_sxpinfo {
-  unsigned int type : 5;
-  unsigned int obj : 1;
-  unsigned int named : 2;
-  unsigned int gp : 16;
-  unsigned int mark : 1;
-  unsigned int debug : 1;
-  unsigned int trace : 1;
-  unsigned int spare : 1;
-  unsigned int gcgen : 1;
-  unsigned int gccls : 3;
-};
-
-typedef int R_xlen_t;
-#endif
+  typedef int R_xlen_t;
+#endif // R_VER_ABOVE_35
 
 struct lgbm_primsxp {
   int offset;
@@ -122,71 +123,71 @@ typedef struct VECTOR_SER {
 
 typedef union { VECTOR_SER s; double align; } SEXPREC_ALIGN;
 
-#define DATAPTR(x)  ((reinterpret_cast<SEXPREC_ALIGN*>(x)) + 1)
+#define DATAPTR(x)     ((reinterpret_cast<SEXPREC_ALIGN*>(x)) + 1)
 
-#define R_CHAR_PTR(x)     (reinterpret_cast<char*>DATAPTR(x))
+#define R_CHAR_PTR(x)  (reinterpret_cast<char*>DATAPTR(x))
 
-#define R_INT_PTR(x)  (reinterpret_cast<int*> DATAPTR(x))
+#define R_INT_PTR(x)   (reinterpret_cast<int*> DATAPTR(x))
 
-#define R_INT64_PTR(x)  (reinterpret_cast<int64_t*> DATAPTR(x))
+#define R_INT64_PTR(x) (reinterpret_cast<int64_t*> DATAPTR(x))
 
-#define R_REAL_PTR(x)     (reinterpret_cast<double*> DATAPTR(x))
+#define R_REAL_PTR(x)  (reinterpret_cast<double*> DATAPTR(x))
 
-#define R_AS_INT(x) (*(reinterpret_cast<int*> DATAPTR(x)))
+#define R_AS_INT(x)    (*(reinterpret_cast<int*> DATAPTR(x)))
 
-#define R_AS_INT64(x) (*(reinterpret_cast<int64_t*> DATAPTR(x)))
+#define R_AS_INT64(x)  (*(reinterpret_cast<int64_t*> DATAPTR(x)))
 
-#define R_IS_NULL(x) ((*reinterpret_cast<LGBM_SE>(x)).sxpinfo.type == 0)
+#define R_IS_NULL(x)   ((*reinterpret_cast<LGBM_SE>(x)).sxpinfo.type == 0)
 
 // 64bit pointer
 #if INTPTR_MAX == INT64_MAX
 
-#define R_ADDR(x)  (reinterpret_cast<int64_t*> DATAPTR(x))
+  #define R_ADDR(x)  (reinterpret_cast<int64_t*> DATAPTR(x))
 
-inline void R_SET_PTR(LGBM_SE x, void* ptr) {
-  if (ptr == nullptr) {
-    R_ADDR(x)[0] = (int64_t)(NULL);
-  } else {
-    R_ADDR(x)[0] = (int64_t)(ptr);
-  }
-}
-
-inline void* R_GET_PTR(LGBM_SE x) {
-  if (R_IS_NULL(x)) {
-    return nullptr;
-  } else {
-    auto ret = reinterpret_cast<void*>(R_ADDR(x)[0]);
-    if (ret == NULL) {
-      ret = nullptr;
+  inline void R_SET_PTR(LGBM_SE x, void* ptr) {
+    if (ptr == nullptr) {
+      R_ADDR(x)[0] = (int64_t)(NULL);
+    } else {
+      R_ADDR(x)[0] = (int64_t)(ptr);
     }
-    return ret;
   }
-}
+
+  inline void* R_GET_PTR(LGBM_SE x) {
+    if (R_IS_NULL(x)) {
+      return nullptr;
+    } else {
+      auto ret = reinterpret_cast<void*>(R_ADDR(x)[0]);
+      if (ret == NULL) {
+        ret = nullptr;
+      }
+      return ret;
+    }
+  }
 
 #else
 
-#define R_ADDR(x)  (reinterpret_cast<int32_t*> DATAPTR(x))
+  #define R_ADDR(x) (reinterpret_cast<int32_t*> DATAPTR(x))
 
-inline void R_SET_PTR(LGBM_SE x, void* ptr) {
-  if (ptr == nullptr) {
-    R_ADDR(x)[0] = (int32_t)(NULL);
-  } else {
-    R_ADDR(x)[0] = (int32_t)(ptr);
-  }
-}
-
-inline void* R_GET_PTR(LGBM_SE x) {
-  if (R_IS_NULL(x)) {
-    return nullptr;
-  } else {
-    auto ret = reinterpret_cast<void*>(R_ADDR(x)[0]);
-    if (ret == NULL) {
-      ret = nullptr;
+  inline void R_SET_PTR(LGBM_SE x, void* ptr) {
+    if (ptr == nullptr) {
+      R_ADDR(x)[0] = (int32_t)(NULL);
+    } else {
+      R_ADDR(x)[0] = (int32_t)(ptr);
     }
-    return ret;
   }
-}
 
-#endif
+  inline void* R_GET_PTR(LGBM_SE x) {
+    if (R_IS_NULL(x)) {
+      return nullptr;
+    } else {
+      auto ret = reinterpret_cast<void*>(R_ADDR(x)[0]);
+      if (ret == NULL) {
+        ret = nullptr;
+      }
+      return ret;
+    }
+  }
+
+#endif // INTPTR_MAX == INT64_MAX
 
 #endif  // R_OBJECT_HELPER_H_

--- a/include/LightGBM/R_object_helper.h
+++ b/include/LightGBM/R_object_helper.h
@@ -59,7 +59,7 @@
   };
 
   typedef int R_xlen_t;
-#endif // R_VER_ABOVE_35
+#endif  // R_VER_ABOVE_35
 
 struct lgbm_primsxp {
   int offset;
@@ -188,6 +188,6 @@ typedef union { VECTOR_SER s; double align; } SEXPREC_ALIGN;
     }
   }
 
-#endif // INTPTR_MAX == INT64_MAX
+#endif  // INTPTR_MAX == INT64_MAX
 
 #endif  // R_OBJECT_HELPER_H_

--- a/include/LightGBM/R_object_helper.h
+++ b/include/LightGBM/R_object_helper.h
@@ -7,7 +7,7 @@
  * \note
  * We previously did not want to use R's headers because of license concerns. This is no longer a concern:
  * https://github.com/microsoft/LightGBM/issues/629#issuecomment-474995635
- * For now, this wrapper is lightgbm's interface from R to C.
+ * For now, this wrapper is LightGBM's interface from R to C.
  * If R changes the way it defines objects, this file will need to be updated as well.
  */
 #ifndef R_OBJECT_HELPER_H_

--- a/include/LightGBM/lightgbm_R.h
+++ b/include/LightGBM/lightgbm_R.h
@@ -15,7 +15,11 @@
 * \return err_msg error information
 * \return error information
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_GetLastError_R(LGBM_SE buf_len, LGBM_SE actual_len, LGBM_SE err_msg);
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_GetLastError_R(
+    LGBM_SE buf_len,
+    LGBM_SE actual_len,
+    LGBM_SE err_msg
+);
 
 // --- start Dataset interface
 
@@ -27,11 +31,13 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_GetLastError_R(LGBM_SE buf_len, LGBM_SE actual_le
 * \param out created dataset
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromFile_R(LGBM_SE filename,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromFile_R(
+  LGBM_SE filename,
   LGBM_SE parameters,
   LGBM_SE reference,
   LGBM_SE out,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief create a dataset from CSC format
@@ -46,7 +52,8 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromFile_R(LGBM_SE filename,
 * \param out created dataset
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromCSC_R(LGBM_SE indptr,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromCSC_R(
+  LGBM_SE indptr,
   LGBM_SE indices,
   LGBM_SE data,
   LGBM_SE nindptr,
@@ -55,8 +62,8 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromCSC_R(LGBM_SE indptr,
   LGBM_SE parameters,
   LGBM_SE reference,
   LGBM_SE out,
-  LGBM_SE call_state);
-
+  LGBM_SE call_state
+);
 
 /*!
 * \brief create dataset from dense matrix
@@ -68,13 +75,15 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromCSC_R(LGBM_SE indptr,
 * \param out created dataset
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromMat_R(LGBM_SE data,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromMat_R(
+  LGBM_SE data,
   LGBM_SE nrow,
   LGBM_SE ncol,
   LGBM_SE parameters,
   LGBM_SE reference,
   LGBM_SE out,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief Create subset of a data
@@ -85,12 +94,14 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromMat_R(LGBM_SE data,
 * \param out created dataset
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetSubset_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetSubset_R(
+  LGBM_SE handle,
   LGBM_SE used_row_indices,
   LGBM_SE len_used_row_indices,
   LGBM_SE parameters,
   LGBM_SE out,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief save feature names to Dataset
@@ -98,9 +109,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetSubset_R(LGBM_SE handle,
 * \param feature_names feature names
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSetFeatureNames_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSetFeatureNames_R(
+  LGBM_SE handle,
   LGBM_SE feature_names,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief save feature names to Dataset
@@ -108,11 +121,13 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSetFeatureNames_R(LGBM_SE handle,
 * \param feature_names feature names
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetFeatureNames_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetFeatureNames_R(
+  LGBM_SE handle,
   LGBM_SE buf_len,
   LGBM_SE actual_len,
   LGBM_SE feature_names,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief save dataset to binary file
@@ -120,17 +135,21 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetFeatureNames_R(LGBM_SE handle,
 * \param filename file name
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSaveBinary_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSaveBinary_R(
+  LGBM_SE handle,
   LGBM_SE filename,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief free dataset
 * \param handle an instance of dataset
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetFree_R(LGBM_SE handle,
-  LGBM_SE call_state);
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetFree_R(
+  LGBM_SE handle,
+  LGBM_SE call_state
+);
 
 /*!
 * \brief set vector to a content in info
@@ -142,11 +161,13 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetFree_R(LGBM_SE handle,
 * \param num_element number of element in field_data
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSetField_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSetField_R(
+  LGBM_SE handle,
   LGBM_SE field_name,
   LGBM_SE field_data,
   LGBM_SE num_element,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief get size of info vector from dataset
@@ -155,10 +176,12 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSetField_R(LGBM_SE handle,
 * \param out size of info vector from dataset
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetFieldSize_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetFieldSize_R(
+  LGBM_SE handle,
   LGBM_SE field_name,
   LGBM_SE out,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief get info vector from dataset
@@ -167,10 +190,12 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetFieldSize_R(LGBM_SE handle,
 * \param field_data pointer to vector
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetField_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetField_R(
+  LGBM_SE handle,
   LGBM_SE field_name,
   LGBM_SE field_data,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
  * \brief Raise errors for attempts to update dataset parameters
@@ -178,9 +203,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetField_R(LGBM_SE handle,
  * \param new_params New dataset parameters
  * \return 0 when succeed, -1 when failure happens
  */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetUpdateParamChecking_R(LGBM_SE old_params,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetUpdateParamChecking_R(
+  LGBM_SE old_params,
   LGBM_SE new_params,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief get number of data.
@@ -188,9 +215,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetUpdateParamChecking_R(LGBM_SE old_params,
 * \param out The address to hold number of data
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetNumData_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetNumData_R(
+  LGBM_SE handle,
   LGBM_SE out,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief get number of features
@@ -198,9 +227,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetNumData_R(LGBM_SE handle,
 * \param out The output of number of features
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetNumFeature_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetNumFeature_R(
+  LGBM_SE handle,
   LGBM_SE out,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 // --- start Booster interfaces
 
@@ -211,18 +242,22 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetNumFeature_R(LGBM_SE handle,
 * \param out handle of created Booster
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCreate_R(LGBM_SE train_data,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCreate_R(
+  LGBM_SE train_data,
   LGBM_SE parameters,
   LGBM_SE out,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief free obj in handle
 * \param handle handle to be freed
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterFree_R(LGBM_SE handle,
-  LGBM_SE call_state);
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterFree_R(
+  LGBM_SE handle,
+  LGBM_SE call_state
+);
 
 /*!
 * \brief load an existing boosting from model file
@@ -230,9 +265,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterFree_R(LGBM_SE handle,
 * \param out handle of created Booster
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCreateFromModelfile_R(LGBM_SE filename,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCreateFromModelfile_R(
+  LGBM_SE filename,
   LGBM_SE out,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief load an existing boosting from model_str
@@ -240,9 +277,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCreateFromModelfile_R(LGBM_SE filename,
 * \param out handle of created Booster
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterLoadModelFromString_R(LGBM_SE model_str,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterLoadModelFromString_R(
+  LGBM_SE model_str,
   LGBM_SE out,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief Merge model in two boosters to first handle
@@ -250,9 +289,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterLoadModelFromString_R(LGBM_SE model_str,
 * \param other_handle
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterMerge_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterMerge_R(
+  LGBM_SE handle,
   LGBM_SE other_handle,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief Add new validation to booster
@@ -260,9 +301,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterMerge_R(LGBM_SE handle,
 * \param valid_data validation data set
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterAddValidData_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterAddValidData_R(
+  LGBM_SE handle,
   LGBM_SE valid_data,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief Reset training data for booster
@@ -270,9 +313,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterAddValidData_R(LGBM_SE handle,
 * \param train_data training data set
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterResetTrainingData_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterResetTrainingData_R(
+  LGBM_SE handle,
   LGBM_SE train_data,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief Reset config for current booster
@@ -280,9 +325,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterResetTrainingData_R(LGBM_SE handle,
 * \param parameters format: 'key1=value1 key2=value2'
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterResetParameter_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterResetParameter_R(
+  LGBM_SE handle,
   LGBM_SE parameters,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief Get number of classes
@@ -290,17 +337,21 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterResetParameter_R(LGBM_SE handle,
 * \param out number of classes
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetNumClasses_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetNumClasses_R(
+  LGBM_SE handle,
   LGBM_SE out,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief update the model in one round
 * \param handle handle
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterUpdateOneIter_R(LGBM_SE handle,
-  LGBM_SE call_state);
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterUpdateOneIter_R(
+  LGBM_SE handle,
+  LGBM_SE call_state
+);
 
 /*!
 * \brief update the model, by directly specify gradient and second order gradient,
@@ -311,28 +362,34 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterUpdateOneIter_R(LGBM_SE handle,
 * \param len length of grad/hess
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterUpdateOneIterCustom_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterUpdateOneIterCustom_R(
+  LGBM_SE handle,
   LGBM_SE grad,
   LGBM_SE hess,
   LGBM_SE len,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief Rollback one iteration
 * \param handle handle
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterRollbackOneIter_R(LGBM_SE handle,
-  LGBM_SE call_state);
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterRollbackOneIter_R(
+  LGBM_SE handle,
+  LGBM_SE call_state
+);
 
 /*!
 * \brief Get iteration of current boosting rounds
 * \param out iteration of boosting rounds
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetCurrentIteration_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetCurrentIteration_R(
+  LGBM_SE handle,
   LGBM_SE out,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief Get model upper bound value.
@@ -363,11 +420,13 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetLowerBoundValue_R(
 * \param eval_names eval names
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetEvalNames_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetEvalNames_R(
+  LGBM_SE handle,
   LGBM_SE buf_len,
   LGBM_SE actual_len,
   LGBM_SE eval_names,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief get evaluation for training data and validation data
@@ -376,10 +435,12 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetEvalNames_R(LGBM_SE handle,
 * \param out_result float array contains result
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetEval_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetEval_R(
+  LGBM_SE handle,
   LGBM_SE data_idx,
   LGBM_SE out_result,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief Get number of prediction for training data and validation data
@@ -388,10 +449,12 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetEval_R(LGBM_SE handle,
 * \param out size of predict
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetNumPredict_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetNumPredict_R(
+  LGBM_SE handle,
   LGBM_SE data_idx,
   LGBM_SE out,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief Get prediction for training data and validation data.
@@ -401,10 +464,12 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetNumPredict_R(LGBM_SE handle,
 * \param out_result, used to store predict result, should pre-allocate memory
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetPredict_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetPredict_R(
+  LGBM_SE handle,
   LGBM_SE data_idx,
   LGBM_SE out_result,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief make prediction for file
@@ -417,7 +482,8 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetPredict_R(LGBM_SE handle,
 * \return 0 when succeed, -1 when failure happens
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForFile_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForFile_R(
+  LGBM_SE handle,
   LGBM_SE data_filename,
   LGBM_SE data_has_header,
   LGBM_SE is_rawscore,
@@ -426,7 +492,8 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForFile_R(LGBM_SE handle,
   LGBM_SE num_iteration,
   LGBM_SE parameter,
   LGBM_SE result_filename,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief Get number of prediction
@@ -438,14 +505,16 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForFile_R(LGBM_SE handle,
 * \param out_len length of prediction
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCalcNumPredict_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCalcNumPredict_R(
+  LGBM_SE handle,
   LGBM_SE num_row,
   LGBM_SE is_rawscore,
   LGBM_SE is_leafidx,
   LGBM_SE is_predcontrib,
   LGBM_SE num_iteration,
   LGBM_SE out_len,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief make prediction for a new data set
@@ -465,7 +534,8 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCalcNumPredict_R(LGBM_SE handle,
 * \param out prediction result
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForCSC_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForCSC_R(
+  LGBM_SE handle,
   LGBM_SE indptr,
   LGBM_SE indices,
   LGBM_SE data,
@@ -478,7 +548,8 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForCSC_R(LGBM_SE handle,
   LGBM_SE num_iteration,
   LGBM_SE parameter,
   LGBM_SE out_result,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief make prediction for a new data set
@@ -495,7 +566,8 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForCSC_R(LGBM_SE handle,
 * \param out prediction result
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForMat_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForMat_R(
+  LGBM_SE handle,
   LGBM_SE data,
   LGBM_SE nrow,
   LGBM_SE ncol,
@@ -505,7 +577,8 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForMat_R(LGBM_SE handle,
   LGBM_SE num_iteration,
   LGBM_SE parameter,
   LGBM_SE out_result,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief save model into file
@@ -514,10 +587,12 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForMat_R(LGBM_SE handle,
 * \param filename file name
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterSaveModel_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterSaveModel_R(
+  LGBM_SE handle,
   LGBM_SE num_iteration,
   LGBM_SE filename,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief create string containing model
@@ -526,12 +601,14 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterSaveModel_R(LGBM_SE handle,
 * \param out_str string of model
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterSaveModelToString_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterSaveModelToString_R(
+  LGBM_SE handle,
   LGBM_SE num_iteration,
   LGBM_SE buffer_len,
   LGBM_SE actual_len,
   LGBM_SE out_str,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 /*!
 * \brief dump model to json
@@ -540,11 +617,13 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterSaveModelToString_R(LGBM_SE handle,
 * \param out_str json format string of model
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterDumpModel_R(LGBM_SE handle,
+LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterDumpModel_R(
+  LGBM_SE handle,
   LGBM_SE num_iteration,
   LGBM_SE buffer_len,
   LGBM_SE actual_len,
   LGBM_SE out_str,
-  LGBM_SE call_state);
+  LGBM_SE call_state
+);
 
 #endif  // LIGHTGBM_R_H_

--- a/src/lightgbm_R.cpp
+++ b/src/lightgbm_R.cpp
@@ -39,7 +39,9 @@ LGBM_SE EncodeChar(LGBM_SE dest, const char* src, LGBM_SE buf_len, LGBM_SE actua
     Log::Fatal("Don't support large string in R-package");
   }
   R_INT_PTR(actual_len)[0] = static_cast<int>(str_len);
-  if (R_AS_INT(buf_len) < static_cast<int>(str_len)) { return dest; }
+  if (R_AS_INT(buf_len) < static_cast<int>(str_len)) {
+    return dest;
+  }
   auto ptr = R_CHAR_PTR(dest);
   std::memcpy(ptr, src, str_len);
   return dest;


### PR DESCRIPTION
This is a **style-only PR**. As I've been working on  #629 , I see a few opportunities to make the current R-specific parts of `lib_lightgbm` a bit easier to read and edit. The diff looks a bit weird here on GitHub, but to be clear I did not change any of what the code in these files does. In this PR, I'm just proposing some indentation changes, for example taking definitions like this:

```
LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromFile_R(LGBM_SE filename,
  LGBM_SE parameters,
  LGBM_SE reference,
  LGBM_SE out,
  LGBM_SE call_state);
```

and turning them into this

```
LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromFile_R(
  LGBM_SE filename,
  LGBM_SE parameters,
  LGBM_SE reference,
  LGBM_SE out,
  LGBM_SE call_state
);
```

I also changed the language in the comment at the top of `R_object_helper.h` to better reflect the current state of the R package.