### PR TITLE
[python] handle RandomState object in Scikit-learn Api

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -334,24 +334,6 @@ class LGBMModel(_LGBMModelBase):
         self._n_classes = None
         self.set_params(**kwargs)
 
-    @property
-    def random_state(self):
-        """Get and set integer seed for random number generation. Can be set using integer or a RandomState object which is used to derive an integer."""
-        return self._random_state
-
-    @random_state.setter
-    def random_state(self, value):
-        if value is not None:
-            try:
-                # Try to get random integer which is used as seed in the low level code
-                max = np.iinfo(np.int).max
-                self._random_state = value.randint(max)
-            except AttributeError:
-                # If not, consider object as integer
-                self._random_state = value
-        else:
-            self._random_state = None
-
     def _more_tags(self):
         return {'allow_nan': True,
                 'X_types': ['2darray', 'sparse', '1dlabels']}
@@ -522,6 +504,8 @@ class LGBMModel(_LGBMModelBase):
         params.pop('importance_type', None)
         params.pop('n_estimators', None)
         params.pop('class_weight', None)
+        if isinstance(params['random_state'], np.random.RandomState):
+            params['random_state'] = params['random_state'].randint(np.iinfo(np.int32).max)
         for alias in _ConfigAliases.get('objective'):
             params.pop(alias, None)
         if self._n_classes is not None and self._n_classes > 2:

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -232,8 +232,9 @@ class LGBMModel(_LGBMModelBase):
             L2 regularization term on weights.
         random_state : int, RandomState object or None, optional (default=None)
             Random number seed.
-            If None, default seeds in C++ code will be used.
-            If RandomState object (numpy) is passed, we pick a random integer based on its state to seed the C++ code.
+            If int, this number is used to seed the C++ code.
+            If RandomState object (numpy), a random integer is picked based on its state to seed the C++ code.
+            If None, default seeds in C++ code are used.
         n_jobs : int, optional (default=-1)
             Number of parallel threads.
         silent : bool, optional (default=True)

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -344,7 +344,8 @@ class LGBMModel(_LGBMModelBase):
         if value is not None:
             try:
                 # Try to get random integer which is used as seed in the low level code
-                self._random_state = value.randint(1e10)
+                max = np.iinfo(np.int).max
+                self._random_state = value.randint(max)
             except AttributeError:
                 # If not, consider object as integer
                 self._random_state = value

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -301,16 +301,6 @@ class LGBMModel(_LGBMModelBase):
             raise RuntimeError("The last supported version of scikit-learn is 0.21.3.\n"
                                "Found version: {0}.".format(SKLEARN_VERSION))
 
-        # Handle possible RandomState object
-        if random_state is not None:
-            try:
-                # Try to get random integer which is used as seed in the low level code
-                state = random_state.randint(1e10)
-            except AttributeError:
-                # If not, consider object as integer
-                state = random_state
-            random_state = state
-
         self.boosting_type = boosting_type
         self.objective = objective
         self.num_leaves = num_leaves
@@ -343,6 +333,23 @@ class LGBMModel(_LGBMModelBase):
         self._classes = None
         self._n_classes = None
         self.set_params(**kwargs)
+
+    @property
+    def random_state(self):
+        return self._random_state
+
+    @random_state.setter
+    def random_state(self, value):
+        # Handle possible RandomState object
+        if value is not None:
+            try:
+                # Try to get random integer which is used as seed in the low level code
+                self._random_state = value.randint(1e10)
+            except AttributeError:
+                # If not, consider object as integer
+                self._random_state = value
+        else:
+            self._random_state = None
 
     def _more_tags(self):
         return {'allow_nan': True,

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -336,11 +336,14 @@ class LGBMModel(_LGBMModelBase):
 
     @property
     def random_state(self):
+        """
+            Optional attribute which stores the integer seed for random number generation.
+            Can be set using integer or a RandomState object which is used to derive an integer.
+        """
         return self._random_state
 
     @random_state.setter
     def random_state(self, value):
-        # Handle possible RandomState object
         if value is not None:
             try:
                 # Try to get random integer which is used as seed in the low level code

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -300,6 +300,17 @@ class LGBMModel(_LGBMModelBase):
             raise RuntimeError("The last supported version of scikit-learn is 0.21.3.\n"
                                "Found version: {0}.".format(SKLEARN_VERSION))
 
+        # Handle possible RandomState object
+        if random_state is not None:
+            try:
+                # Try to get random integer which is used as seed in the low level code
+                state = random_state.randint(1e10)
+            except AttributeError:
+                # If not, consider object as integer
+                state = random_state
+            random_state = state
+
+
         self.boosting_type = boosting_type
         self.objective = objective
         self.num_leaves = num_leaves

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -230,9 +230,10 @@ class LGBMModel(_LGBMModelBase):
             L1 regularization term on weights.
         reg_lambda : float, optional (default=0.)
             L2 regularization term on weights.
-        random_state : int or None, optional (default=None)
+        random_state : int, RandomState object or None, optional (default=None)
             Random number seed.
             If None, default seeds in C++ code will be used.
+            If RandomState object (numpy) is passed, we pick a random integer based on its state to seed the C++ code.
         n_jobs : int, optional (default=-1)
             Number of parallel threads.
         silent : bool, optional (default=True)

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -311,7 +311,6 @@ class LGBMModel(_LGBMModelBase):
                 state = random_state
             random_state = state
 
-
         self.boosting_type = boosting_type
         self.objective = objective
         self.num_leaves = num_leaves

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -336,10 +336,7 @@ class LGBMModel(_LGBMModelBase):
 
     @property
     def random_state(self):
-        """
-            Optional attribute which stores the integer seed for random number generation.
-            Can be set using integer or a RandomState object which is used to derive an integer.
-        """
+        """Get and set integer seed for random number generation. Can be set using integer or a RandomState object which is used to derive an integer."""
         return self._random_state
 
     @random_state.setter

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -230,17 +230,19 @@ class TestSklearn(unittest.TestCase):
     def test_random_state_object(self):
         X, y = load_iris(True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
-        state = np.random.RandomState(123)
-        clf = lgb.LGBMClassifier(n_estimators=10, subsample=0.5, subsample_freq=1, random_state=state)
-        self.assertIs(clf.random_state, state)
-        clf.fit(X_train, y_train)
-        y_pred1 = clf.predict(X_test, raw_score=True)
-        clf.fit(X_train, y_train)
-        y_pred2 = clf.predict(X_test, raw_score=True)
-        self.assertIs(clf.random_state, state)
-        self.assertRaises(AssertionError,
-                          np.testing.assert_allclose,
-                          y_pred1, y_pred2)
+        state1 = np.random.RandomState(123)
+        state2 = np.random.RandomState(123)
+        clf1 = lgb.LGBMClassifier(n_estimators=10, subsample=0.5, subsample_freq=1, random_state=state1)
+        clf2 = lgb.LGBMClassifier(n_estimators=10, subsample=0.5, subsample_freq=1, random_state=state2)
+        self.assertIs(clf1.random_state, state1)
+        clf1.fit(X_train, y_train)
+        clf2.fit(X_train, y_train)
+        y_pred1 = clf1.predict(X_test, raw_score=True)
+        y_pred2 = clf2.predict(X_test, raw_score=True)
+        self.assertEqual(clf1.best_iteration_, clf2.best_iteration_)
+        self.assertEqual(clf1.best_score_, clf2.best_score_)
+        np.testing.assert_array_equal(y_pred1, y_pred2)
+        np.testing.assert_array_equal(clf1.feature_importances_, clf2.feature_importances_)
 
     def test_feature_importances_single_leaf(self):
         data = load_iris()

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -239,10 +239,12 @@ class TestSklearn(unittest.TestCase):
         clf2.fit(X_train, y_train)
         y_pred1 = clf1.predict(X_test, raw_score=True)
         y_pred2 = clf2.predict(X_test, raw_score=True)
-        self.assertEqual(clf1.best_iteration_, clf2.best_iteration_)
         self.assertEqual(clf1.best_score_, clf2.best_score_)
         np.testing.assert_array_equal(y_pred1, y_pred2)
         np.testing.assert_array_equal(clf1.feature_importances_, clf2.feature_importances_)
+        df1 = clf1.booster_.model_to_string(num_iteration=0)
+        df2 = clf2.booster_.model_to_string(num_iteration=0)
+        self.assertMultiLineEqual(df1,df2)
 
     def test_feature_importances_single_leaf(self):
         data = load_iris()

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -244,7 +244,7 @@ class TestSklearn(unittest.TestCase):
         np.testing.assert_array_equal(clf1.feature_importances_, clf2.feature_importances_)
         df1 = clf1.booster_.model_to_string(num_iteration=0)
         df2 = clf2.booster_.model_to_string(num_iteration=0)
-        self.assertMultiLineEqual(df1,df2)
+        self.assertMultiLineEqual(df1, df2)
 
     def test_feature_importances_single_leaf(self):
         data = load_iris()

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -228,11 +228,19 @@ class TestSklearn(unittest.TestCase):
         np.testing.assert_allclose(pred_origin, pred_pickle)
 
     def test_random_state_object(self):
-        data = load_iris()
+        X, y = load_iris(True)
+        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         state = np.random.RandomState(123)
-        clf = lgb.LGBMClassifier(random_state=state)
-        self.assertIsInstance(clf.random_state, np.random.RandomState)
-        clf.fit(data.data, data.target)
+        clf = lgb.LGBMClassifier(n_estimators=10, subsample=0.5, subsample_freq=1, random_state=state)
+        self.assertIs(clf.random_state, state)
+        clf.fit(X_train, y_train)
+        y_pred1 = clf.predict(X_test, raw_score=True)
+        clf.fit(X_train, y_train)
+        y_pred2 = clf.predict(X_test, raw_score=True)
+        self.assertIs(clf.random_state, state)
+        self.assertRaises(AssertionError,
+                          np.testing.assert_allclose,
+                          y_pred1, y_pred2)
 
     def test_feature_importances_single_leaf(self):
         data = load_iris()

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -236,13 +236,13 @@ class TestSklearn(unittest.TestCase):
         clf2 = lgb.LGBMClassifier(n_estimators=10, subsample=0.5, subsample_freq=1, random_state=state2)
         # Test if random_state is properly stored
         self.assertIs(clf1.random_state, state1)
+        self.assertIs(clf2.random_state, state2)
         # Test if two random states produce identical models
         clf1.fit(X_train, y_train)
         clf2.fit(X_train, y_train)
         y_pred1 = clf1.predict(X_test, raw_score=True)
         y_pred2 = clf2.predict(X_test, raw_score=True)
-        self.assertEqual(clf1.best_score_, clf2.best_score_)
-        np.testing.assert_array_equal(y_pred1, y_pred2)
+        np.testing.assert_allclose(y_pred1, y_pred2)
         np.testing.assert_array_equal(clf1.feature_importances_, clf2.feature_importances_)
         df1 = clf1.booster_.model_to_string(num_iteration=0)
         df2 = clf2.booster_.model_to_string(num_iteration=0)
@@ -251,8 +251,10 @@ class TestSklearn(unittest.TestCase):
         clf1.fit(X_train, y_train)
         y_pred1_refit = clf1.predict(X_test, raw_score=True)
         df3 = clf1.booster_.model_to_string(num_iteration=0)
+        self.assertIs(clf1.random_state, state1)
+        self.assertIs(clf2.random_state, state2)
         self.assertRaises(AssertionError,
-                          np.testing.assert_array_equal,
+                          np.testing.assert_allclose,
                           y_pred1, y_pred1_refit)
         self.assertRaises(AssertionError,
                           self.assertMultiLineEqual,

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -227,6 +227,11 @@ class TestSklearn(unittest.TestCase):
         pred_pickle = gbm_pickle.predict(X_test)
         np.testing.assert_allclose(pred_origin, pred_pickle)
 
+    def test_random_state_object(self):
+        state = np.random.RandomState(123)
+        clf = lgb.LGBMClassifier(random_state=state)
+        self.assertIsInstance(clf.random_state, int)
+
     def test_feature_importances_single_leaf(self):
         data = load_iris()
         clf = lgb.LGBMClassifier(n_estimators=10)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -228,9 +228,11 @@ class TestSklearn(unittest.TestCase):
         np.testing.assert_allclose(pred_origin, pred_pickle)
 
     def test_random_state_object(self):
+        data = load_iris()
         state = np.random.RandomState(123)
         clf = lgb.LGBMClassifier(random_state=state)
-        self.assertIsInstance(clf.random_state, int)
+        self.assertIsInstance(clf.random_state, np.random.RandomState)
+        clf.fit(data.data, data.target)
 
     def test_feature_importances_single_leaf(self):
         data = load_iris()

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -234,7 +234,9 @@ class TestSklearn(unittest.TestCase):
         state2 = np.random.RandomState(123)
         clf1 = lgb.LGBMClassifier(n_estimators=10, subsample=0.5, subsample_freq=1, random_state=state1)
         clf2 = lgb.LGBMClassifier(n_estimators=10, subsample=0.5, subsample_freq=1, random_state=state2)
+        # Test if random_state is properly stored
         self.assertIs(clf1.random_state, state1)
+        # Test if two random states produce identical models
         clf1.fit(X_train, y_train)
         clf2.fit(X_train, y_train)
         y_pred1 = clf1.predict(X_test, raw_score=True)
@@ -245,6 +247,16 @@ class TestSklearn(unittest.TestCase):
         df1 = clf1.booster_.model_to_string(num_iteration=0)
         df2 = clf2.booster_.model_to_string(num_iteration=0)
         self.assertMultiLineEqual(df1, df2)
+        # Test if subsequent fits sample from random_state object and produce different models
+        clf1.fit(X_train, y_train)
+        y_pred1_refit = clf1.predict(X_test, raw_score=True)
+        df3 = clf1.booster_.model_to_string(num_iteration=0)
+        self.assertRaises(AssertionError,
+                          np.testing.assert_array_equal,
+                          y_pred1, y_pred1_refit)
+        self.assertRaises(AssertionError,
+                          self.assertMultiLineEqual,
+                          df1, df3)
 
     def test_feature_importances_single_leaf(self):
         data = load_iris()


### PR DESCRIPTION
I am using LightGBM with its scikit-learn API in a wrapper model called [Boruta](https://github.com/scikit-learn-contrib/boruta_py).
Boruta is using multiple cloned LGBM models in sequence.
In every iteration, it is cloning and setting parameters, including the random_state used in random number generation.

LGBM is not able to handle a RandomState object from Numpys random module which is the standard in scikit-learn models.
Because of that, many wrappers just pass down the RandomState in their inner models.
This was already discussed in #730.
LGBM is using an integer to seed its number generators and expects an integer, which makes it unusable in this context.

In this PR I added a random_state property with a setter method to handle RandomState objects.
If an RS object is passed, It derives an integer based on its state.
The advantage of the property is, that it handles both use cases:
1. normal initialisation
2. cloning and setting parameters via set_params

This change is quite minimal in my opinion and still allows the passing of integers as before.