### PR TITLE
[ci] fixed cpplint warnings about braces

### DIFF
--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -134,7 +134,6 @@ class Tree {
   inline int PredictLeafIndex(const double* feature_values) const;
   inline int PredictLeafIndexByMap(const std::unordered_map<int, double>& feature_values) const;
 
-
   inline void PredictContrib(const double* feature_values, int num_features, double* output);
 
   /*! \brief Get Number of leaves*/
@@ -150,7 +149,6 @@ class Tree {
 
   /*! \brief Get the number of data points that fall at or below this node*/
   inline int data_count(int node) const { return node >= 0 ? internal_count_[node] : leaf_count_[~node]; }
-
 
   /*!
   * \brief Shrinkage for the tree's output

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -151,7 +151,7 @@ class Tree {
   /*! \brief Get the number of data points that fall at or below this node*/
   inline int data_count(int node) const { return node >= 0 ? internal_count_[node] : leaf_count_[~node]; }
 
-  
+
   /*!
   * \brief Shrinkage for the tree's output
   *        shrinkage rate (a.k.a learning rate) is used to tune the training process

--- a/src/io/file_io.cpp
+++ b/src/io/file_io.cpp
@@ -170,11 +170,9 @@ std::unique_ptr<VirtualFileReader> VirtualFileReader::Make(
   if (0 == filename.find(kHdfsProto)) {
     WITH_HDFS(return std::unique_ptr<VirtualFileReader>(
         new HDFSFile(filename, O_RDONLY)));
-  } else
-#endif
-  {
-    return std::unique_ptr<VirtualFileReader>(new LocalFile(filename, "rb"));
   }
+#endif
+  return std::unique_ptr<VirtualFileReader>(new LocalFile(filename, "rb"));
 }
 
 std::unique_ptr<VirtualFileWriter> VirtualFileWriter::Make(
@@ -183,23 +181,19 @@ std::unique_ptr<VirtualFileWriter> VirtualFileWriter::Make(
   if (0 == filename.find(kHdfsProto)) {
     WITH_HDFS(return std::unique_ptr<VirtualFileWriter>(
         new HDFSFile(filename, O_WRONLY)));
-  } else
-#endif
-  {
-    return std::unique_ptr<VirtualFileWriter>(new LocalFile(filename, "wb"));
   }
+#endif
+  return std::unique_ptr<VirtualFileWriter>(new LocalFile(filename, "wb"));
 }
 
 bool VirtualFileWriter::Exists(const std::string& filename) {
 #ifdef USE_HDFS
   if (0 == filename.find(kHdfsProto)) {
     WITH_HDFS(HDFSFile file(filename, O_RDONLY); return file.Exists());
-  } else
-#endif
-  {
-    LocalFile file(filename, "rb");
-    return file.Exists();
   }
+#endif
+  LocalFile file(filename, "rb");
+  return file.Exists();
 }
 
 }  // namespace LightGBM


### PR DESCRIPTION
This PR eliminates 5 of the 49 remaining `cpplint` issues, noted in #1990 --> https://github.com/microsoft/LightGBM/issues/1990#issuecomment-594687740

```
src/io/file_io.cpp:173:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
src/io/file_io.cpp:186:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
src/io/file_io.cpp:197:  If an else has a brace on one side, it should have it on both  [readability/braces] [5]
src/io/file_io.cpp:197:  If/else bodies with multiple statements require braces  [readability/braces] [4]
Done processing src/io/file_io.cpp
...
include/LightGBM/tree.h:154:  Line ends in whitespace.  Consider deleting these extra spaces.  [whitespace/end_of_line] [4]
```

4 of the 5 relate to handling of HDFS files in `src/io/file_io.cpp`. Instead of using an `if-else` construct, I think we can get around the linting issue by just relying on the fact that the affected functions already use multiple return statements.

Looks like the relevant lines were introduced in #2769 , @guolinke 