### PR TITLE
[R-package] [docs] remove unnecessary build in test coverage

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -147,7 +147,7 @@ The example below shows how to generate code coverage for the R package on a mac
 # Install
 export CXX=/usr/local/bin/g++-8
 export CC=/usr/local/bin/gcc-8
-Rscript build_r.R
+Rscript build_r.R --skip-install
 
 # Get coverage
 Rscript -e " \


### PR DESCRIPTION
As of #2957 , you can use `Rscript build_r.R --skip-install` to build the R package without installing it. Right now the instructions for generating R test coverage doesn't take advantage of that, so you end up compiling `LightGBM` twice. This PR fixes that.