### PR TITLE
[ci] fix R tests for macOS on Azure Pipelines

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -5,7 +5,6 @@ if [[ $OS_NAME == "macos" ]]; then
         brew install libomp
         if [[ $AZURE == "true" ]]; then
             sudo xcode-select -s /Applications/Xcode_9.4.1.app/Contents/Developer
-            sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
         fi
     else  # gcc
         if [[ $TASK != "mpi" ]]; then

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -5,6 +5,7 @@ if [[ $OS_NAME == "macos" ]]; then
         brew install libomp
         if [[ $AZURE == "true" ]]; then
             sudo xcode-select -s /Applications/Xcode_9.4.1.app/Contents/Developer
+            sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
         fi
     else  # gcc
         if [[ $TASK != "mpi" ]]; then

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -65,7 +65,11 @@ conda install \
 
 # Manually install Depends and Imports libraries + 'testthat'
 # to avoid a CI-time dependency on devtools (for devtools::install_deps())
-Rscript -e "install.packages(c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat'))" || exit -1
+packages="c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat')"
+if [[ $OS_NAME == "macos" ]]; then
+    packages+=", type = 'binary'"
+fi
+Rscript -e "install.packages(${packages})" || exit -1
 
 cd ${BUILD_DIRECTORY}
 Rscript build_r.R || exit -1


### PR DESCRIPTION
Fix current `master` fails.
Have no idea why it started to fail:
```
* installing *source* package ‘rlang’ ...
** package ‘rlang’ successfully unpacked and MD5 sums checked

** using staged installation
** libs
clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I./lib/  -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/usr/local/include  -fPIC  -Wall -g -O2  -c capture.c -o capture.o
clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I./lib/  -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/usr/local/include  -fPIC  -Wall -g -O2  -c export.c -o export.o
clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I./lib/  -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/usr/local/include  -fPIC  -Wall -g -O2  -c internal.c -o internal.o
clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I./lib/  -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/usr/local/include  -fPIC  -Wall -g -O2  -c lib.c -o lib.o
clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I./lib/  -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/usr/local/include  -fPIC  -Wall -g -O2  -c version.c -o version.o
clang -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o rlang.so capture.o export.o internal.o lib.o version.o -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
ld: malformed file
/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/lib/libSystem.tbd:4:18: error: unknown enumerated scalar
platform:        zippered
                 ^~~~~~~~
 file '/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/lib/libSystem.tbd'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [rlang.so] Error 1
ERROR: compilation failed for package ‘rlang’
```
Refer to https://github.com/golang/go/issues/31159#issuecomment-481910401.