### PR TITLE
replace built-in assert with own CHECK macro

### DIFF
--- a/src/io/json11.cpp
+++ b/src/io/json11.cpp
@@ -20,13 +20,12 @@
  */
 #include <LightGBM/utils/json11.h>
 
-#include <limits>
-#ifndef LGB_R_BUILD
-  #include <cassert>
-#endif
+#include <LightGBM/utils/log.h>
+
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 
 namespace json11 {
 
@@ -38,6 +37,8 @@ using std::map;
 using std::make_shared;
 using std::initializer_list;
 using std::move;
+
+using LightGBM::Log;
 
 /* Helper for representing null - just a do-nothing struct, plus comparison
  * operators so the helpers in JsonValue work. We can't use nullptr_t because
@@ -626,9 +627,7 @@ struct JsonParser final {
      * the input and return res. If not, flag an error.
      */
     Json expect(const string &expected, Json res) {
-        #ifndef LGB_R_BUILD
-          assert(i != 0);
-        #endif
+        CHECK_NE(i, 0)
         i--;
         if (str.compare(i, expected.length(), expected) == 0) {
             i += expected.length();


### PR DESCRIPTION
It removes the difference between R-specific library and ordinary one.

Refer to #2837.