### PR TITLE
changed sprintf uses to snprintf

### DIFF
--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -376,15 +376,11 @@ inline static void Int32ToStr(int32_t value, char* buffer) {
   Uint32ToStr(u, buffer);
 }
 
-inline static void DoubleToStr(double value, char* buffer, size_t
-                               #ifdef _MSC_VER
-                               buffer_len
-                               #endif
-) {
+inline static void DoubleToStr(double value, char* buffer, size_t buffer_len) {
   #ifdef _MSC_VER
   sprintf_s(buffer, buffer_len, "%.17g", value);
   #else
-  sprintf(buffer, "%.17g", value);
+  snprintf(buffer, buffer_len, "%.17g", value);
   #endif
 }
 
@@ -420,16 +416,12 @@ struct __TToStringHelperFast {
 
 template<typename T>
 struct __TToStringHelperFast<T, true, false> {
-  void operator()(T value, char* buffer, size_t
-                  #ifdef _MSC_VER
-                  buf_len
-                  #endif
-                  )
+  void operator()(T value, char* buffer, size_t buf_len)
   const {
     #ifdef _MSC_VER
     sprintf_s(buffer, buf_len, "%g", value);
     #else
-    sprintf(buffer, "%g", value);
+    snprintf(buffer, buf_len, "%g", value);
     #endif
   }
 };

--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -378,10 +378,11 @@ inline static void Int32ToStr(int32_t value, char* buffer) {
 
 inline static void DoubleToStr(double value, char* buffer, size_t buffer_len) {
   #ifdef _MSC_VER
-  sprintf_s(buffer, buffer_len, "%.17g", value);
+  int num_chars = sprintf_s(buffer, buffer_len, "%.17g", value);
   #else
-  snprintf(buffer, buffer_len, "%.17g", value);
+  int num_chars = snprintf(buffer, buffer_len, "%.17g", value);
   #endif
+  CHECK_GE(num_chars, 0);
 }
 
 inline static const char* SkipSpaceAndTab(const char* p) {
@@ -419,10 +420,11 @@ struct __TToStringHelperFast<T, true, false> {
   void operator()(T value, char* buffer, size_t buf_len)
   const {
     #ifdef _MSC_VER
-    sprintf_s(buffer, buf_len, "%g", value);
+    int num_chars = sprintf_s(buffer, buf_len, "%g", value);
     #else
-    snprintf(buffer, buf_len, "%g", value);
+    int num_chars = snprintf(buffer, buf_len, "%g", value);
     #endif
+    CHECK_GE(num_chars, 0);
   }
 };
 


### PR DESCRIPTION
This PR fixes two `cpplint` warnings (#1990). It replaces uses of `sprintf` with `snprintf`. `sprintf` is dangerous because it doesn't know about the size of the buffer it's writing to.

Since we already had the buffer size easily available in the places that call the relevant functions, and since we were already passing it in, I _think_ that this was an easy change that doesn't break any APIs. However I'm not that good at C++ so very possible I've misunderstood something.

<details><summary>`cpplint` errors after this PR: 42 (click me)</summary>

```
Done processing src/io/dense_bin.hpp
Done processing src/main.cpp
Done processing src/application/application.cpp
Done processing src/metric/map_metric.hpp
Done processing include/LightGBM/feature_group.h
Done processing src/objective/rank_objective.hpp
Done processing include/LightGBM/meta.h
Done processing src/io/config_auto.cpp
Done processing include/LightGBM/utils/file_io.h
Done processing src/io/parser.cpp
Done processing src/treelearner/gpu_tree_learner.cpp
Done processing src/treelearner/cost_effective_gradient_boosting.hpp
src/c_api.cpp:545:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing src/c_api.cpp
Done processing src/io/config.cpp
Done processing include/LightGBM/utils/text_reader.h
Done processing src/io/dataset_loader.cpp
Done processing src/treelearner/parallel_tree_learner.h
Done processing src/treelearner/split_info.hpp
Done processing include/LightGBM/objective_function.h
Done processing src/boosting/goss.hpp
Done processing src/metric/rank_metric.hpp
Done processing src/objective/multiclass_objective.hpp
Done processing src/metric/regression_metric.hpp
Done processing src/io/multi_val_dense_bin.hpp
Done processing include/LightGBM/dataset.h
Done processing include/LightGBM/tree.h
Done processing src/treelearner/feature_parallel_tree_learner.cpp
Done processing src/metric/multiclass_metric.hpp
Done processing src/treelearner/tree_learner.cpp
Done processing src/application/predictor.hpp
Done processing src/metric/dcg_calculator.cpp
include/LightGBM/c_api.h:1061:  Almost always, snprintf is better than strcpy  [runtime/printf] [4]
Done processing include/LightGBM/c_api.h
include/LightGBM/utils/common.h:316:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
Done processing include/LightGBM/utils/common.h
Done processing include/LightGBM/lightgbm_R.h
Done processing src/objective/xentropy_objective.hpp
Done processing src/io/file_io.cpp
Done processing include/LightGBM/utils/openmp_wrapper.h
Done processing src/network/linkers_socket.cpp
Done processing src/metric/xentropy_metric.hpp
Done processing src/objective/binary_objective.hpp
Done processing src/metric/binary_metric.hpp
Done processing src/network/linkers_mpi.cpp
Done processing include/LightGBM/utils/pipeline_reader.h
Done processing include/LightGBM/config.h
Done processing src/boosting/prediction_early_stop.cpp
Done processing src/objective/regression_objective.hpp
Done processing src/treelearner/data_partition.hpp
Done processing include/LightGBM/R_object_helper.h
Done processing src/metric/metric.cpp
Done processing include/LightGBM/metric.h
Done processing src/boosting/gbdt_prediction.cpp
Done processing src/treelearner/leaf_splits.hpp
Done processing src/boosting/gbdt.cpp
Done processing src/io/multi_val_sparse_bin.hpp
Done processing include/LightGBM/application.h
Done processing src/boosting/score_updater.hpp
include/LightGBM/utils/json11.h:80:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:81:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:82:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:83:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:84:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:85:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:86:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:87:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:88:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:89:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:90:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:94:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:101:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:107:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:111:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:144:  Is this a non-const reference? If so, make const or use a pointer: std::string &out  [runtime/references] [2]
include/LightGBM/utils/json11.h:153:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/utils/json11.h:156:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/utils/json11.h:168:  Is this a non-const reference? If so, make const or use a pointer: std::string::size_type & parser_stop_pos  [runtime/references] [2]
include/LightGBM/utils/json11.h:169:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/utils/json11.h:174:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/utils/json11.h:193:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/utils/json11.h:208:  Is this a non-const reference? If so, make const or use a pointer: std::string &out  [runtime/references] [2]
Done processing include/LightGBM/utils/json11.h
Done processing src/network/network.cpp
Done processing src/network/linkers.h
Done processing src/treelearner/feature_histogram.hpp
src/network/socket_wrapper.hpp:221:  Are you taking an address of a cast?  This is dangerous: could be a temp var.  Take the address before doing the cast, rather than after  [runtime/casting] [4]
Done processing src/network/socket_wrapper.hpp
Done processing src/io/bin.cpp
Done processing src/objective/objective_function.cpp
Done processing src/treelearner/data_parallel_tree_learner.cpp
src/lightgbm_R.cpp:35:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing src/lightgbm_R.cpp
Done processing include/LightGBM/dataset_loader.h
Done processing src/boosting/gbdt.h
Done processing src/treelearner/serial_tree_learner.h
Done processing src/treelearner/gpu_tree_learner.h
Done processing src/treelearner/serial_tree_learner.cpp
Done processing include/LightGBM/boosting.h
Done processing include/LightGBM/utils/log.h
Done processing src/boosting/gbdt_model_text.cpp
Done processing src/network/linker_topo.cpp
Done processing src/boosting/dart.hpp
src/io/dataset.cpp:437:  Is this a non-const reference? If so, make const or use a pointer: std::vector<std::vector<std::unique_ptr<BinIterator>>>& iters  [runtime/references] [2]
Done processing src/io/dataset.cpp
Done processing include/LightGBM/utils/array_args.h
Done processing src/io/tree.cpp
Done processing include/LightGBM/tree_learner.h
Done processing src/treelearner/col_sampler.hpp
src/io/json11.cpp:55:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:59:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:69:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:75:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:79:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:116:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:128:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:341:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
src/io/json11.cpp:353:  const string& members are dangerous. It is much better to use alternatives, such as pointers or simple constants.  [runtime/member_string_references] [2]
src/io/json11.cpp:454:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
src/io/json11.cpp:454:  Is this a non-const reference? If so, make const or use a pointer: string & out  [runtime/references] [2]
src/io/json11.cpp:481:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
src/io/json11.cpp:525:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
Done processing src/io/json11.cpp
Done processing include/LightGBM/utils/threading.h
Done processing include/LightGBM/bin.h
Done processing src/treelearner/voting_parallel_tree_learner.cpp
Done processing src/io/sparse_bin.hpp
Done processing include/LightGBM/network.h
Done processing src/io/parser.hpp
Done processing include/LightGBM/utils/random.h
Done processing src/treelearner/monotone_constraints.hpp
Done processing src/boosting/rf.hpp
Done processing include/LightGBM/prediction_early_stop.h
Done processing src/io/metadata.cpp
Done processing src/boosting/boosting.cpp
Done processing include/LightGBM/export.h
Total errors found: 42
```

</details>