### PR TITLE
[R-package] removed unused imports from R-specific lib_lightgbm components

### DIFF
--- a/include/LightGBM/R_object_helper.h
+++ b/include/LightGBM/R_object_helper.h
@@ -12,7 +12,6 @@
 #define R_OBJECT_HELPER_H_
 
 #include <cstdint>
-#include <cstdio>
 
 #define TYPE_BITS 5
 // use .Internal(internalsID()) to uuid

--- a/include/LightGBM/lightgbm_R.h
+++ b/include/LightGBM/lightgbm_R.h
@@ -8,8 +8,6 @@
 #include <LightGBM/c_api.h>
 #include <LightGBM/R_object_helper.h>
 
-#include <cstdint>
-
 /*!
 * \brief get string message of the last error
 *  all functions in this file will return 0 on success

--- a/src/lightgbm_R.cpp
+++ b/src/lightgbm_R.cpp
@@ -13,7 +13,6 @@
 #include <cstdio>
 #include <cstring>
 #include <memory>
-#include <sstream>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
In this PR, I propose removing some unused includes from `R_object_helper.h`, `lightgbm_R.cpp`, and `R_object_helper.h`.