### PR TITLE
[ci][docs] downgrade breathe

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 -r requirements_base.txt
-breathe
+breathe < 4.15


### PR DESCRIPTION
Temporary fix error in `master`:
```
ERROR: breathe 4.15.0 has requirement Sphinx>=3.0, but you'll have sphinx 2.4.4 which is incompatible.
```
Continuation of #2974.
New `breathe` version is still incompatible with Sphinx 3.
Refer to https://github.com/michaeljones/breathe/pull/491#issuecomment-610581862 and https://github.com/sphinx-doc/sphinx/issues/7423#issuecomment-610668512.