### PR TITLE
[R-package] [ci] Add option to skip installation in build_r.R

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -72,7 +72,7 @@ fi
 Rscript --vanilla -e "install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}')" || exit -1
 
 cd ${BUILD_DIRECTORY}
-Rscript build_r.R || exit -1
+Rscript build_r.R --skip-install || exit -1
 
 PKG_TARBALL="lightgbm_${LGB_VER}.tar.gz"
 LOG_FILE_NAME="lightgbm.Rcheck/00check.log"

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -69,7 +69,7 @@ packages="c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat')"
 if [[ $OS_NAME == "macos" ]]; then
     packages+=", type = 'binary'"
 fi
-Rscript --vanilla -e "install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}')" || exit -1
+Rscript --vanilla -e "install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
 
 cd ${BUILD_DIRECTORY}
 Rscript build_r.R --skip-install || exit -1

--- a/build_r.R
+++ b/build_r.R
@@ -5,6 +5,9 @@
 # Sys.setenv("CXX" = "/usr/local/bin/g++-8")
 # Sys.setenv("CC" = "/usr/local/bin/gcc-8")
 
+args <- commandArgs(trailingOnly=TRUE)
+INSTALL_AFTER_BUILD <- !("--skip-install" %in% args)
+
 # R returns FALSE (not a non-zero exit code) if a file copy operation
 # breaks. Let's fix that
 .handle_result <- function(res) {
@@ -86,4 +89,8 @@ version <- gsub(
 tarball <- file.path(getwd(), sprintf("lightgbm_%s.tar.gz", version))
 
 cmd <- sprintf("R CMD INSTALL %s --no-multiarch --with-keep.source", tarball)
-.run_shell_command(cmd)
+if (INSTALL_AFTER_BUILD){
+  .run_shell_command(cmd)
+} else  {
+  print(sprintf("Skipping installation. Install the package with command '%s'", cmd))
+}

--- a/build_r.R
+++ b/build_r.R
@@ -5,7 +5,7 @@
 # Sys.setenv("CXX" = "/usr/local/bin/g++-8")
 # Sys.setenv("CC" = "/usr/local/bin/gcc-8")
 
-args <- commandArgs(trailingOnly=TRUE)
+args <- commandArgs(trailingOnly = TRUE)
 INSTALL_AFTER_BUILD <- !("--skip-install" %in% args)
 
 # R returns FALSE (not a non-zero exit code) if a file copy operation
@@ -89,7 +89,7 @@ version <- gsub(
 tarball <- file.path(getwd(), sprintf("lightgbm_%s.tar.gz", version))
 
 cmd <- sprintf("R CMD INSTALL %s --no-multiarch --with-keep.source", tarball)
-if (INSTALL_AFTER_BUILD){
+if (INSTALL_AFTER_BUILD) {
   .run_shell_command(cmd)
 } else  {
   print(sprintf("Skipping installation. Install the package with command '%s'", cmd))

--- a/build_r.R
+++ b/build_r.R
@@ -5,11 +5,7 @@
 # Sys.setenv("CXX" = "/usr/local/bin/g++-8")
 # Sys.setenv("CC" = "/usr/local/bin/gcc-8")
 
-<<<<<<< HEAD
 args <- commandArgs(trailingOnly = TRUE)
-=======
-args <- commandArgs(trailingOnly=TRUE)
->>>>>>> [R-package] [ci] Add option to skip installation in build_r.R
 INSTALL_AFTER_BUILD <- !("--skip-install" %in% args)
 
 # R returns FALSE (not a non-zero exit code) if a file copy operation

--- a/build_r.R
+++ b/build_r.R
@@ -5,7 +5,11 @@
 # Sys.setenv("CXX" = "/usr/local/bin/g++-8")
 # Sys.setenv("CC" = "/usr/local/bin/gcc-8")
 
+<<<<<<< HEAD
 args <- commandArgs(trailingOnly = TRUE)
+=======
+args <- commandArgs(trailingOnly=TRUE)
+>>>>>>> [R-package] [ci] Add option to skip installation in build_r.R
 INSTALL_AFTER_BUILD <- !("--skip-install" %in% args)
 
 # R returns FALSE (not a non-zero exit code) if a file copy operation

--- a/build_r.R
+++ b/build_r.R
@@ -91,6 +91,6 @@ tarball <- file.path(getwd(), sprintf("lightgbm_%s.tar.gz", version))
 cmd <- sprintf("R CMD INSTALL %s --no-multiarch --with-keep.source", tarball)
 if (INSTALL_AFTER_BUILD) {
   .run_shell_command(cmd)
-} else  {
+} else {
   print(sprintf("Skipping installation. Install the package with command '%s'", cmd))
 }


### PR DESCRIPTION
Right now, `Rscript build_r.R` will build a source distribution of the R package and install it. In this PR, I propose an addition to the script to tell `build_r.R` to just build the package tarball but not install it.

This should allow us to cut a few minutes out of the `r-package` tasks in CI!

Right now we are doing this:

```
Rscript build_r.R
R CMD check lightgbm_*.tar.gz
```

That means we're building `lib_lightgbm` twice, without getting any extra testing benefit. In fact, I think that the scenario of checking a source tarball on a system where `lightgbm` hasn't been installed already is an even better test of the experience for our users!

Note that this PR won't change the existing behavior for anyone using  `build_r.R`. The default will still be to both build and install.