### PR TITLE
[ci] fixed cpplint errors about namespace using-directives

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -553,7 +553,23 @@ class Booster {
 
 }  // namespace LightGBM
 
-using namespace LightGBM;
+// explicitly declare symbols from LightGBM namespace
+using LightGBM::AllgatherFunction;
+using LightGBM::Booster;
+using LightGBM::Common::CheckElementsIntervalClosed;
+using LightGBM::Common::RemoveQuotationSymbol;
+using LightGBM::Common::Vector2Ptr;
+using LightGBM::Common::VectorSize;
+using LightGBM::Config;
+using LightGBM::data_size_t;
+using LightGBM::Dataset;
+using LightGBM::DatasetLoader;
+using LightGBM::kZeroThreshold;
+using LightGBM::LGBM_APIHandleException;
+using LightGBM::Log;
+using LightGBM::Network;
+using LightGBM::Random;
+using LightGBM::ReduceScatterFunction;
 
 // some help functions used to convert data
 
@@ -785,10 +801,10 @@ int LGBM_DatasetCreateFromMats(int32_t nmat,
       }
     }
     DatasetLoader loader(config, nullptr, 1, nullptr);
-    ret.reset(loader.CostructFromSampleData(Common::Vector2Ptr<double>(&sample_values).data(),
-                                            Common::Vector2Ptr<int>(&sample_idx).data(),
+    ret.reset(loader.CostructFromSampleData(Vector2Ptr<double>(&sample_values).data(),
+                                            Vector2Ptr<int>(&sample_idx).data(),
                                             ncol,
-                                            Common::VectorSize<double>(sample_values).data(),
+                                            VectorSize<double>(sample_values).data(),
                                             sample_cnt, total_nrow));
   } else {
     ret.reset(new Dataset(total_nrow));
@@ -861,10 +877,10 @@ int LGBM_DatasetCreateFromCSR(const void* indptr,
       }
     }
     DatasetLoader loader(config, nullptr, 1, nullptr);
-    ret.reset(loader.CostructFromSampleData(Common::Vector2Ptr<double>(&sample_values).data(),
-                                            Common::Vector2Ptr<int>(&sample_idx).data(),
+    ret.reset(loader.CostructFromSampleData(Vector2Ptr<double>(&sample_values).data(),
+                                            Vector2Ptr<int>(&sample_idx).data(),
                                             static_cast<int>(num_col),
-                                            Common::VectorSize<double>(sample_values).data(),
+                                            VectorSize<double>(sample_values).data(),
                                             sample_cnt, nrow));
   } else {
     ret.reset(new Dataset(nrow));
@@ -929,10 +945,10 @@ int LGBM_DatasetCreateFromCSRFunc(void* get_row_funptr,
       }
     }
     DatasetLoader loader(config, nullptr, 1, nullptr);
-    ret.reset(loader.CostructFromSampleData(Common::Vector2Ptr<double>(&sample_values).data(),
-                                            Common::Vector2Ptr<int>(&sample_idx).data(),
+    ret.reset(loader.CostructFromSampleData(Vector2Ptr<double>(&sample_values).data(),
+                                            Vector2Ptr<int>(&sample_idx).data(),
                                             static_cast<int>(num_col),
-                                            Common::VectorSize<double>(sample_values).data(),
+                                            VectorSize<double>(sample_values).data(),
                                             sample_cnt, nrow));
   } else {
     ret.reset(new Dataset(nrow));
@@ -1002,10 +1018,10 @@ int LGBM_DatasetCreateFromCSC(const void* col_ptr,
     }
     OMP_THROW_EX();
     DatasetLoader loader(config, nullptr, 1, nullptr);
-    ret.reset(loader.CostructFromSampleData(Common::Vector2Ptr<double>(&sample_values).data(),
-                                            Common::Vector2Ptr<int>(&sample_idx).data(),
+    ret.reset(loader.CostructFromSampleData(Vector2Ptr<double>(&sample_values).data(),
+                                            Vector2Ptr<int>(&sample_idx).data(),
                                             static_cast<int>(sample_values.size()),
-                                            Common::VectorSize<double>(sample_values).data(),
+                                            VectorSize<double>(sample_values).data(),
                                             sample_cnt, nrow));
   } else {
     ret.reset(new Dataset(nrow));
@@ -1063,7 +1079,7 @@ int LGBM_DatasetGetSubset(
   CHECK_GT(num_used_row_indices, 0);
   const int32_t lower = 0;
   const int32_t upper = full_dataset->num_data() - 1;
-  Common::CheckElementsIntervalClosed(used_row_indices, lower, upper, num_used_row_indices, "Used indices of subset");
+  CheckElementsIntervalClosed(used_row_indices, lower, upper, num_used_row_indices, "Used indices of subset");
   if (!std::is_sorted(used_row_indices, used_row_indices + num_used_row_indices)) {
     Log::Fatal("used_row_indices should be sorted in Subset");
   }
@@ -1755,7 +1771,7 @@ int LGBM_NetworkInit(const char* machines,
                      int num_machines) {
   API_BEGIN();
   Config config;
-  config.machines = Common::RemoveQuotationSymbol(std::string(machines));
+  config.machines = RemoveQuotationSymbol(std::string(machines));
   config.local_listen_port = local_listen_port;
   config.num_machines = num_machines;
   config.time_out = listen_time_out;

--- a/src/lightgbm_R.cpp
+++ b/src/lightgbm_R.cpp
@@ -32,7 +32,9 @@
     return call_state;\
   }
 
-using namespace LightGBM;
+using LightGBM::Common::Join;
+using LightGBM::Common::Split;
+using LightGBM::Log;
 
 LGBM_SE EncodeChar(LGBM_SE dest, const char* src, LGBM_SE buf_len, LGBM_SE actual_len, size_t str_len) {
   if (str_len > INT32_MAX) {
@@ -134,7 +136,7 @@ LGBM_SE LGBM_DatasetSetFeatureNames_R(LGBM_SE handle,
   LGBM_SE feature_names,
   LGBM_SE call_state) {
   R_API_BEGIN();
-  auto vec_names = Common::Split(R_CHAR_PTR(feature_names), '\t');
+  auto vec_names = Split(R_CHAR_PTR(feature_names), '\t');
   std::vector<const char*> vec_sptr;
   int len = static_cast<int>(vec_names.size());
   for (int i = 0; i < len; ++i) {
@@ -163,7 +165,7 @@ LGBM_SE LGBM_DatasetGetFeatureNames_R(LGBM_SE handle,
   CHECK_CALL(LGBM_DatasetGetFeatureNames(R_GET_PTR(handle),
     ptr_names.data(), &out_len));
   CHECK_EQ(len, out_len);
-  auto merge_str = Common::Join<char*>(ptr_names, "\t");
+  auto merge_str = Join<char*>(ptr_names, "\t");
   EncodeChar(feature_names, merge_str.c_str(), buf_len, actual_len, merge_str.size() + 1);
   R_API_END();
 }
@@ -468,7 +470,7 @@ LGBM_SE LGBM_BoosterGetEvalNames_R(LGBM_SE handle,
       ptr_names.data()));
   CHECK_EQ(out_len, len);
   CHECK_GE(reserved_string_size, required_string_size);
-  auto merge_names = Common::Join<char*>(ptr_names, "\t");
+  auto merge_names = Join<char*>(ptr_names, "\t");
   EncodeChar(eval_names, merge_names.c_str(), buf_len, actual_len, merge_names.size() + 1);
   R_API_END();
 }


### PR DESCRIPTION
In this PR, I tried to address the two instances of this `cpplint` error (from #1990):

> Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]

I did some research tonight, and found some good resources that explain this. According to [this blog post](https://abseil.io/tips/153):

> The vast majority of C++ users think that the using-directive is injecting names into the scope where it’s declared.... [for example] the scope of [a] function. In reality, the names are injected into the nearest common ancestor of the target namespace ...and the usage namespace ... [which could easily be] the global namespace!

So a directive like `using namespace LightGBM` is risky because it means all the names from the namespace  `LightGBM` will be defined in some shared parent namespace of `LightGBM` and the target scope. That increases the likelihood of naming conflicts.

A using-declaration, like `using LightGBM::Booster`, is safer, because it targets a single name. From [cppreference](https://en.cppreference.com/w/cpp/language/using_declaration):

> Using-declaration introduces a member of another namespace into current namespace or block scope

These changes will take us down to 40 `cpplint` errors (42  in the log below because #2920 is awaiting review):

<details><summary>cpplint log (click me)</summary>
Done processing src/boosting/gbdt_model_text.cpp
Done processing src/boosting/gbdt.h
Done processing src/network/network.cpp
Done processing src/treelearner/serial_tree_learner.h
Done processing src/objective/xentropy_objective.hpp
Done processing src/metric/multiclass_metric.hpp
Done processing src/metric/dcg_calculator.cpp
Done processing src/objective/rank_objective.hpp
Done processing src/io/metadata.cpp
Done processing include/LightGBM/dataset_loader.h
Done processing src/treelearner/data_partition.hpp
Done processing src/boosting/boosting.cpp
Done processing src/io/multi_val_sparse_bin.hpp
Done processing include/LightGBM/export.h
Done processing include/LightGBM/utils/pipeline_reader.h
Done processing src/metric/binary_metric.hpp
Done processing src/io/dense_bin.hpp
Done processing include/LightGBM/prediction_early_stop.h
Done processing src/treelearner/data_parallel_tree_learner.cpp
Done processing include/LightGBM/metric.h
Done processing src/c_api.cpp
Done processing src/network/linkers_mpi.cpp
Done processing src/metric/xentropy_metric.hpp
Done processing src/metric/rank_metric.hpp
include/LightGBM/utils/common.h:316:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
include/LightGBM/utils/common.h:387:  Never use sprintf. Use snprintf instead.  [runtime/printf] [5]
include/LightGBM/utils/common.h:432:  Never use sprintf. Use snprintf instead.  [runtime/printf] [5]
Done processing include/LightGBM/utils/common.h
Done processing include/LightGBM/utils/array_args.h
Done processing src/treelearner/voting_parallel_tree_learner.cpp
Done processing src/io/bin.cpp
Done processing include/LightGBM/dataset.h
Done processing src/boosting/score_updater.hpp
Done processing src/io/config.cpp
Done processing src/io/sparse_bin.hpp
Done processing include/LightGBM/utils/threading.h
Done processing include/LightGBM/application.h
Done processing src/io/config_auto.cpp
Done processing src/io/dataset_loader.cpp
Done processing include/LightGBM/tree.h
Done processing src/metric/map_metric.hpp
Done processing src/treelearner/serial_tree_learner.cpp
Done processing src/boosting/dart.hpp
Done processing include/LightGBM/tree_learner.h
Done processing src/io/parser.cpp
Done processing src/network/linkers_socket.cpp
Done processing src/treelearner/cost_effective_gradient_boosting.hpp
src/io/dataset.cpp:437:  Is this a non-const reference? If so, make const or use a pointer: std::vector<std::vector<std::unique_ptr<BinIterator>>>& iters  [runtime/references] [2]
Done processing src/io/dataset.cpp
Done processing src/lightgbm_R.cpp
Done processing src/boosting/gbdt.cpp
Done processing src/main.cpp
src/network/socket_wrapper.hpp:221:  Are you taking an address of a cast?  This is dangerous: could be a temp var.  Take the address before doing the cast, rather than after  [runtime/casting] [4]
Done processing src/network/socket_wrapper.hpp
Done processing src/metric/regression_metric.hpp
Done processing include/LightGBM/network.h
Done processing src/treelearner/gpu_tree_learner.h
Done processing include/LightGBM/utils/log.h
Done processing src/boosting/goss.hpp
Done processing src/objective/regression_objective.hpp
Done processing src/boosting/prediction_early_stop.cpp
include/LightGBM/utils/json11.h:80:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:81:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:82:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:83:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:84:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:85:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:86:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:87:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:88:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:89:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:90:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:94:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:101:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:107:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:111:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
include/LightGBM/utils/json11.h:144:  Is this a non-const reference? If so, make const or use a pointer: std::string &out  [runtime/references] [2]
include/LightGBM/utils/json11.h:153:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/utils/json11.h:156:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/utils/json11.h:168:  Is this a non-const reference? If so, make const or use a pointer: std::string::size_type & parser_stop_pos  [runtime/references] [2]
include/LightGBM/utils/json11.h:169:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/utils/json11.h:174:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/utils/json11.h:193:  Is this a non-const reference? If so, make const or use a pointer: std::string & err  [runtime/references] [2]
include/LightGBM/utils/json11.h:208:  Is this a non-const reference? If so, make const or use a pointer: std::string &out  [runtime/references] [2]
Done processing include/LightGBM/utils/json11.h
Done processing src/io/parser.hpp
Done processing include/LightGBM/lightgbm_R.h
Done processing src/treelearner/gpu_tree_learner.cpp
Done processing src/boosting/gbdt_prediction.cpp
Done processing src/metric/metric.cpp
Done processing src/io/multi_val_dense_bin.hpp
Done processing src/application/application.cpp
Done processing include/LightGBM/config.h
Done processing include/LightGBM/R_object_helper.h
Done processing include/LightGBM/feature_group.h
Done processing include/LightGBM/meta.h
Done processing src/objective/multiclass_objective.hpp
Done processing include/LightGBM/utils/random.h
Done processing include/LightGBM/utils/openmp_wrapper.h
Done processing include/LightGBM/utils/locale_context.h
Done processing src/network/linkers.h
Done processing src/io/tree.cpp
Done processing src/boosting/rf.hpp
Done processing src/treelearner/monotone_constraints.hpp
Done processing src/treelearner/feature_histogram.hpp
Done processing src/treelearner/parallel_tree_learner.h
Done processing src/treelearner/feature_parallel_tree_learner.cpp
Done processing src/network/linker_topo.cpp
Done processing include/LightGBM/bin.h
Done processing src/objective/objective_function.cpp
Done processing src/io/file_io.cpp
Done processing src/treelearner/col_sampler.hpp
Done processing src/treelearner/leaf_splits.hpp
Done processing src/treelearner/split_info.hpp
include/LightGBM/c_api.h:1077:  Almost always, snprintf is better than strcpy  [runtime/printf] [4]
Done processing include/LightGBM/c_api.h
Done processing include/LightGBM/objective_function.h
Done processing src/objective/binary_objective.hpp
Done processing src/application/predictor.hpp
Done processing include/LightGBM/utils/text_reader.h
Done processing src/treelearner/tree_learner.cpp
Done processing include/LightGBM/utils/file_io.h
src/io/json11.cpp:55:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:59:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:69:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:75:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:79:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:116:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:128:  Is this a non-const reference? If so, make const or use a pointer: string &out  [runtime/references] [2]
src/io/json11.cpp:341:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
src/io/json11.cpp:353:  const string& members are dangerous. It is much better to use alternatives, such as pointers or simple constants.  [runtime/member_string_references] [2]
src/io/json11.cpp:454:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
src/io/json11.cpp:454:  Is this a non-const reference? If so, make const or use a pointer: string & out  [runtime/references] [2]
src/io/json11.cpp:481:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
src/io/json11.cpp:525:  Use int16/int64/etc, rather than the C type long  [runtime/int] [4]
Done processing src/io/json11.cpp
Done processing include/LightGBM/boosting.h
Total errors found: 42
</details>