### PR TITLE
[ci][docs] downdrage sphinx and fix LaTeX error in R-package tests

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -38,10 +38,8 @@ if [[ $OS_NAME == "macos" ]]; then
     brew install qpdf
     brew cask install basictex
     export PATH="/Library/TeX/texbin:$PATH"
-
-    # Workaround for "/Library/TeX/texbin/tlmgr: unexpected return value from verify_checksum: -5"
-    # https://tug.org/pipermail/tex-live/2020-February/044772.html
-    curl -fsSL https://www.preining.info/rsa.asc | sudo tlmgr key add -
+    sudo tlmgr update --self
+    sudo tlmgr install inconsolata helvetic
 
     wget -q https://cran.r-project.org/bin/macosx/R-${R_MAC_VERSION}.pkg -O R.pkg
     sudo installer \
@@ -58,10 +56,6 @@ if [[ $OS_NAME == "macos" ]]; then
             /Library/Frameworks/R.framework/Versions/${R_MAJOR_MINOR}/Resources/lib/libomp.dylib
     fi
 fi
-
-# Fix "! LaTeX Error: File `inconsolata.sty' not found."
-sudo tlmgr update --self
-sudo tlmgr install inconsolata helvetic
 
 conda install \
     -y \

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -38,8 +38,8 @@ if [[ $OS_NAME == "macos" ]]; then
     brew install qpdf
     brew cask install basictex
     export PATH="/Library/TeX/texbin:$PATH"
-    sudo tlmgr update --self
-    sudo tlmgr install inconsolata helvetic
+    sudo tlmgr --verify-repo=none update --self
+    sudo tlmgr --verify-repo=none install inconsolata helvetic
 
     wget -q https://cran.r-project.org/bin/macosx/R-${R_MAC_VERSION}.pkg -O R.pkg
     sudo installer \

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -38,8 +38,10 @@ if [[ $OS_NAME == "macos" ]]; then
     brew install qpdf
     brew cask install basictex
     export PATH="/Library/TeX/texbin:$PATH"
-    sudo tlmgr update --self
-    sudo tlmgr install inconsolata helvetic
+
+    # Workaround for "/Library/TeX/texbin/tlmgr: unexpected return value from verify_checksum: -5"
+    # https://tug.org/pipermail/tex-live/2020-February/044772.html
+    curl -fsSL https://www.preining.info/rsa.asc | sudo tlmgr key add -
 
     wget -q https://cran.r-project.org/bin/macosx/R-${R_MAC_VERSION}.pkg -O R.pkg
     sudo installer \
@@ -56,6 +58,10 @@ if [[ $OS_NAME == "macos" ]]; then
             /Library/Frameworks/R.framework/Versions/${R_MAJOR_MINOR}/Resources/lib/libomp.dylib
     fi
 fi
+
+# Fix "! LaTeX Error: File `inconsolata.sty' not found."
+sudo tlmgr update --self
+sudo tlmgr install inconsolata helvetic
 
 conda install \
     -y \

--- a/docs/requirements_base.txt
+++ b/docs/requirements_base.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx < 3.0
 sphinx_rtd_theme >= 0.3
 mock; python_version < '3'


### PR DESCRIPTION
Fixed #2974.

While we are waiting new breathe release which will be compatible with sphinx 3, let's downgrade sphinx version to fix our CI.
Refer to https://github.com/michaeljones/breathe/pull/491.