### PR TITLE
Document cmake+MinGW (fixes #3060)

### DIFF
--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -186,6 +186,18 @@ The appropriate splitting strategy depends on the task and domain of the data, i
 
 LightGBM supports loading data from zero-based LibSVM format file directly.
 
+14. Why cmake cannot find the compiler when compiling LightGBM with MinGW?
+--------------------------------------------------------------------------
+
+.. code-block:: bash
+
+    CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
+    CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
+
+This is a known issue of `cmake` when using MinGW. The easiest solution is to run again `cmake` to bypass the one time stopper from `cmake`.
+
+See `Microsoft/LightGBM#3060 <https://github.com/microsoft/LightGBM/issues/3060#issuecomment-62633853>`__ for more details.
+
 ------
 
 R-package


### PR DESCRIPTION
This PR documents the solution to the issue found on #3060 (workaround of PR #664).

Users should run `cmake` twice when the compiler is MinGW, because `cmake` has a one time stopper when it detects MinGW.

This one time stopper was removed from `cmake` on the following commit: https://github.com/microsoft/LightGBM/commit/3421bc6ce6f7294e22db7abad48a42e94fcc92cc#diff-473c89bfc9641f554ac12d37ebc3d377R61 (version = ???)

This issue also applies to most of R users who use MinGW as the compiler of choice (default of Rtools, and for those modifying the LightGBM installation script to explicitly compile using MinGW).

