### PR TITLE
[ci] reduce duplication in Python Windows CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,10 +9,8 @@ environment:
   matrix:
     - COMPILER: MSVC
       TASK: python
-      CONDA_ENV: test-env
     - COMPILER: MINGW
       TASK: python
-      CONDA_ENV: test-env
 
 clone_depth: 5
 
@@ -21,6 +19,7 @@ install:
   - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%  # delete sh.exe from PATH (mingw32-make fix)
   - set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH%
   - set PYTHON_VERSION=%CONFIGURATION%
+  - set CONDA_ENV="test-env"
   - ps: >-
       switch ($env:PYTHON_VERSION) {
           "2.7" {$env:MINICONDA = "C:\Miniconda-x64"}
@@ -35,5 +34,4 @@ install:
 build: false
 
 test_script:
-  - conda init powershell
   - powershell.exe -ExecutionPolicy Bypass -File .\.ci\test_windows.ps1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,4 +36,4 @@ build: false
 
 test_script:
   - conda init powershell
-  - poowershell.exe -ExecutionPolicy Bypass -File .\.ci\test_windows.ps1
+  - powershell.exe -ExecutionPolicy Bypass -File .\.ci\test_windows.ps1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,4 +35,4 @@ build: false
 
 test_script:
   - conda init powershell
-  - powershell.exe -ExecutionPolicy Bypass -File $env:APPVEYOR_BUILD_FOLDER\.ci\test_windows.ps1
+  - powershell.exe -ExecutionPolicy Bypass -File %APPVEYOR_BUILD_FOLDER%\.ci\test_windows.ps1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,11 @@ configuration:  # a trick to construct a build matrix with multiple Python versi
 environment:
   matrix:
     - COMPILER: MSVC
+      TASK: appveyor-python
+      CONDA_ENV: test-env
     - COMPILER: MINGW
+      TASK: appveyor-python
+      CONDA_ENV: test-env
 
 clone_depth: 5
 
@@ -19,39 +23,17 @@ install:
   - set PYTHON_VERSION=%CONFIGURATION%
   - ps: >-
       switch ($env:PYTHON_VERSION) {
-          "2.7" {$env:MINICONDA = """C:\Miniconda-x64"""}
-          "3.5" {$env:MINICONDA = """C:\Miniconda35-x64"""}
-          "3.6" {$env:MINICONDA = """C:\Miniconda36-x64"""}
-          "3.7" {$env:MINICONDA = """C:\Miniconda37-x64"""}
-          default {$env:MINICONDA = """C:\Miniconda37-x64"""}
+          "2.7" {$env:MINICONDA = "C:\Miniconda-x64"}
+          "3.5" {$env:MINICONDA = "C:\Miniconda35-x64"}
+          "3.6" {$env:MINICONDA = "C:\Miniconda36-x64"}
+          "3.7" {$env:MINICONDA = "C:\Miniconda37-x64"}
+          default {$env:MINICONDA = "C:\Miniconda37-x64"}
       }
-  - set PATH=%MINICONDA%;%MINICONDA%\Scripts;%PATH%
+      $env:PATH="$env:MINICONDA;$env:MINICONDA\Scripts;$env:PATH"
   - ps: $env:LGB_VER = (Get-Content VERSION.txt).trim()
-  - activate
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q -y conda
-  - conda create -q -y -n test-env python=%PYTHON_VERSION% joblib matplotlib numpy pandas psutil pytest python-graphviz "scikit-learn<=0.21.3" scipy
-  - activate test-env
 
-build_script:
-  - cd %APPVEYOR_BUILD_FOLDER%\python-package
-  - IF "%COMPILER%"=="MINGW" (
-    python setup.py install --mingw)
-    ELSE (
-    python setup.py install)
+build: false
 
 test_script:
-  - pytest %APPVEYOR_BUILD_FOLDER%\tests\python_package_test
-  - cd %APPVEYOR_BUILD_FOLDER%\examples\python-guide
-  - ps: >-
-      @("import matplotlib", "matplotlib.use('Agg')") + (Get-Content "plot_example.py") | Set-Content "plot_example.py"  # prevent interactive window mode
-      (Get-Content "plot_example.py").replace('graph.render(view=True)', 'graph.render(view=False)') | Set-Content "plot_example.py"
-  - ps: >-
-      foreach ($file in @(Get-ChildItem *.py)) {
-        @("import sys, warnings", "warnings.showwarning = lambda message, category, filename, lineno, file=None, line=None: sys.stdout.write(warnings.formatwarning(message, category, filename, lineno, line))") + (Get-Content $file) | Set-Content $file
-        python $file
-        if (!$?) { $host.SetShouldExit(-1) }
-      }  # run all examples
-  - cd %APPVEYOR_BUILD_FOLDER%\examples\python-guide\notebooks
-  - conda install -q -y -n test-env ipywidgets notebook
-  - jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb  # run all notebooks
+  - conda init powershell
+  - poowershell.exe -ExecutionPolicy Bypass -File .\.ci\test_windows.ps1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,10 +29,10 @@ install:
           default {$env:MINICONDA = "C:\Miniconda37-x64"}
       }
       $env:PATH="$env:MINICONDA;$env:MINICONDA\Scripts;$env:PATH"
-  - ps: $env:LGB_VER = (Get-Content VERSION.txt).trim()
+  - ps: $env:LGB_VER = (Get-Content $env:APPVEYOR_BUILD_FOLDER\VERSION.txt).trim()
 
 build: false
 
 test_script:
   - conda init powershell
-  - powershell.exe -ExecutionPolicy Bypass -File .\.ci\test_windows.ps1
+  - powershell.exe -ExecutionPolicy Bypass -File $env:APPVEYOR_BUILD_FOLDER\.ci\test_windows.ps1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,4 +34,5 @@ install:
 build: false
 
 test_script:
+  - conda init powershell
   - powershell.exe -ExecutionPolicy Bypass -File .\.ci\test_windows.ps1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,10 +8,10 @@ configuration:  # a trick to construct a build matrix with multiple Python versi
 environment:
   matrix:
     - COMPILER: MSVC
-      TASK: appveyor-python
+      TASK: python
       CONDA_ENV: test-env
     - COMPILER: MINGW
-      TASK: appveyor-python
+      TASK: python
       CONDA_ENV: test-env
 
 clone_depth: 5

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -52,7 +52,7 @@ elseif ($env:TASK -eq "bdist") {
   if ($env:COMPILER -eq "MINGW") {
     python setup.py install --mingw ; Check-Output $?
   } else {
-    python setup.py install | Check-Output $?
+    python setup.py install ; Check-Output $?
   }
 }
 

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -17,7 +17,7 @@ conda init powershell
 conda activate
 conda config --set always_yes yes --set changeps1 no
 conda update -q -y conda
-conda create -q -y -n $env:CONDA_ENV python=$env:PYTHON_VERSION joblib matplotlib numpy pandas psutil pytest python-graphviz "scikit-learn<=0.21.3" scipy wheel ; Check-Output $?
+conda create -q -y -n $env:CONDA_ENV python=$env:PYTHON_VERSION joblib matplotlib numpy pandas psutil pytest python-graphviz "scikit-learn<=0.21.3" scipy ; Check-Output $?
 conda activate $env:CONDA_ENV
 
 if ($env:TASK -eq "regular") {

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -8,6 +8,7 @@ function Check-Output {
 
 # unify environment variables for Azure devops and AppVeyor
 if (Test-Path env:APPVEYOR) {
+  $env:APPVEYOR = "true"
   $env:BUILD_SOURCESDIRECTORY = $env:APPVEYOR_BUILD_FOLDER
 }
 
@@ -46,7 +47,7 @@ elseif ($env:TASK -eq "bdist") {
   python setup.py bdist_wheel --plat-name=win-amd64 --universal ; Check-Output $?
   cd dist; pip install @(Get-ChildItem *.whl) ; Check-Output $?
   cp @(Get-ChildItem *.whl) $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-} elseif ($env:TASK -eq "appveyor-python") {
+} elseif (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python")) {
   cd $env:BUILD_SOURCESDIRECTORY\python-package
   if ($env:COMPILER -eq "MINGW") {
     python setup.py install --mingw | Check-Output $?
@@ -55,10 +56,15 @@ elseif ($env:TASK -eq "bdist") {
   }
 }
 
-$tests = $env:BUILD_SOURCESDIRECTORY + $(If (($env:TASK -eq "sdist") -or ($env:TASK -eq "appveyor-python")) {"/tests/python_package_test"} Else {"/tests"})  # cannot test C API with "sdist" task
+if (($env:TASK -eq "sdist") -or (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python"))) {
+  $tests = $env:BUILD_SOURCESDIRECTORY + "/tests/python_package_test"
+} else {
+  # cannot test C API with "sdist" task
+  $tests = $env:BUILD_SOURCESDIRECTORY + "/tests"
+}
 pytest $tests ; Check-Output $?
 
-if (($env:TASK -eq "regular") -or ($env:TASK -eq "appveyor-python")) {
+if (($env:TASK -eq "regular") -or (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python"))) {
   cd $env:BUILD_SOURCESDIRECTORY/examples/python-guide
   @("import matplotlib", "matplotlib.use('Agg')") + (Get-Content "plot_example.py") | Set-Content "plot_example.py"
   (Get-Content "plot_example.py").replace('graph.render(view=True)', 'graph.render(view=False)') | Set-Content "plot_example.py"  # prevent interactive window mode

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -50,7 +50,7 @@ elseif ($env:TASK -eq "bdist") {
 } elseif (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python")) {
   cd $env:BUILD_SOURCESDIRECTORY\python-package
   if ($env:COMPILER -eq "MINGW") {
-    python setup.py install --mingw | Check-Output $?
+    python setup.py install --mingw ; Check-Output $?
   } else {
     python setup.py install | Check-Output $?
   }

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -134,6 +134,7 @@ jobs:
       Write-Host "##vso[task.setvariable variable=AZURE]true"
     displayName: 'Set Variables'
   - script: |
+      cmd /c "conda init powershell"
       cmd /c "powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/test_windows.ps1"
     displayName: Test
   - task: PublishBuildArtifacts@1

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -108,7 +108,7 @@ jobs:
   - task: PublishBuildArtifacts@1
     condition: and(succeeded(), in(variables['TASK'], 'regular', 'sdist', 'bdist'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
     inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)' 
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: PackageAssets
       artifactType: container
 ###########################################
@@ -129,11 +129,13 @@ jobs:
         TASK: bdist
         PYTHON_VERSION: 3.5
   steps:
-  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-    displayName: Enable conda
+  - powershell: |
+      Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+      Write-Host "##vso[task.setvariable variable=AZURE]true"
+    displayName: 'Set Variables'
   - script: |
-      cmd /c 'activate & conda config --set always_yes yes --set changeps1 no & conda update -q -y conda & conda create -q -y -n %CONDA_ENV% python=%PYTHON_VERSION% joblib matplotlib numpy pandas psutil pytest python-graphviz "scikit-learn<=0.21.3" scipy'
-      cmd /c "activate %CONDA_ENV% & powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/test_windows.ps1"
+      cmd /c "conda init powershell"
+      cmd /c "powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/test_windows.ps1"
     displayName: Test
   - task: PublishBuildArtifacts@1
     condition: and(succeeded(), in(variables['TASK'], 'regular', 'sdist', 'bdist'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -134,7 +134,6 @@ jobs:
       Write-Host "##vso[task.setvariable variable=AZURE]true"
     displayName: 'Set Variables'
   - script: |
-      cmd /c "conda init powershell"
       cmd /c "powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/test_windows.ps1"
     displayName: Test
   - task: PublishBuildArtifacts@1


### PR DESCRIPTION
Per discussion from https://github.com/microsoft/LightGBM/pull/2936#issuecomment-606720235. Right now some CI logic is duplicated in `.vsts-ci.yml` and `.appveyor.yml`. Similar to how we've centralized that logic for mac and linux builds in `.ci/` scripts, in this PR I propose cutting out that duplication and centralizing the logic in `.ci/tetst_windows.ps1`.

This should make it a little easier to make changes (such as changing our pegged version of scikit-learn whenever #2949 is merged) and should make #2936 easier to review.