### PR TITLE
[R-package] [docs] Added documentation on lgb.dl() and data.table version (fixes #2715)

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -7,6 +7,7 @@ LightGBM R-package
 * [Examples](#examples)
 * [Testing](#testing)
 * [External Repositories](#external-unofficial-repositories)
+* [Known Issues](#known-issues)
 
 Installation
 ------------
@@ -167,6 +168,6 @@ Projects listed here are not maintained or endorsed by the `LightGBM` developmen
 Known Issues
 ------------
 
-## `error in data.table::data.table()...argument 2 is NULL`
+### `error in data.table::data.table()...argument 2 is NULL`
 
 If you experiencing this error when running `lightgbm`, you may be facing the same issue reported in [#2715](https://github.com/microsoft/LightGBM/issues/2715). If you use `lgb.dl()` to build from source  (i.e. not using pre-compiled dll), you need to upgrade your version of `data.table` to at least  version 1.12.0.

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -1,6 +1,13 @@
 LightGBM R-package
 ==================
 
+### Contents
+
+* [Installation](#installation)
+* [Examples](#examples)
+* [Testing](#testing)
+* [External Repositories](#external-unofficial-repositories)
+
 Installation
 ------------
 
@@ -156,3 +163,10 @@ External (Unofficial) Repositories
 Projects listed here are not maintained or endorsed by the `LightGBM` development team, but may offer some features currently missing from the main R package.
 
 * [lightgbm.py](https://github.com/kapsner/lightgbm.py): This R package offers a wrapper built with `reticulate`, a package used to call Python code from R. If you are comfortable with the added installation complexity of installing `lightgbm`'s Python package and the performance cost of passing data between R and Python, you might find that this package offers some features that are not yet available in the native `lightgbm` R package.
+
+Known Issues
+------------
+
+## `error in data.table::data.table()...argument 2 is NULL`
+
+If you experiencing this error when running `lightgbm`, you may be facing the same issue reported in [#2715](https://github.com/microsoft/LightGBM/issues/2715). If you use `lgb.dl()` to build from source  (i.e. not using pre-compiled dll), you need to upgrade your version of `data.table` to at least  version 1.12.0.

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -168,6 +168,4 @@ Projects listed here are not maintained or endorsed by the `LightGBM` developmen
 Known Issues
 ------------
 
-### `error in data.table::data.table()...argument 2 is NULL`
-
-If you experiencing this error when running `lightgbm`, you may be facing the same issue reported in [#2715](https://github.com/microsoft/LightGBM/issues/2715). If you use `lgb.dl()` to build from source  (i.e. not using pre-compiled dll), you need to upgrade your version of `data.table` to at least  version 1.12.0.
+For information about known issues with the R package, see the [R-package section of LightGBM's main FAQ page](https://lightgbm.readthedocs.io/en/latest/FAQ.html#r-package).

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -201,11 +201,15 @@ Run ``lgb.unloader(wipe = TRUE)`` in the R console, and recreate the LightGBM da
 Due to the pointers, choosing to not wipe variables will not fix the error.
 This is a known issue: `Microsoft/LightGBM#698 <https://github.com/microsoft/LightGBM/issues/698>`__.
 
-2. I used ``setinfo``, tried to print my ``lgb.Dataset``, and now the R console froze!
---------------------------------------------------------------------------------------
+2. I used ``setinfo()``, tried to print my ``lgb.Dataset``, and now the R console froze!
+----------------------------------------------------------------------------------------
 
 Avoid printing the ``lgb.Dataset`` after using ``setinfo``.
 This is a known bug: `Microsoft/LightGBM#539 <https://github.com/microsoft/LightGBM/issues/539>`__.
+
+3. `error in data.table::data.table()...argument 2 is NULL`
+
+If you experiencing this error when running `lightgbm`, you may be facing the same issue reported in `#2715 <https://github.com/microsoft/LightGBM/issues/2715>`_. If you use ``lgb.dl()`` to build from source (i.e. not using pre-compiled dll), you need to upgrade your version of ``data.table`` to at least version 1.12.0.
 
 ------
 

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -207,7 +207,8 @@ This is a known issue: `Microsoft/LightGBM#698 <https://github.com/microsoft/Lig
 Avoid printing the ``lgb.Dataset`` after using ``setinfo``.
 This is a known bug: `Microsoft/LightGBM#539 <https://github.com/microsoft/LightGBM/issues/539>`__.
 
-3. `error in data.table::data.table()...argument 2 is NULL`
+3. ``error in data.table::data.table()...argument 2 is NULL``
+-------------------------------------------------------------
 
 If you experiencing this error when running `lightgbm`, you may be facing the same issue reported in `#2715 <https://github.com/microsoft/LightGBM/issues/2715>`_. If you use ``lgb.dl()`` to build from source (i.e. not using pre-compiled dll), you need to upgrade your version of ``data.table`` to at least version 1.12.0.
 


### PR DESCRIPTION
Per conversationi n #2715 , this PR adds documentation on the need to upgrade `data.table`  if you are using `lgb.dl()` to install the R package.