### PR TITLE
[ci] changed CRAN mirror to fix failing installs

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -47,6 +47,7 @@ if [[ $TRAVIS == "true" ]] && [[ $TASK == "lint" ]]; then
         r-stringi  # stringi needs to be installed separate from r-lintr to avoid issues like 'unable to load shared object stringi.so'
     conda install -q -y -n $CONDA_ENV \
         -c conda-forge \
+            libxml2 \
             r-lintr>=2.0
     pip install --user cpplint
     echo "Linting Python code"

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -69,7 +69,7 @@ packages="c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat')"
 if [[ $OS_NAME == "macos" ]]; then
     packages+=", type = 'binary'"
 fi
-Rscript -e --vanilla "install.packages(${packages}, repos = '${CRAN_MIRROR}')" || exit -1
+Rscript --vanilla -e "install.packages(${packages}, repos = '${CRAN_MIRROR}')" || exit -1
 
 cd ${BUILD_DIRECTORY}
 Rscript --vanilla build_r.R || exit -1

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # set up R environment
+CRAN_MIRROR="https://cloud.r-project.org/"
 R_LIB_PATH=~/Rlib
 mkdir -p $R_LIB_PATH
 echo "R_LIBS=$R_LIB_PATH" > ${HOME}/.Renviron
-CRAN_MIRROR="https://cloud.r-project.org/"
 export PATH="$R_LIB_PATH/R/bin:$PATH"
 
 # installing precompiled R for Ubuntu

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -4,7 +4,7 @@
 R_LIB_PATH=~/Rlib
 mkdir -p $R_LIB_PATH
 echo "R_LIBS=$R_LIB_PATH" > ${HOME}/.Renviron
-echo 'options(repos = "https://cran.rstudio.com")' > ${HOME}/.Rprofile
+CRAN_MIRROR="https://cloud.r-project.org/"
 export PATH="$R_LIB_PATH/R/bin:$PATH"
 
 # installing precompiled R for Ubuntu
@@ -69,7 +69,7 @@ packages="c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat')"
 if [[ $OS_NAME == "macos" ]]; then
     packages+=", type = 'binary'"
 fi
-Rscript -e "install.packages(${packages})" || exit -1
+Rscript -e "install.packages(${packages}, repos = '${CRAN_MIRROR}')" || exit -1
 
 cd ${BUILD_DIRECTORY}
 Rscript build_r.R || exit -1

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -69,10 +69,10 @@ packages="c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat')"
 if [[ $OS_NAME == "macos" ]]; then
     packages+=", type = 'binary'"
 fi
-Rscript -e "install.packages(${packages}, repos = '${CRAN_MIRROR}')" || exit -1
+Rscript -e --vanilla "install.packages(${packages}, repos = '${CRAN_MIRROR}')" || exit -1
 
 cd ${BUILD_DIRECTORY}
-Rscript build_r.R || exit -1
+Rscript --vanilla build_r.R || exit -1
 
 PKG_TARBALL="lightgbm_${LGB_VER}.tar.gz"
 LOG_FILE_NAME="lightgbm.Rcheck/00check.log"

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -69,10 +69,10 @@ packages="c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat')"
 if [[ $OS_NAME == "macos" ]]; then
     packages+=", type = 'binary'"
 fi
-Rscript --vanilla -e "install.packages(${packages}, repos = '${CRAN_MIRROR}')" || exit -1
+Rscript --vanilla -e "install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}')" || exit -1
 
 cd ${BUILD_DIRECTORY}
-Rscript --vanilla build_r.R || exit -1
+Rscript build_r.R || exit -1
 
 PKG_TARBALL="lightgbm_${LGB_VER}.tar.gz"
 LOG_FILE_NAME="lightgbm.Rcheck/00check.log"


### PR DESCRIPTION
This fixes the issue we are seeing in Mac builds  across all PRs right now.

@StrikerRUS I know you tried a similar change in https://github.com/microsoft/LightGBM/pull/2949#issuecomment-605034139 and said it didn't work. I don't see anything obviously wrong with your approach, but I do know the change I'm suggesting in this PR works on my Mac.

Changes:

1. Change from RStudio CRAN mirror to  https://cloud.r-project.org/
2. Make that explicit, instead of relying on `.Rprofile`

Since  we only have one `install.packages()` call, I don't think we need to deal with the complexity of when and if the `.Rprofile` file gets sourced.

on my Mac: 

<img width="632" alt="Screen Shot 2020-03-27 at 10 23 28 AM" src="https://user-images.githubusercontent.com/7608904/77772023-78b56780-7015-11ea-8c34-74fff748b8ca.png">

My best  guess about what happened is:

1. R binaries for macOS became temporarily unavailable on CRAN
2. this broke whatever process mirrors them from CRAN's main repository to https//cran.rstudio.com
3. CRAN repository was still broken when @StrikerRUS tried it (see that comment above)
4. CRAN is now fixed so it succeeded for me
5. RStudio still hasn't caught up (maybe CRAN fixed the issue in a way that breaks RStudio's mirroring or something)

Even if that is true and a few hours from now the RStudio repo will be back up, I _still_ think this PR should be accepted. It removes unnecessary indirection (with `.Rprofile`) and points our builds at the real source of truth for R packages.