### PR TITLE
[python] Re-enable scikit-learn 0.22+ support

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -73,7 +73,7 @@ if [[ $TASK == "r-package" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV joblib matplotlib numpy pandas psutil pytest python-graphviz "scikit-learn<=0.21.3" scipy
+conda install -q -y -n $CONDA_ENV joblib matplotlib numpy pandas psutil pytest python-graphviz "scikit-learn!=0.22.0" scipy
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     # fix "OMP: Error #15: Initializing libiomp5.dylib, but found libomp.dylib already initialized." (OpenMP library conflict due to conda's MKL)

--- a/docker/dockerfile-python
+++ b/docker/dockerfile-python
@@ -18,7 +18,7 @@ RUN apt-get update && \
     export PATH="$CONDA_DIR/bin:$PATH" && \
     conda config --set always_yes yes --set changeps1 no && \
     # lightgbm
-    conda install -q -y numpy scipy "scikit-learn<=0.22.0" pandas && \
+    conda install -q -y numpy scipy "scikit-learn!=0.22.0" pandas && \
     git clone --recursive --branch stable --depth 1 https://github.com/Microsoft/LightGBM && \
     cd LightGBM/python-package && python setup.py install && \
     # clean

--- a/docker/dockerfile-python
+++ b/docker/dockerfile-python
@@ -18,7 +18,7 @@ RUN apt-get update && \
     export PATH="$CONDA_DIR/bin:$PATH" && \
     conda config --set always_yes yes --set changeps1 no && \
     # lightgbm
-    conda install -q -y numpy scipy "scikit-learn<=0.21.3" pandas && \
+    conda install -q -y numpy scipy "scikit-learn<=0.22.0" pandas && \
     git clone --recursive --branch stable --depth 1 https://github.com/Microsoft/LightGBM && \
     cd LightGBM/python-package && python setup.py install && \
     # clean

--- a/docker/gpu/dockerfile.gpu
+++ b/docker/gpu/dockerfile.gpu
@@ -75,8 +75,8 @@ RUN echo "export PATH=$CONDA_DIR/bin:"'$PATH' > /etc/profile.d/conda.sh && \
     rm ~/miniconda.sh
 
 RUN conda config --set always_yes yes --set changeps1 no && \
-    conda create -y -q -n py2 python=2.7 mkl numpy scipy "scikit-learn<=0.21.3" jupyter notebook ipython pandas matplotlib && \
-    conda create -y -q -n py3 python=3.6 mkl numpy scipy "scikit-learn<=0.21.3" jupyter notebook ipython pandas matplotlib
+    conda create -y -q -n py2 python=2.7 mkl numpy scipy "scikit-learn!=0.22.0" jupyter notebook ipython pandas matplotlib && \
+    conda create -y -q -n py3 python=3.6 mkl numpy scipy "scikit-learn!=0.22.0" jupyter notebook ipython pandas matplotlib
 
 #################################################################################################################
 #           LightGBM

--- a/docs/GPU-Tutorial.rst
+++ b/docs/GPU-Tutorial.rst
@@ -78,7 +78,7 @@ If you want to use the Python interface of LightGBM, you can install it now (alo
 ::
 
     sudo apt-get -y install python-pip
-    sudo -H pip install setuptools numpy scipy "scikit-learn<=0.21.3" -U
+    sudo -H pip install setuptools numpy scipy "scikit-learn!=0.22.0" -U
     cd python-package/
     sudo python setup.py install --precompile
     cd ..

--- a/docs/Python-API.rst
+++ b/docs/Python-API.rst
@@ -24,10 +24,6 @@ Training API
 Scikit-learn API
 ----------------
 
-.. warning::
-
-    The last supported version of scikit-learn is ``0.21.3``. Our estimators are incompatible with newer versions.
-
 .. autosummary::
     :toctree: pythonapi/
 

--- a/docs/Python-Intro.rst
+++ b/docs/Python-Intro.rst
@@ -15,11 +15,11 @@ Install
 -------
 
 Install Python-package dependencies,
-``setuptools``, ``wheel``, ``numpy`` and ``scipy`` are required, ``scikit-learn<=0.21.3`` is required for sklearn interface and recommended:
+``setuptools``, ``wheel``, ``numpy`` and ``scipy`` are required, ``scikit-learn!=0.22.0`` is required for sklearn interface and recommended:
 
 ::
 
-    pip install setuptools wheel numpy scipy "scikit-learn<=0.21.3" -U
+    pip install setuptools wheel numpy scipy "scikit-learn!=0.22.0" -U
 
 Refer to `Python-package`_ folder for the installation guide.
 

--- a/examples/python-guide/README.md
+++ b/examples/python-guide/README.md
@@ -8,7 +8,7 @@ You should install LightGBM [Python-package](https://github.com/microsoft/LightG
 You also need scikit-learn, pandas, matplotlib (only for plot example), and scipy (only for logistic regression example) to run the examples, but they are not required for the package itself. You can install them with pip:
 
 ```
-pip install "scikit-learn<=0.21.3" pandas matplotlib scipy -U
+pip install "scikit-learn!=0.22.0" pandas matplotlib scipy -U
 ```
 
 Now you can run examples in this folder, for example:

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -298,9 +298,6 @@ class LGBMModel(_LGBMModelBase):
         """
         if not SKLEARN_INSTALLED:
             raise LightGBMError('Scikit-learn is required for this module')
-        elif SKLEARN_VERSION > '0.21.3':
-            raise RuntimeError("The last supported version of scikit-learn is 0.21.3.\n"
-                               "Found version: {0}.".format(SKLEARN_VERSION))
 
         self.boosting_type = boosting_type
         self.objective = objective

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -276,7 +276,7 @@ if __name__ == "__main__":
           install_requires=[
               'numpy',
               'scipy',
-              'scikit-learn<=0.21.3'
+              'scikit-learn!=0.22.0'
           ],
           maintainer='Guolin Ke',
           maintainer_email='guolin.ke@microsoft.com',

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -293,6 +293,11 @@ class TestSklearn(unittest.TestCase):
                 check_name = check.func.__name__ if hasattr(check, 'func') else check.__name__
                 if check_name == 'check_estimators_nan_inf':
                     continue  # skip test because LightGBM deals with nan
+                elif (check_name == "check_no_attributes_set_in_init"
+                      and sk_version < '0.23.0'):
+                    # scikit-learn <0.23 incorrectly asserts that private attributes
+                    # cannot be set in __init__.
+                    continue
                 try:
                     check(name, estimator)
                 except SkipTest as message:


### PR DESCRIPTION
As discussed in https://github.com/microsoft/LightGBM/issues/2628#issuecomment-604519043 re-enables scikit-learn 0.22+ support.

Skips the `check_no_attributes_set_in_init` common check in check_estimator. Hopefully it will be fixed before 0.23 https://github.com/scikit-learn/scikit-learn/issues/16241

Reverts https://github.com/microsoft/LightGBM/pull/2637

Another downside of not supporting scikit-learn 0.22+ is that users will have to compile scikit-learn 0.21.3 from sources on Python 3.8 since there are no wheels there. On conda it would mean that it's simply not possible to install lightgbm on Python 3.8 if you also have scikit-learn installed.