### PR TITLE
fix MSVC warning about control paths (fixes #3067)

### DIFF
--- a/src/boosting/prediction_early_stop.cpp
+++ b/src/boosting/prediction_early_stop.cpp
@@ -74,18 +74,18 @@ PredictionEarlyStopInstance CreateBinary(const PredictionEarlyStopConfig& config
 
 PredictionEarlyStopInstance CreatePredictionEarlyStopInstance(const std::string& type,
                                                               const PredictionEarlyStopConfig& config) {
-  if (type != "none" && type != "multiclass" && type != "binary") {
-    Log::Fatal("Unknown early stopping type: %s", type.c_str());
-  }
-
   if (type == "none") {
     return CreateNone(config);
   } else if (type == "multiclass") {
     return CreateMulticlass(config);
+  } else if (type == "binary") {
+    return CreateBinary(config);
+  } else {
+    Log::Fatal("Unknown early stopping type: %s", type.c_str());
   }
 
-  // "binary"
-  return CreateBinary(config);
+  // Fix for compiler warnings about reaching end of control
+  return CreateNone(config);
 }
 
 }  // namespace LightGBM

--- a/src/boosting/prediction_early_stop.cpp
+++ b/src/boosting/prediction_early_stop.cpp
@@ -74,15 +74,19 @@ PredictionEarlyStopInstance CreateBinary(const PredictionEarlyStopConfig& config
 
 PredictionEarlyStopInstance CreatePredictionEarlyStopInstance(const std::string& type,
                                                               const PredictionEarlyStopConfig& config) {
+
+  if (type != "none" && type != "multiclass" && type != "binary") {
+    Log::Fatal("Unknown early stopping type: %s", type.c_str());
+  }
+
   if (type == "none") {
     return CreateNone(config);
   } else if (type == "multiclass") {
     return CreateMulticlass(config);
-  } else if (type == "binary") {
-    return CreateBinary(config);
-  } else {
-    Log::Fatal("Unknown early stopping type: %s", type.c_str());
   }
+
+  // "binary"
+  return CreateBinary(config);
 }
 
 }  // namespace LightGBM

--- a/src/boosting/prediction_early_stop.cpp
+++ b/src/boosting/prediction_early_stop.cpp
@@ -74,7 +74,6 @@ PredictionEarlyStopInstance CreateBinary(const PredictionEarlyStopConfig& config
 
 PredictionEarlyStopInstance CreatePredictionEarlyStopInstance(const std::string& type,
                                                               const PredictionEarlyStopConfig& config) {
-
   if (type != "none" && type != "multiclass" && type != "binary") {
     Log::Fatal("Unknown early stopping type: %s", type.c_str());
   }


### PR DESCRIPTION
See #3067 for details. When building for the R package, `Log::Fatal` calls `Rf_error`:

https://github.com/microsoft/LightGBM/blob/master/include/LightGBM/utils/log.h#L123

That function will result in a fatal error, but not on the C++ side...it tells the calling R process to throw n R error. I think that is why MSVC thinks it's possible for control to reach the end of `PredictionEarlyStopInstance`.

In this PR, I'd like to propose refactoring `PredictionEarlyStopInstance` to make it clearer to compilers that this function's control flow does always end.

We don't have CI for MSVC + R builds yet (it's in progress in #2965 ), but I tested this on my laptop tonight (Windows 10, Visual Studio 16 2019, R 3.6.1, Rtools 3.5). You can see in this log from running `Rscript build_r.R` that the warning is gone:

![image](https://user-images.githubusercontent.com/7608904/81514488-5195c980-9327-11ea-9220-fd5b95b51963.png)
