### PR TITLE
[ci] fix flaky test

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -37,7 +37,6 @@ jobs:
       mpi_source:
         TASK: mpi
         METHOD: source
-        PYTHON_VERSION: 2.7
       gpu_source:
         TASK: gpu
         METHOD: source


### PR DESCRIPTION
I noticed that Linux MPI builds at Azure Pipelines have started to fail (refer for example to #3055). Seems that dropping outdated Python 2.7 version from that build fixes the issue.

On Linux we have tests with Python 2.7 here, so this version is still covered by our CIs.
https://github.com/microsoft/LightGBM/blob/18c706dc840c72341a2a85e05dfb5fad6366902a/.travis.yml#L18

Refer to https://github.com/microsoft/LightGBM/pull/1964#issuecomment-458674944.