### PR TITLE
[ci] peg MiKTeX mirror

### DIFF
--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -18,6 +18,7 @@ $env:R_LIBS = "$env:R_LIB_PATH"
 $env:PATH = "$env:R_LIB_PATH/Rtools/bin;" + "$env:R_LIB_PATH/R/bin/x64;" + "$env:R_LIB_PATH/miktex/texmfs/install/miktex/bin/x64;" + $env:PATH
 $env:CRAN_MIRROR = "https://cloud.r-project.org/"
 $env:CTAN_MIRROR = "https://ctan.math.illinois.edu/systems/win32/miktex/tm/packages/"
+$env:MIKTEX_ZIP = "https://ctan.math.illinois.edu/systems/win32/miktex/setup/windows-x64/miktexsetup-2.9.7442-x64.zip"
 
 if ($env:COMPILER -eq "MINGW") {
   $env:CXX = "$env:R_LIB_PATH/Rtools/mingw_64/bin/g++.exe"
@@ -52,7 +53,7 @@ Write-Output "Done installing Rtools"
 # build the package documentation for those
 if ($env:COMPILER -eq "MINGW") {
     Write-Output "Downloading MiKTeX"
-    Download-File-With-Retries -url "https://miktex.org/download/win/miktexsetup-x64.zip" -destfile "miktexsetup-x64.zip"
+    Download-File-With-Retries -url "$env:MIKTEX_ZIP" -destfile "miktexsetup-x64.zip"
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     [System.IO.Compression.ZipFile]::ExtractToDirectory("miktexsetup-x64.zip", "miktex")
     Write-Output "Setting up MiKTeX"


### PR DESCRIPTION
I learned tonight that the download link from the main MiKTeX site redirects to individual mirrors. I'm not sure what strategy it uses, but it seems to change pretty frequently. Here's an example from four requests executed within 15 seconds:

![image](https://user-images.githubusercontent.com/7608904/82745834-50649380-9d4e-11ea-90b0-4fd82569c4b2.png)

I think that pegging to a single mirror will reduce the frequency of errors like this downloading MiKTeX:

![image](https://user-images.githubusercontent.com/7608904/82745896-2eb7dc00-9d4f-11ea-81d4-d8f76c5f92f7.png)

In theory that redirect mechanism they have is great because it means the download link should work whenever a particular mirror fails, but as we've seen it regularly routes us to a mirror that we can't successfully download from (for whatever reason). Since the `r-package` jobs already rely on the University of Illinois mirror being up (to install additional LaTeX packages), I'd like to propose that we should just go directly to that mirror for MiKTeX too.