### PR TITLE
[R-package] [ci] added check on number of R CMD CHECK notes

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -91,4 +91,15 @@ if grep -q -R "WARNING" "$LOG_FILE_NAME"; then
     exit -1
 fi
 
+ALLOWED_CHECK_NOTES=3
+NUM_CHECK_NOTES=$(
+    cat ${LOG_FILE_NAME} \
+        | grep -e '^Status: .* NOTE.*' \
+        | sed 's/[^0-9]*//g'
+)
+if [[ ${NUM_CHECK_NOTES} -gt ${ALLOWED_CHECK_NOTES} ]]; then
+    echo "Found ${NUM_CHECK_NOTES} NOTEs from R CMD check. Only ${ALLOWED_CHECK_NOTES} are allowed"
+    exit -1
+fi
+
 exit 0


### PR DESCRIPTION
Currently in CI, we run `R CMD check` on the R package and fail builds if ERRORs or WARNINGs  are encountered. As we get closer to CRAN (#629), I'd like to start limiting the NOTEs being generated. Currently Linux and macOS builds have 3 NOTEs. One is being addressed in #2911 , the other two are not problematic.

Following @StrikerRUS 's suggestion in https://github.com/microsoft/LightGBM/pull/2911#issuecomment-602979163, this PR proposing putting an upper limit on the number of NOTEs.

This PR has it set to 3, and mainly introduces _how we'll enforce this_. I think we should merge this, then change it from 3 to 2 on #2911 . I think it's better for this to be a separate PR so that other changes in the repo don't introduce new notes (like I accidentally did in #2803 and then had to fix in #2928 ).