### PR TITLE
[R-package] [docs] fix warnings in pkgdown site  building

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -71,7 +71,7 @@ fi
 Rscript --vanilla -e "install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
 
 cd ${BUILD_DIRECTORY}
-Rscript build_r.R --skip-install || exit -1
+Rscript build_r.R || exit -1
 
 PKG_TARBALL="lightgbm_${LGB_VER}.tar.gz"
 LOG_FILE_NAME="lightgbm.Rcheck/00check.log"

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -71,7 +71,7 @@ fi
 Rscript --vanilla -e "install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
 
 cd ${BUILD_DIRECTORY}
-Rscript build_r.R || exit -1
+Rscript build_r.R --skip-install || exit -1
 
 PKG_TARBALL="lightgbm_${LGB_VER}.tar.gz"
 LOG_FILE_NAME="lightgbm.Rcheck/00check.log"

--- a/.gitignore
+++ b/.gitignore
@@ -397,6 +397,7 @@ python-package/compile/
 python-package/lightgbm/VERSION.txt
 
 # R build artefacts
+R-package/docs
 R-package/src/CMakeLists.txt
 R-package/src/lib_lightgbm.so.dSYM/
 R-package/src/src/

--- a/R-package/R/lightgbm.R
+++ b/R-package/R/lightgbm.R
@@ -15,6 +15,7 @@
 #' @param nrounds number of training rounds
 #' @param params List of parameters
 #' @param verbose verbosity for output, if <= 0, also will disable the print of evaluation during training
+#' @keywords internal
 NULL
 
 #' @name lightgbm

--- a/R-package/man/lgb_shared_params.Rd
+++ b/R-package/man/lgb_shared_params.Rd
@@ -29,3 +29,4 @@ If early stopping occurs, the model will have 'best_iter' field.}
 \description{
 Parameter docs shared by \code{lgb.train}, \code{lgb.cv}, and \code{lightgbm}
 }
+\keyword{internal}

--- a/R-package/pkgdown/_pkgdown.yml
+++ b/R-package/pkgdown/_pkgdown.yml
@@ -72,6 +72,7 @@ reference:
     - '`lgb.prepare2`'
     - '`lgb.prepare_rules`'
     - '`lgb.prepare_rules2`'
+    - '`lightgbm`'
     - '`lgb.train`'
     - '`lgb.cv`'
   - title: Saving / Loading Models


### PR DESCRIPTION
This PR fixes the warnings from the last outstanding item in this comment: https://github.com/microsoft/LightGBM/issues/1143#issuecomment-526936690

```text
Warning message:
Topics missing from index:
* lgb_shared_params
* lightgbm
```

To confirm, I ran:

```shell
Rscript build_r.R
cd lightgbm_r
Rscript -e "pkgdown::build_site(install = FALSE)"
```

re-using this branch from #3072 since it's already enabled on readthedocs.