### PR TITLE
[SWIG][mmlspark] fix seg fault in LGBM_BoosterGetEvalNamesSWIG

### DIFF
--- a/swig/StringArray_API_extensions.i
+++ b/swig/StringArray_API_extensions.i
@@ -50,7 +50,7 @@
         API_OK_OR_NULL(LGBM_BoosterGetEvalNames(handle,
                                                 0, &eval_counts,
                                                 0, &string_size,
-                                                strings->data()));
+                                                nullptr));
 
         try {
             strings.reset(new StringArray(eval_counts, string_size));


### PR DESCRIPTION
fix seg fault in LGBM_BoosterGetEvalNamesSWIG