### PR TITLE
[ci] avoid duplicate AppVeyor builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,12 @@ platform: x64
 configuration:  # a trick to construct a build matrix with multiple Python versions
   - 3.7
 
+# only build pull requests and
+# commits to 'master'
+branches:
+  only:
+    - master
+
 environment:
   matrix:
     - COMPILER: MINGW


### PR DESCRIPTION
Currently, we run the same build logic twice on AppVeyor for every commit to `master` or a branch with a PR into `master`.

This slows development because on the free tier of AppVeyor we are limited to one build at a time.

In this PR, I propose that we only build once on PRs and on every commit to `master`. I think this should work per: https://help.appveyor.com/discussions/problems/14586-build-any-pull-requests-against-any-branches.