### PR TITLE
[python][tests] unused and missing imports

### DIFF
--- a/tests/c_api_test/test_.py
+++ b/tests/c_api_test/test_.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import ctypes
 import os
-import sys
 
 from platform import system
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1857,7 +1857,6 @@ class TestEngine(unittest.TestCase):
         self.assertEqual(len(set([iter_valid1_l1, iter_valid1_l2, iter_valid2_l1, iter_valid2_l2])), 4)
         iter_min_l1 = min([iter_valid1_l1, iter_valid2_l1])
         iter_min_l2 = min([iter_valid1_l2, iter_valid2_l2])
-        iter_min = min([iter_min_l1, iter_min_l2])
         iter_min_valid1 = min([iter_valid1_l1, iter_valid1_l2])
 
         iter_cv_l1 = 4

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -4,6 +4,7 @@ import joblib
 import math
 import os
 import unittest
+import warnings
 
 import lightgbm as lgb
 import numpy as np


### PR DESCRIPTION
Just out of curiosity, I ran this on the codebase tonight:

```shell
flake8 --exclude=E501,W503
```

This PR fixes these warnings from it

```text
./tests/python_package_test/test_engine.py:1860:9: F841 local variable 'iter_min' is assigned to but never used
./tests/python_package_test/test_sklearn.py:304:21: F821 undefined name 'warnings'
./tests/c_api_test/test_.py:4:1: F401 'sys' imported but unused
```

A couple other warnings are generated but I think they should be ignored. Some thing in outt tests look like "local variable never used" but they're things like this where even if we don't test the value, generating acts as a smoke test:

```python
model = lgb.train(default_params, lgb_train, valid_sets=[lgb_val])
```

Here is the full log if you're curious:

<details><summary>flake8 logs</summary>

```
./tests/python_package_test/test_engine.py:924:9: F841 local variable 'gbm' is assigned to but never used
./tests/python_package_test/test_engine.py:1024:13: F841 local variable 'gbm' is assigned to but never used
./tests/python_package_test/test_engine.py:1860:9: F841 local variable 'iter_min' is assigned to but never used
./tests/python_package_test/test_engine.py:2102:9: F841 local variable 'model' is assigned to but never used
./tests/python_package_test/test_plotting.py:149:9: F841 local variable 'gbm0' is assigned to but never used
./tests/python_package_test/test_plotting.py:164:9: F841 local variable 'gbm1' is assigned to but never used
./tests/python_package_test/test_sklearn.py:193:9: F841 local variable 'gbm_clone' is assigned to but never used
./tests/python_package_test/test_sklearn.py:304:21: F821 undefined name 'warnings'
./tests/c_api_test/test_.py:4:1: F401 'sys' imported but unused
./python-package/lightgbm/compat.py:28:5: F401 'itertools.izip as zip_' imported but unused
./python-package/lightgbm/compat.py:29:19: F821 undefined name 'basestring'
./python-package/lightgbm/compat.py:30:27: F821 undefined name 'long'
./python-package/lightgbm/compat.py:31:27: F821 undefined name 'long'
./python-package/lightgbm/compat.py:32:14: F821 undefined name 'xrange'
./python-package/lightgbm/compat.py:48:5: F401 'json' imported but unused
./python-package/lightgbm/compat.py:83:5: F401 'matplotlib' imported but unused
./python-package/lightgbm/compat.py:90:5: F401 'graphviz' imported but unused
```

</details>