### PR TITLE
[R-package] Removed unused constant in R_object_helper.h

### DIFF
--- a/include/LightGBM/R_object_helper.h
+++ b/include/LightGBM/R_object_helper.h
@@ -15,7 +15,6 @@
 
 #include <cstdint>
 
-#define TYPE_BITS 5
 // use .Internal(internalsID()) to uuid
 #define R_INTERNALS_UUID "2fdf6c18-697a-4ba7-b8ef-11c0d92f1327"
 


### PR DESCRIPTION
I noticed this constant `TYPE_BITS` defined in `R_object_helper.h`. It isn't used anywhere (`git grep TYPE_BITS`) so I think we can remove it.