### PR TITLE
[ci] upgrade to R 3.6.3 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,11 @@ before_install:
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
         export OS_NAME="macos";
         export COMPILER="gcc";
-        export R_MAC_VERSION=3.6.1;
+        export R_MAC_VERSION=3.6.3;
     else
         export OS_NAME="linux";
         export COMPILER="clang";
-        export R_TRAVIS_LINUX_VERSION=3.6.1-3bionic;
+        export R_TRAVIS_LINUX_VERSION=3.6.3-1bionic;
     fi
   - export CONDA="$HOME/miniconda"
   - export PATH="$CONDA/bin:$PATH"

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -99,7 +99,7 @@ jobs:
       echo "##vso[task.setvariable variable=CONDA]$CONDA"
       echo "##vso[task.prependpath]$CONDA/bin"
       echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_8_X64"
-      echo "##vso[task.setvariable variable=R_MAC_VERSION]3.6.1"
+      echo "##vso[task.setvariable variable=R_MAC_VERSION]3.6.3"
     displayName: 'Set variables'
   - bash: $(Build.SourcesDirectory)/.ci/setup.sh
     displayName: Setup


### PR DESCRIPTION
We currently test the R package against R 3.6.1,  a version from July 2019. In this PR, I'd like to propose we upgrade to R 3.6.3, the most recent version of the 3.x series.

I had this in #2936 but I think that PR will still take a few more rounds of reviews.

([list of R versions and release dates](https://cran.r-project.org/bin/windows/base/old/))