### PR TITLE
adding sparse support to TreeSHAP in lightgbm

### DIFF
--- a/include/LightGBM/boosting.h
+++ b/include/LightGBM/boosting.h
@@ -166,10 +166,11 @@ class LIGHTGBM_EXPORT Boosting {
   * \brief Feature contributions for the model's prediction of one record
   * \param feature_values Feature value on this record
   * \param output Prediction result for this record
-  * \param early_stop Early stopping instance. If nullptr, no early stopping is applied and all models are evaluated.
   */
-  virtual void PredictContrib(const double* features, double* output,
-                              const PredictionEarlyStopInstance* early_stop) const = 0;
+  virtual void PredictContrib(const double* features, double* output) const = 0;
+
+  virtual void PredictContribByMap(const std::unordered_map<int, double>& features,
+                                   std::vector<std::unordered_map<int, double>>* output) const = 0;
 
   /*!
   * \brief Dump model to json format string

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -33,6 +33,9 @@ typedef void* BoosterHandle;  /*!< \brief Handle of booster. */
 #define C_API_PREDICT_LEAF_INDEX (2)  /*!< \brief Predict leaf index. */
 #define C_API_PREDICT_CONTRIB    (3)  /*!< \brief Predict feature contributions (SHAP values). */
 
+#define C_API_MATRIX_TYPE_CSR (0)  /*!< \brief CSR sparse matrix type. */
+#define C_API_MATRIX_TYPE_CSC (1)  /*!< \brief CSC sparse matrix type. */
+
 /*!
  * \brief Get string message of the last error.
  * \return Error information
@@ -743,31 +746,32 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSR(BoosterHandle handle,
                                                 double* out_result);
 
 /*!
- * \brief Make sparse prediction for a new dataset in CSR format.  Currently only used for feature contributions.
+ * \brief Make sparse prediction for a new dataset in CSR or CSC format.  Currently only used for feature contributions.
  * \note
  * The outputs are pre-allocated, as they can vary for each invocation, but the shape should be the same:
  *   - for feature contributions, the shape of sparse matrix will be ``num_class * num_data * (num_feature + 1)``.
  * The output indptr_type for the sparse matrix will be the same as the given input indptr_type.
  * \param handle Handle of booster
- * \param indptr Pointer to row headers
+ * \param indptr Pointer to row headers for CSR or col headers for CSC
  * \param indptr_type Type of ``indptr``, can be ``C_API_DTYPE_INT32`` or ``C_API_DTYPE_INT64``
- * \param indices Pointer to column indices
+ * \param indices Pointer to column indices for CSR or row indices for CSC
  * \param data Pointer to the data space
  * \param data_type Type of ``data`` pointer, can be ``C_API_DTYPE_FLOAT32`` or ``C_API_DTYPE_FLOAT64``
  * \param nindptr Number of rows in the matrix + 1
  * \param nelem Number of nonzero elements in the matrix
- * \param num_col Number of columns
+ * \param num_col_or_row Number of columns for CSR or number of rows for CSC
  * \param predict_type What should be predicted, only feature contributions supported currently
  *   - ``C_API_PREDICT_CONTRIB``: feature contributions (SHAP values)
  * \param num_iteration Number of iterations for prediction, <= 0 means no limit
  * \param parameter Other parameters for prediction, e.g. early stopping for prediction
+ * \param matrix_type The type of matrix that is input and output, 0 for CSR and 1 for CSC
  * \param[out] out_len Length of output indices and data
- * \param[out] out_indptr Pointer to output row headers
- * \param[out] out_indices Pointer to sparse indices
+ * \param[out] out_indptr Pointer to output row headers for CSR or col headers for CSC
+ * \param[out] out_indices Pointer to sparse column indices for CSR or row indices for CSC
  * \param[out] out_data Pointer to sparse data space
  * \return 0 when succeed, -1 when failure happens
  */
-LIGHTGBM_C_EXPORT int LGBM_BoosterPredictSparseForCSR(BoosterHandle handle,
+LIGHTGBM_C_EXPORT int LGBM_BoosterPredictSparseOutput(BoosterHandle handle,
                                                       const void* indptr,
                                                       int indptr_type,
                                                       const int32_t* indices,
@@ -775,10 +779,11 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictSparseForCSR(BoosterHandle handle,
                                                       int data_type,
                                                       int64_t nindptr,
                                                       int64_t nelem,
-                                                      int64_t num_col,
+                                                      int64_t num_col_or_row,
                                                       int predict_type,
                                                       int num_iteration,
                                                       const char* parameter,
+                                                      int matrix_type,
                                                       int64_t* out_len,
                                                       void** out_indptr,
                                                       int32_t** out_indices,
@@ -879,48 +884,6 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSC(BoosterHandle handle,
                                                 const char* parameter,
                                                 int64_t* out_len,
                                                 double* out_result);
-
-/*!
- * \brief Make sparse prediction for a new dataset in CSC format.  Currently only used for feature contributions.
- * \note
- * The outputs are pre-allocated, as they can vary for each invocation, but the shape should be the same:
- *   - for feature contributions, the shape of sparse matrix will be ``num_class * num_data * (num_feature + 1)``.
- * The output indptr_type for the sparse matrix will be the same as the given input indptr_type.
- * \param handle Handle of booster
- * \param col_ptr Pointer to column headers
- * \param col_ptr_type Type of ``col_ptr``, can be ``C_API_DTYPE_INT32`` or ``C_API_DTYPE_INT64``
- * \param indices Pointer to row indices
- * \param data Pointer to the data space
- * \param data_type Type of ``data`` pointer, can be ``C_API_DTYPE_FLOAT32`` or ``C_API_DTYPE_FLOAT64``
- * \param ncol_ptr Number of columns in the matrix + 1
- * \param nelem Number of nonzero elements in the matrix
- * \param num_row Number of rows
- * \param predict_type What should be predicted
- *   - ``C_API_PREDICT_CONTRIB``: feature contributions (SHAP values)
- * \param num_iteration Number of iteration for prediction, <= 0 means no limit
- * \param parameter Other parameters for prediction, e.g. early stopping for prediction
- * \param[out] out_len Length of output indices and data
- * \param[out] out_col_ptr Pointer to output column headers
- * \param[out] out_indices Pointer to sparse indices
- * \param[out] out_data Pointer to sparse data space
- * \return 0 when succeed, -1 when failure happens
- */
-LIGHTGBM_C_EXPORT int LGBM_BoosterPredictSparseForCSC(BoosterHandle handle,
-                                                      const void* col_ptr,
-                                                      int col_ptr_type,
-                                                      const int32_t* indices,
-                                                      const void* data,
-                                                      int data_type,
-                                                      int64_t ncol_ptr,
-                                                      int64_t nelem,
-                                                      int64_t num_row,
-                                                      int predict_type,
-                                                      int num_iteration,
-                                                      const char* parameter,
-                                                      int64_t* out_len,
-                                                      void** out_col_ptr,
-                                                      int32_t** out_indices,
-                                                      void** out_data);
 
 /*!
  * \brief Make prediction for a new dataset.

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -746,13 +746,14 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSR(BoosterHandle handle,
                                                 double* out_result);
 
 /*!
- * \brief Make sparse prediction for a new dataset in CSR or CSC format.  Currently only used for feature contributions.
+ * \brief Make sparse prediction for a new dataset in CSR or CSC format. Currently only used for feature contributions.
  * \note
  * The outputs are pre-allocated, as they can vary for each invocation, but the shape should be the same:
  *   - for feature contributions, the shape of sparse matrix will be ``num_class * num_data * (num_feature + 1)``.
  * The output indptr_type for the sparse matrix will be the same as the given input indptr_type.
+ * Call ``LGBM_BoosterFreePredictSparse`` to deallocate resources.
  * \param handle Handle of booster
- * \param indptr Pointer to row headers for CSR or col headers for CSC
+ * \param indptr Pointer to row headers for CSR or column headers for CSC
  * \param indptr_type Type of ``indptr``, can be ``C_API_DTYPE_INT32`` or ``C_API_DTYPE_INT64``
  * \param indices Pointer to column indices for CSR or row indices for CSC
  * \param data Pointer to the data space
@@ -764,9 +765,9 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSR(BoosterHandle handle,
  *   - ``C_API_PREDICT_CONTRIB``: feature contributions (SHAP values)
  * \param num_iteration Number of iterations for prediction, <= 0 means no limit
  * \param parameter Other parameters for prediction, e.g. early stopping for prediction
- * \param matrix_type The type of matrix that is input and output, 0 for CSR and 1 for CSC
+ * \param matrix_type Type of matrix input and output, can be ``C_API_MATRIX_TYPE_CSR`` or ``C_API_MATRIX_TYPE_CSC``
  * \param[out] out_len Length of output indices and data
- * \param[out] out_indptr Pointer to output row headers for CSR or col headers for CSC
+ * \param[out] out_indptr Pointer to output row headers for CSR or column headers for CSC
  * \param[out] out_indices Pointer to sparse column indices for CSR or row indices for CSC
  * \param[out] out_data Pointer to sparse data space
  * \return 0 when succeed, -1 when failure happens
@@ -790,8 +791,8 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictSparseOutput(BoosterHandle handle,
                                                       void** out_data);
 
 /*!
- * \brief Method corresponding to LGBM_BoosterPredictSparseForCSR to free the allocated data.
- * \param indptr Pointer to output row headers or col headers to be deallocated
+ * \brief Method corresponding to ``LGBM_BoosterPredictSparseOutput`` to free the allocated data.
+ * \param indptr Pointer to output row headers or column headers to be deallocated
  * \param indices Pointer to sparse indices to be deallocated
  * \param data Pointer to sparse data space to be deallocated
  * \param indptr_type Type of ``indptr``, can be ``C_API_DTYPE_INT32`` or ``C_API_DTYPE_INT64``

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -743,6 +743,59 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSR(BoosterHandle handle,
                                                 double* out_result);
 
 /*!
+ * \brief Make sparse prediction for a new dataset in CSR format.  Currently only used for feature contributions.
+ * \note
+ * The outputs are pre-allocated, as they can vary for each invocation, but the shape should be the same:
+ *   - for feature contributions, the shape of sparse matrix will be ``num_class * num_data * (num_feature + 1)``.
+ * The output indptr_type for the sparse matrix will be the same as the given input indptr_type.
+ * \param handle Handle of booster
+ * \param indptr Pointer to row headers
+ * \param indptr_type Type of ``indptr``, can be ``C_API_DTYPE_INT32`` or ``C_API_DTYPE_INT64``
+ * \param indices Pointer to column indices
+ * \param data Pointer to the data space
+ * \param data_type Type of ``data`` pointer, can be ``C_API_DTYPE_FLOAT32`` or ``C_API_DTYPE_FLOAT64``
+ * \param nindptr Number of rows in the matrix + 1
+ * \param nelem Number of nonzero elements in the matrix
+ * \param num_col Number of columns
+ * \param predict_type What should be predicted, only feature contributions supported currently
+ *   - ``C_API_PREDICT_CONTRIB``: feature contributions (SHAP values)
+ * \param num_iteration Number of iterations for prediction, <= 0 means no limit
+ * \param parameter Other parameters for prediction, e.g. early stopping for prediction
+ * \param[out] out_len Length of output indices and data
+ * \param[out] out_indptr Pointer to output row headers
+ * \param[out] out_indices Pointer to sparse indices
+ * \param[out] out_data Pointer to sparse data space
+ * \return 0 when succeed, -1 when failure happens
+ */
+LIGHTGBM_C_EXPORT int LGBM_BoosterPredictSparseForCSR(BoosterHandle handle,
+                                                      const void* indptr,
+                                                      int indptr_type,
+                                                      const int32_t* indices,
+                                                      const void* data,
+                                                      int data_type,
+                                                      int64_t nindptr,
+                                                      int64_t nelem,
+                                                      int64_t num_col,
+                                                      int predict_type,
+                                                      int num_iteration,
+                                                      const char* parameter,
+                                                      int64_t* out_len,
+                                                      void** out_indptr,
+                                                      int32_t** out_indices,
+                                                      void** out_data);
+
+/*!
+ * \brief Method corresponding to LGBM_BoosterPredictSparseForCSR to free the allocated data.
+ * \param indptr Pointer to output row headers or col headers to be deallocated
+ * \param indices Pointer to sparse indices to be deallocated
+ * \param data Pointer to sparse data space to be deallocated
+ * \param indptr_type Type of ``indptr``, can be ``C_API_DTYPE_INT32`` or ``C_API_DTYPE_INT64``
+ * \param data_type Type of ``data`` pointer, can be ``C_API_DTYPE_FLOAT32`` or ``C_API_DTYPE_FLOAT64``
+ * \return 0 when succeed, -1 when failure happens
+ */
+LIGHTGBM_C_EXPORT int LGBM_BoosterFreePredictSparse(void* indptr, int32_t* indices, void* data, int indptr_type, int data_type);
+
+/*!
  * \brief Make prediction for a new dataset in CSR format. This method re-uses the internal predictor structure
  *        from previous calls and is optimized for single row invocation.
  * \note
@@ -826,6 +879,48 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictForCSC(BoosterHandle handle,
                                                 const char* parameter,
                                                 int64_t* out_len,
                                                 double* out_result);
+
+/*!
+ * \brief Make sparse prediction for a new dataset in CSC format.  Currently only used for feature contributions.
+ * \note
+ * The outputs are pre-allocated, as they can vary for each invocation, but the shape should be the same:
+ *   - for feature contributions, the shape of sparse matrix will be ``num_class * num_data * (num_feature + 1)``.
+ * The output indptr_type for the sparse matrix will be the same as the given input indptr_type.
+ * \param handle Handle of booster
+ * \param col_ptr Pointer to column headers
+ * \param col_ptr_type Type of ``col_ptr``, can be ``C_API_DTYPE_INT32`` or ``C_API_DTYPE_INT64``
+ * \param indices Pointer to row indices
+ * \param data Pointer to the data space
+ * \param data_type Type of ``data`` pointer, can be ``C_API_DTYPE_FLOAT32`` or ``C_API_DTYPE_FLOAT64``
+ * \param ncol_ptr Number of columns in the matrix + 1
+ * \param nelem Number of nonzero elements in the matrix
+ * \param num_row Number of rows
+ * \param predict_type What should be predicted
+ *   - ``C_API_PREDICT_CONTRIB``: feature contributions (SHAP values)
+ * \param num_iteration Number of iteration for prediction, <= 0 means no limit
+ * \param parameter Other parameters for prediction, e.g. early stopping for prediction
+ * \param[out] out_len Length of output indices and data
+ * \param[out] out_col_ptr Pointer to output column headers
+ * \param[out] out_indices Pointer to sparse indices
+ * \param[out] out_data Pointer to sparse data space
+ * \return 0 when succeed, -1 when failure happens
+ */
+LIGHTGBM_C_EXPORT int LGBM_BoosterPredictSparseForCSC(BoosterHandle handle,
+                                                      const void* col_ptr,
+                                                      int col_ptr_type,
+                                                      const int32_t* indices,
+                                                      const void* data,
+                                                      int data_type,
+                                                      int64_t ncol_ptr,
+                                                      int64_t nelem,
+                                                      int64_t num_row,
+                                                      int predict_type,
+                                                      int num_iteration,
+                                                      const char* parameter,
+                                                      int64_t* out_len,
+                                                      void** out_col_ptr,
+                                                      int32_t** out_indices,
+                                                      void** out_data);
 
 /*!
  * \brief Make prediction for a new dataset.

--- a/include/LightGBM/meta.h
+++ b/include/LightGBM/meta.h
@@ -5,9 +5,9 @@
 #ifndef LIGHTGBM_META_H_
 #define LIGHTGBM_META_H_
 
-#include <limits>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <unordered_map>
 #include <utility>

--- a/include/LightGBM/meta.h
+++ b/include/LightGBM/meta.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <unordered_map>
 
 #if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64))) || defined(__INTEL_COMPILER) || MM_PREFETCH
   #include <xmmintrin.h>
@@ -57,6 +58,9 @@ typedef int32_t comm_size_t;
 
 using PredictFunction =
 std::function<void(const std::vector<std::pair<int, double>>&, double* output)>;
+
+using PredictSparseFunction =
+std::function<void(const std::vector<std::pair<int, double>>&, std::vector<std::unordered_map<int, double>>* output)>;
 
 typedef void(*ReduceFunction)(const char* input, char* output, int type_size, comm_size_t array_size);
 

--- a/include/LightGBM/meta.h
+++ b/include/LightGBM/meta.h
@@ -9,9 +9,9 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <unordered_map>
 #include <utility>
 #include <vector>
-#include <unordered_map>
 
 #if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64))) || defined(__INTEL_COMPILER) || MM_PREFETCH
   #include <xmmintrin.h>

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -136,6 +136,8 @@ class Tree {
   inline int PredictLeafIndexByMap(const std::unordered_map<int, double>& feature_values) const;
 
   inline void PredictContrib(const double* feature_values, int num_features, double* output);
+  inline void PredictContribByMap(const std::unordered_map<int, double>& feature_values,
+                                  int num_features, std::unordered_map<int, double>* output);
 
   /*! \brief Get Number of leaves*/
   inline int num_leaves() const { return num_leaves_; }
@@ -387,6 +389,12 @@ class Tree {
                 PathElement *parent_unique_path, double parent_zero_fraction,
                 double parent_one_fraction, int parent_feature_index) const;
 
+  void TreeSHAPByMap(const std::unordered_map<int, double>& feature_values,
+                     std::unordered_map<int, double>* phi,
+                     int node, int unique_depth,
+                     PathElement *parent_unique_path, double parent_zero_fraction,
+                     double parent_one_fraction, int parent_feature_index) const;
+
   /*! \brief Extend our decision path with a fraction of one and zero extensions for TreeSHAP*/
   static void ExtendPath(PathElement *unique_path, int unique_depth,
                          double zero_fraction, double one_fraction, int feature_index);
@@ -536,6 +544,18 @@ inline void Tree::PredictContrib(const double* feature_values, int num_features,
     const int max_path_len = max_depth_ + 1;
     std::vector<PathElement> unique_path_data(max_path_len*(max_path_len + 1) / 2);
     TreeSHAP(feature_values, output, 0, 0, unique_path_data.data(), 1, 1, -1);
+  }
+}
+
+inline void Tree::PredictContribByMap(const std::unordered_map<int, double>& feature_values,
+                                      int num_features, std::unordered_map<int, double>* output) {
+  (*output)[num_features] += ExpectedValue();
+  // Run the recursion with preallocated space for the unique path data
+  if (num_leaves_ > 1) {
+    CHECK_GE(max_depth_, 0);
+    const int max_path_len = max_depth_ + 1;
+    std::vector<PathElement> unique_path_data(max_path_len*(max_path_len + 1) / 2);
+    TreeSHAPByMap(feature_values, output, 0, 0, unique_path_data.data(), 1, 1, -1);
   }
 }
 

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -538,7 +538,8 @@ class _InnerPredictor(object):
         Returns
         -------
         result : numpy array, scipy.sparse or list of scipy.sparse
-            Prediction result, can be sparse for feature contributions (when ``pred_contrib=True``).
+            Prediction result.
+            Can be sparse or a list of sparse objects (each element represents predictions for one class) for feature contributions (when ``pred_contrib=True``).
         """
         if isinstance(data, Dataset):
             raise TypeError("Cannot use Dataset instance for prediction, please use raw data instead")
@@ -2817,7 +2818,8 @@ class Booster(object):
         Returns
         -------
         result : numpy array, scipy.sparse or list of scipy.sparse
-            Prediction result, can be sparse for feature contributions (when ``pred_contrib=True``).
+            Prediction result.
+            Can be sparse or a list of sparse objects (each element represents predictions for one class) for feature contributions (when ``pred_contrib=True``).
         """
         predictor = self._to_predictor(copy.deepcopy(kwargs))
         if num_iteration is None:

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -842,11 +842,11 @@ class _InnerPredictor(object):
             nrow = csc.shape[0]
             return matrices, nrow
 
-        if predict_type == C_API_PREDICT_CONTRIB:
-            return inner_predict_sparse(csc, num_iteration, predict_type)
         nrow = csc.shape[0]
         if nrow > MAX_INT32:
             return self.__pred_for_csr(csc.tocsr(), num_iteration, predict_type)
+        if predict_type == C_API_PREDICT_CONTRIB:
+            return inner_predict_sparse(csc, num_iteration, predict_type)
         n_preds = self.__get_num_preds(num_iteration, nrow, predict_type)
         preds = np.zeros(n_preds, dtype=np.float64)
         out_num_preds = ctypes.c_int64(0)

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -591,7 +591,8 @@ class _InnerPredictor(object):
             preds, nrow = self.__pred_for_csr(csr, num_iteration, predict_type)
         if pred_leaf:
             preds = preds.astype(np.int32)
-        if is_reshape and preds.size != nrow:
+        is_sparse = scipy.sparse.issparse(preds) or isinstance(preds, list)
+        if is_reshape and not is_sparse and preds.size != nrow:
             if preds.size % nrow == 0:
                 preds = preds.reshape(nrow, -1)
             else:

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, print_function
 import copy
 import ctypes
 import os
-import sys
 import warnings
 from tempfile import NamedTemporaryFile
 from collections import OrderedDict
@@ -538,8 +537,8 @@ class _InnerPredictor(object):
 
         Returns
         -------
-        result : numpy array or scipy.sparse or list[scipy.sparse]
-            Prediction result, can be sparse for feature contributions (when pred_contrib=True).
+        result : numpy array, scipy.sparse or list of scipy.sparse
+            Prediction result, can be sparse for feature contributions (when ``pred_contrib=True``).
         """
         if isinstance(data, Dataset):
             raise TypeError("Cannot use Dataset instance for prediction, please use raw data instead")
@@ -703,7 +702,7 @@ class _InnerPredictor(object):
                 cs_output_matrices.append(scipy.sparse.csr_matrix((cs_data, cs_indices, cs_indptr), cs_shape))
             else:
                 cs_output_matrices.append(scipy.sparse.csc_matrix((cs_data, cs_indices, cs_indptr), cs_shape))
-            # free the temporary native indptr, indices, and data
+        # free the temporary native indptr, indices, and data
         _safe_call(_LIB.LGBM_BoosterFreePredictSparse(out_ptr_indptr, out_ptr_indices, out_ptr_data,
                                                       ctypes.c_int(indptr_type), ctypes.c_int(data_type)))
         if len(cs_output_matrices) == 1:
@@ -2816,8 +2815,8 @@ class Booster(object):
 
         Returns
         -------
-        result : numpy array
-            Prediction result.
+        result : numpy array, scipy.sparse or list of scipy.sparse
+            Prediction result, can be sparse for feature contributions (when ``pred_contrib=True``).
         """
         predictor = self._to_predictor(copy.deepcopy(kwargs))
         if num_iteration is None:

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -648,7 +648,7 @@ class LGBMModel(_LGBMModelBase):
             The predicted values.
         X_leaves : array-like of shape = [n_samples, n_trees] or shape = [n_samples, n_trees * n_classes]
             If ``pred_leaf=True``, the predicted leaf of every tree for each sample.
-        X_SHAP_values : array-like of shape = [n_samples, n_features + 1] or shape = [n_samples, (n_features + 1) * n_classes] or list of such objects
+        X_SHAP_values : array-like of shape = [n_samples, n_features + 1] or shape = [n_samples, (n_features + 1) * n_classes] or list with n_classes length of such objects
             If ``pred_contrib=True``, the feature contributions for each sample.
         """
         if self._n_features is None:
@@ -873,7 +873,7 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
             The predicted probability for each class for each sample.
         X_leaves : array-like of shape = [n_samples, n_trees * n_classes]
             If ``pred_leaf=True``, the predicted leaf of every tree for each sample.
-        X_SHAP_values : array-like of shape = [n_samples, (n_features + 1) * n_classes] or list of such objects
+        X_SHAP_values : array-like of shape = [n_samples, (n_features + 1) * n_classes] or list with n_classes length of such objects
             If ``pred_contrib=True``, the feature contributions for each sample.
         """
         result = super(LGBMClassifier, self).predict(X, raw_score, num_iteration,

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -648,7 +648,7 @@ class LGBMModel(_LGBMModelBase):
             The predicted values.
         X_leaves : array-like of shape = [n_samples, n_trees] or shape = [n_samples, n_trees * n_classes]
             If ``pred_leaf=True``, the predicted leaf of every tree for each sample.
-        X_SHAP_values : array-like of shape = [n_samples, n_features + 1] or shape = [n_samples, (n_features + 1) * n_classes]
+        X_SHAP_values : array-like of shape = [n_samples, n_features + 1] or shape = [n_samples, (n_features + 1) * n_classes] or list of such objects
             If ``pred_contrib=True``, the feature contributions for each sample.
         """
         if self._n_features is None:
@@ -873,7 +873,7 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
             The predicted probability for each class for each sample.
         X_leaves : array-like of shape = [n_samples, n_trees * n_classes]
             If ``pred_leaf=True``, the predicted leaf of every tree for each sample.
-        X_SHAP_values : array-like of shape = [n_samples, (n_features + 1) * n_classes]
+        X_SHAP_values : array-like of shape = [n_samples, (n_features + 1) * n_classes] or list of such objects
             If ``pred_contrib=True``, the feature contributions for each sample.
         """
         result = super(LGBMClassifier, self).predict(X, raw_score, num_iteration,

--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -570,8 +570,7 @@ const double* GBDT::GetTrainingScore(int64_t* out_len) {
   return train_score_updater_->score();
 }
 
-void GBDT::PredictContrib(const double* features, double* output, const PredictionEarlyStopInstance* early_stop) const {
-  int early_stop_round_counter = 0;
+void GBDT::PredictContrib(const double* features, double* output) const {
   // set zero
   const int num_features = max_feature_idx_ + 1;
   std::memset(output, 0, sizeof(double) * num_tree_per_iteration_ * (num_features + 1));
@@ -580,13 +579,16 @@ void GBDT::PredictContrib(const double* features, double* output, const Predicti
     for (int k = 0; k < num_tree_per_iteration_; ++k) {
       models_[i * num_tree_per_iteration_ + k]->PredictContrib(features, num_features, output + k*(num_features + 1));
     }
-    // check early stopping
-    ++early_stop_round_counter;
-    if (early_stop->round_period == early_stop_round_counter) {
-      if (early_stop->callback_function(output, num_tree_per_iteration_)) {
-        return;
-      }
-      early_stop_round_counter = 0;
+  }
+}
+
+void GBDT::PredictContribByMap(const std::unordered_map<int, double>& features,
+                               std::vector<std::unordered_map<int, double>>* output) const {
+  const int num_features = max_feature_idx_ + 1;
+  for (int i = 0; i < num_iteration_for_pred_; ++i) {
+    // predict all the trees for one iteration
+    for (int k = 0; k < num_tree_per_iteration_; ++k) {
+      models_[i * num_tree_per_iteration_ + k]->PredictContribByMap(features, num_features, &((*output)[k]));
     }
   }
 }

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -210,18 +210,18 @@ class GBDT : public GBDTBase {
   * \return number of prediction
   */
   inline int NumPredictOneRow(int num_iteration, bool is_pred_leaf, bool is_pred_contrib) const override {
-    int num_preb_in_one_row = num_class_;
+    int num_pred_in_one_row = num_class_;
     if (is_pred_leaf) {
       int max_iteration = GetCurrentIteration();
       if (num_iteration > 0) {
-        num_preb_in_one_row *= static_cast<int>(std::min(max_iteration, num_iteration));
+        num_pred_in_one_row *= static_cast<int>(std::min(max_iteration, num_iteration));
       } else {
-        num_preb_in_one_row *= max_iteration;
+        num_pred_in_one_row *= max_iteration;
       }
     } else if (is_pred_contrib) {
-      num_preb_in_one_row = num_tree_per_iteration_ * (max_feature_idx_ + 2);  // +1 for 0-based indexing, +1 for baseline
+      num_pred_in_one_row = num_tree_per_iteration_ * (max_feature_idx_ + 2);  // +1 for 0-based indexing, +1 for baseline
     }
-    return num_preb_in_one_row;
+    return num_pred_in_one_row;
   }
 
   void PredictRaw(const double* features, double* output,
@@ -240,8 +240,10 @@ class GBDT : public GBDTBase {
 
   void PredictLeafIndexByMap(const std::unordered_map<int, double>& features, double* output) const override;
 
-  void PredictContrib(const double* features, double* output,
-                      const PredictionEarlyStopInstance* earlyStop) const override;
+  void PredictContrib(const double* features, double* output) const override;
+
+  void PredictContribByMap(const std::unordered_map<int, double>& features,
+                           std::vector<std::unordered_map<int, double>>* output) const override;
 
   /*!
   * \brief Dump model to json format string

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -433,7 +433,7 @@ class Booster {
     *out_len = num_pred_in_one_row * nrow;
   }
 
-  void PredictSparse(int num_iteration, int predict_type, int nrow, int ncol,
+  void PredictSparse(int num_iteration, int predict_type, int64_t nrow, int ncol,
                      std::function<std::vector<std::pair<int, double>>(int row_idx)> get_row_fun,
                      const Config& config, int* out_elements_size,
                      std::vector<std::vector<std::unordered_map<int, double>>>* agg_ptr,
@@ -475,7 +475,7 @@ class Booster {
     *out_indices = new int32_t[elements_size];
   }
 
-  void PredictSparseCSR(int num_iteration, int predict_type, int nrow, int ncol,
+  void PredictSparseCSR(int num_iteration, int predict_type, int64_t nrow, int ncol,
                         std::function<std::vector<std::pair<int, double>>(int row_idx)> get_row_fun,
                         const Config& config,
                         int64_t* out_len, void** out_indptr, int indptr_type,
@@ -485,7 +485,7 @@ class Booster {
     int num_matrices = boosting_->NumModelPerIteration();
     bool is_indptr_int32 = false;
     bool is_data_float32 = false;
-    int indptr_size = (nrow + 1) * num_matrices;
+    int64_t indptr_size = (nrow + 1) * num_matrices;
     if (indptr_type == C_API_DTYPE_INT32) {
       *out_indptr = new int32_t[indptr_size];
       is_indptr_int32 = true;
@@ -560,7 +560,7 @@ class Booster {
   }
 
 
-  void PredictSparseCSC(int num_iteration, int predict_type, int nrow, int ncol,
+  void PredictSparseCSC(int num_iteration, int predict_type, int64_t nrow, int ncol,
                         std::function<std::vector<std::pair<int, double>>(int row_idx)> get_row_fun,
                         const Config& config,
                         int64_t* out_len, void** out_col_ptr, int col_ptr_type,
@@ -1801,7 +1801,7 @@ int LGBM_BoosterPredictSparseOutput(BoosterHandle handle,
       Log::Fatal("The number of columns should be smaller than INT32_MAX.");
     }
     auto get_row_fun = RowFunctionFromCSR(indptr, indptr_type, indices, data, data_type, nindptr, nelem);
-    int nrow = static_cast<int>(nindptr - 1);
+    int64_t nrow = nindptr - 1;
     ref_booster->PredictSparseCSR(num_iteration, predict_type, nrow, static_cast<int>(num_col_or_row), get_row_fun,
                                   config, out_len, out_indptr, indptr_type, out_indices, out_data, data_type);
   } else if (matrix_type == C_API_MATRIX_TYPE_CSC) {
@@ -1826,7 +1826,7 @@ int LGBM_BoosterPredictSparseOutput(BoosterHandle handle,
       }
       return one_row;
     };
-    ref_booster->PredictSparseCSC(num_iteration, predict_type, static_cast<int>(num_col_or_row), ncol, get_row_fun, config,
+    ref_booster->PredictSparseCSC(num_iteration, predict_type, num_col_or_row, ncol, get_row_fun, config,
                                   out_len, out_indptr, indptr_type, out_indices, out_data, data_type);
   } else {
     Log::Fatal("Unknown matrix type in LGBM_BoosterPredictSparseOutput");

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -546,7 +546,7 @@ class Booster {
         }
         int64_t indptr_value = row_matrix_offsets[row_start_index] + row_sizes[row_start_index];
         if (is_indptr_int32) {
-          (reinterpret_cast<int32_t*>(*out_indptr))[indptr_loop_index] = indptr_value;
+          (reinterpret_cast<int32_t*>(*out_indptr))[indptr_loop_index] = static_cast<int32_t>(indptr_value);
         } else {
           (reinterpret_cast<int64_t*>(*out_indptr))[indptr_loop_index] = indptr_value;
         }
@@ -611,7 +611,7 @@ class Booster {
       column_start_indices[m] = std::vector<int64_t>(num_output_cols, 0);
       column_counts[m] = std::vector<int64_t>(num_output_cols, 0);
       if (is_col_ptr_int32) {
-        (reinterpret_cast<int32_t*>(*out_col_ptr))[col_ptr_index] = col_ptr_value;
+        (reinterpret_cast<int32_t*>(*out_col_ptr))[col_ptr_index] = static_cast<int32_t>(col_ptr_value);
       } else {
         (reinterpret_cast<int64_t*>(*out_col_ptr))[col_ptr_index] = col_ptr_value;
       }
@@ -619,7 +619,7 @@ class Booster {
       for (int64_t i = 1; i < static_cast<int64_t>(column_sizes[m].size()); ++i) {
         column_start_indices[m][i] = column_sizes[m][i - 1] + column_start_indices[m][i - 1];
         if (is_col_ptr_int32) {
-          (reinterpret_cast<int32_t*>(*out_col_ptr))[col_ptr_index] = column_start_indices[m][i];
+          (reinterpret_cast<int32_t*>(*out_col_ptr))[col_ptr_index] = static_cast<int32_t>(column_start_indices[m][i]);
         } else {
           (reinterpret_cast<int64_t*>(*out_col_ptr))[col_ptr_index] = column_start_indices[m][i];
         }
@@ -629,7 +629,7 @@ class Booster {
       int64_t last_column_start_index = column_start_indices[m][last_elem_index];
       int64_t last_column_size = column_sizes[m][last_elem_index];
       if (is_col_ptr_int32) {
-        (reinterpret_cast<int32_t*>(*out_col_ptr))[col_ptr_index] = last_column_start_index + last_column_size;
+        (reinterpret_cast<int32_t*>(*out_col_ptr))[col_ptr_index] = static_cast<int32_t>(last_column_start_index + last_column_size);
       } else {
         (reinterpret_cast<int64_t*>(*out_col_ptr))[col_ptr_index] = last_column_start_index + last_column_size;
       }
@@ -648,7 +648,7 @@ class Booster {
             matrix_start_indices[m] +
             column_counts[m][col_idx];
           // store the row index
-          (*out_indices)[element_index] = i;
+          (*out_indices)[element_index] = static_cast<int32_t>(i);
           // update column count
           column_counts[m][col_idx]++;
           if (is_data_float32) {
@@ -1819,7 +1819,7 @@ int LGBM_BoosterPredictSparseOutput(BoosterHandle handle,
       one_row.reserve(ncol);
       const int tid = omp_get_thread_num();
       for (int j = 0; j < ncol; ++j) {
-        auto val = iterators[tid][j].Get(i);
+        auto val = iterators[tid][j].Get(static_cast<int>(i));
         if (std::fabs(val) > kZeroThreshold || std::isnan(val)) {
           one_row.emplace_back(j, val);
         }

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -454,9 +454,9 @@ class Booster {
     OMP_THROW_EX();
     // calculate the nonzero data and indices size
     int elements_size = 0;
-    for (int i = 0; i < static_cast<int>(agg.size()); i++) {
+    for (int i = 0; i < static_cast<int>(agg.size()); ++i) {
       auto row_vector = agg[i];
-      for (int j = 0; j < static_cast<int>(row_vector.size()); j++) {
+      for (int j = 0; j < static_cast<int>(row_vector.size()); ++j) {
         elements_size += row_vector[j].size();
       }
     }
@@ -503,8 +503,8 @@ class Booster {
     std::vector<int> row_sizes(num_matrices * nrow);
     std::vector<int> row_matrix_offsets(num_matrices * nrow);
     int row_vector_cnt = 0;
-    for (int m = 0; m < num_matrices; m++) {
-      for (int i = 0; i < static_cast<int>(agg.size()); i++) {
+    for (int m = 0; m < num_matrices; ++m) {
+      for (int i = 0; i < static_cast<int>(agg.size()); ++i) {
         auto row_vector = agg[i];
         auto row_vector_size = row_vector[m].size();
         // keep track of the row_vector sizes for parallelization
@@ -519,7 +519,7 @@ class Booster {
     }
     // copy vector results to output for each row
     int indptr_index = 0;
-    for (int m = 0; m < num_matrices; m++) {
+    for (int m = 0; m < num_matrices; ++m) {
       if (is_indptr_int32) {
         (reinterpret_cast<int32_t*>(*out_indptr))[indptr_index] = 0;
       } else {
@@ -529,7 +529,7 @@ class Booster {
       int matrix_start_index = m * agg.size();
       OMP_INIT_EX();
       #pragma omp parallel for schedule(static)
-      for (int i = 0; i < static_cast<int>(agg.size()); i++) {
+      for (int i = 0; i < static_cast<int>(agg.size()); ++i) {
         OMP_LOOP_EX_BEGIN();
         auto row_vector = agg[i];
         int row_start_index = matrix_start_index + i;
@@ -591,9 +591,9 @@ class Booster {
     // calculate number of elements per column to construct
     // the CSC matrix with random access
     std::vector<std::vector<int>> column_sizes(num_matrices);
-    for (int m = 0; m < num_matrices; m++) {
+    for (int m = 0; m < num_matrices; ++m) {
       column_sizes[m] = std::vector<int>(num_output_cols, 0);
-      for (int i = 0; i < static_cast<int>(agg.size()); i++) {
+      for (int i = 0; i < static_cast<int>(agg.size()); ++i) {
         auto row_vector = agg[i];
         for (auto it = row_vector[m].begin(); it != row_vector[m].end(); ++it) {
           column_sizes[m][it->first] += 1;
@@ -607,7 +607,7 @@ class Booster {
     // keep track of beginning index for each matrix
     std::vector<int> matrix_start_indices(num_matrices, 0);
     int col_ptr_index = 0;
-    for (int m = 0; m < num_matrices; m++) {
+    for (int m = 0; m < num_matrices; ++m) {
       int col_ptr_value = 0;
       column_start_indices[m] = std::vector<int>(num_output_cols, 0);
       column_counts[m] = std::vector<int>(num_output_cols, 0);
@@ -617,7 +617,7 @@ class Booster {
         (reinterpret_cast<int64_t*>(*out_col_ptr))[col_ptr_index] = col_ptr_value;
       }
       col_ptr_index++;
-      for (int i = 1; i < static_cast<int>(column_sizes[m].size()); i++) {
+      for (int i = 1; i < static_cast<int>(column_sizes[m].size()); ++i) {
         column_start_indices[m][i] = column_sizes[m][i - 1] + column_start_indices[m][i - 1];
         if (is_col_ptr_int32) {
           (reinterpret_cast<int32_t*>(*out_col_ptr))[col_ptr_index] = column_start_indices[m][i];
@@ -640,8 +640,8 @@ class Booster {
           last_column_size;
       }
     }
-    for (int m = 0; m < num_matrices; m++) {
-      for (int i = 0; i < static_cast<int>(agg.size()); i++) {
+    for (int m = 0; m < num_matrices; ++m) {
+      for (int i = 0; i < static_cast<int>(agg.size()); ++i) {
         auto row_vector = agg[i];
         for (auto it = row_vector[m].begin(); it != row_vector[m].end(); ++it) {
           int col_idx = it->first;

--- a/src/io/tree.cpp
+++ b/src/io/tree.cpp
@@ -730,6 +730,56 @@ void Tree::TreeSHAP(const double *feature_values, double *phi,
   }
 }
 
+// recursive sparse computation of SHAP values for a decision tree
+void Tree::TreeSHAPByMap(const std::unordered_map<int, double>& feature_values, std::unordered_map<int, double>* phi,
+                         int node, int unique_depth,
+                         PathElement *parent_unique_path, double parent_zero_fraction,
+                         double parent_one_fraction, int parent_feature_index) const {
+  // extend the unique path
+  PathElement* unique_path = parent_unique_path + unique_depth;
+  if (unique_depth > 0) std::copy(parent_unique_path, parent_unique_path + unique_depth, unique_path);
+  ExtendPath(unique_path, unique_depth, parent_zero_fraction,
+             parent_one_fraction, parent_feature_index);
+
+  // leaf node
+  if (node < 0) {
+    for (int i = 1; i <= unique_depth; ++i) {
+      const double w = UnwoundPathSum(unique_path, unique_depth, i);
+      const PathElement &el = unique_path[i];
+      (*phi)[el.feature_index] += w*(el.one_fraction - el.zero_fraction)*leaf_value_[~node];
+    }
+
+    // internal node
+  } else {
+    const int hot_index = Decision(feature_values.count(split_feature_[node]) > 0 ? feature_values.at(split_feature_[node]) : 0.0f, node);
+    const int cold_index = (hot_index == left_child_[node] ? right_child_[node] : left_child_[node]);
+    const double w = data_count(node);
+    const double hot_zero_fraction = data_count(hot_index) / w;
+    const double cold_zero_fraction = data_count(cold_index) / w;
+    double incoming_zero_fraction = 1;
+    double incoming_one_fraction = 1;
+
+    // see if we have already split on this feature,
+    // if so we undo that split so we can redo it for this node
+    int path_index = 0;
+    for (; path_index <= unique_depth; ++path_index) {
+      if (unique_path[path_index].feature_index == split_feature_[node]) break;
+    }
+    if (path_index != unique_depth + 1) {
+      incoming_zero_fraction = unique_path[path_index].zero_fraction;
+      incoming_one_fraction = unique_path[path_index].one_fraction;
+      UnwindPath(unique_path, unique_depth, path_index);
+      unique_depth -= 1;
+    }
+
+    TreeSHAPByMap(feature_values, phi, hot_index, unique_depth + 1, unique_path,
+                  hot_zero_fraction*incoming_zero_fraction, incoming_one_fraction, split_feature_[node]);
+
+    TreeSHAPByMap(feature_values, phi, cold_index, unique_depth + 1, unique_path,
+                  cold_zero_fraction*incoming_zero_fraction, 0, split_feature_[node]);
+  }
+}
+
 double Tree::ExpectedValue() const {
   if (num_leaves_ == 1) return LeafOutput(0);
   const double total_count = internal_count_[0];

--- a/src/io/tree.cpp
+++ b/src/io/tree.cpp
@@ -687,7 +687,9 @@ void Tree::TreeSHAP(const double *feature_values, double *phi,
                     double parent_one_fraction, int parent_feature_index) const {
   // extend the unique path
   PathElement* unique_path = parent_unique_path + unique_depth;
-  if (unique_depth > 0) std::copy(parent_unique_path, parent_unique_path + unique_depth, unique_path);
+  if (unique_depth > 0) {
+    std::copy(parent_unique_path, parent_unique_path + unique_depth, unique_path);
+  }
   ExtendPath(unique_path, unique_depth, parent_zero_fraction,
              parent_one_fraction, parent_feature_index);
 
@@ -737,7 +739,9 @@ void Tree::TreeSHAPByMap(const std::unordered_map<int, double>& feature_values, 
                          double parent_one_fraction, int parent_feature_index) const {
   // extend the unique path
   PathElement* unique_path = parent_unique_path + unique_depth;
-  if (unique_depth > 0) std::copy(parent_unique_path, parent_unique_path + unique_depth, unique_path);
+  if (unique_depth > 0) {
+    std::copy(parent_unique_path, parent_unique_path + unique_depth, unique_path);
+  }
   ExtendPath(unique_path, unique_depth, parent_zero_fraction,
              parent_one_fraction, parent_feature_index);
 
@@ -749,7 +753,7 @@ void Tree::TreeSHAPByMap(const std::unordered_map<int, double>& feature_values, 
       (*phi)[el.feature_index] += w*(el.one_fraction - el.zero_fraction)*leaf_value_[~node];
     }
 
-    // internal node
+  // internal node
   } else {
     const int hot_index = Decision(feature_values.count(split_feature_[node]) > 0 ? feature_values.at(split_feature_[node]) : 0.0f, node);
     const int cold_index = (hot_index == left_child_[node] ? right_child_[node] : left_child_[node]);

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -11,10 +11,9 @@ import lightgbm as lgb
 import numpy as np
 from scipy.sparse import csr_matrix
 from sklearn.datasets import (load_boston, load_breast_cancer, load_digits,
-                              load_iris, load_svmlight_file)
+                              load_iris, load_svmlight_file, make_multilabel_classification)
 from sklearn.metrics import log_loss, mean_absolute_error, mean_squared_error, roc_auc_score
 from sklearn.model_selection import train_test_split, TimeSeriesSplit, GroupKFold
-from sklearn.datasets import make_multilabel_classification
 
 try:
     import cPickle as pickle
@@ -974,7 +973,7 @@ class TestEngine(unittest.TestCase):
         gbm = lgb.train(params, lgb_train, num_boost_round=20)
         contribs_csc = gbm.predict(X_test_csc, pred_contrib=True)
         # validate the values are the same
-        np.testing.assert_allclose(contribs_csr.toarray(), contribs_csc.toarray())
+        np.testing.assert_allclose(contribs_csc.toarray(), contribs_dense)
 
     def test_sliced_data(self):
         def train_and_get_predictions(features, labels):

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -975,6 +975,20 @@ class TestEngine(unittest.TestCase):
         # validate the values are the same
         np.testing.assert_allclose(contribs_csc.toarray(), contribs_dense)
 
+    def test_int32_max_sparse_contribs(self):
+        params = {
+            'objective': 'binary'
+        }
+        train_features = np.random.rand(100, 1000)
+        train_targets = [0] * 50 + [1] * 50
+        lgb_train = lgb.Dataset(train_features, train_targets)
+        gbm = lgb.train(params, lgb_train, num_boost_round=5)
+        test_features = csr_matrix((3000000, 1000))
+        for i in range(0, 3000000, 500000):
+            for j in range(0, 1000, 100):
+                test_features[i, j] = random.random()
+        gbm.predict(test_features, pred_contrib=True)
+
     def test_sliced_data(self):
         def train_and_get_predictions(features, labels):
             dataset = lgb.Dataset(features, label=labels)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -981,16 +981,19 @@ class TestEngine(unittest.TestCase):
         train_features = np.random.rand(100, 1000)
         train_targets = [0] * 50 + [1] * 50
         lgb_train = lgb.Dataset(train_features, train_targets)
-        gbm = lgb.train(params, lgb_train, num_boost_round=5)
+        gbm = lgb.train(params, lgb_train, num_boost_round=2)
         csr_input_shape = (3000000, 1000)
         test_features = csr_matrix(csr_input_shape)
         for i in range(0, csr_input_shape[0], csr_input_shape[0] // 6):
             for j in range(0, 1000, 100):
                 test_features[i, j] = random.random()
-        y_pred = gbm.predict(test_features, pred_contrib=True)
+        y_pred_csr = gbm.predict(test_features, pred_contrib=True)
         # Note there is an extra column added to the output for the expected value
         csr_output_shape = (csr_input_shape[0], csr_input_shape[1] + 1)
-        self.assertTupleEqual(y_pred.shape, csr_output_shape)
+        self.assertTupleEqual(y_pred_csr.shape, csr_output_shape)
+        y_pred_csc = gbm.predict(test_features.tocsc(), pred_contrib=True)
+        # Note output CSC shape should be same as CSR output shape
+        self.assertTupleEqual(y_pred_csc.shape, csr_output_shape)
 
     def test_sliced_data(self):
         def train_and_get_predictions(features, labels):


### PR DESCRIPTION
Adding sparse support to TreeSHAP algorithm in lightgbm.  The feature importances for a sparse matrix should be returned as a sparse matrix as well.  This should improve both performance and memory usage for very sparse datasets.

Unlike other predict APIs, it's not as easy to figure out prior to prediction what the size will be of the sparse matrix result, so we allocate the data on the native-side and expose an additional API to deallocate the sparse matrix arrays.