### PR TITLE
[R-package] add conda dir for LIBR_CORE_LIBRARY (fixes #3045)

### DIFF
--- a/R-package/src/cmake/modules/FindLibR.cmake
+++ b/R-package/src/cmake/modules/FindLibR.cmake
@@ -176,7 +176,7 @@ set(LIBR_EXECUTABLE ${LIBR_EXECUTABLE} CACHE PATH "R executable")
 set(LIBR_INCLUDE_DIRS ${LIBR_INCLUDE_DIRS} CACHE PATH "R include directory")
 
 # where is R.so / R.dll / libR.so likely to be found?
-set(LIBR_PATH_HINTS "${CMAKE_CURRENT_BINARY_DIR}" "${LIBR_HOME}/bin/${R_ARCH}" "${LIBR_HOME}/bin" "${LIBR_LIBRARIES}")
+set(LIBR_PATH_HINTS "${CMAKE_CURRENT_BINARY_DIR}" "${LIBR_HOME}/lib" "${LIBR_HOME}/bin/${R_ARCH}" "${LIBR_HOME}/bin" "${LIBR_LIBRARIES}")
 
 # look for the core R library
 find_library(


### PR DESCRIPTION
I think that `conda` installations of R put the core library at `${R_HOME}/lib`. See https://github.com/microsoft/LightGBM/issues/3045#issuecomment-623208825 and the rest of #3045 for details.

@StrikerRUS I created this as a `LightGBM` branch so it can be tested on readthedocs. Could you enable this branch there?