### PR TITLE
[ci] fix add-apt-repository warning

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -14,11 +14,11 @@ export PATH="$R_LIB_PATH/R/bin:$PATH"
 # This only needs to get run on Travis because R environment for Linux
 # used by Azure pipelines is set up in https://github.com/guolinke/lightgbm-ci-docker
 if [[ $TRAVIS == "true" ]] && [[ $OS_NAME == "linux" ]]; then
-    sudo add-apt-repository \
-        "deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/"
     sudo apt-key adv \
         --keyserver keyserver.ubuntu.com \
         --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+    sudo add-apt-repository \
+        "deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/"
     sudo apt-get update
     sudo apt-get install \
         --no-install-recommends \


### PR DESCRIPTION
This PR fixes this error in `r-package` linux CI builds (see [the most recent master build](https://travis-ci.org/github/microsoft/LightGBM/jobs/688107049) for an example)

> W: GPG error: https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/ InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 51716619E084DAB9
E: The repository 'https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/ InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.

This isn't breaking our builds right now, but it's a distracting error taking up space in the logs.

Confirmed on [my fork](https://travis-ci.com/github/jameslamb/LightGBM/jobs/337353541) that the change in this PR removes the error.