### PR TITLE
[R-package] fixed NOTE about unrecognized global variable

### DIFF
--- a/R-package/R/lightgbm.R
+++ b/R-package/R/lightgbm.R
@@ -182,6 +182,7 @@ globalVariables(c(
     , ".N"
     , ".SD"
     , "abs_contribution"
+    , "bar_color"
     , "Contribution"
     , "Cover"
     , "Feature"


### PR DESCRIPTION
This PR fixes a new `R CMD CHECK` note introduced in #2803 . See https://github.com/microsoft/LightGBM/pull/2803#issuecomment-601840250 for background.

The note is:

```
* checking R code for possible problems ... NOTE
multiple.tree.plot.interpretation: no visible binding for global
  variable ‘bar_color’
Undefined global functions or variables:
  bar_color
```