### PR TITLE
[R-package] Add support for R 4.0 (fixes #3064, fixes #3024)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,10 +14,6 @@ branches:
 environment:
   matrix:
     - TASK: r-package
-      R_VERSION: 3.6
-      COMPILER: MINGW
-      TOOLCHAIN: MINGW
-    - TASK: r-package
       R_VERSION: 4.0
       COMPILER: MINGW
       TOOLCHAIN: MSYS

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,13 +15,13 @@ environment:
   matrix:
     - COMPILER: MINGW
       TASK: r-package
-      R_WINDOWS_VERSION: 3.6.3
+      R_VERSION: 3.6
     - COMPILER: MINGW
       TASK: r-package
-      R_WINDOWS_VERSION: 4.0.0
+      R_VERSION: 4.0
     - COMPILER: MSVC
       TASK: r-package
-      R_WINDOWS_VERSION: 4.0.0
+      R_VERSION: 4.0
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     # - COMPILER: MSVC
     #   TASK: python

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,9 +16,11 @@ environment:
     - COMPILER: MINGW
       TASK: r-package
       R_VERSION: 3.6
+      TOOLCHAIN: MINGW
     - COMPILER: MINGW
       TASK: r-package
       R_VERSION: 4.0
+      TOOLCHAIN: MSYS
     - COMPILER: MSVC
       TASK: r-package
       R_VERSION: 4.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,20 +13,20 @@ branches:
 
 environment:
   matrix:
-    # - COMPILER: MINGW
-    #   TASK: r-package
-    #   R_WINDOWS_VERSION: 3.6.3
-    # - COMPILER: MINGW
-    #   TASK: r-package
-    #   R_WINDOWS_VERSION: 4.0.0
-    # - COMPILER: MSVC
-    #   TASK: r-package
-    #   R_WINDOWS_VERSION: 4.0.0
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    - COMPILER: MSVC
-      TASK: python
     - COMPILER: MINGW
-      TASK: python
+      TASK: r-package
+      R_WINDOWS_VERSION: 3.6.3
+    - COMPILER: MINGW
+      TASK: r-package
+      R_WINDOWS_VERSION: 4.0.0
+    - COMPILER: MSVC
+      TASK: r-package
+      R_WINDOWS_VERSION: 4.0.0
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    # - COMPILER: MSVC
+    #   TASK: python
+    # - COMPILER: MINGW
+    #   TASK: python
 
 clone_depth: 5
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,13 +13,14 @@ branches:
 
 environment:
   matrix:
-    - TASK: r-package
+    - COMPILER: MINGW
+      TASK: r-package
+      R_VERSION: 3.6
+      TOOLCHAIN: MINGW
+    - COMPILER: MSVC 
+      TASK: r-package
       R_VERSION: 4.0
-      COMPILER: MINGW
-      TOOLCHAIN: MSYS
-    - TASK: r-package
-      R_VERSION: 4.0
-      COMPILER: MSVC
+      TOOLCHAIN: MSVC
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - COMPILER: MSVC
       TASK: python

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,18 +13,18 @@ branches:
 
 environment:
   matrix:
-    - COMPILER: MINGW
-      TASK: r-package
-      R_VERSION: 3.6
-      TOOLCHAIN: MINGW
+    # - COMPILER: MINGW
+    #   TASK: r-package
+    #   R_VERSION: 3.6
+    #   TOOLCHAIN: MINGW
     - COMPILER: MINGW
       TASK: r-package
       R_VERSION: 4.0
       TOOLCHAIN: MSYS
-    - COMPILER: MSVC
-      TASK: r-package
-      R_VERSION: 4.0
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    # - COMPILER: MSVC
+    #   TASK: r-package
+    #   R_VERSION: 4.0
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     # - COMPILER: MSVC
     #   TASK: python
     # - COMPILER: MINGW

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,22 +13,22 @@ branches:
 
 environment:
   matrix:
-    # - COMPILER: MINGW
-    #   TASK: r-package
-    #   R_VERSION: 3.6
-    #   TOOLCHAIN: MINGW
-    - COMPILER: MINGW
-      TASK: r-package
+    - TASK: r-package
+      R_VERSION: 3.6
+      COMPILER: MINGW
+      TOOLCHAIN: MINGW
+    - TASK: r-package
       R_VERSION: 4.0
+      COMPILER: MINGW
       TOOLCHAIN: MSYS
-    # - COMPILER: MSVC
-    #   TASK: r-package
-    #   R_VERSION: 4.0
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    # - COMPILER: MSVC
-    #   TASK: python
-    # - COMPILER: MINGW
-    #   TASK: python
+    - TASK: r-package
+      R_VERSION: 4.0
+      COMPILER: MSVC
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - COMPILER: MSVC
+      TASK: python
+    - COMPILER: MINGW
+      TASK: python
 
 clone_depth: 5
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,10 @@ environment:
   matrix:
     - COMPILER: MINGW
       TASK: r-package
+      R_WINDOWS_VERSION: 3.6.3
+    - COMPILER: MINGW
+      TASK: r-package
+      R_WINDOWS_VERSION: 4.0.0
     - COMPILER: MSVC
       TASK: r-package
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,15 +13,16 @@ branches:
 
 environment:
   matrix:
-    - COMPILER: MINGW
-      TASK: r-package
-      R_WINDOWS_VERSION: 3.6.3
-    - COMPILER: MINGW
-      TASK: r-package
-      R_WINDOWS_VERSION: 4.0.0
-    - COMPILER: MSVC
-      TASK: r-package
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    # - COMPILER: MINGW
+    #   TASK: r-package
+    #   R_WINDOWS_VERSION: 3.6.3
+    # - COMPILER: MINGW
+    #   TASK: r-package
+    #   R_WINDOWS_VERSION: 4.0.0
+    # - COMPILER: MSVC
+    #   TASK: r-package
+    #   R_WINDOWS_VERSION: 4.0.0
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - COMPILER: MSVC
       TASK: python
     - COMPILER: MINGW

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -12,7 +12,7 @@ if [[ ${R_MAJOR_VERSION} == "3" ]]; then
     export R_MAC_VERSION=3.6.3
     export R_TRAVIS_LINUX_VERSION="3.6.3-1bionic"
     export R_APT_REPO="bionic-cran35/"
-elif [[ ${R_MAJOR_VERSION} == "4" ]];
+elif [[ ${R_MAJOR_VERSION} == "4" ]]; then
     export R_MAC_VERSION=4.0.0
     export R_TRAVIS_LINUX_VERSION="4.0.0-1.1804.0"
     export R_APT_REPO="bionic-cran40/"

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -7,18 +7,22 @@ mkdir -p $R_LIB_PATH
 echo "R_LIBS=$R_LIB_PATH" > ${HOME}/.Renviron
 export PATH="$R_LIB_PATH/R/bin:$PATH"
 
-R_MAJOR_VERSION=( ${R_VERSION//./ } )
-if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
-    export R_MAC_VERSION=3.6.3
-    export R_TRAVIS_LINUX_VERSION="3.6.3-1bionic"
-    export R_APT_REPO="bionic-cran35/"
-elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
-    export R_MAC_VERSION=4.0.0
-    export R_TRAVIS_LINUX_VERSION="4.0.0-1.1804.0"
-    export R_APT_REPO="bionic-cran40/"
-else
-    echo "Unrecognized R version: ${R_VERSION}"
-    exit -1
+# Get details needed for installing R components
+# Linux builds on Azure use a container and don't need these details
+if ! { [[ $AZURE == "true" ]] && [[ $OS_NAME == "linux" ]] }; then
+    R_MAJOR_VERSION=( ${R_VERSION//./ } )
+    if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
+        export R_MAC_VERSION=3.6.3
+        export R_TRAVIS_LINUX_VERSION="3.6.3-1bionic"
+        export R_APT_REPO="bionic-cran35/"
+    elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
+        export R_MAC_VERSION=4.0.0
+        export R_TRAVIS_LINUX_VERSION="4.0.0-1.1804.0"
+        export R_APT_REPO="bionic-cran40/"
+    else
+        echo "Unrecognized R version: ${R_VERSION}"
+        exit -1
+    fi
 fi
 
 # installing precompiled R for Ubuntu

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -15,11 +15,11 @@ if ! { [[ $AZURE == "true" ]] && [[ $OS_NAME == "linux" ]]; }; then
     R_MAJOR_VERSION=( ${R_VERSION//./ } )
     if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
         export R_MAC_VERSION=3.6.3
-        export R_TRAVIS_LINUX_VERSION="3.6.3-1bionic"
+        export R_LINUX_VERSION="3.6.3-1bionic"
         export R_APT_REPO="bionic-cran35/"
     elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
         export R_MAC_VERSION=4.0.0
-        export R_TRAVIS_LINUX_VERSION="4.0.0-1.1804.0"
+        export R_LINUX_VERSION="4.0.0-1.1804.0"
         export R_APT_REPO="bionic-cran40/"
     else
         echo "Unrecognized R version: ${R_VERSION}"

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -8,7 +8,9 @@ echo "R_LIBS=$R_LIB_PATH" > ${HOME}/.Renviron
 export PATH="$R_LIB_PATH/R/bin:$PATH"
 
 # Get details needed for installing R components
-# Linux builds on Azure use a container and don't need these details
+#
+# NOTES:
+#    * Linux builds on Azure use a container and don't need these details
 if ! { [[ $AZURE == "true" ]] && [[ $OS_NAME == "linux" ]]; }; then
     R_MAJOR_VERSION=( ${R_VERSION//./ } )
     if [[ "${R_MAJOR_VERSION}" == "3" ]]; then

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -7,6 +7,20 @@ mkdir -p $R_LIB_PATH
 echo "R_LIBS=$R_LIB_PATH" > ${HOME}/.Renviron
 export PATH="$R_LIB_PATH/R/bin:$PATH"
 
+R_MAJOR_VERSION="$( ${R_VERSION//./ } )[0]"
+if [[ ${R_MAJOR_VERSION} == "3" ]]; then
+    export R_MAC_VERSION=3.6.3
+    export R_TRAVIS_LINUX_VERSION="3.6.3-1bionic"
+    export R_APT_REPO="bionic-cran35/"
+elif [[ ${R_MAJOR_VERSION} == "4" ]];
+    export R_MAC_VERSION=4.0.0
+    export R_TRAVIS_LINUX_VERSION="4.0.0-1.1804.0"
+    export R_APT_REPO="bionic-cran40/"
+else
+    echo "Unrecognized R version: ${R_VERSION}"
+    exit -1
+fi
+
 # installing precompiled R for Ubuntu
 # https://cran.r-project.org/bin/linux/ubuntu/#installation
 # adding steps from https://stackoverflow.com/a/56378217/3986677 to get latest version
@@ -18,7 +32,7 @@ if [[ $AZURE != "true" ]] && [[ $OS_NAME == "linux" ]]; then
         --keyserver keyserver.ubuntu.com \
         --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
     sudo add-apt-repository \
-        "deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/"
+        "deb https://cloud.r-project.org/bin/linux/ubuntu ${R_APT_REPO}"
     sudo apt-get update
     sudo apt-get install \
         --no-install-recommends \

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -7,12 +7,12 @@ mkdir -p $R_LIB_PATH
 echo "R_LIBS=$R_LIB_PATH" > ${HOME}/.Renviron
 export PATH="$R_LIB_PATH/R/bin:$PATH"
 
-R_MAJOR_VERSION="$( ${R_VERSION//./ } )[0]"
-if [[ ${R_MAJOR_VERSION} == "3" ]]; then
+R_MAJOR_VERSION=( ${R_VERSION//./ } )
+if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
     export R_MAC_VERSION=3.6.3
     export R_TRAVIS_LINUX_VERSION="3.6.3-1bionic"
     export R_APT_REPO="bionic-cran35/"
-elif [[ ${R_MAJOR_VERSION} == "4" ]]; then
+elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
     export R_MAC_VERSION=4.0.0
     export R_TRAVIS_LINUX_VERSION="4.0.0-1.1804.0"
     export R_APT_REPO="bionic-cran40/"

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -9,7 +9,7 @@ export PATH="$R_LIB_PATH/R/bin:$PATH"
 
 # Get details needed for installing R components
 # Linux builds on Azure use a container and don't need these details
-if ! { [[ $AZURE == "true" ]] && [[ $OS_NAME == "linux" ]] }; then
+if ! { [[ $AZURE == "true" ]] && [[ $OS_NAME == "linux" ]]; }; then
     R_MAJOR_VERSION=( ${R_VERSION//./ } )
     if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
         export R_MAC_VERSION=3.6.3

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -71,7 +71,7 @@ if ($env:TOOLCHAIN -eq "MINGW") {
 } elseif ($env:TOOLCHAIN -eq "MSYS") {
   Write-Output "Telling R to use MSYS"
   $install_libs = "$env:BUILD_SOURCESDIRECTORY/R-package/src/install.libs.R"
-  ((Get-Content -path $install_libs -Raw) -replace 'use_msys <- FALSE','use_msys <- TRUE') | Set-Content -Path $install_libs
+  ((Get-Content -path $install_libs -Raw) -replace 'use_msys2 <- FALSE','use_msys2 <- TRUE') | Set-Content -Path $install_libs
 }
 
 # download R and RTools

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -19,12 +19,16 @@ $env:CRAN_MIRROR = "https://cloud.r-project.org/"
 $env:CTAN_MIRROR = "https://ctan.math.illinois.edu/systems/win32/miktex/tm/packages/"
 
 # some paths and file names are different on R4.0
-if ($env:R_WINDOWS_VERSION -eq "4.0.0") {
+$env:R_MAJOR_VERSION=$env:R_VERSION.split('.')[0]
+if ($env:R_MAJOR_VERSION -eq "3") {
+  $env:RTOOLS_MINGW_BIN = "$env:R_LIB_PATH/Rtools/mingw_64/bin"
+  $env:RTOOLS_EXE_FILE = "Rtools35.exe"
+} elseif ($env:R_MAJOR_VERSION -eq "4") {
   $env:RTOOLS_MINGW_BIN = "$env:R_LIB_PATH/Rtools/mingw64/bin"
   $env:RTOOLS_EXE_FILE = "rtools40-x86_64.exe"
 } else {
-  $env:RTOOLS_MINGW_BIN = "$env:R_LIB_PATH/Rtools/mingw_64/bin"
-  $env:RTOOLS_EXE_FILE = "Rtools35.exe"
+  Write-Output "Unrecognized R version: $env:R_VERSION"
+  Check-Output $false
 }
 
 if ($env:COMPILER -eq "MINGW") {
@@ -44,13 +48,8 @@ if ($env:COMPILER -eq "MINGW") {
 
 # download R and RTools
 Write-Output "Downloading R and Rtools"
-Download-File-With-Retries -url "https://cloud.r-project.org/bin/windows/base/old/$env:R_WINDOWS_VERSION/R-$env:R_WINDOWS_VERSION-win.exe" -destfile "R-win.exe"
-
-if ($env:R_WINDOWS_VERSION -eq "4.0.0") {
-  Download-File-With-Retries -url "https://cran.r-project.org/bin/windows/Rtools/$env:RTOOLS_EXE_FILE" -destfile "Rtools.exe"
-} else {
-  Download-File-With-Retries -url "https://cloud.r-project.org/bin/windows/Rtools/$env:RTOOLS_EXE_FILE" -destfile "Rtools.exe"
-}
+Download-File-With-Retries -url "https://cloud.r-project.org/bin/windows/base/old/$env:R_VERSION/R-$env:R_VERSION-win.exe" -destfile "R-win.exe"
+Download-File-With-Retries -url "https://cloud.r-project.org/bin/windows/Rtools/$env:RTOOLS_EXE_FILE" -destfile "Rtools.exe"
 
 # Install R
 Write-Output "Installing R"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -53,7 +53,7 @@ if ($env:TOOLCHAIN -eq "MINGW") {
 if ($env:TOOLCHAIN -eq "MSYS") {
   Write-Output "Telling R to use MSYS"
   $install_libs = "$env:BUILD_SOURCESDIRECTORY/R-package/src/install.libs.R"
-  ((Get-Content -path $install_libs -Raw) -replace 'use_msys <- FALSE','use_mingw <- TRUE') | Set-Content -Path $install_libs
+  ((Get-Content -path $install_libs -Raw) -replace 'use_msys <- FALSE','use_msys <- TRUE') | Set-Content -Path $install_libs
 }
 
 # download R and RTools

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -18,7 +18,10 @@ $env:PATH = "$env:R_LIB_PATH/Rtools/bin;" + "$env:R_LIB_PATH/Rtools/usr/bin;" + 
 $env:CRAN_MIRROR = "https://cloud.r-project.org/"
 $env:CTAN_MIRROR = "https://ctan.math.illinois.edu/systems/win32/miktex/tm/packages/"
 
-# some paths and file names are different on R4.0
+# Get details needed for installing R components
+#
+# NOTES:
+#    * some paths and file names are different on R4.0
 $env:R_MAJOR_VERSION=$env:R_VERSION.split('.')[0]
 if ($env:R_MAJOR_VERSION -eq "3") {
   $env:RTOOLS_MINGW_BIN = "$env:R_LIB_PATH/Rtools/mingw_64/bin"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -75,7 +75,8 @@ if ($env:TOOLCHAIN -eq "MINGW") {
 } elseif ($env:TOOLCHAIN -eq "MSVC") {
   # no customization for MSVC
 } else {
-  Write-Output "[ERROR] Unrecognized coompiler: $env:TOOLCHAIN"
+  Write-Output "[ERROR] Unrecognized compiler: $env:TOOLCHAIN"
+  Check-Output $false
 }
 
 # download R and RTools

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -26,9 +26,11 @@ $env:R_MAJOR_VERSION=$env:R_VERSION.split('.')[0]
 if ($env:R_MAJOR_VERSION -eq "3") {
   $env:RTOOLS_MINGW_BIN = "$env:R_LIB_PATH/Rtools/mingw_64/bin"
   $env:RTOOLS_EXE_FILE = "Rtools35.exe"
+  $env:R_WINDOWS_VERSION = "3.6.3"
 } elseif ($env:R_MAJOR_VERSION -eq "4") {
   $env:RTOOLS_MINGW_BIN = "$env:R_LIB_PATH/Rtools/mingw64/bin"
   $env:RTOOLS_EXE_FILE = "rtools40-x86_64.exe"
+  $env:R_WINDOWS_VERSION = "4.0.0"
 } else {
   Write-Output "Unrecognized R version: $env:R_VERSION"
   Check-Output $false
@@ -51,7 +53,7 @@ if ($env:COMPILER -eq "MINGW") {
 
 # download R and RTools
 Write-Output "Downloading R and Rtools"
-Download-File-With-Retries -url "https://cloud.r-project.org/bin/windows/base/old/$env:R_VERSION/R-$env:R_VERSION-win.exe" -destfile "R-win.exe"
+Download-File-With-Retries -url "https://cloud.r-project.org/bin/windows/base/old/$env:R_WINDOWS_VERSION/R-$env:R_WINDOWS_VERSION-win.exe" -destfile "R-win.exe"
 Download-File-With-Retries -url "https://cloud.r-project.org/bin/windows/Rtools/$env:RTOOLS_EXE_FILE" -destfile "Rtools.exe"
 
 # Install R

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -51,7 +51,7 @@ if ($env:R_MAJOR_VERSION -eq "3") {
   $env:RTOOLS_EXE_FILE = "rtools40-x86_64.exe"
   $env:R_WINDOWS_VERSION = "4.0.0"
 } else {
-  Write-Output "Unrecognized R version: $env:R_VERSION"
+  Write-Output "[ERROR] Unrecognized R version: $env:R_VERSION"
   Check-Output $false
 }
 
@@ -72,6 +72,10 @@ if ($env:TOOLCHAIN -eq "MINGW") {
   Write-Output "Telling R to use MSYS"
   $install_libs = "$env:BUILD_SOURCESDIRECTORY/R-package/src/install.libs.R"
   ((Get-Content -Path $install_libs -Raw) -Replace 'use_msys2 <- FALSE','use_msys2 <- TRUE') | Set-Content -Path $install_libs
+} elseif ($env:TOOLCHAIN -eq "MSVC") {
+  # no customization for MSVC
+} else {
+  Write-Output "[ERROR] Unrecognized coompiler: $env:TOOLCHAIN"
 }
 
 # download R and RTools

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -14,7 +14,7 @@ function Download-File-With-Retries {
 
 $env:R_LIB_PATH = "$env:BUILD_SOURCESDIRECTORY/RLibrary" -replace '[\\]', '/'
 $env:R_LIBS = "$env:R_LIB_PATH"
-$env:PATH = "$env:R_LIB_PATH/Rtools/bin;" + "$env:R_LIB_PATH/R/bin/x64;" + "$env:R_LIB_PATH/miktex/texmfs/install/miktex/bin/x64;" + $env:PATH
+$env:PATH = "$env:R_LIB_PATH/Rtools/bin;" + "$env:R_LIB_PATH/Rtools/usr/bin;" + "$env:R_LIB_PATH/R/bin/x64;" + "$env:R_LIB_PATH/miktex/texmfs/install/miktex/bin/x64;" + $env:PATH
 $env:CRAN_MIRROR = "https://cloud.r-project.org/"
 $env:CTAN_MIRROR = "https://ctan.math.illinois.edu/systems/win32/miktex/tm/packages/"
 

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -36,7 +36,7 @@ if ($env:R_MAJOR_VERSION -eq "3") {
   Check-Output $false
 }
 
-if ($env:COMPILER -ne "MSVC") {
+if ($env:COMPILER -ne "MINGW") {
   $env:CXX = "$env:RTOOLS_MINGW_BIN/g++.exe"
   $env:CC = "$env:RTOOLS_MINGW_BIN/gcc.exe"
 }
@@ -49,8 +49,7 @@ if ($env:TOOLCHAIN -eq "MINGW") {
   Write-Output "Telling R to use MinGW"
   $install_libs = "$env:BUILD_SOURCESDIRECTORY/R-package/src/install.libs.R"
   ((Get-Content -path $install_libs -Raw) -replace 'use_mingw <- FALSE','use_mingw <- TRUE') | Set-Content -Path $install_libs
-}
-if ($env:TOOLCHAIN -eq "MSYS") {
+} elseif ($env:TOOLCHAIN -eq "MSYS") {
   Write-Output "Telling R to use MSYS"
   $install_libs = "$env:BUILD_SOURCESDIRECTORY/R-package/src/install.libs.R"
   ((Get-Content -path $install_libs -Raw) -replace 'use_msys <- FALSE','use_msys <- TRUE') | Set-Content -Path $install_libs
@@ -70,7 +69,7 @@ Write-Output "Installing Rtools"
 Start-Process -FilePath Rtools.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH/Rtools" ; Check-Output $?
 Write-Output "Done installing Rtools"
 
-# MiKTeX and pandoc can be skipped on non-MINGW builds, since we don't
+# MiKTeX and pandoc can be skipped on MSVC builds, since we don't
 # build the package documentation for those
 if ($env:COMPILER -ne "MSVC") {
     Write-Output "Downloading MiKTeX"
@@ -119,7 +118,7 @@ if ($env:COMPILER -ne "MSVC") {
   $note_str = Get-Content "${LOG_FILE_NAME}" | Select-String -Pattern ' NOTE' | Out-String ; Check-Output $?
   $relevant_line = $note_str -match '.*Status: (\d+) NOTE.*'
   $NUM_CHECK_NOTES = $matches[1]
-  $ALLOWED_CHECK_NOTES = 3
+  $ALLOWED_CHECK_NOTES = 4
   if ([int]$NUM_CHECK_NOTES -gt $ALLOWED_CHECK_NOTES) {
       Write-Output "Found ${NUM_CHECK_NOTES} NOTEs from R CMD check. Only ${ALLOWED_CHECK_NOTES} are allowed"
       Check-Output $False

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -41,7 +41,7 @@ $env:CTAN_PACKAGE_ARCHIVE = "$env:CTAN_MIRROR/tm/packages/"
 #
 # NOTES:
 #    * some paths and file names are different on R4.0
-$env:R_MAJOR_VERSION=$env:R_VERSION.split('.')[0]
+$env:R_MAJOR_VERSION = $env:R_VERSION.split('.')[0]
 if ($env:R_MAJOR_VERSION -eq "3") {
   $env:RTOOLS_MINGW_BIN = "$env:R_LIB_PATH/Rtools/mingw_64/bin"
   $env:RTOOLS_EXE_FILE = "Rtools35.exe"
@@ -67,11 +67,11 @@ tzutil /s "GMT Standard Time"
 if ($env:TOOLCHAIN -eq "MINGW") {
   Write-Output "Telling R to use MinGW"
   $install_libs = "$env:BUILD_SOURCESDIRECTORY/R-package/src/install.libs.R"
-  ((Get-Content -path $install_libs -Raw) -replace 'use_mingw <- FALSE','use_mingw <- TRUE') | Set-Content -Path $install_libs
+  ((Get-Content -Path $install_libs -Raw) -Replace 'use_mingw <- FALSE','use_mingw <- TRUE') | Set-Content -Path $install_libs
 } elseif ($env:TOOLCHAIN -eq "MSYS") {
   Write-Output "Telling R to use MSYS"
   $install_libs = "$env:BUILD_SOURCESDIRECTORY/R-package/src/install.libs.R"
-  ((Get-Content -path $install_libs -Raw) -replace 'use_msys2 <- FALSE','use_msys2 <- TRUE') | Set-Content -Path $install_libs
+  ((Get-Content -Path $install_libs -Raw) -Replace 'use_msys2 <- FALSE','use_msys2 <- TRUE') | Set-Content -Path $install_libs
 }
 
 # download R and RTools

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -67,7 +67,8 @@ Write-Output "Done installing Rtools"
 
 # MiKTeX and pandoc can be skipped on non-MINGW builds, since we don't
 # build the package documentation for those
-if ($env:COMPILER -eq "MINGW") {
+#if ($env:COMPILER -eq "MINGW") {
+if ($false) {
     Write-Output "Downloading MiKTeX"
     Download-File-With-Retries -url "https://miktex.org/download/win/miktexsetup-x64.zip" -destfile "miktexsetup-x64.zip"
     Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -85,6 +86,9 @@ if ($env:COMPILER -eq "MINGW") {
 Write-Output "Installing dependencies"
 $packages = "c('data.table', 'jsonlite', 'Matrix', 'processx', 'R6', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
 Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')" ; Check-Output $?
+
+Rscript build_r.R
+Check-Output $false
 
 Write-Output "Building R package"
 

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -36,7 +36,7 @@ if ($env:R_MAJOR_VERSION -eq "3") {
   Check-Output $false
 }
 
-if ($env:COMPILER -eq "MINGW") {
+if ($env:COMPILER -ne "MSVC") {
   $env:CXX = "$env:RTOOLS_MINGW_BIN/g++.exe"
   $env:CC = "$env:RTOOLS_MINGW_BIN/gcc.exe"
 }
@@ -45,10 +45,15 @@ cd $env:BUILD_SOURCESDIRECTORY
 tzutil /s "GMT Standard Time"
 [Void][System.IO.Directory]::CreateDirectory($env:R_LIB_PATH)
 
-if ($env:COMPILER -eq "MINGW") {
+if ($env:TOOLCHAIN -eq "MINGW") {
   Write-Output "Telling R to use MinGW"
   $install_libs = "$env:BUILD_SOURCESDIRECTORY/R-package/src/install.libs.R"
   ((Get-Content -path $install_libs -Raw) -replace 'use_mingw <- FALSE','use_mingw <- TRUE') | Set-Content -Path $install_libs
+}
+if ($env:TOOLCHAIN -eq "MSYS") {
+  Write-Output "Telling R to use MSYS"
+  $install_libs = "$env:BUILD_SOURCESDIRECTORY/R-package/src/install.libs.R"
+  ((Get-Content -path $install_libs -Raw) -replace 'use_msys <- FALSE','use_mingw <- TRUE') | Set-Content -Path $install_libs
 }
 
 # download R and RTools

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -12,16 +12,24 @@ function Download-File-With-Retries {
   } while(!$?);
 }
 
-$env:R_WINDOWS_VERSION = "3.6.3"
 $env:R_LIB_PATH = "$env:BUILD_SOURCESDIRECTORY/RLibrary" -replace '[\\]', '/'
 $env:R_LIBS = "$env:R_LIB_PATH"
 $env:PATH = "$env:R_LIB_PATH/Rtools/bin;" + "$env:R_LIB_PATH/R/bin/x64;" + "$env:R_LIB_PATH/miktex/texmfs/install/miktex/bin/x64;" + $env:PATH
 $env:CRAN_MIRROR = "https://cloud.r-project.org/"
 $env:CTAN_MIRROR = "https://ctan.math.illinois.edu/systems/win32/miktex/tm/packages/"
 
+# some paths and file names are different on R4.0
+if ($env:R_WINDOWS_VERSION -eq "4.0.0") {
+  $env:RTOOLS_MINGW_BIN = "$env:R_LIB_PATH/Rtools/mingw64/bin"
+  $env:RTOOLS_EXE_FILE = "rtools40-x86_64.exe"
+} else {
+  $env:RTOOLS_MINGW_BIN = "$env:R_LIB_PATH/Rtools/mingw_64/bin"
+  $env:RTOOLS_EXE_FILE = "Rtools35.exe"
+}
+
 if ($env:COMPILER -eq "MINGW") {
-  $env:CXX = "$env:R_LIB_PATH/Rtools/mingw_64/bin/g++.exe"
-  $env:CC = "$env:R_LIB_PATH/Rtools/mingw_64/bin/gcc.exe"
+  $env:CXX = "$env:RTOOLS_MINGW_BIN/g++.exe"
+  $env:CC = "$env:RTOOLS_MINGW_BIN/gcc.exe"
 }
 
 cd $env:BUILD_SOURCESDIRECTORY
@@ -37,7 +45,12 @@ if ($env:COMPILER -eq "MINGW") {
 # download R and RTools
 Write-Output "Downloading R and Rtools"
 Download-File-With-Retries -url "https://cloud.r-project.org/bin/windows/base/old/$env:R_WINDOWS_VERSION/R-$env:R_WINDOWS_VERSION-win.exe" -destfile "R-win.exe"
-Download-File-With-Retries -url "https://cloud.r-project.org/bin/windows/Rtools/Rtools35.exe" -destfile "Rtools.exe"
+
+if ($env:R_WINDOWS_VERSION -eq "4.0.0") {
+  Download-File-With-Retries -url "https://cran.r-project.org/bin/windows/Rtools/$env:RTOOLS_EXE_FILE" -destfile "Rtools.exe"
+} else {
+  Download-File-With-Retries -url "https://cloud.r-project.org/bin/windows/Rtools/$env:RTOOLS_EXE_FILE" -destfile "Rtools.exe"
+}
 
 # Install R
 Write-Output "Installing R"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -36,7 +36,7 @@ if ($env:R_MAJOR_VERSION -eq "3") {
   Check-Output $false
 }
 
-if ($env:COMPILER -ne "MINGW") {
+if ($env:COMPILER -eq "MINGW") {
   $env:CXX = "$env:RTOOLS_MINGW_BIN/g++.exe"
   $env:CC = "$env:RTOOLS_MINGW_BIN/gcc.exe"
 }

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -72,8 +72,7 @@ Write-Output "Done installing Rtools"
 
 # MiKTeX and pandoc can be skipped on non-MINGW builds, since we don't
 # build the package documentation for those
-#if ($env:COMPILER -eq "MINGW") {
-if ($false) {
+if ($env:COMPILER -ne "MSVC") {
     Write-Output "Downloading MiKTeX"
     Download-File-With-Retries -url "https://miktex.org/download/win/miktexsetup-x64.zip" -destfile "miktexsetup-x64.zip"
     Add-Type -AssemblyName System.IO.Compression.FileSystem

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,20 +15,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r_version: [3.6, 4.0]
         include:
           - os: ubuntu-latest
             task: r-package
             compiler: gcc
+            r_version: 3.6
+          - os: ubuntu-latest
+            task: r-package
+            compiler: gcc
+            r_version: 4.0
           - os: ubuntu-latest
             task: r-package
             compiler: clang
+            r_version: 3.6
+          - os: ubuntu-latest
+            task: r-package
+            compiler: clang
+            r_version: 4.0
           - os: macOS-latest
             task: r-package
             compiler: gcc
+            r_version: 3.6
+          - os: macOS-latest
+            task: r-package
+            compiler: gcc
+            r_version: 4.0
           - os: macOS-latest
             task: r-package
             compiler: clang
+            r_version: 3.6
+          - os: macOS-latest
+            task: r-package
+            compiler: clang
+            r_version: 4.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,39 +15,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        r_version: [3.6, 4.0]
         include:
           - os: ubuntu-latest
             task: r-package
             compiler: gcc
-            r_version: 3.6
-          - os: ubuntu-latest
-            task: r-package
-            compiler: gcc
-            r_version: 4.0
           - os: ubuntu-latest
             task: r-package
             compiler: clang
-            r_version: 3.6
-          - os: ubuntu-latest
-            task: r-package
-            compiler: clang
-            r_version: 4.0
           - os: macOS-latest
             task: r-package
             compiler: gcc
-            r_version: 3.6
-          - os: macOS-latest
-            task: r-package
-            compiler: gcc
-            r_version: 4.0
           - os: macOS-latest
             task: r-package
             compiler: clang
-            r_version: 3.6
-          - os: macOS-latest
-            task: r-package
-            compiler: clang
-            r_version: 4.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
@@ -73,6 +54,6 @@ jobs:
           export CONDA="$HOME/miniconda"
           export PATH="$CONDA/bin:${HOME}/.local/bin:$PATH"
           export LGB_VER=$(head -n 1 VERSION.txt)
-          export R_VERSION="{{ matrix.r_version }}"
+          export R_VERSION="${{ matrix.r_version }}"
           $GITHUB_WORKSPACE/.ci/setup.sh
           $GITHUB_WORKSPACE/.ci/test.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        r_version: [3.6, 4.0]
         include:
           - os: ubuntu-latest
             task: r-package
@@ -53,5 +54,6 @@ jobs:
           export CONDA="$HOME/miniconda"
           export PATH="$CONDA/bin:${HOME}/.local/bin:$PATH"
           export LGB_VER=$(head -n 1 VERSION.txt)
+          export R_VERSION="{{ matrix.r_version }}"
           $GITHUB_WORKSPACE/.ci/setup.sh
           $GITHUB_WORKSPACE/.ci/test.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.task }} (${{ matrix.os }}, ${{ matrix.compiler }})
+    name: ${{ matrix.task }} (${{ matrix.os }}, ${{ matrix.compiler }}, R ${{ matrix.r_version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -406,6 +406,7 @@ R-package/src-i386
 lightgbm_r/*
 lightgbm*.tar.gz
 lightgbm.Rcheck/
+*.def
 
 # Files created by R examples and tests
 **/lgb-Dataset.data

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -109,11 +109,16 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   strategy:
-    maxParallel: 4
+    maxParallel: 5
     matrix:
       r_package:
         TASK: r-package
         COMPILER: MSVC
+        R_VERSION: 3.6
+      r_package:
+        TASK: r-package
+        COMPILER: MINGW
+        TOOLCHAIN: MINGW
         R_VERSION: 3.6
       regular:
         TASK: regular

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -114,7 +114,7 @@ jobs:
       r_package:
         TASK: r-package
         COMPILER: MSVC
-        R_WINDOWS_VERSION: 3.6.3
+        R_VERSION: 3.6.3
       regular:
         TASK: regular
         PYTHON_VERSION: 3.6

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -111,11 +111,11 @@ jobs:
   strategy:
     maxParallel: 5
     matrix:
-      r_package:
+      r_package_msvc:
         TASK: r-package
         COMPILER: MSVC
         R_VERSION: 3.6
-      r_package:
+      r_package_mingw:
         TASK: r-package
         COMPILER: MINGW
         TOOLCHAIN: MINGW

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -116,7 +116,7 @@ jobs:
         COMPILER: MSVC
         R_VERSION: 3.6
         TOOLCHAIN: MSVC
-      r_package_mingw:
+      r_package_msys:
         TASK: r-package
         COMPILER: MINGW
         R_VERSION: 4.0

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -114,15 +114,15 @@ jobs:
       r_package:
         TASK: r-package
         COMPILER: MSVC
-        R_VERSION: 3.6.3
-      regular:
-        TASK: regular
-        PYTHON_VERSION: 3.6
-      sdist:
-        TASK: sdist
-        PYTHON_VERSION: 2.7
-      bdist:
-        TASK: bdist
+        R_VERSION: 3.6
+      # regular:
+      #   TASK: regular
+      #   PYTHON_VERSION: 3.6
+      # sdist:
+      #   TASK: sdist
+      #   PYTHON_VERSION: 2.7
+      # bdist:
+      #   TASK: bdist
   steps:
   - powershell: |
       Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -115,11 +115,12 @@ jobs:
         TASK: r-package
         COMPILER: MSVC
         R_VERSION: 3.6
+        TOOLCHAIN: MSVC
       r_package_mingw:
         TASK: r-package
         COMPILER: MINGW
-        TOOLCHAIN: MINGW
-        R_VERSION: 3.6
+        R_VERSION: 4.0
+        TOOLCHAIN: MSYS
       regular:
         TASK: regular
         PYTHON_VERSION: 3.6

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -114,6 +114,7 @@ jobs:
       r_package:
         TASK: r-package
         COMPILER: MSVC
+        R_WINDOWS_VERSION: 3.6.3
       regular:
         TASK: regular
         PYTHON_VERSION: 3.6

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -115,14 +115,14 @@ jobs:
         TASK: r-package
         COMPILER: MSVC
         R_VERSION: 3.6
-      # regular:
-      #   TASK: regular
-      #   PYTHON_VERSION: 3.6
-      # sdist:
-      #   TASK: sdist
-      #   PYTHON_VERSION: 2.7
-      # bdist:
-      #   TASK: bdist
+      regular:
+        TASK: regular
+        PYTHON_VERSION: 3.6
+      sdist:
+        TASK: sdist
+        PYTHON_VERSION: 2.7
+      bdist:
+        TASK: bdist
   steps:
   - powershell: |
       Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -22,13 +22,7 @@ Note: 32-bit (i386) R/Rtools is currently not supported.
 
 Installing a 64-bit version of [Rtools](https://cran.r-project.org/bin/windows/Rtools/) is mandatory.
 
-The default compiler is Visual Studio (or [VS Build Tools](https://visualstudio.microsoft.com/downloads/)) in Windows, with an automatic fallback to Rtools or any [MinGW64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/) (x86_64-posix-seh) available. This means if you have only Rtools and CMake, you can still compile the library.
-
-To force the usage of Rtools / MinGW, you can set `use_mingw` to `TRUE` in `R-package/src/install.libs.R`.
-
-**Warning for Windows users**: it is recommended to use *Visual Studio* for its better multi-threading efficiency in Windows for many core systems. For very simple systems (dual core computers or worse), MinGW64 is recommended for maximum performance. If you do not know what to choose, it is recommended to use [Visual Studio](https://visualstudio.microsoft.com/downloads/), the default compiler. **Do not try using MinGW in Windows on many core systems. It may result in 10x slower results than Visual Studio.**
-
-After installing the software mentioned above, be sure the following paths are added to the environment variable `PATH`. These may have been automatically when installing other software.
+After installing `Rtools` and `CMake`, be sure the following paths are added to the environment variable `PATH`. These may have been automatically added when installing other software.
 
 * `Rtools` MinGW bin:
     - example: `C:\Rtools\mingw_64\bin`
@@ -37,12 +31,40 @@ After installing the software mentioned above, be sure the following paths are a
 * `R`
     - example: `C\Program Files\R\R-3.6.1\bin`
 
-**Notes for R4.0+ users**
-
 As of `Rtools` 4.0, some common paths changed and software was removed from `Rtools`. If you are using `R` 4.0 or later and the corresponding `Rtools`, you need to add one additional path to `PATH`.
 
 * `Rtools` usr bin:
     - example: `C:\Rtools\usr\bin`
+
+##### Windows Compiler options
+
+The R package can be built with three different toolchains.
+
+**Warning for Windows users**: it is recommended to use *Visual Studio* for its better multi-threading efficiency in Windows for many core systems. For very simple systems (dual core computers or worse), MinGW64 is recommended for maximum performance. If you do not know what to choose, it is recommended to use [Visual Studio](https://visualstudio.microsoft.com/downloads/), the default compiler. **Do not try using MinGW in Windows on many core systems. It may result in 10x slower results than Visual Studio.**
+
+**Visual Studio (default)**
+
+By default, the package will be built with [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/).
+
+**MinGW (R 3.x)**
+
+If you are using R 3.x and installation fails with Visual Studio, `LightGBM` will fall back to using [MinGW](http://www.mingw.org/). This should work with the tools already bundled in `Rtools` 3.5.
+
+If you want to force `LightGBM` to use MinGW (for any R version), open `R-package/src/install.libs.R` and change `use_mingw`:
+
+```r
+use_mingw <- TRUE
+```
+
+**MSYS (R 4.x)**
+
+If you are using R 4.x and installation fails with Visual Studio, `LightGBM` will fall back to using [MSYS](http://www.mingw.org/wiki/msys). This should work with the tools already bundled in `Rtools` 4.0.
+
+If you want to force `LightGBM` to use MSYS (for any R version), open `R-package/src/install.libs.R` and change `use_msys`:
+
+```r
+use_msys <- TRUE
+```
 
 #### Mac OS Preparation
 

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -24,8 +24,12 @@ Installing a 64-bit version of [Rtools](https://cran.r-project.org/bin/windows/R
 
 After installing `Rtools` and `CMake`, be sure the following paths are added to the environment variable `PATH`. These may have been automatically added when installing other software.
 
-* `Rtools` MinGW bin:
-    - example: `C:\Rtools\mingw_64\bin`
+* `Rtools`
+    - If you have `Rtools` 3.x, example:
+        - `C:\Rtools\mingw_64\bin`
+    - If you have `Rtools` 4.0, example:
+        - `C:\rtools40\mingw64\bin`
+        - `C:\rtools40\usr\bin`
 * `CMake`
     - example: `C:\Program Files\CMake\bin`
 * `R`
@@ -48,7 +52,7 @@ By default, the package will be built with [Visual Studio Build Tools](https://v
 
 **MinGW (R 3.x)**
 
-If you are using R 3.x and installation fails with Visual Studio, `LightGBM` will fall back to using [MinGW](http://mingw-w64.org/doku.php). This should work with the tools already bundled in `Rtools` 3.5.
+If you are using R 3.x and installation fails with Visual Studio, `LightGBM` will fall back to using [MinGW](http://mingw-w64.org/doku.php) bundled with `Rtools`.
 
 If you want to force `LightGBM` to use MinGW (for any R version), open `R-package/src/install.libs.R` and change `use_mingw`:
 

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -33,7 +33,7 @@ After installing `Rtools` and `CMake`, be sure the following paths are added to 
 * `CMake`
     - example: `C:\Program Files\CMake\bin`
 * `R`
-    - example: `C\Program Files\R\R-3.6.1\bin`
+    - example: `C:\Program Files\R\R-3.6.1\bin`
 
 As of `Rtools` 4.0, some common paths changed and software was removed from `Rtools`. If you are using `R` 4.0 or later and the corresponding `Rtools`, you need to add one additional path to `PATH`.
 
@@ -62,9 +62,9 @@ use_mingw <- TRUE
 
 **MSYS2 (R 4.x)**
 
-If you are using R 4.x and installation fails with Visual Studio, `LightGBM` will fall back to using [MSYS](https://www.msys2.org/). This should work with the tools already bundled in `Rtools` 4.0.
+If you are using R 4.x and installation fails with Visual Studio, `LightGBM` will fall back to using [MSYS2](https://www.msys2.org/). This should work with the tools already bundled in `Rtools` 4.0.
 
-If you want to force `LightGBM` to use MSYS2 (for any R version), open `R-package/src/install.libs.R` and change `use_msys`:
+If you want to force `LightGBM` to use MSYS2 (for any R version), open `R-package/src/install.libs.R` and change `use_msys2`:
 
 ```r
 use_msys2 <- TRUE

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -35,10 +35,7 @@ After installing `Rtools` and `CMake`, be sure the following paths are added to 
 * `R`
     - example: `C:\Program Files\R\R-3.6.1\bin`
 
-As of `Rtools` 4.0, some common paths changed and software was removed from `Rtools`. If you are using `R` 4.0 or later and the corresponding `Rtools`, you need to add one additional path to `PATH`.
-
-* `Rtools` usr bin:
-    - example: `C:\Rtools\usr\bin`
+NOTE: Two `Rtools` paths are required from `Rtools` 4.0 onwards because paths and the list of included software was changed in `Rtools` 4.0.
 
 #### Windows Toolchain Options
 

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -48,7 +48,7 @@ By default, the package will be built with [Visual Studio Build Tools](https://v
 
 **MinGW (R 3.x)**
 
-If you are using R 3.x and installation fails with Visual Studio, `LightGBM` will fall back to using [MinGW](http://www.mingw.org/). This should work with the tools already bundled in `Rtools` 3.5.
+If you are using R 3.x and installation fails with Visual Studio, `LightGBM` will fall back to using [MinGW](http://mingw-w64.org/doku.php). This should work with the tools already bundled in `Rtools` 3.5.
 
 If you want to force `LightGBM` to use MinGW (for any R version), open `R-package/src/install.libs.R` and change `use_mingw`:
 
@@ -56,14 +56,14 @@ If you want to force `LightGBM` to use MinGW (for any R version), open `R-packag
 use_mingw <- TRUE
 ```
 
-**MSYS (R 4.x)**
+**MSYS2 (R 4.x)**
 
-If you are using R 4.x and installation fails with Visual Studio, `LightGBM` will fall back to using [MSYS](http://www.mingw.org/wiki/msys). This should work with the tools already bundled in `Rtools` 4.0.
+If you are using R 4.x and installation fails with Visual Studio, `LightGBM` will fall back to using [MSYS](https://www.msys2.org/). This should work with the tools already bundled in `Rtools` 4.0.
 
-If you want to force `LightGBM` to use MSYS (for any R version), open `R-package/src/install.libs.R` and change `use_msys`:
+If you want to force `LightGBM` to use MSYS2 (for any R version), open `R-package/src/install.libs.R` and change `use_msys`:
 
 ```r
-use_msys <- TRUE
+use_msys2 <- TRUE
 ```
 
 #### Mac OS Preparation

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -28,7 +28,7 @@ To force the usage of Rtools / MinGW, you can set `use_mingw` to `TRUE` in `R-pa
 
 **Warning for Windows users**: it is recommended to use *Visual Studio* for its better multi-threading efficiency in Windows for many core systems. For very simple systems (dual core computers or worse), MinGW64 is recommended for maximum performance. If you do not know what to choose, it is recommended to use [Visual Studio](https://visualstudio.microsoft.com/downloads/), the default compiler. **Do not try using MinGW in Windows on many core systems. It may result in 10x slower results than Visual Studio.**
 
-After installing the software mentioned above, be sure the following paths are added to the environment variable `PATH`. These may have been automatically when installing other software
+After installing the software mentioned above, be sure the following paths are added to the environment variable `PATH`. These may have been automatically when installing other software.
 
 * `Rtools` MinGW bin:
     - example: `C:\Rtools\mingw_64\bin`

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -36,9 +36,9 @@ As of `Rtools` 4.0, some common paths changed and software was removed from `Rto
 * `Rtools` usr bin:
     - example: `C:\Rtools\usr\bin`
 
-##### Windows Compiler options
+#### Windows Toolchain Options
 
-The R package can be built with three different toolchains.
+A "toolchain" refers to the collection of software used to build the library. The R package can be built with three different toolchains.
 
 **Warning for Windows users**: it is recommended to use *Visual Studio* for its better multi-threading efficiency in Windows for many core systems. For very simple systems (dual core computers or worse), MinGW64 is recommended for maximum performance. If you do not know what to choose, it is recommended to use [Visual Studio](https://visualstudio.microsoft.com/downloads/), the default compiler. **Do not try using MinGW in Windows on many core systems. It may result in 10x slower results than Visual Studio.**
 

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -20,13 +20,29 @@ Note: 32-bit (i386) R/Rtools is currently not supported.
 
 #### Windows Preparation
 
-Installing [Rtools](https://cran.r-project.org/bin/windows/Rtools/) is mandatory, and only support the 64-bit version. It requires to add to PATH the Rtools MinGW64 folder, if it was not done automatically during installation.
+Installing a 64-bit version of [Rtools](https://cran.r-project.org/bin/windows/Rtools/) is mandatory.
 
-The default compiler is Visual Studio (or [VS Build Tools](https://visualstudio.microsoft.com/downloads/)) in Windows, with an automatic fallback to Rtools or any [MinGW64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/) (x86_64-posix-seh) available (this means if you have only Rtools and CMake, it will compile fine).
+The default compiler is Visual Studio (or [VS Build Tools](https://visualstudio.microsoft.com/downloads/)) in Windows, with an automatic fallback to Rtools or any [MinGW64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/) (x86_64-posix-seh) available. This means if you have only Rtools and CMake, you can still compile the library.
 
 To force the usage of Rtools / MinGW, you can set `use_mingw` to `TRUE` in `R-package/src/install.libs.R`.
 
 **Warning for Windows users**: it is recommended to use *Visual Studio* for its better multi-threading efficiency in Windows for many core systems. For very simple systems (dual core computers or worse), MinGW64 is recommended for maximum performance. If you do not know what to choose, it is recommended to use [Visual Studio](https://visualstudio.microsoft.com/downloads/), the default compiler. **Do not try using MinGW in Windows on many core systems. It may result in 10x slower results than Visual Studio.**
+
+After installing the software mentioned above, be sure the following paths are added to the environment variable `PATH`. These may have been automatically when installing other software
+
+* `Rtools` MinGW bin:
+    - example: `C:\Rtools\mingw_64\bin`
+* `CMake`
+    - example: `C:\Program Files\CMake\bin`
+* `R`
+    - example: `C\Program Files\R\R-3.6.1\bin`
+
+**Notes for R4.0+ users**
+
+As of `Rtools` 4.0, some common paths changed and software was removed from `Rtools`. If you are using `R` 4.0 or later and the corresponding `Rtools`, you need to add one additional path to `PATH`.
+
+* `Rtools` usr bin:
+    - example: `C:\Rtools\usr\bin`
 
 #### Mac OS Preparation
 

--- a/R-package/inst/make-r-def.R
+++ b/R-package/inst/make-r-def.R
@@ -2,7 +2,7 @@
 #     Create a definition file (.def) from a .dll file, using objdump.
 #
 # [usage]
-# 
+#
 #     Rscript make-r-def.R something.dll something.def
 #
 # [references]
@@ -10,14 +10,11 @@
 
 args <- commandArgs(trailingOnly = TRUE)
 
-IN_DLL_FILE <- args[[1]]
-OUT_DEF_FILE <- args[[2]]
+IN_DLL_FILE <- args[[1L]]
+OUT_DEF_FILE <- args[[2L]]
 DLL_BASE_NAME <- basename(IN_DLL_FILE)
 
 print(sprintf("Creating '%s' from '%s'", OUT_DEF_FILE, IN_DLL_FILE))
-
-# Creates a .def file from R.dll, using tools bundled with R4.0
-#LIBR_CORE_LIBRARY <- "C:/Program Files/R/R-3.6.1/bin/x64/R.dll"
 
 # use objdump to dump all the symbols
 OBJDUMP_FILE <- "objdump-out.txt"
@@ -43,10 +40,10 @@ start_index <- which(
     )
 )
 empty_lines <- which(objdump_results == "")
-end_of_table <- empty_lines[empty_lines > start_index][1]
+end_of_table <- empty_lines[empty_lines > start_index][1L]
 
 # Read the contents of the table
-exported_symbols <- objdump_results[(start_index + 1):end_of_table]
+exported_symbols <- objdump_results[(start_index + 1L):end_of_table]
 exported_symbols <- gsub("\t", "", exported_symbols)
 exported_symbols <- gsub(".*\\] ", "", exported_symbols)
 exported_symbols <- gsub(" ", "", exported_symbols)

--- a/R-package/inst/make-r-def.R
+++ b/R-package/inst/make-r-def.R
@@ -62,6 +62,9 @@ OBJDUMP_FILE <- "objdump-out.txt"
 objdump_results <- readLines(OBJDUMP_FILE)
 result <- file.remove(OBJDUMP_FILE)
 
+print("------- objdump results --------------")
+print(objdump_results)
+
 # Only one table in the objdump results matters for our purposes,
 # see https://www.cs.colorado.edu/~main/cs1300/doc/mingwfaq.html
 start_index <- which(

--- a/R-package/inst/make-r-def.R
+++ b/R-package/inst/make-r-def.R
@@ -32,7 +32,9 @@ message(sprintf("Creating '%s' from '%s'", OUT_DEF_FILE, IN_DLL_FILE))
             command = command
             , args = args
             , stdout = out_file
-        )$wait()
+            , windows_verbatim_args = FALSE
+        )
+        invisible(p$wait())
     } else {
         message(paste0(
           "Using system2() to run shell commands. Installing "
@@ -55,7 +57,7 @@ message(sprintf("Creating '%s' from '%s'", OUT_DEF_FILE, IN_DLL_FILE))
 OBJDUMP_FILE <- "objdump-out.txt"
 .pipe_shell_command_to_stdout(
     command = "objdump"
-    , args = c("-p", shQuote(IN_DLL_FILE))
+    , args = c("-p", IN_DLL_FILE)
     , out_file = OBJDUMP_FILE
 )
 

--- a/R-package/inst/make-r-def.R
+++ b/R-package/inst/make-r-def.R
@@ -64,9 +64,6 @@ OBJDUMP_FILE <- "objdump-out.txt"
 objdump_results <- readLines(OBJDUMP_FILE)
 result <- file.remove(OBJDUMP_FILE)
 
-print("------- objdump results --------------")
-print(objdump_results)
-
 # Only one table in the objdump results matters for our purposes,
 # see https://www.cs.colorado.edu/~main/cs1300/doc/mingwfaq.html
 start_index <- which(

--- a/R-package/inst/make-r-def.R
+++ b/R-package/inst/make-r-def.R
@@ -41,9 +41,12 @@ message(sprintf("Creating '%s' from '%s'", OUT_DEF_FILE, IN_DLL_FILE))
           , "'processx' with install.packages('processx') might "
           , "make this faster."
         ))
+        # shQuote() is necessary here since one of the arguments
+        # is a file-path to R.dll, which may have spaces. processx
+        # does such quoting but system2() does not
         exit_code <- system2(
             command = command
-            , args = args
+            , args = shoQuote(args)
             , stdout = out_file
         )
         if (exit_code != 0L) {

--- a/R-package/inst/make-r-def.R
+++ b/R-package/inst/make-r-def.R
@@ -21,7 +21,7 @@ message(sprintf("Creating '%s' from '%s'", OUT_DEF_FILE, IN_DLL_FILE))
 #
 # system() introduces a lot of overhead, at least on Windows,
 # so trying processx if it is available
-.pipe_shell_command_to_stdout <- function(cmd, args, out_file) {
+.pipe_shell_command_to_stdout <- function(command, args, out_file) {
     has_processx <- suppressMessages({
       suppressWarnings({
         require("processx")  # nolint

--- a/R-package/inst/make-r-def.R
+++ b/R-package/inst/make-r-def.R
@@ -62,7 +62,7 @@ OBJDUMP_FILE <- "objdump-out.txt"
 )
 
 objdump_results <- readLines(OBJDUMP_FILE)
-result <- file.remove(OBJDUMP_FILE)
+invisible(file.remove(OBJDUMP_FILE))
 
 # Only one table in the objdump results matters for our purposes,
 # see https://www.cs.colorado.edu/~main/cs1300/doc/mingwfaq.html

--- a/R-package/inst/make-r-def.R
+++ b/R-package/inst/make-r-def.R
@@ -14,7 +14,7 @@ IN_DLL_FILE <- args[[1L]]
 OUT_DEF_FILE <- args[[2L]]
 DLL_BASE_NAME <- basename(IN_DLL_FILE)
 
-print(sprintf("Creating '%s' from '%s'", OUT_DEF_FILE, IN_DLL_FILE))
+message(sprintf("Creating '%s' from '%s'", OUT_DEF_FILE, IN_DLL_FILE))
 
 # use objdump to dump all the symbols
 OBJDUMP_FILE <- "objdump-out.txt"
@@ -58,3 +58,4 @@ writeLines(
     , con = OUT_DEF_FILE
     , sep = "\n"
 )
+message(sprintf("Successfully created '%s'", OUT_DEF_FILE))

--- a/R-package/src/cmake/modules/FindLibR.cmake
+++ b/R-package/src/cmake/modules/FindLibR.cmake
@@ -41,22 +41,15 @@ function(create_rlib_for_msvc)
     message(FATAL_ERROR "LIBR_CORE_LIBRARY, '${LIBR_CORE_LIBRARY}', not found")
   endif()
 
-  # find_program(GENDEF_EXE gendef)
   find_program(DLLTOOL_EXE dlltool)
 
-  #if(NOT GENDEF_EXE OR NOT DLLTOOL_EXE)
   if(NOT DLLTOOL_EXE)
-    message(FATAL_ERROR "Either gendef.exe or dlltool.exe not found!\
+    message(FATAL_ERROR "Either dlltool.exe not found!\
       \nDo you have Rtools installed with its MinGW's bin/ in PATH?")
   endif()
 
   set(LIBR_MSVC_CORE_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/R.lib" CACHE PATH "R.lib filepath")
 
-  # extract symbols from R.dll into R.def and R.lib import library
-  #execute_process(COMMAND ${GENDEF_EXE}
-  #  "-" "${LIBR_CORE_LIBRARY}"
-  #  OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/R.def"
-  #)
   execute_process(
     COMMAND "${LIBR_HOME}/bin/Rscript"
     "${CMAKE_CURRENT_BINARY_DIR}/make-r-def.R"

--- a/R-package/src/cmake/modules/FindLibR.cmake
+++ b/R-package/src/cmake/modules/FindLibR.cmake
@@ -41,10 +41,11 @@ function(create_rlib_for_msvc)
     message(FATAL_ERROR "LIBR_CORE_LIBRARY, '${LIBR_CORE_LIBRARY}', not found")
   endif()
 
-  find_program(GENDEF_EXE gendef)
+  # find_program(GENDEF_EXE gendef)
   find_program(DLLTOOL_EXE dlltool)
 
-  if(NOT GENDEF_EXE OR NOT DLLTOOL_EXE)
+  #if(NOT GENDEF_EXE OR NOT DLLTOOL_EXE)
+  if(NOT DLLTOOL_EXE)
     message(FATAL_ERROR "Either gendef.exe or dlltool.exe not found!\
       \nDo you have Rtools installed with its MinGW's bin/ in PATH?")
   endif()
@@ -52,9 +53,14 @@ function(create_rlib_for_msvc)
   set(LIBR_MSVC_CORE_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/R.lib" CACHE PATH "R.lib filepath")
 
   # extract symbols from R.dll into R.def and R.lib import library
-  execute_process(COMMAND ${GENDEF_EXE}
-    "-" "${LIBR_CORE_LIBRARY}"
-    OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/R.def"
+  #execute_process(COMMAND ${GENDEF_EXE}
+  #  "-" "${LIBR_CORE_LIBRARY}"
+  #  OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/R.def"
+  #)
+  execute_process(
+    COMMAND "${LIBR_HOME}/bin/Rscript"
+    "${CMAKE_CURRENT_BINARY_DIR}/make-r-def.R"
+    "${LIBR_CORE_LIBRARY}" "${CMAKE_CURRENT_BINARY_DIR}/R.def"
   )
   execute_process(COMMAND ${DLLTOOL_EXE}
     "--input-def" "${CMAKE_CURRENT_BINARY_DIR}/R.def"

--- a/R-package/src/cmake/modules/FindLibR.cmake
+++ b/R-package/src/cmake/modules/FindLibR.cmake
@@ -50,8 +50,15 @@ function(create_rlib_for_msvc)
 
   set(LIBR_MSVC_CORE_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/R.lib" CACHE PATH "R.lib filepath")
 
+  get_filename_component(
+    LIBR_RSCRIPT_EXECUTABLE_DIR
+    ${LIBR_EXECUTABLE}
+    DIRECTORY
+  )
+  set(LIBR_RSCRIPT_EXECUTABLE "${LIBR_RSCRIPT_EXECUTABLE_DIR}/Rscript")
+
   execute_process(
-    COMMAND "${LIBR_HOME}/bin/Rscript"
+    COMMAND ${LIBR_RSCRIPT_EXECUTABLE}
     "${CMAKE_CURRENT_BINARY_DIR}/make-r-def.R"
     "${LIBR_CORE_LIBRARY}" "${CMAKE_CURRENT_BINARY_DIR}/R.def"
   )

--- a/R-package/src/cmake/modules/FindLibR.cmake
+++ b/R-package/src/cmake/modules/FindLibR.cmake
@@ -44,7 +44,7 @@ function(create_rlib_for_msvc)
   find_program(DLLTOOL_EXE dlltool)
 
   if(NOT DLLTOOL_EXE)
-    message(FATAL_ERROR "Either dlltool.exe not found!\
+    message(FATAL_ERROR "dlltool.exe not found!\
       \nDo you have Rtools installed with its MinGW's bin/ in PATH?")
   endif()
 

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -157,7 +157,7 @@ if (!use_precompile) {
       # Must build twice for Windows due sh.exe in Rtools
       cmake_args <- c(cmake_args, "-G", shQuote("MinGW Makefiles"))
       .run_shell_command("cmake", c(cmake_args, ".."), strict = FALSE)
-      build_cmd <- "make"
+      build_cmd <- "mingw32-make"
       build_args <- "_lightgbm"
     } else {
       visual_studio_succeeded <- .generate_vs_makefiles(cmake_args)
@@ -169,7 +169,7 @@ if (!use_precompile) {
         build_cmd <- "make"
         build_args <- "_lightgbm"
       } else {
-        build_cmd <- "cmake"
+        build_cmd <- "mingw32-make"
         build_args <- c("--build", ".", "--target", "_lightgbm", "--config", "Release")
         lib_folder <- file.path(source_dir, "Release", fsep = "/")
         makefiles_already_generated <- TRUE

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -155,7 +155,7 @@ if (!use_precompile) {
     windows_toolchain <- "MSYS"
   } else {
     # Rtools 4.0 moved from MinGW to MSYS toolchain. If user tries
-    # Visual Studio install but that fails, fall back to 
+    # Visual Studio install but that fails, fall back to
     if (R_ver >= 4.0) {
       windows_toolchain <- "MSYS"
     } else {

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -2,7 +2,8 @@
 use_precompile <- FALSE
 use_gpu <- FALSE
 
-# Package will be built with Visual Studio unless you set one of these to TRUE
+# For Windows, the package will be built with Visual Studio
+# unless you set one of these to TRUE
 use_mingw <- FALSE
 use_msys2 <- FALSE
 
@@ -246,7 +247,7 @@ if (!use_precompile) {
   }
 
   # build the library
-  message("building lib_lightgbm")
+  message("Building lib_lightgbm")
   .run_shell_command(build_cmd, build_args)
   src <- file.path(lib_folder, paste0("lib_lightgbm", SHLIB_EXT), fsep = "/")
 

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -2,7 +2,7 @@
 use_precompile <- FALSE
 use_gpu <- FALSE
 
-# Package will be built with Visual Studio unless you set one of these
+# Package will be built with Visual Studio unless you set one of these to TRUE
 use_mingw <- FALSE
 use_msys <- FALSE
 
@@ -155,7 +155,8 @@ if (!use_precompile) {
     windows_toolchain <- "MSYS"
   } else {
     # Rtools 4.0 moved from MinGW to MSYS toolchain. If user tries
-    # Visual Studio install but that fails, fall back to
+    # Visual Studio install but that fails, fall back to the toolchain
+    # supported in Rtools
     if (R_ver >= 4.0) {
       windows_toolchain <- "MSYS"
     } else {

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -130,10 +130,7 @@ if (!use_precompile) {
   lib_folder <- file.path(source_dir, fsep = "/")
 
   # Rtools 4.0 removed mingw32-make.exe
-  windows_cmake_exe <- "mingw32-make.exe"
-  if (R_ver >= 4.0) {
-    windows_cmake_exe <- "make.exe"
-  }
+  windows_cmake_exe <- "make.exe"
 
   if (use_gpu) {
     cmake_args <- c(cmake_args, "-DUSE_GPU=ON")

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -117,9 +117,11 @@ if (!use_precompile) {
   )
   setwd(build_dir)
 
+  use_visual_studio <- !(use_mingw || use_msys)
+
   # If using MSVC to build, pull in the script used
   # to create R.def from R.dll
-  if (WINDOWS && !use_mingw) {
+  if (WINDOWS && !use_visual_studio) {
     write_succeeded <- file.copy(
       "../../inst/make-r-def.R"
       , file.path(build_dir, "make-r-def.R")
@@ -186,7 +188,7 @@ if (!use_precompile) {
 
   # Check if Windows installation (for gcc vs Visual Studio)
   if (WINDOWS) {
-    if (use_mingw) {
+    if (!use_visual_studio) {
       message(sprintf("Trying to build with %s", windows_toolchain))
       # Must build twice for Windows due sh.exe in Rtools
       cmake_args <- c(cmake_args, "-G", shQuote(windows_makefile_generator))

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -157,7 +157,7 @@ if (!use_precompile) {
       # Must build twice for Windows due sh.exe in Rtools
       cmake_args <- c(cmake_args, "-G", shQuote("MinGW Makefiles"))
       .run_shell_command("cmake", c(cmake_args, ".."), strict = FALSE)
-      build_cmd <- "make.exe"
+      build_cmd <- "make"
       build_args <- "_lightgbm"
     } else {
       visual_studio_succeeded <- .generate_vs_makefiles(cmake_args)
@@ -166,7 +166,7 @@ if (!use_precompile) {
         # Must build twice for Windows due sh.exe in Rtools
         cmake_args <- c(cmake_args, "-G", shQuote("MinGW Makefiles"))
         .run_shell_command("cmake", c(cmake_args, ".."), strict = FALSE)
-        build_cmd <- "make.exe"
+        build_cmd <- "make"
         build_args <- "_lightgbm"
       } else {
         build_cmd <- "cmake"
@@ -209,6 +209,7 @@ if (!use_precompile) {
   }
 
   # build the library
+  message("building lib_lightgbm")
   .run_shell_command(build_cmd, build_args)
   src <- file.path(lib_folder, paste0("lib_lightgbm", SHLIB_EXT), fsep = "/")
 

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -4,10 +4,10 @@ use_gpu <- FALSE
 
 # Package will be built with Visual Studio unless you set one of these to TRUE
 use_mingw <- FALSE
-use_msys <- FALSE
+use_msys2 <- FALSE
 
-if (use_mingw && use_msys) {
-  stop("Cannot use both MinGW and MSYS. Please choose only one.")
+if (use_mingw && use_msys2) {
+  stop("Cannot use both MinGW and MSYS2. Please choose only one.")
 }
 
 if (.Machine$sizeof.pointer != 8L) {
@@ -117,7 +117,7 @@ if (!use_precompile) {
   )
   setwd(build_dir)
 
-  use_visual_studio <- !(use_mingw || use_msys)
+  use_visual_studio <- !(use_mingw || use_msys2)
 
   # If using MSVC to build, pull in the script used
   # to create R.def from R.dll
@@ -143,7 +143,7 @@ if (!use_precompile) {
       build_tool = "mingw32-make.exe"
       , makefile_generator = "MinGW Makefiles"
     )
-    , "MSYS" = c(
+    , "MSYS2" = c(
       build_tool = "make.exe"
       , makefile_generator = "MSYS Makefiles"
     )
@@ -151,14 +151,14 @@ if (!use_precompile) {
 
   if (use_mingw) {
     windows_toolchain <- "MinGW"
-  } else if (use_msys) {
-    windows_toolchain <- "MSYS"
+  } else if (use_msys2) {
+    windows_toolchain <- "MSYS2"
   } else {
     # Rtools 4.0 moved from MinGW to MSYS toolchain. If user tries
     # Visual Studio install but that fails, fall back to the toolchain
     # supported in Rtools
     if (R_ver >= 4.0) {
-      windows_toolchain <- "MSYS"
+      windows_toolchain <- "MSYS2"
     } else {
       windows_toolchain <- "MinGW"
     }

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -121,7 +121,7 @@ if (!use_precompile) {
 
   # If using MSVC to build, pull in the script used
   # to create R.def from R.dll
-  if (WINDOWS && !use_visual_studio) {
+  if (WINDOWS && use_visual_studio) {
     write_succeeded <- file.copy(
       "../../inst/make-r-def.R"
       , file.path(build_dir, "make-r-def.R")

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -110,7 +110,7 @@ if (!use_precompile) {
   )
   setwd(build_dir)
 
- # If using MSVC to build, pull in the file used
+  # If using MSVC to build, pull in the script used
   # to create R.def from R.dll
   if (WINDOWS && !use_mingw) {
     write_succeeded <- file.copy(
@@ -128,9 +128,6 @@ if (!use_precompile) {
   build_cmd <- "make"
   build_args <- "_lightgbm"
   lib_folder <- file.path(source_dir, fsep = "/")
-
-  # Rtools 4.0 removed mingw32-make.exe
-  windows_cmake_exe <- "make.exe"
 
   if (use_gpu) {
     cmake_args <- c(cmake_args, "-DUSE_GPU=ON")
@@ -160,7 +157,7 @@ if (!use_precompile) {
       # Must build twice for Windows due sh.exe in Rtools
       cmake_args <- c(cmake_args, "-G", shQuote("MinGW Makefiles"))
       .run_shell_command("cmake", c(cmake_args, ".."), strict = FALSE)
-      build_cmd <- windows_cmake_exe
+      build_cmd <- "make.exe"
       build_args <- "_lightgbm"
     } else {
       visual_studio_succeeded <- .generate_vs_makefiles(cmake_args)
@@ -169,7 +166,7 @@ if (!use_precompile) {
         # Must build twice for Windows due sh.exe in Rtools
         cmake_args <- c(cmake_args, "-G", shQuote("MinGW Makefiles"))
         .run_shell_command("cmake", c(cmake_args, ".."), strict = FALSE)
-        build_cmd <- windows_cmake_exe
+        build_cmd <- "make.exe"
         build_args <- "_lightgbm"
       } else {
         build_cmd <- "cmake"

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -172,7 +172,7 @@ if (!use_precompile) {
         build_cmd <- windows_cmake_exe
         build_args <- "_lightgbm"
       } else {
-        build_cmd <- windows_cmake_exe
+        build_cmd <- "cmake"
         build_args <- c("--build", ".", "--target", "_lightgbm", "--config", "Release")
         lib_folder <- file.path(source_dir, "Release", fsep = "/")
         makefiles_already_generated <- TRUE

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -109,10 +109,10 @@ if (!use_precompile) {
     , showWarnings = FALSE
   )
   setwd(build_dir)
-  
-  # If using MSVC to build, pull in the file used
+
+ # If using MSVC to build, pull in the file used
   # to create R.def from R.dll
-  if (WINDOWS && !use_mingw){
+  if (WINDOWS && !use_mingw) {
     write_succeeded <- file.copy(
       "../../inst/make-r-def.R"
       , file.path(build_dir, "make-r-def.R")
@@ -128,6 +128,12 @@ if (!use_precompile) {
   build_cmd <- "make"
   build_args <- "_lightgbm"
   lib_folder <- file.path(source_dir, fsep = "/")
+
+  # Rtools 4.0 removed mingw32-make.exe
+  windows_cmake_exe <- "mingw32-make.exe"
+  if (R_ver >= 4.0) {
+    windows_cmake_exe <- "make.exe"
+  }
 
   if (use_gpu) {
     cmake_args <- c(cmake_args, "-DUSE_GPU=ON")
@@ -157,7 +163,7 @@ if (!use_precompile) {
       # Must build twice for Windows due sh.exe in Rtools
       cmake_args <- c(cmake_args, "-G", shQuote("MinGW Makefiles"))
       .run_shell_command("cmake", c(cmake_args, ".."), strict = FALSE)
-      build_cmd <- "mingw32-make.exe"
+      build_cmd <- windows_cmake_exe
       build_args <- "_lightgbm"
     } else {
       visual_studio_succeeded <- .generate_vs_makefiles(cmake_args)
@@ -166,10 +172,10 @@ if (!use_precompile) {
         # Must build twice for Windows due sh.exe in Rtools
         cmake_args <- c(cmake_args, "-G", shQuote("MinGW Makefiles"))
         .run_shell_command("cmake", c(cmake_args, ".."), strict = FALSE)
-        build_cmd <- "mingw32-make.exe"
+        build_cmd <- windows_cmake_exe
         build_args <- "_lightgbm"
       } else {
-        build_cmd <- "cmake"
+        build_cmd <- windows_cmake_exe
         build_args <- c("--build", ".", "--target", "_lightgbm", "--config", "Release")
         lib_folder <- file.path(source_dir, "Release", fsep = "/")
         makefiles_already_generated <- TRUE

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -109,6 +109,19 @@ if (!use_precompile) {
     , showWarnings = FALSE
   )
   setwd(build_dir)
+  
+  # If using MSVC to build, pull in the file used
+  # to create R.def from R.dll
+  if (WINDOWS && !use_mingw){
+    write_succeeded <- file.copy(
+      "../../inst/bin/make-r-def.R"
+      , file.path(build_dir, "make-r-def.R")
+      , overwrite = TRUE
+    )
+    if (!write_succeeded) {
+      stop("Copying make-r-def.R failed")
+    }
+  }
 
   # Prepare installation steps
   cmake_args <- NULL

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -114,7 +114,7 @@ if (!use_precompile) {
   # to create R.def from R.dll
   if (WINDOWS && !use_mingw){
     write_succeeded <- file.copy(
-      "../../inst/bin/make-r-def.R"
+      "../../inst/make-r-def.R"
       , file.path(build_dir, "make-r-def.R")
       , overwrite = TRUE
     )

--- a/R-package/src/make-r-def.R
+++ b/R-package/src/make-r-def.R
@@ -1,0 +1,64 @@
+# [description]
+#     Create a definition file (.def) from a .dll file, using objdump.
+#
+# [usage]
+# 
+#     Rscript make-r-def.R something.dll something.def
+#
+# [references]
+#    * https://www.cs.colorado.edu/~main/cs1300/doc/mingwfaq.html
+
+args <- commandArgs(trailingOnly = TRUE)
+
+IN_DLL_FILE <- args[[1]]
+OUT_DEF_FILE <- args[[2]]
+print(sprintf("Creating '%s' from '%s'", IN_DLL_FILE, OUT_DEF_FILE))
+
+# Creates a .def file from R.dll, using tools bundled with R4.0
+#LIBR_CORE_LIBRARY <- "C:/Program Files/R/R-3.6.1/bin/x64/R.dll"
+
+# use objdump to dump all the symbols
+OBJDUMP_FILE <- "R.fil"
+exit_code <- system2(
+    command = "objdump"
+    , args = c(
+        "-p"
+        , shQuote(IN_DLL_FILE)
+    )
+    , stdout = OBJDUMP_FILE
+)
+
+objdump_results <- readLines(OBJDUMP_FILE)
+file.remove(OBJDUMP_FILE)
+
+# Name Pointer table start
+# https://www.cs.colorado.edu/~main/cs1300/doc/mingwfaq.html
+start_index <- which(
+    grepl(
+        pattern = "[Ordinal/Name Pointer] Table"
+        , x = objdump_results
+        , fixed = TRUE
+    )
+)
+empty_lines <- which(objdump_results == "")
+end_of_table <- empty_lines[empty_lines > start_index][1]
+
+# Read the contents of the table
+exported_symbols <- objdump_results[(start_index + 1):end_of_table]
+exported_symbols <- gsub("\t", "", exported_symbols)
+exported_symbols <- gsub(".*\\] ", "", exported_symbols)
+exported_symbols <- gsub(" ", "", exported_symbols)
+
+# Write R.def file
+write_succeeded <- writeLines(
+    text = c(
+        paste0("LIBRARY ", '\"R.dll\"')
+        , "EXPORTS"
+        , exported_symbols
+    )
+    , con = OUT_DEF_FILE
+    , sep = "\n"
+)
+if (!isTRUE(write_succeeded)){
+    stop("Failed to create R.def")
+}

--- a/build_r.R
+++ b/build_r.R
@@ -117,7 +117,7 @@ for (src_file in c("lightgbm_R.cpp", "lightgbm_R.h", "R_object_helper.h")) {
 
 result <- file.copy(
   from = file.path("R-package", "inst", "make-r-def.R")
-  , to = file.path("lightgbm_r", "inst", "bin/")
+  , to = file.path(TEMP_R_DIR, "inst", "bin/")
   , overwrite = TRUE
 )
 .handle_result(result)

--- a/build_r.R
+++ b/build_r.R
@@ -116,7 +116,7 @@ for (src_file in c("lightgbm_R.cpp", "lightgbm_R.h", "R_object_helper.h")) {
 }
 
 result <- file.copy(
-  from = file.path("R-package", "src", "make-r-def.R")
+  from = file.path("R-package", "inst", "make-r-def.R")
   , to = file.path("lightgbm_r", "inst", "bin/")
   , overwrite = TRUE
 )

--- a/build_r.R
+++ b/build_r.R
@@ -115,6 +115,13 @@ for (src_file in c("lightgbm_R.cpp", "lightgbm_R.h", "R_object_helper.h")) {
   .handle_result(result)
 }
 
+result <- file.copy(
+  from = file.path("R-package", "src", "make-r-def.R")
+  , to = file.path("lightgbm_r", "inst", "bin/")
+  , overwrite = TRUE
+)
+.handle_result(result)
+
 # NOTE: --keep-empty-dirs is necessary to keep the deep paths expected
 #       by CMake while also meeting the CRAN req to create object files
 #       on demand

--- a/docs/GPU-Windows.rst
+++ b/docs/GPU-Windows.rst
@@ -135,7 +135,7 @@ To check whether you need 32-bit or 64-bit MinGW for R, install LightGBM as usua
 If it says ``mingw_64`` then you need the 64-bit version (PATH with ``c:\Rtools\bin;c:\Rtools\mingw_64\bin``),
 otherwise you need the 32-bit version (``c:\Rtools\bin;c:\Rtools\mingw_32\bin``), the latter being a very rare and untested case.
 
---------------
+NOTE: As of `Rtools` 4.0, the `_` in these paths has been removed. If you are using `Rtools` 4.0 or later, the path will have `mingw64` instead of `mingw_64` and `mingw32` instead of `mingw_32`.
 
 Download the prebuilt Boost
 ---------------------------

--- a/docs/GPU-Windows.rst
+++ b/docs/GPU-Windows.rst
@@ -135,7 +135,7 @@ To check whether you need 32-bit or 64-bit MinGW for R, install LightGBM as usua
 If it says ``mingw_64`` then you need the 64-bit version (PATH with ``c:\Rtools\bin;c:\Rtools\mingw_64\bin``),
 otherwise you need the 32-bit version (``c:\Rtools\bin;c:\Rtools\mingw_32\bin``), the latter being a very rare and untested case.
 
-NOTE: As of `Rtools` 4.0, the `_` in these paths has been removed. If you are using `Rtools` 4.0 or later, the path will have `mingw64` instead of `mingw_64` and `mingw32` instead of `mingw_32`.
+NOTE: If you are using `Rtools` 4.0 or later, the path will have `mingw64` instead of `mingw_64` (PATH with `C:\rtools40\mingw64\bin`), and `mingw32` instead of `mingw_32` (`C:\rtools40\mingw32\bin`). The 32-bit version remains an unsupported solution under Rtools 4.0.
 
 Download the prebuilt Boost
 ---------------------------


### PR DESCRIPTION
Experimental fix for https://github.com/microsoft/LightGBM/issues/3064. Opening this PR to show the way I'm thinking about adding support for R 4.0. I will remove the `[WIP]` and request reviewers when it's ready for review, but any comments before then are welcomed if you have time!

## R4.0 breaking changes that affect LightGBM

* `gendef.exe` removed from Rtools 😭 
* `mingw32-make.exe` is no longer bundled with `Rtools` 😭 
* `Rtools` paths removed underscores, so `mingw_64/` becomes `mingw64/` 😂 

## Short description of the fix

**gendef.exe fix**

Building the `LightGBM` R package on Windows with Visual Studio compilers requires `gendef.exe`. That was bundled in previous versions of `RTools` but isn't part of `Rtools` 4.0.

This PR replaces it with an R script that uses `objdump.exe`, software bundled in old and new distributions of `Rtools`.

**mingw32-make.exe fix**

Using `Rtools/usr/bin/make.exe` instead of `Rtools/mingw_64/bin/mingw32-make.exe` if using R version 4.0 or greater.

**mingw path change fix**

It  includes updates to docs and CI scripts for the `mingw_64/` --> `mingw64/` change.

## How you can test this

In a Windows environment with R 4.0, Rtools 4.0, CMake, and Visual Studio, run the following:

```shell
git clone https://github.com/jameslamb/LightGBM.git
cd LightGBM
git fetch origin fix/r-4.0
git checkout fix/r-4.0

# install LightGBM
Rscript build_r.R

# test that it worked
cd R-package/tests
Rscript testthat.R
```

## Long Description

Here's how building the R package with Visual Studio works today:

1. The LightGBM R package has to be linked to `R.dll` to use R-provided C/C++ functions such as `Rprintf` for printing.
2. Linking with Visual Studio compilers requires a `.lib` file (https://docs.microsoft.com/en-us/cpp/build/reference/link-input-files?redirectedfrom=MSDN&view=vs-2019)
3. To create a `.lib` file from `R.dll` on Windows, we create a definition file (`.def`) and then use that to make a library file (`.lib`).
    - `R.dll` ships with R
    - A file `R.def` is created from `R.dll`,  using `gendef.exe`
    - A file `R.lib` is created from `R.def` using `dlltool.exe`

The issue: `gendefe.exe` is not part of [RTools](https://cran.r-project.org/bin/windows/Rtools/) 4.0.

My solution in this PR is to use `objdump.exe` + an R script to generate `R.def`. `objdump` creates output intended for humans not machines...it uses indentation and special chracters to make the file visually appealing. So the R script is used to run `objdump`, but more importantly to read in the text it produces and do some simple cleaning to get it into a machine-friendly format that can be re-written as a `.def` file.

From the "How to create a def file from a dll" section of [this amazing MinGW documentation](https://www.cs.colorado.edu/~main/cs1300/doc/mingwfaq.html).

> If the previous options don't work, you can still try to create a def file using the output from the objdump program (from the mingw distribution).
Here's an example.
objdump -p file.dll > dll.fil

> Search for [Ordinal/Name Pointer] Table in dll.fil and use the list of functions following it to create your def file.

## References

A lot of the content for this PR was totally new to me. Here are some links I found very helpful.

* `.def` file: text file that contains the names of objections exported from a DLL
    - ["Exporting from a DLL using def files"](https://docs.microsoft.com/en-us/cpp/build/exporting-from-a-dll-using-def-files?view=vs-2019)
* `.lib` file: a library file, basically a specific format that describe DLL so a linker understands how to link to it
    - [StackOverflow answer explaining .lib vs .dll](https://stackoverflow.com/questions/913691/dll-and-lib-files-what-and-why/913744)
    - [".lib file as linker input"](https://docs.microsoft.com/en-us/cpp/build/reference/dot-lib-files-as-linker-input?view=vs-2019)
* R uses the MinGW toolchain for R
    - ["MinGW FAQ"](https://www.cs.colorado.edu/~main/cs1300/doc/mingwfaq.html) is an AMAZING resource on how to work with libraries using MinGW tools
* RTools
    - [official CRAN docs on RTools 4.0](https://cran.r-project.org/bin/windows/Rtools/)
    - [more detailed docs on what is new in RTools 4.0 (work in progress)](https://github.com/r-windows/docs)
