### PR TITLE
[R-package] [ci] added echoing of R CMD check logs to CI

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -86,9 +86,17 @@ export _R_CHECK_FORCE_SUGGESTS_=0
 
 # fails tests if either ERRORs or WARNINGs are thrown by
 # R CMD CHECK
+check_succeeded="yes"
 R CMD check ${PKG_TARBALL} \
     --as-cran \
-|| exit -1
+|| check_succeeded="no"
+
+echo "R CMD check build logs:"
+cat ${BUILD_DIRECTORY}/lightgbm.Rcheck/00install.out
+
+if [[ $check_succeeded == "no" ]]; then
+    exit -1
+fi
 
 if grep -q -R "WARNING" "$LOG_FILE_NAME"; then
     echo "WARNINGS have been found by R CMD check!"


### PR DESCRIPTION
No that we use `Rscript build_r.R --skip--install`, the only build of the R package is from `R CMD check`. `R CMD check` suppresses output from the build and writes it to a file. Those logs are useful for us to check for compiler warnings and debug issues.

See https://github.com/microsoft/LightGBM/pull/2936/files#r411607175