### PR TITLE
[R-package] Updated package metadata in DESCRIPTION

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -4,11 +4,11 @@ Title: Light Gradient Boosting Machine
 Version: 2.3.2
 Date: 2019-11-26
 Authors@R: c(
-	person("Guolin", "Ke", email = "guolin.ke@microsoft.com", role = c("aut", "cre")),
-	person("Damien", "Soukhavong", email = "damien.soukhavong@skema.edu", role = c("ctb")),
-	person("Yachen", "Yan", role = c("ctb")),
-	person("James", "Lamb", email="jaylamb20@gmail.com", role = c("ctb"))
-	)
+    person("Guolin", "Ke", email = "guolin.ke@microsoft.com", role = c("aut", "cre")),
+    person("Damien", "Soukhavong", email = "damien.soukhavong@skema.edu", role = c("ctb")),
+    person("Yachen", "Yan", role = c("ctb")),
+    person("James", "Lamb", email="jaylamb20@gmail.com", role = c("ctb"))
+    )
 Description: Tree based algorithms can be improved by introducing boosting frameworks. LightGBM is one such framework, and this package offers an R interface to work with it.
     It is designed to be distributed and efficient with the following advantages:
         1. Faster training speed and higher efficiency.
@@ -16,12 +16,14 @@ Description: Tree based algorithms can be improved by introducing boosting frame
         3. Better accuracy.
         4. Parallel learning supported.
         5. Capable of handling large-scale data.
-    In recognition of these advantages, LightGBM has being widely-used in many winning solutions of machine learning competitions.
+    In recognition of these advantages, LightGBM has been widely-used in many winning solutions of machine learning competitions.
     Comparison experiments on public datasets suggest that LightGBM can outperform existing boosting frameworks on both efficiency and accuracy, with significantly lower memory consumption. In addition, parallel experiments suggest that in certain circumstances, LightGBM can achieve a linear speed-up in training time by using multiple machines.
 Encoding: UTF-8
 License: MIT + file LICENSE
 URL: https://github.com/Microsoft/LightGBM
 BugReports: https://github.com/Microsoft/LightGBM/issues
+NeedsCompilation: yes
+Biarch: false
 Suggests:
     ggplot2 (>= 1.0.1),
     knitr,
@@ -37,4 +39,6 @@ Imports:
     Matrix (>= 1.1-0),
     methods,
     utils
+SystemRequirements:
+    C++11
 RoxygenNote: 7.0.2


### PR DESCRIPTION
I've been reading the `DESCRIPTION` section of [Writing R Extensions](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file), and found a few other fields we should be setting in our package metadata. I think this will help with #629 as well.

* changed tabs to spaces in author section of the DESCRIPTION
* fixed a minor typo in description of the package
* added `NeedsCompilation: yes`

> The ‘NeedsCompilation’ field should be set to "yes" if the package contains code which to be compiled, otherwise "no" (when the package could be installed from source on any platform without additional tools). This is used by install.packages(type = "both") in R >= 2.15.2 on platforms where binary packages are the norm: it is normally set by R CMD build or the repository assuming compilation is required if and only if the package has a src directory.

* added `Biarch: false`

> The ‘Biarch’ logical field is used on Windows to select the INSTALL option --force-biarch for this package.

> --force-biarch	attempt to build both architectures even if there is a non-empty configure.win

* added 'SystemRequirements: C++11'

> Packages without a src/Makevars or src/Makefile file may specify that they require C++11 for code in the src directory by including ‘C++11’ in the ‘SystemRequirements’ field of the DESCRIPTION file, e.g. SystemRequirements: C++11. If a package does have a src/Makevars[.win] file then setting the make variable ‘CXX_STD’ is preferred, as it allows R CMD SHLIB to work correctly in the package’s src directory.

When we add content to `Makevar[.win]` (I'm working on [that PR](https://github.com/jameslamb/LightGBM/pull/15) now actually), it will include `CXX_STD`. `SystemRequirements` is mostly a documentation field, similar to [trove classifiers](https://pypi.org/classifiers/) used in Python, so I still think it's worth having it.