### PR TITLE
[R-package] Added tests on LGBM_GetLastError_R

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -19,6 +19,8 @@ lgb.encode.char <- function(arr, len) {
 
 }
 
+# [description] Raise an error. Before raising that error, check for any error message
+#               stored in a buffer on the C++ side.
 lgb.last_error <- function() {
   # Perform text error buffering
   buf_len <- 200L

--- a/R-package/tests/testthat/test_utils.R
+++ b/R-package/tests/testthat/test_utils.R
@@ -48,3 +48,23 @@ test_that("lgb.params2str() works as expected for a key in params with multiple 
         , "objective=magic metric=a,ab,abc,abcdefg nrounds=10 learning_rate=0.0000001"
     )
 })
+
+context("lgb.last_error")
+
+test_that("lgb.last_error() throws an error if there are no errors", {
+    expect_error({
+        lgb.last_error()
+    }, regexp = "Everything is fine")
+})
+
+test_that("lgb.last_error() correctly returns errors from the C++ side", {
+    data(agaricus.train, package = "lightgbm")
+    train <- agaricus.train
+    dvalid1 <- lgb.Dataset(
+        data = train$data
+        , label = as.matrix(rnorm(5L))
+    )
+    expect_error({
+        dvalid1$construct()
+    }, regexp = "[LightGBM] [Fatal] Length of label is not same with #data", fixed = TRUE)
+})


### PR DESCRIPTION
Continuing work on #2944, trying to cover all calls from the R package to the C++ side in R unit tests. These tests cover  `LGBM_GetLastError_R`.

Confirmed by running https://github.com/microsoft/LightGBM/blob/master/R-package/README.md#testing.

These changes increase the test coverage of the R package from 79.71% to 80.27%.