### PR TITLE
[R-package] fixed some minor issues with testing on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,6 +400,8 @@ python-package/lightgbm/VERSION.txt
 R-package/src/CMakeLists.txt
 R-package/src/lib_lightgbm.so.dSYM/
 R-package/src/src/
+R-package/src-x64
+R-package/src-i386
 lightgbm_r/*
 lightgbm*.tar.gz
 lightgbm.Rcheck/

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -86,5 +86,5 @@ test_that("lgb.get.eval.result() should throw an informative error for incorrect
             , data_name = "test"
             , eval_name = "l1"
         )
-    }, regexp = "Only the following eval_names exist for dataset 'test': [l2]", fixed = TRUE)
+    }, regexp = "Only the following eval_names exist for dataset.*\\: \\[l2\\]", fixed = FALSE)
 })


### PR DESCRIPTION
I started working on #2335 tonight, specifically adding CI for Windows.

In this PR, I'd like to propose a few small fixes to start improving support on Windows.

1. Added architecture-specific source directories to `.gitignore`. These come from multi-architecture R package builds on Windows, and shouldn't be checked into source control
2. Minor readability cleanup in Windows section of `install.libs.R`, added some logs and clarified existing logs
3. Fixed one unit test that fails on Windows because of different default quoting between Windows and other operating system

I tested these changes locally on Windows 10, using Visual Studio 16 2019, with `Rscript build_r.R`