### PR TITLE
fix inf in json model dump

### DIFF
--- a/src/boosting/gbdt_model_text.cpp
+++ b/src/boosting/gbdt_model_text.cpp
@@ -48,8 +48,12 @@ std::string GBDT::DumpModel(int start_iteration, int num_iteration) const {
     if (strs[0][0] == '[') {
       strs[0].erase(0, 1);  // remove '['
       strs[1].erase(strs[1].size() - 1);  // remove ']'
-      json_str_buf << "{\"min_value\":" << strs[0] << ",";
-      json_str_buf << "\"max_value\":" << strs[1] << ",";
+      double max_, min_;
+      Common::Atof(strs[0].c_str(), &min_);
+      Common::Atof(strs[1].c_str(), &max_);
+      json_str_buf << std::setprecision(std::numeric_limits<double>::digits10 + 2);
+      json_str_buf << "{\"min_value\":" << Common::AvoidInf(min_) << ",";
+      json_str_buf << "\"max_value\":" << Common::AvoidInf(max_) << ",";
       json_str_buf << "\"values\":[]}";
     } else if (strs[0] != "none") {  // categorical feature
       auto vals = Common::StringToArray<int>(feature_infos_[i], ':');


### PR DESCRIPTION
Fixed #2933.

The same we have for `split_gain` and `threshold`:
https://github.com/microsoft/LightGBM/blob/a8c1e0a11a5cbfac62fb57d16901fea16de95412/src/io/tree.cpp#L294
https://github.com/microsoft/LightGBM/blob/a8c1e0a11a5cbfac62fb57d16901fea16de95412/src/io/tree.cpp#L310