### PR TITLE
[R-package] removed unnecessary flag in tests

### DIFF
--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -5,8 +5,6 @@ data(agaricus.test, package = "lightgbm")
 train <- agaricus.train
 test <- agaricus.test
 
-windows_flag <- grepl("Windows", Sys.info()[["sysname"]])
-
 TOLERANCE <- 1e-6
 
 test_that("train and predict binary classification", {


### PR DESCRIPTION
This PR removes an object, `windows_flag`, that is created but never used in tests on `lgb.train()` and `lightgbm()`.