### PR TITLE
[docs] document one more workaround for CMake and MinGW build and fix typos

### DIFF
--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -337,7 +337,7 @@ test_that("Booster$update() passing a train_set works as expected", {
     expect_true(lgb.is.Booster(bst))
     expect_equal(bst$current_iter(), nrounds + 1L)
 
-    # train with 3 rounds directlry
+    # train with 3 rounds directly
     bst2 <- lightgbm(
         data = as.matrix(agaricus.train$data)
         , label = agaricus.train$label

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -186,7 +186,7 @@ The appropriate splitting strategy depends on the task and domain of the data, i
 
 LightGBM supports loading data from zero-based LibSVM format file directly.
 
-14. Why cmake cannot find the compiler when compiling LightGBM with MinGW?
+14. Why CMake cannot find the compiler when compiling LightGBM with MinGW?
 --------------------------------------------------------------------------
 
 .. code-block:: bash
@@ -194,9 +194,9 @@ LightGBM supports loading data from zero-based LibSVM format file directly.
     CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
     CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
 
-This is a known issue of `cmake` when using MinGW. The easiest solution is to run again `cmake` to bypass the one time stopper from `cmake`.
+This is a known issue of CMake when using MinGW. The easiest solution is to run again your ``cmake`` command to bypass the one time stopper from CMake. Or you can upgrade your version of CMake to at least version 3.17.0.
 
-See `Microsoft/LightGBM#3060 <https://github.com/microsoft/LightGBM/issues/3060#issuecomment-62633853>`__ for more details.
+See `Microsoft/LightGBM#3060 <https://github.com/microsoft/LightGBM/issues/3060#issuecomment-626338538>`__ for more details.
 
 ------
 


### PR DESCRIPTION
> The MinGW Makefiles generator no longer issues an error if sh.exe is present in the environment’s PATH.
  https://cmake.org/cmake/help/v3.17/release/3.17.html#other-changes

Refer to #3078.