### PR TITLE
[ci][docs] Fix RTD builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ formats:
 python:
   version: 3
   install:
-    - requirements: docs/requirements.txt
+    - requirements: docs/requirements_rtd.txt
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,6 +273,9 @@ def setup(app):
     first_run = not os.path.exists(os.path.join(CURR_PATH, '_FIRST_RUN.flag'))
     if first_run and RTD:
         open(os.path.join(CURR_PATH, '_FIRST_RUN.flag'), 'w').close()
+        # Temp fix for https://github.com/pypa/pip/issues/8001 on RTD site
+        Popen(["pip" "install" "Sphinx" "--upgrade"],
+              stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate()
     if C_API:
         app.connect("builder-inited", generate_doxygen_xml)
     else:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,9 +273,6 @@ def setup(app):
     first_run = not os.path.exists(os.path.join(CURR_PATH, '_FIRST_RUN.flag'))
     if first_run and RTD:
         open(os.path.join(CURR_PATH, '_FIRST_RUN.flag'), 'w').close()
-        # Temp fix for https://github.com/pypa/pip/issues/8001 on RTD site
-        Popen(["pip" "install" "Sphinx" "--upgrade"],
-              stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate()
     if C_API:
         app.connect("builder-inited", generate_doxygen_xml)
     else:
@@ -286,5 +283,8 @@ def setup(app):
         app.connect("build-finished",
                     lambda app, exception: copy_tree(os.path.join(CURR_PATH, os.path.pardir, "lightgbm_r", "docs"),
                                                      os.path.join(app.outdir, "R"), verbose=0))
+        # Temp fix for https://github.com/pypa/pip/issues/8001 on RTD site
+        Popen(["pip" "install" "Sphinx" "--upgrade"],
+              stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate()
     add_js_file = getattr(app, 'add_js_file', False) or app.add_javascript
     add_js_file("js/script.js")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ if needs_sphinx > sphinx.__version__:
     raise VersionRequirementError(message)
 # Temp fix for https://github.com/pypa/pip/issues/8001 on RTD site
 if RTD:
-    Popen(["pip" "install" "Sphinx" "--upgrade"],
+    Popen(["pip", "install", "Sphinx", "--upgrade"],
           stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate()
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,10 @@ needs_sphinx = '1.3'  # Due to sphinx.ext.napoleon
 if needs_sphinx > sphinx.__version__:
     message = 'This project needs at least Sphinx v%s' % needs_sphinx
     raise VersionRequirementError(message)
+# Temp fix for https://github.com/pypa/pip/issues/8001 on RTD site
+if RTD:
+    Popen(["pip" "install" "Sphinx" "--upgrade"],
+          stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate()
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -283,8 +287,5 @@ def setup(app):
         app.connect("build-finished",
                     lambda app, exception: copy_tree(os.path.join(CURR_PATH, os.path.pardir, "lightgbm_r", "docs"),
                                                      os.path.join(app.outdir, "R"), verbose=0))
-        # Temp fix for https://github.com/pypa/pip/issues/8001 on RTD site
-        Popen(["pip" "install" "Sphinx" "--upgrade"],
-              stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate()
     add_js_file = getattr(app, 'add_js_file', False) or app.add_javascript
     add_js_file("js/script.js")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,10 +64,6 @@ needs_sphinx = '1.3'  # Due to sphinx.ext.napoleon
 if needs_sphinx > sphinx.__version__:
     message = 'This project needs at least Sphinx v%s' % needs_sphinx
     raise VersionRequirementError(message)
-# Temp fix for https://github.com/pypa/pip/issues/8001 on RTD site
-if RTD:
-    Popen(["pip", "install", "Sphinx", "--upgrade"],
-          stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate()
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -1,0 +1,4 @@
+sphinx >= 3.0.2
+sphinx_rtd_theme >= 0.3
+mock; python_version < '3'
+breathe


### PR DESCRIPTION
Upstream bugs... again.

Continuation of #3013.

Default installed Sphinx version at RTD is `1.8.5`.

Refer to https://github.com/michaeljones/breathe/issues/495#issuecomment-610710637 and https://github.com/pypa/pip/issues/8001#issuecomment-611785558.

In this workaround separate config for RTD duplicates code but allows to not touch LightGBM's users - they are free to continue using old Sphinx in their environments.

I hope https://github.com/pypa/pip/issues/8001 will be resolved soon (https://github.com/pypa/pip/issues/988#issuecomment-617142142) and we'll be able to revert this PR.

![image](https://user-images.githubusercontent.com/25141164/80030928-9fba6880-84f1-11ea-9afa-4926eeb0a047.png)
