### PR TITLE
Add public accessors to tree for decision_type and threshold

### DIFF
--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -16,8 +16,8 @@
 
 namespace LightGBM {
 
-#define kCategoricalMask (1)
-#define kDefaultLeftMask (2)
+constexpr uint8_t kCategoricalMask = 1;
+constexpr uint8_t kDefaultLeftMask = 2;
 
 /*!
 * \brief Tree model
@@ -158,12 +158,20 @@ class Tree {
     return !GetDecisionType(decision_type_[node_idx], kCategoricalMask);
   }
 
+  inline uint8_t decision_type(int node_idx) const {
+    return decision_type_[node_idx];
+  }
+
   inline int left_child(int node_idx) const { return left_child_[node_idx]; }
 
   inline int right_child(int node_idx) const { return right_child_[node_idx]; }
 
   inline int split_feature_inner(int node_idx) const {
     return split_feature_inner_[node_idx];
+  }
+
+  inline double threshold(int node_idx) const {
+    return threshold_[node_idx];
   }
 
   inline uint32_t threshold_in_bin(int node_idx) const {


### PR DESCRIPTION
Two very short changes to enable 3rd-party libraries to parse LightGBM trees more safely.

- Expose public accessors to `threshold_` and `decision_type_`. Libraries that want to read LightGBM trees need access to these fields if they want to reuse `tree.h` for parsing `LightGBM_Model.txt` files rather than parsing it themselves.
- Convert the `#define`s to `constexpr`s. As of today, including `tree.h` pollutes C and C++ codebases with defines they may accidentially overwrite or forget to `#undef`. In general, for global constants, we should prefer namespaces.