### PR TITLE
[R-package] fix R examples and lgb.plot.interpretation()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -406,6 +406,15 @@ lightgbm_r/*
 lightgbm*.tar.gz
 lightgbm.Rcheck/
 
+# Files created by R examples and tests
+**/lgb-Dataset.data
+**/lgb-model.rds
+**/lgb.Dataset.data
+**/model.rds
+**/model.txt
+**/lgb-model.txt
+
+
 # Files from interactive R sessions
 .Rproj.user
 **/.Rhistory

--- a/.gitignore
+++ b/.gitignore
@@ -414,7 +414,6 @@ lightgbm.Rcheck/
 **/model.txt
 **/lgb-model.txt
 
-
 # Files from interactive R sessions
 .Rproj.user
 **/.Rhistory

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -41,4 +41,4 @@ Imports:
     utils
 SystemRequirements:
     C++11
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -845,7 +845,7 @@ lgb.load <- function(filename = NULL, model_str = NULL) {
 #'   , learning_rate = 1.0
 #'   , early_stopping_rounds = 5L
 #' )
-#' lgb.save(model, "model.txt")
+#' lgb.save(model, "lgb-model.txt")
 #' }
 #' @export
 lgb.save <- function(booster, filename, num_iteration = NULL) {

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -1073,8 +1073,8 @@ setinfo.lgb.Dataset <- function(dataset, name, info, ...) {
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
-#' lgb.Dataset.save(dtrain, "lgb.Dataset.data")
-#' dtrain <- lgb.Dataset("lgb.Dataset.data")
+#' lgb.Dataset.save(dtrain, "lgb-Dataset.data")
+#' dtrain <- lgb.Dataset("lgb-Dataset.data")
 #' lgb.Dataset.set.categorical(dtrain, 1L:2L)
 #'
 #' @rdname lgb.Dataset.set.categorical

--- a/R-package/R/lgb.plot.interpretation.R
+++ b/R-package/R/lgb.plot.interpretation.R
@@ -49,7 +49,7 @@
 #' )
 #' lgb.plot.interpretation(
 #'   tree_interpretation_dt = tree_interpretation[[1L]]
-#'   , top_n = 5L
+#'   , top_n = 3L
 #' )
 #' }
 #' @importFrom data.table setnames
@@ -141,7 +141,7 @@ multiple.tree.plot.interpretation <- function(tree_interpretation,
   }
 
   # create plot
-  tree_interpretation[Contribution > 0.0, bar_color := "firebrick"]
+  tree_interpretation[abs(Contribution) > 0.0, bar_color := "firebrick"]
   tree_interpretation[Contribution == 0.0, bar_color := "steelblue"]
   tree_interpretation[.N:1L,
                       graphics::barplot(

--- a/R-package/R/lgb.prepare_rules.R
+++ b/R-package/R/lgb.prepare_rules.R
@@ -36,9 +36,13 @@
 #' data(iris) # Erase iris dataset
 #'
 #' # We remapped values differently
-#' personal_rules <- list(Species = c("setosa" = 3L,
-#'                                    "versicolor" = 2L,
-#'                                    "virginica" = 1L))
+#' personal_rules <- list(
+#'     Species = c(
+#'         "setosa" = 3L
+#'         , "versicolor" = 2L
+#'         , "virginica" = 1L
+#'     )
+#' )
 #' newest_iris <- lgb.prepare_rules(data = iris, rules = personal_rules)
 #' str(newest_iris$data) # SUCCESS!
 #'

--- a/R-package/R/saveRDS.lgb.Booster.R
+++ b/R-package/R/saveRDS.lgb.Booster.R
@@ -37,7 +37,7 @@
 #'     , learning_rate = 1.0
 #'     , early_stopping_rounds = 5L
 #' )
-#' saveRDS.lgb.Booster(model, "model.rds")
+#' saveRDS.lgb.Booster(model, "lgb-model.rds")
 #' }
 #' @export
 saveRDS.lgb.Booster <- function(object,

--- a/R-package/man/agaricus.test.Rd
+++ b/R-package/man/agaricus.test.Rd
@@ -4,8 +4,10 @@
 \name{agaricus.test}
 \alias{agaricus.test}
 \title{Test part from Mushroom Data Set}
-\format{A list containing a label vector, and a dgCMatrix object with 1611
-rows and 126 variables}
+\format{
+A list containing a label vector, and a dgCMatrix object with 1611
+rows and 126 variables
+}
 \usage{
 data(agaricus.test)
 }

--- a/R-package/man/agaricus.train.Rd
+++ b/R-package/man/agaricus.train.Rd
@@ -4,8 +4,10 @@
 \name{agaricus.train}
 \alias{agaricus.train}
 \title{Training part from Mushroom Data Set}
-\format{A list containing a label vector, and a dgCMatrix object with 6513
-rows and 127 variables}
+\format{
+A list containing a label vector, and a dgCMatrix object with 6513
+rows and 127 variables
+}
 \usage{
 data(agaricus.train)
 }

--- a/R-package/man/bank.Rd
+++ b/R-package/man/bank.Rd
@@ -4,7 +4,9 @@
 \name{bank}
 \alias{bank}
 \title{Bank Marketing Data Set}
-\format{A data.table with 4521 rows and 17 variables}
+\format{
+A data.table with 4521 rows and 17 variables
+}
 \usage{
 data(bank)
 }

--- a/R-package/man/lgb.Dataset.set.categorical.Rd
+++ b/R-package/man/lgb.Dataset.set.categorical.Rd
@@ -24,8 +24,8 @@ Set the categorical features of an \code{lgb.Dataset} object. Use this function
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
-lgb.Dataset.save(dtrain, "lgb.Dataset.data")
-dtrain <- lgb.Dataset("lgb.Dataset.data")
+lgb.Dataset.save(dtrain, "lgb-Dataset.data")
+dtrain <- lgb.Dataset("lgb-Dataset.data")
 lgb.Dataset.set.categorical(dtrain, 1L:2L)
 
 }

--- a/R-package/man/lgb.plot.interpretation.Rd
+++ b/R-package/man/lgb.plot.interpretation.Rd
@@ -68,7 +68,7 @@ tree_interpretation <- lgb.interprete(
 )
 lgb.plot.interpretation(
   tree_interpretation_dt = tree_interpretation[[1L]]
-  , top_n = 5L
+  , top_n = 3L
 )
 }
 }

--- a/R-package/man/lgb.prepare_rules.Rd
+++ b/R-package/man/lgb.prepare_rules.Rd
@@ -48,9 +48,13 @@ all.equal(new_iris$data, newer_iris$data)
 data(iris) # Erase iris dataset
 
 # We remapped values differently
-personal_rules <- list(Species = c("setosa" = 3L,
-                                   "versicolor" = 2L,
-                                   "virginica" = 1L))
+personal_rules <- list(
+    Species = c(
+        "setosa" = 3L
+        , "versicolor" = 2L
+        , "virginica" = 1L
+    )
+)
 newest_iris <- lgb.prepare_rules(data = iris, rules = personal_rules)
 str(newest_iris$data) # SUCCESS!
 

--- a/R-package/man/lgb.save.Rd
+++ b/R-package/man/lgb.save.Rd
@@ -39,6 +39,6 @@ model <- lgb.train(
   , learning_rate = 1.0
   , early_stopping_rounds = 5L
 )
-lgb.save(model, "model.txt")
+lgb.save(model, "lgb-model.txt")
 }
 }

--- a/R-package/man/saveRDS.lgb.Booster.Rd
+++ b/R-package/man/saveRDS.lgb.Booster.Rd
@@ -61,6 +61,6 @@ model <- lgb.train(
     , learning_rate = 1.0
     , early_stopping_rounds = 5L
 )
-saveRDS.lgb.Booster(model, "model.rds")
+saveRDS.lgb.Booster(model, "lgb-model.rds")
 }
 }

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -210,7 +210,7 @@ This is a known bug: `Microsoft/LightGBM#539 <https://github.com/microsoft/Light
 3. ``error in data.table::data.table()...argument 2 is NULL``
 -------------------------------------------------------------
 
-If you experiencing this error when running `lightgbm`, you may be facing the same issue reported in `#2715 <https://github.com/microsoft/LightGBM/issues/2715>`_. If you use ``lgb.dl()`` to build from source (i.e. not using pre-compiled dll), you need to upgrade your version of ``data.table`` to at least version 1.12.0.
+If you are experiencing this error when running ``lightgbm``, you may be facing the same issue reported in `#2715 <https://github.com/microsoft/LightGBM/issues/2715>`_ and later in `#2989 <https://github.com/microsoft/LightGBM/pull/2989#issuecomment-614374151>`_. We have seen that some in some situations, using ``data.table`` 1.11.x results in this error. To get around this, you can upgrade your version of ``data.table`` to at least version 1.12.0.
 
 ------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -227,7 +227,7 @@ def generate_r_docs(app):
     /home/docs/.conda/bin/conda create -q -y -n r_env \
         r-base=3.5.1=h1e0a451_2 \
         r-devtools=1.13.6=r351h6115d3f_0 \
-        r-data.table=1.11.4=r351h96ca727_0 \
+        r-data.table=1.12.2=r36h96ca727_0 \
         r-jsonlite=1.5=r351h96ca727_0 \
         r-matrix=1.2_14=r351h96ca727_0 \
         r-testthat=2.0.0=r351h29659fb_0 \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -227,13 +227,13 @@ def generate_r_docs(app):
     /home/docs/.conda/bin/conda create -q -y -n r_env \
         r-base=3.5.1=h1e0a451_2 \
         r-devtools=1.13.6=r351h6115d3f_0 \
-        r-data.table=1.12.2=r36h96ca727_0 \
         r-jsonlite=1.5=r351h96ca727_0 \
         r-matrix=1.2_14=r351h96ca727_0 \
         r-testthat=2.0.0=r351h29659fb_0 \
         cmake=3.14.0=h52cb24c_0 \
         ca-certificates=2019.11.27=0
     /home/docs/.conda/bin/conda install -q -y -n r_env -c conda-forge \
+        r-data.table=1.12.8=r35hcdcec82_0 \
         r-pkgdown=1.3.0=r35h6115d3f_1001 \
         r-roxygen2=6.1.1=r35h0357c0b_1001
     source /home/docs/.conda/bin/activate r_env


### PR DESCRIPTION
**NOTE:* Moving #2999 over here (based on a LightGBM branch) so we can test readthedocs builds. See https://github.com/microsoft/LightGBM/pull/2999#issuecomment-614648492

--------

See comments from @StrikerRUS 

* https://github.com/microsoft/LightGBM/pull/2989#issuecomment-614374151
* https://github.com/microsoft/LightGBM/pull/2989#issuecomment-614375963

A few of the R examples are broken right now. These weren't caught by tests because one is only a warning, one is a plot that is generated successfully but is incorrect, and one is an issue specific to our readthedocs builds.

I think the issue for `lgb.cv()` is #2715. In that issue we found that `data.table 1.11.4` and R 3.6.0 lead to a data.table error ending in `column or argument 2 is NULL`. I think this can be fixed by upgrading to the `data.table`  1.12.1 in `conf.py`.

To fix the `lgb.set.categorical()` example, I changed file names across several examples to be sure that no two examples write to the same file name.

![image](https://user-images.githubusercontent.com/7608904/79412582-c3375d80-7f9d-11ea-91a3-df08450295f7.png)

This issue with `lgb.plot.interpretation()` is because I made a change and forgot to use `abs()`.

![image](https://user-images.githubusercontent.com/7608904/79412746-2628f480-7f9e-11ea-9030-a83dd150086e.png)

new plot:

![image](https://user-images.githubusercontent.com/7608904/79412840-507ab200-7f9e-11ea-94de-20f99a1bab94.png)

I was not able to reproduce the `data.table` error in  https://github.com/microsoft/LightGBM/pull/2989#issuecomment-614374151. It 