### PR TITLE
[docs] Add LightGBM Tuner by Optuna links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Some old update logs are available at [Key Events](https://github.com/microsoft/
 External (Unofficial) Repositories
 ----------------------------------
 
-Optuna LightGBM Tuner (Automated tuning of LightGBM hyperparameters code): https://github.com/optuna/optuna/blob/master/examples/lightgbm_tuner_simple.py
+Optuna (hyperparameter optimization framework): https://github.com/optuna/optuna
 
 Julia-package: https://github.com/Allardvm/LightGBM.jl
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ LightGBM, Light Gradient Boosting Machine
 [![PyPI Version](https://img.shields.io/pypi/v/lightgbm.svg?logo=pypi&logoColor=white)](https://pypi.org/project/lightgbm)
 [![Join Gitter at https://gitter.im/Microsoft/LightGBM](https://badges.gitter.im/Microsoft/LightGBM.svg)](https://gitter.im/Microsoft/LightGBM?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Slack](https://lightgbm-slack-autojoin.herokuapp.com/badge.svg)](https://lightgbm-slack-autojoin.herokuapp.com)
-[![Optuna](https://img.shields.io/badge/Optuna-integrated-blue)](https://medium.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b7095e99258)
 
 LightGBM is a gradient boosting framework that uses tree based learning algorithms. It is designed to be distributed and efficient with the following advantages:
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Some old update logs are available at [Key Events](https://github.com/microsoft/
 External (Unofficial) Repositories
 ----------------------------------
 
+Optuna LightGBM Tuner (Automated tuning of LightGBM hyperparameters code): https://github.com/optuna/optuna/blob/master/examples/lightgbm_tuner_simple.py
+
 Julia-package: https://github.com/Allardvm/LightGBM.jl
 
 JPMML (Java PMML converter): https://github.com/jpmml/jpmml-lightgbm

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ LightGBM, Light Gradient Boosting Machine
 [![PyPI Version](https://img.shields.io/pypi/v/lightgbm.svg?logo=pypi&logoColor=white)](https://pypi.org/project/lightgbm)
 [![Join Gitter at https://gitter.im/Microsoft/LightGBM](https://badges.gitter.im/Microsoft/LightGBM.svg)](https://gitter.im/Microsoft/LightGBM?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Slack](https://lightgbm-slack-autojoin.herokuapp.com/badge.svg)](https://lightgbm-slack-autojoin.herokuapp.com)
+[![Optuna](https://img.shields.io/badge/Optuna-integrated-blue)](https://medium.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b7095e99258)
 
 LightGBM is a gradient boosting framework that uses tree based learning algorithms. It is designed to be distributed and efficient with the following advantages:
 
@@ -37,6 +38,7 @@ Next you may want to read:
 - [**Parameters**](https://github.com/microsoft/LightGBM/blob/master/docs/Parameters.rst) is an exhaustive list of customization you can make.
 - [**Parallel Learning**](https://github.com/microsoft/LightGBM/blob/master/docs/Parallel-Learning-Guide.rst) and [**GPU Learning**](https://github.com/microsoft/LightGBM/blob/master/docs/GPU-Tutorial.rst) can speed up computation.
 - [**Laurae++ interactive documentation**](https://sites.google.com/view/lauraepp/parameters) is a detailed guide for hyperparameters.
+- [**Optuna Hyperparameter Tuner**](https://medium.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b7095e99258) provides automated tuning for LightGBM hyperparameters.
 
 Documentation for contributors:
 


### PR DESCRIPTION
Hi!

Optuna is a new hyperparameter optimization library, and we've written an [tuner module for LightGBM](https://medium.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b7095e99258) to make it easy to use Optuna to search for good hyperparameter settings and prune unpromising trials. We're looking for ways to let users of LightGBM know this is available and thought a badge to show Optuna integration is available would be helpful along with a link to Optuna in the further readings section.

If there are other ways you would recommend reaching out to LightGBM users to let them know about Optuna, please let us know.

Thanks!