### PR TITLE
[python-package] Use set for OS check

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -121,7 +121,7 @@ def compile_cpp(use_mingw=False, use_gpu=False, use_mpi=False,
     if use_hdfs:
         cmake_cmd.append("-DUSE_HDFS=ON")
 
-    if system() in ('Windows', 'Microsoft'):
+    if system() in {'Windows', 'Microsoft'}:
         if use_mingw:
             if use_mpi:
                 raise Exception('MPI version cannot be compiled by MinGW due to the miss of MPI library in it')


### PR DESCRIPTION
I found that there is one place in the Python package where we're using a tuple instead of a `set`  for an `in` condition.

I'd like to propose we change to a set, like we use everywhere else in the package, since `in` operations are O(1) with sets, faster than the O(n) with tuples.