### PR TITLE
fix a bug when we set the default score

### DIFF
--- a/src/boosting/score_updater.hpp
+++ b/src/boosting/score_updater.hpp
@@ -29,7 +29,7 @@ class ScoreUpdater {
     int64_t total_size = static_cast<int64_t>(num_data_) * num_tree_per_iteration;
     score_.resize(total_size);
     // default start score is zero
-    std::memset(score_.data(), '0', total_size * sizeof(double));
+    std::memset(score_.data(), 0, total_size * sizeof(double));
     has_init_score_ = false;
     const double* init_score = data->metadata().init_score();
     // if exists initial score, will start from it


### PR DESCRIPTION
Using '0' results in a very small number in double, so in practice it seems okay, but in theory, the initial scores are wrong if we're not using the external initial scores.

This patch fixes this issue.