### PR TITLE
[R-package] characterize all cmake messages

### DIFF
--- a/R-package/src/cmake/modules/FindLibR.cmake
+++ b/R-package/src/cmake/modules/FindLibR.cmake
@@ -30,7 +30,7 @@ endif()
 # https://docs.microsoft.com/en-us/cpp/build/reference/link-input-files?redirectedfrom=MSDN&view=vs-2019
 function(create_rlib_for_msvc)
 
-  message("Creating R.lib and R.def")
+  message(STATUS "Creating R.lib and R.def")
 
   # various checks and warnings
   if(NOT WIN32 OR NOT MSVC)
@@ -67,7 +67,7 @@ endfunction(create_rlib_for_msvc)
 # an R script (src/install.libs.R), that script uses R's built-ins to
 # find the version of R and pass it through as a CMake variable
 if(CMAKE_R_VERSION)
-  message("R version passed into FindLibR.cmake: ${CMAKE_R_VERSION}")
+  message(STATUS "R version passed into FindLibR.cmake: ${CMAKE_R_VERSION}")
 elseif(WIN32)
   message(FATAL_ERROR "Expected CMAKE_R_VERSION to be passed in on Windows but none was provided. Check src/install.libs.R")
 endif()


### PR DESCRIPTION
I've noticed in the logs from running `Rscript build_r.R` that one log message seems misaligned

```text
-- Check for working CXX compiler: /usr/local/clang-7.0.0/bin/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
R version passed into FindLibR.cmake: 3.6.3
-- Found LibR: /usr/lib/R  
-- LIBR_EXECUTABLE: /usr/bin/R
-- LIBR_INCLUDE_DIRS: /usr/share/R/include
-- LIBR_CORE_LIBRARY: /usr/lib/R/lib/libR.so
```

I looked into it tonight, and this is because the `"R version passed into...`"` message produced in `FindLibR.cmake` is not characterized. In other words, it is using `message("R version...")` instead of `message(STATUS "R version...")`.

This PR proposes characterizing this and one other message produced by `CMake` when building the R package. That line is not special and it shouldn't be drawing any special attention in the log.