### PR TITLE
[R-package] added command to remove build/ dir in install.libs.R

### DIFF
--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -142,8 +142,18 @@ if (!use_precompile) {
 dest <- file.path(R_PACKAGE_DIR, paste0("libs", R_ARCH), fsep = "/")
 dir.create(dest, recursive = TRUE, showWarnings = FALSE)
 if (file.exists(src)) {
-  cat("Found library file: ", src, " to move to ", dest, sep = "")
+  print(paste0("Found library file: ", src, " to move to ", dest))
   file.copy(src, dest, overwrite = TRUE)
 } else {
   stop(paste0("Cannot find lib_lightgbm", SHLIB_EXT))
+}
+
+# clean up the "build" directory
+if (dir.exists(build_dir)){
+  print("Removing 'build/' directory")
+  unlink(
+    x = file.path(R_PACKAGE_SOURCE, "src", "build")
+    , recursive = TRUE
+    , force = TRUE
+  )
 }

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -149,7 +149,7 @@ if (file.exists(src)) {
 }
 
 # clean up the "build" directory
-if (dir.exists(build_dir)){
+if (dir.exists(build_dir)) {
   print("Removing 'build/' directory")
   unlink(
     x = file.path(R_PACKAGE_SOURCE, "src", "build")

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -20,16 +20,19 @@ if (!file.copy("../inst/bin/CMakeLists.txt", "CMakeLists.txt", overwrite = TRUE)
   stop("Copying CMakeLists failed")
 }
 
+# Get some paths
+source_dir <- file.path(R_PACKAGE_SOURCE, "src", fsep = "/")
+build_dir <- file.path(source_dir, "build", fsep = "/")
+
 # Check for precompilation
 if (!use_precompile) {
 
-  # Check repository content
-  source_dir <- file.path(R_PACKAGE_SOURCE, "src", fsep = "/")
-  setwd(source_dir)
-
   # Prepare building package
-  build_dir <- file.path(source_dir, "build", fsep = "/")
-  dir.create(build_dir, recursive = TRUE, showWarnings = FALSE)
+  dir.create(
+    build_dir
+    , recursive = TRUE
+    , showWarnings = FALSE
+  )
   setwd(build_dir)
 
   # Prepare installation steps


### PR DESCRIPTION
Another piece of adding Windows CI for the R package (#2335) and, as a result, #629

This PR fixes this Windows-specific NOTE that shows up in `R CMD check --as-cran`:

```
* checking line endings in C/C++/Fortran sources/headers ... NOTE
Found the following sources/headers with CR or CRLF line endings:
    src/build/CMakeFiles/3.16.5/CompilerIdC/CMakeCCompilerId.c
src/build/CMakeFiles/3.16.5/CompilerIdCXX/CMakeCXXCompilerId.cpp
src/build/CMakeFiles/FindOpenMP/OpenMPCheckVersion.c
src/build/CMakeFiles/FindOpenMP/OpenMPCheckVersion.cpp
src/build/CMakeFiles/FindOpenMP/OpenMPTryFlag.c
src/build/CMakeFiles/FindOpenMP/OpenMPTryFlag.cpp
Some Unix compilers require LF line endings.
* checking line endings in Makefiles ... OK
```

R does have a method for cleaning up intermediate files, with a `cleanup` script ([reference](https://colinfay.me/writing-r-extensions/creating-r-packages.html#configure-and-cleanup)). I tried that first, but it didn't work. I think those scripts are used in `R CMD build` and not run immediately after installation, which is why adding them with content like `rm -r src/build` did not work.