### PR TITLE
[ci] use GitHub Actions for R CI jobs (fixes #2353)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,11 +13,8 @@ branches:
 
 environment:
   matrix:
-    # - COMPILER: MSVC
-    #   TASK: r-package
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    # - COMPILER: MSVC
-    #   TASK: python
+    - COMPILER: MSVC
+      TASK: python
     - COMPILER: MINGW
       TASK: python
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,11 +13,11 @@ branches:
 
 environment:
   matrix:
-    - COMPILER: MSVC
-      TASK: r-package
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    - COMPILER: MSVC
-      TASK: python
+    # - COMPILER: MSVC
+    #   TASK: r-package
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    # - COMPILER: MSVC
+    #   TASK: python
     - COMPILER: MINGW
       TASK: python
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,8 +13,6 @@ branches:
 
 environment:
   matrix:
-    - COMPILER: MINGW
-      TASK: r-package
     - COMPILER: MSVC
       TASK: r-package
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019

--- a/.ci/download-miktex.R
+++ b/.ci/download-miktex.R
@@ -1,0 +1,25 @@
+# mirrors that host miktexsetup.zip do so only with explicitly-named
+# files like miktexsetup-2.4.5.zip, so hard-coding a link to an archive as a
+# way to peg to one mirror does not work
+#
+# this script will find the specific version of miktexsetup.zip at a given
+# mirror
+library(httr)
+args <- commandArgs(trailingOnly = TRUE)
+DESTFILE <- args[[1L]]
+MIRROR <- "https://ctan.math.illinois.edu/systems/win32/miktex/setup/windows-x64/"
+mirror_contents <- httr::content(
+    httr::RETRY("GET", mirror)
+    , as = "text"
+)
+content_lines <- strsplit(mirror_contents, "\n")[[1L]]
+content_lines <- content_lines[grepl("miktexsetup-.*", content_lines)]
+zip_loc <- regexpr(">miktexsetup-[0-9]+.*x64\\.zip", content_lines)
+zip_name <- gsub(">", "", regmatches(content_lines, zip_loc))
+full_zip_url <- file.path(MIRROR, zip_name)
+print(sprintf("downloading %s", full_zip_url))
+download.file(
+    url = full_zip_url
+    , destfile = DESTFILE
+)
+print(sprintf("MiKTeX setup downloaded to %s", DESTFILE))

--- a/.ci/download-miktex.R
+++ b/.ci/download-miktex.R
@@ -9,7 +9,7 @@ args <- commandArgs(trailingOnly = TRUE)
 DESTFILE <- args[[1L]]
 MIRROR <- "https://ctan.math.illinois.edu/systems/win32/miktex/setup/windows-x64/"
 mirror_contents <- httr::content(
-    httr::RETRY("GET", mirror)
+    httr::RETRY("GET", MIRROR)
     , as = "text"
 )
 content_lines <- strsplit(mirror_contents, "\n")[[1L]]

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -46,11 +46,3 @@ if [[ $TRAVIS == "true" ]] || [[ $GITHUB_ACTIONS == "true" ]] || [[ $OS_NAME == 
 fi
 conda config --set always_yes yes --set changeps1 no
 conda update -q -y conda
-
-echo '----- CONDA/bin -----'
-ls $CONDA/bin
-echo '----- CONDA -----'
-ls $CONDA
-echo '----- PATH -----'
-echo "PATH: $PATH"
-echo '--------------'

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -41,7 +41,7 @@ else  # Linux
     fi
 fi
 
-if [[ $TRAVIS == "true" ]] || [[ $OS_NAME == "macos" ]]; then
+if [[ $TRAVIS == "true" ]] || [[ $GITHUB_ACTIONS == "true" ]] || [[ $OS_NAME == "macos" ]]; then
     sh conda.sh -b -p $CONDA
 fi
 conda config --set always_yes yes --set changeps1 no

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -36,7 +36,7 @@ else  # Linux
         mv $AMDAPPSDK_PATH/lib/x86_64/sdk/* $AMDAPPSDK_PATH/lib/x86_64/
         echo libamdocl64.so > $OPENCL_VENDOR_PATH/amdocl64.icd
     fi
-    if [[ $TRAVIS == "true" ]] || [[ $GITHUB_ACTIOONS == "true" ]]; then
+    if [[ $TRAVIS == "true" ]] || [[ $GITHUB_ACTIONS == "true" ]]; then
         wget -q -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
     fi
 fi

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -48,6 +48,10 @@ Write-Output "Installing Rtools"
 Start-Process -FilePath Rtools.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH/Rtools" ; Check-Output $?
 Write-Output "Done installing Rtools"
 
+Write-Output "Installing dependencies"
+$packages = "c('data.table', 'jsonlite', 'Matrix', 'processx', 'R6', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
+Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')" ; Check-Output $?
+
 # MiKTeX and pandoc can be skipped on non-MINGW builds, since we don't
 # build the package documentation for those
 if ($env:COMPILER -eq "MINGW") {
@@ -65,10 +69,6 @@ if ($env:COMPILER -eq "MINGW") {
     initexmf --set-config-value [MPM]AutoInstall=1
     conda install -q -y --no-deps pandoc
 }
-
-Write-Output "Installing dependencies"
-$packages = "c('data.table', 'jsonlite', 'Matrix', 'processx', 'R6', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
-Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')" ; Check-Output $?
 
 Write-Output "Building R package"
 

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -12,10 +12,6 @@ function Download-File-With-Retries {
   } while(!$?);
 }
 
-# GitHub Actions puts $ErrorActionPreference = 'stop' on the top of powershell scripts,
-# which causes the script to fail if anything is written to stderr
-$ErrorActionPreference = "Continue"
-
 $env:R_WINDOWS_VERSION = "3.6.3"
 $env:R_LIB_PATH = "$env:BUILD_SOURCESDIRECTORY/RLibrary" -replace '[\\]', '/'
 $env:R_LIBS = "$env:R_LIB_PATH"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -50,7 +50,7 @@ Write-Output "Done installing Rtools"
 
 # MiKTeX and pandoc can be skipped on non-MINGW builds, since we don't
 # build the package documentation for those
-if ($env:COMPILER -ne "MSVC") {
+if ($env:COMPILER -eq "MINGW") {
     Write-Output "Downloading MiKTeX"
     Download-File-With-Retries -url "https://miktex.org/download/win/miktexsetup-x64.zip" -destfile "miktexsetup-x64.zip"
     Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -72,7 +72,7 @@ Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.pac
 Write-Output "Building R package"
 
 # R CMD check is not used for MSVC builds
-if ($env:COMPILER -eq "MINGW") {
+if ($env:COMPILER -ne "MSVC") {
   Rscript build_r.R --skip-install ; Check-Output $?
 
   $PKG_FILE_NAME = Get-Item *.tar.gz

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -12,7 +12,6 @@ function Download-File-With-Retries {
   } while(!$?);
 }
 
-Write-Output "schmibberty"
 Write-Output "BUILD_SOURCESDIRECTORY (test-r): $env:BUILD_SOURCESDIRECTORY"
 
 $env:R_WINDOWS_VERSION = "3.6.3"
@@ -72,7 +71,7 @@ Write-Output "Installing dependencies"
 $packages = "c('data.table', 'jsonlite', 'Matrix', 'processx', 'R6', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
 
 # have to divert stderr to null because GitHub Actions treats writing to stderr as a failed task
-Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')" 2> $null ; Check-Output $?
+Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')" 2> $null # ; Check-Output $?
 
 Write-Output "Building R package"
 

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -13,6 +13,7 @@ function Download-File-With-Retries {
 }
 
 Write-Output "schmibberty"
+Write-Output "BUILD_SOURCESDIRECTORY (test-r): $env:BUILD_SOURCESDIRECTORY"
 
 $env:R_WINDOWS_VERSION = "3.6.3"
 $env:R_LIB_PATH = "$env:BUILD_SOURCESDIRECTORY/RLibrary" -replace '[\\]', '/'

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -18,6 +18,7 @@ $env:R_LIBS = "$env:R_LIB_PATH"
 $env:PATH = "$env:R_LIB_PATH/Rtools/bin;" + "$env:R_LIB_PATH/R/bin/x64;" + "$env:R_LIB_PATH/miktex/texmfs/install/miktex/bin/x64;" + $env:PATH
 $env:CRAN_MIRROR = "https://cloud.r-project.org/"
 $env:CTAN_MIRROR = "https://ctan.math.illinois.edu/systems/win32/miktex/tm/packages/"
+$env:MIKTEX_ZIP = "https://ctan.math.illinois.edu/systems/win32/miktex/setup/windows-x64/miktexsetup-2.9.7442-x64.zip"
 
 if ($env:COMPILER -eq "MINGW") {
   $env:CXX = "$env:R_LIB_PATH/Rtools/mingw_64/bin/g++.exe"
@@ -52,7 +53,7 @@ Write-Output "Done installing Rtools"
 # build the package documentation for those
 if ($env:COMPILER -eq "MINGW") {
     Write-Output "Downloading MiKTeX"
-    Download-File-With-Retries -url "https://miktex.org/download/win/miktexsetup-x64.zip" -destfile "miktexsetup-x64.zip"
+    Download-File-With-Retries -url "$env:MIKTEX_ZIP" -destfile "miktexsetup-x64.zip"
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     [System.IO.Compression.ZipFile]::ExtractToDirectory("miktexsetup-x64.zip", "miktex")
     Write-Output "Setting up MiKTeX"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -67,12 +67,12 @@ if ($env:COMPILER -ne "MSVC") {
 
 Write-Output "Installing dependencies"
 $packages = "c('data.table', 'jsonlite', 'Matrix', 'processx', 'R6', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
-Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')"  ; Check-Output $?
+Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')" ; Check-Output $?
 
 Write-Output "Building R package"
 
 # R CMD check is not used for MSVC builds
-if ($env:COMPILER -ne "MSVC") {
+if ($env:COMPILER -eq "MINGW") {
   Rscript build_r.R --skip-install ; Check-Output $?
 
   $PKG_FILE_NAME = Get-Item *.tar.gz

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -67,7 +67,7 @@ if ($env:COMPILER -ne "MSVC") {
 
 Write-Output "Installing dependencies"
 $packages = "c('data.table', 'jsonlite', 'Matrix', 'processx', 'R6', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
-Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')"
+Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')"  ; Check-Output $?
 
 Write-Output "Building R package"
 

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -95,7 +95,7 @@ if ($env:COMPILER -ne "MSVC") {
       Check-Output $False
   }
 
-  $note_str = Get-Content "${LOG_FILE_NAME}" | Select-String -Pattern ' NOTE' | Out-String ; Check-Output $?
+  $note_str = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern ' NOTE' | Out-String ; Check-Output $?
   Write-Output "note_str:"
   Write-Output $note_str
   $stuff = Get-Content "${LOG_FILE_NAME}"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -95,22 +95,24 @@ if ($env:COMPILER -ne "MSVC") {
       Check-Output $False
   }
 
-  $note_str = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern ' NOTE' | Out-String ; Check-Output $?
+  $note_str = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern '.*Status.* NOTE' | Out-String ; Check-Output $?
   Write-Output "note_str:"
   Write-Output $note_str
   Write-Output "---- stuff ----"
   $stuff = Get-Content "${LOG_FILE_NAME}"
   Write-Output $stuff
-  $stuff2 = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern ' NOTE' | Out-String
+  $stuff2 = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern '.*Status.* NOTE' | Out-String
   Write-Output "---- stuff2 ----"
   Write-Output $stuff2
-  $relevant_line = $note_str -match '.*Status: (\d+) NOTE.*'
+  $relevant_line = $note_str -match '(\d+) NOTE'
   Write-Output "----- matches -----"
   Write-Output $matches
   Write-Output "----- Matches ----"
   Write-Output $Matches
-  Write-Outpu "-----------"
-  $NUM_CHECK_NOTES = $Matches[1]
+  Write-Output "-----------"
+  Write-Output "----- relevant_line -----"
+  Write-Output $relevant_line
+  $NUM_CHECK_NOTES = $matches[1]
   $ALLOWED_CHECK_NOTES = 3
   if ([int]$NUM_CHECK_NOTES -gt $ALLOWED_CHECK_NOTES) {
       Write-Output "Found ${NUM_CHECK_NOTES} NOTEs from R CMD check. Only ${ALLOWED_CHECK_NOTES} are allowed"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -12,8 +12,6 @@ function Download-File-With-Retries {
   } while(!$?);
 }
 
-Write-Output "BUILD_SOURCESDIRECTORY (test-r): $env:BUILD_SOURCESDIRECTORY"
-
 $env:R_WINDOWS_VERSION = "3.6.3"
 $env:R_LIB_PATH = "$env:BUILD_SOURCESDIRECTORY/RLibrary" -replace '[\\]', '/'
 $env:R_LIBS = "$env:R_LIB_PATH"
@@ -52,7 +50,7 @@ Write-Output "Done installing Rtools"
 
 # MiKTeX and pandoc can be skipped on non-MINGW builds, since we don't
 # build the package documentation for those
-if ($env:COMPILER -eq "MINGW") {
+if ($env:COMPILER -ne "MSVC") {
     Write-Output "Downloading MiKTeX"
     Download-File-With-Retries -url "https://miktex.org/download/win/miktexsetup-x64.zip" -destfile "miktexsetup-x64.zip"
     Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -69,9 +67,7 @@ if ($env:COMPILER -eq "MINGW") {
 
 Write-Output "Installing dependencies"
 $packages = "c('data.table', 'jsonlite', 'Matrix', 'processx', 'R6', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
-
-# have to divert stderr to null because GitHub Actions treats writing to stderr as a failed task
-Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')" 2> $null # ; Check-Output $?
+Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')"
 
 Write-Output "Building R package"
 

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -98,8 +98,8 @@ if ($env:COMPILER -ne "MSVC") {
   $note_str = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern ' NOTE' | Out-String ; Check-Output $?
   Write-Output "note_str:"
   Write-Output $note_str
-  $stuff = Get-Content "${LOG_FILE_NAME}"
   Write-Output "---- stuff ----"
+  $stuff = Get-Content "${LOG_FILE_NAME}"
   Write-Output $stuff
   $stuff2 = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern ' NOTE' | Out-String
   Write-Output "---- stuff2 ----"
@@ -107,7 +107,10 @@ if ($env:COMPILER -ne "MSVC") {
   $relevant_line = $note_str -match '.*Status: (\d+) NOTE.*'
   Write-Output "----- matches -----"
   Write-Output $matches
-  $NUM_CHECK_NOTES = $matches[1]
+  Write-Output "----- Matches ----"
+  Write-Output $Matches
+  Write-Outpu "-----------"
+  $NUM_CHECK_NOTES = $Matches[1]
   $ALLOWED_CHECK_NOTES = 3
   if ([int]$NUM_CHECK_NOTES -gt $ALLOWED_CHECK_NOTES) {
       Write-Output "Found ${NUM_CHECK_NOTES} NOTEs from R CMD check. Only ${ALLOWED_CHECK_NOTES} are allowed"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -70,7 +70,9 @@ if ($env:COMPILER -eq "MINGW") {
 
 Write-Output "Installing dependencies"
 $packages = "c('data.table', 'jsonlite', 'Matrix', 'processx', 'R6', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
-Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')" ; Check-Output $?
+
+# have to divert stderr to null because GitHub Actions treats writing to stderr as a failed task
+Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')" 2> $null ; Check-Output $?
 
 Write-Output "Building R package"
 

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -12,6 +12,8 @@ function Download-File-With-Retries {
   } while(!$?);
 }
 
+Write-Output "schmibberty"
+
 $env:R_WINDOWS_VERSION = "3.6.3"
 $env:R_LIB_PATH = "$env:BUILD_SOURCESDIRECTORY/RLibrary" -replace '[\\]', '/'
 $env:R_LIBS = "$env:R_LIB_PATH"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -18,7 +18,6 @@ $env:R_LIBS = "$env:R_LIB_PATH"
 $env:PATH = "$env:R_LIB_PATH/Rtools/bin;" + "$env:R_LIB_PATH/R/bin/x64;" + "$env:R_LIB_PATH/miktex/texmfs/install/miktex/bin/x64;" + $env:PATH
 $env:CRAN_MIRROR = "https://cloud.r-project.org/"
 $env:CTAN_MIRROR = "https://ctan.math.illinois.edu/systems/win32/miktex/tm/packages/"
-$env:MIKTEX_ZIP = "https://ctan.math.illinois.edu/systems/win32/miktex/setup/windows-x64/miktexsetup-2.9.7442-x64.zip"
 
 if ($env:COMPILER -eq "MINGW") {
   $env:CXX = "$env:R_LIB_PATH/Rtools/mingw_64/bin/g++.exe"
@@ -53,7 +52,7 @@ Write-Output "Done installing Rtools"
 # build the package documentation for those
 if ($env:COMPILER -eq "MINGW") {
     Write-Output "Downloading MiKTeX"
-    Download-File-With-Retries -url "$env:MIKTEX_ZIP" -destfile "miktexsetup-x64.zip"
+    Download-File-With-Retries -url "https://miktex.org/download/win/miktexsetup-x64.zip" -destfile "miktexsetup-x64.zip"
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     [System.IO.Compression.ZipFile]::ExtractToDirectory("miktexsetup-x64.zip", "miktex")
     Write-Output "Setting up MiKTeX"
@@ -96,22 +95,7 @@ if ($env:COMPILER -ne "MSVC") {
   }
 
   $note_str = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern '.*Status.* NOTE' | Out-String ; Check-Output $?
-  Write-Output "note_str:"
-  Write-Output $note_str
-  Write-Output "---- stuff ----"
-  $stuff = Get-Content "${LOG_FILE_NAME}"
-  Write-Output $stuff
-  $stuff2 = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern '.*Status.* NOTE' | Out-String
-  Write-Output "---- stuff2 ----"
-  Write-Output $stuff2
   $relevant_line = $note_str -match '(\d+) NOTE'
-  Write-Output "----- matches -----"
-  Write-Output $matches
-  Write-Output "----- Matches ----"
-  Write-Output $Matches
-  Write-Output "-----------"
-  Write-Output "----- relevant_line -----"
-  Write-Output $relevant_line
   $NUM_CHECK_NOTES = $matches[1]
   $ALLOWED_CHECK_NOTES = 3
   if ([int]$NUM_CHECK_NOTES -gt $ALLOWED_CHECK_NOTES) {

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -52,7 +52,8 @@ Write-Output "Done installing Rtools"
 # build the package documentation for those
 if ($env:COMPILER -eq "MINGW") {
     Write-Output "Downloading MiKTeX"
-    Download-File-With-Retries -url "https://miktex.org/download/win/miktexsetup-x64.zip" -destfile "miktexsetup-x64.zip"
+    Rscript $env:BUILD_SOURCESDIRECTORY\.ci\download-miktex.R "miktexsetup-x64.zip"
+    #Download-File-With-Retries -url "https://miktex.org/download/win/miktexsetup-x64.zip" -destfile "miktexsetup-x64.zip"
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     [System.IO.Compression.ZipFile]::ExtractToDirectory("miktexsetup-x64.zip", "miktex")
     Write-Output "Setting up MiKTeX"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -98,6 +98,12 @@ if ($env:COMPILER -ne "MSVC") {
   $note_str = Get-Content "${LOG_FILE_NAME}" | Select-String -Pattern ' NOTE' | Out-String ; Check-Output $?
   Write-Output "note_str:"
   Write-Output $note_str
+  $stuff = Get-Content "${LOG_FILE_NAME}"
+  Write-Output "---- stuff ----"
+  Write-Output $stuff
+  $stuff2 = Get-Content -Path "${LOG_FILE_NAME}"
+  Write-Output "---- stuff2 ----"
+  Write-Output $stuff2
   $relevant_line = $note_str -match '.*Status: (\d+) NOTE.*'
   $NUM_CHECK_NOTES = $matches[1]
   $ALLOWED_CHECK_NOTES = 3

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -57,7 +57,6 @@ Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.pac
 if ($env:COMPILER -eq "MINGW") {
     Write-Output "Downloading MiKTeX"
     Rscript $env:BUILD_SOURCESDIRECTORY\.ci\download-miktex.R "miktexsetup-x64.zip"
-    #Download-File-With-Retries -url "https://miktex.org/download/win/miktexsetup-x64.zip" -destfile "miktexsetup-x64.zip"
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     [System.IO.Compression.ZipFile]::ExtractToDirectory("miktexsetup-x64.zip", "miktex")
     Write-Output "Setting up MiKTeX"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -12,6 +12,10 @@ function Download-File-With-Retries {
   } while(!$?);
 }
 
+# GitHub Actions puts $ErrorActionPreference = 'stop' on the top of powershell scripts,
+# which causes the script to fail if anything is written to stderr
+$ErrorActionPreference = "Continue"
+
 $env:R_WINDOWS_VERSION = "3.6.3"
 $env:R_LIB_PATH = "$env:BUILD_SOURCESDIRECTORY/RLibrary" -replace '[\\]', '/'
 $env:R_LIBS = "$env:R_LIB_PATH"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -49,7 +49,7 @@ Start-Process -FilePath Rtools.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT
 Write-Output "Done installing Rtools"
 
 Write-Output "Installing dependencies"
-$packages = "c('data.table', 'jsonlite', 'Matrix', 'processx', 'R6', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
+$packages = "c('data.table', 'jsonlite', 'httr', 'Matrix', 'processx', 'R6', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
 Rscript --vanilla -e "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH')" ; Check-Output $?
 
 # MiKTeX and pandoc can be skipped on non-MINGW builds, since we don't

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -96,6 +96,8 @@ if ($env:COMPILER -ne "MSVC") {
   }
 
   $note_str = Get-Content "${LOG_FILE_NAME}" | Select-String -Pattern ' NOTE' | Out-String ; Check-Output $?
+  Write-Output "note_str:"
+  Write-Output $note_str
   $relevant_line = $note_str -match '.*Status: (\d+) NOTE.*'
   $NUM_CHECK_NOTES = $matches[1]
   $ALLOWED_CHECK_NOTES = 3

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -101,10 +101,12 @@ if ($env:COMPILER -ne "MSVC") {
   $stuff = Get-Content "${LOG_FILE_NAME}"
   Write-Output "---- stuff ----"
   Write-Output $stuff
-  $stuff2 = Get-Content -Path "${LOG_FILE_NAME}"
+  $stuff2 = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern ' NOTE' | Out-String
   Write-Output "---- stuff2 ----"
   Write-Output $stuff2
   $relevant_line = $note_str -match '.*Status: (\d+) NOTE.*'
+  Write-Output "----- matches -----"
+  Write-Output $matches
   $NUM_CHECK_NOTES = $matches[1]
   $ALLOWED_CHECK_NOTES = 3
   if ([int]$NUM_CHECK_NOTES -gt $ALLOWED_CHECK_NOTES) {

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -10,8 +10,6 @@ function Check-Output {
 if (Test-Path env:APPVEYOR) {
   $env:APPVEYOR = "true"
   $env:BUILD_SOURCESDIRECTORY = $env:APPVEYOR_BUILD_FOLDER
-} elseif ($env:GITHUB_ACTIONS -eq "true") {
-  $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
 }
 
 if ($env:TASK -eq "r-package") {

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -5,16 +5,20 @@ function Check-Output {
     Exit -1
   }
 }
+Write-Output "here"
 
 # unify environment variables for Azure devops and AppVeyor
 if (Test-Path env:APPVEYOR) {
   $env:APPVEYOR = "true"
   $env:BUILD_SOURCESDIRECTORY = $env:APPVEYOR_BUILD_FOLDER
 } elseif ($env:GITHUB_ACTIONS -eq "true") {
+  Write-Output "there"
   $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
 }
+Write-Output "libberty"
 
 if ($env:TASK -eq "r-package") {
+  Write-Output "bibberty"
   & $env:BUILD_SOURCESDIRECTORY\.ci\test_r_package_windows.ps1 ; Check-Output $?
   Exit 0
 }

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -13,10 +13,9 @@ if (Test-Path env:APPVEYOR) {
 } elseif ($env:GITHUB_ACTIONS -eq "true") {
   $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
 }
+Write-Output "BUILD_SOURCESDIRECTORY (test): $env:BUILD_SOURCESDIRECTORY"
 
-Write-Output "TASK: $env:TASK"
 if ($env:TASK -eq "r-package") {
-  Write-Output "libberty"
   & $env:BUILD_SOURCESDIRECTORY\.ci\test_r_package_windows.ps1 ; Check-Output $?
   Exit 0
 }

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -5,20 +5,17 @@ function Check-Output {
     Exit -1
   }
 }
-Write-Output "here"
 
 # unify environment variables for Azure devops and AppVeyor
 if (Test-Path env:APPVEYOR) {
   $env:APPVEYOR = "true"
   $env:BUILD_SOURCESDIRECTORY = $env:APPVEYOR_BUILD_FOLDER
 } elseif ($env:GITHUB_ACTIONS -eq "true") {
-  Write-Output "there"
   $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
 }
-Write-Output "libberty"
 
 if ($env:TASK -eq "r-package") {
-  Write-Output "bibberty"
+  Write-Output "libberty"
   & $env:BUILD_SOURCESDIRECTORY\.ci\test_r_package_windows.ps1 ; Check-Output $?
   Exit 0
 }

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -10,7 +10,7 @@ function Check-Output {
 if (Test-Path env:APPVEYOR) {
   $env:APPVEYOR = "true"
   $env:BUILD_SOURCESDIRECTORY = $env:APPVEYOR_BUILD_FOLDER
-} elseif ($env:APPVEYOR -eq "true") {
+} elseif ($env:GITHUB_ACTIONS -eq "true") {
   $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
 }
 

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -14,6 +14,7 @@ if (Test-Path env:APPVEYOR) {
   $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
 }
 
+Write-Output "TASK: $env:TASK"
 if ($env:TASK -eq "r-package") {
   Write-Output "libberty"
   & $env:BUILD_SOURCESDIRECTORY\.ci\test_r_package_windows.ps1 ; Check-Output $?

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -10,6 +10,8 @@ function Check-Output {
 if (Test-Path env:APPVEYOR) {
   $env:APPVEYOR = "true"
   $env:BUILD_SOURCESDIRECTORY = $env:APPVEYOR_BUILD_FOLDER
+} elseif ($env:APPVEYOR -eq "true") {
+  $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
 }
 
 if ($env:TASK -eq "r-package") {

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -13,7 +13,6 @@ if (Test-Path env:APPVEYOR) {
 } elseif ($env:GITHUB_ACTIONS -eq "true") {
   $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
 }
-Write-Output "BUILD_SOURCESDIRECTORY (test): $env:BUILD_SOURCESDIRECTORY"
 
 if ($env:TASK -eq "r-package") {
   & $env:BUILD_SOURCESDIRECTORY\.ci\test_r_package_windows.ps1 ; Check-Output $?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - os: ubuntu-latest
-          #   task: r-package
-          #   subtitle: ""
+          - os: ubuntu-latest
+            task: r-package
+            subtitle: ""
           # - os: macOS-latest
           #   task: r-package
           #   subtitle: ""
@@ -35,9 +35,6 @@ jobs:
       - name: Setup and run tests on Linux and macOS
         if: matrix.os != 'windows-latest'
         shell: bash
-        # export AMDAPPSDK_PATH=$HOME/AMDAPPSDK
-        # export LD_LIBRARY_PATH="$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH"
-        # export HOME_DIRECTORY="$HOME"
         env:
           COMPILER: "${{ matrix.compiler }}"
           CONDA_ENV: "test-env"
@@ -68,10 +65,10 @@ jobs:
         uses: goanpeca/setup-miniconda@v1
         with:
           auto-update-conda: false
-      - name: conda init powershell
-        if: matrix.os == 'windows-latest'
-        shell: cmd
-        run: conda init powershell
+      # - name: conda init powershell
+      #   if: matrix.os == 'windows-latest'
+      #   shell: cmd
+      #   run: conda init powershell
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
         shell: pwsh
@@ -79,23 +76,13 @@ jobs:
           COMPILER: "${{ matrix.compiler }}"
           GITHUB_ACTIONS: "true"
           TASK: "${{ matrix.task }}"
-        # https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide
-        # https://stackoverflow.com/a/11826589/3986677
-        # run: |
-        #   if ("${{ matrix.compiler }}" -ne "") {
-        #     $env:COMPILER = "${{ matrix.compiler }}"
-        #   }
-        #   $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
-        #   cmd /c "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
         run: |
           $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
+          conda init powershell
           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
 
 # set BUILD_SOURCESDIRECTORY=%GITHUB_WORKSPACE%
 # powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
-
-# Write-Output "CI default for Errors: $ErrorActionPreference"
-# $ErrorActionPreference = "Continue"
 
 # links
 # * https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun
@@ -105,4 +92,4 @@ jobs:
 # * https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
 # * https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
 # * https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide/2095623#2095623
-# 
+# * https://stackoverflow.com/a/11826589/3986677

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
           auto-update-conda: false
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
-        shell: pwsh
+        shell: powershell
         env:
           COMPILER: "${{ matrix.compiler }}"
           GITHUB_ACTIONS: "true"
@@ -94,3 +94,4 @@ jobs:
 # * https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide/2095623#2095623
 # * https://stackoverflow.com/a/11826589/3986677
 # * https://github.com/marketplace/actions/setup-miniconda
+# * https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,4 @@ jobs:
         run: |
           $env:HOME_DIRECTORY=$env:HOME
           $env:GITHUB_ACTIONS="true"
-          $env:CONDA_ENV="test-env"
-          & "conda init powershell"
           & "powershell -ExecutionPolicy Bypass -File %BUILD_DIRECTORY%/.ci/test_windows.ps1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,11 @@ jobs:
           - os: windows-latest
             task: r-package
             compiler: MINGW
-          - os: windows-latest
-            task: r-package
-            compiler: MSVC
-          - os: ubuntu-latest
-            task: lint
+          # - os: windows-latest
+          #   task: r-package
+          #   compiler: MSVC
+          # - os: ubuntu-latest
+          #   task: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
@@ -86,11 +86,9 @@ jobs:
           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
 
 # links
-# * https://github.com/microsoft/LightGBM/issues/2353
-# *  https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun
+# * https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun
 # * https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
 # * https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
 # * https://github.com/marketplace/actions/setup-miniconda
 # * https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
 # * https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
-# * https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
           - os: windows-latest
             task: r-package
             compiler: MSVC
-          # - os: ubuntu-latest
-          #   task: lint
+          - os: ubuntu-latest
+            task: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
@@ -32,8 +32,6 @@ jobs:
         if: matrix.os != 'windows-latest'
         shell: bash
         run: |
-          export HOME_DIRECTORY="$HOME"
-          export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
               export OS_NAME="macos"
               export COMPILER="gcc"
@@ -65,12 +63,6 @@ jobs:
           export LD_LIBRARY_PATH="$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH"
           $GITHUB_WORKSPACE/.ci/setup.sh
           $GITHUB_WORKSPACE/.ci/test.sh
-      # # reference: https://github.com/marketplace/actions/setup-conda
-      # - name: Use conda on Windows
-      #   if: matrix.os == 'windows-latest'
-      #   uses: s-weigand/setup-conda@v1
-      #   with:
-      #     activate-conda: true
       #  https://github.com/marketplace/actions/setup-miniconda
       - name: Use conda on Windows
         if: matrix.os == 'windows-latest'
@@ -88,6 +80,9 @@ jobs:
           GITHUB_ACTIONS: "true"
           TASK: "r-package"
         run: |
+          if ("${{ matrix.compiler }}" -ne "") {
+            $env:COMPILER = "${{ matrix.compiler }}"
+          }
           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
 
 # links

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,7 @@ jobs:
           GITHUB_ACTIONS: "true"
           TASK: "${{ matrix.task }}"
         run: |
+          $ErrorActionPreference = "Continue"
           $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
           conda init powershell
           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
           $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
           Write-Output "CI default for Errors: $ErrorActionPreference"
           $ErrorActionPreference = "Continue"
-          & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
+          & cmd /c "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1 2>&1"
 
 # links
 # * https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,32 +10,32 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            task: r-package
-            compiler: gcc
-            subtitle: gcc
-          - os: ubuntu-latest
-            task: r-package
-            compiler: clang
-            subtitle: clang
-          - os: macOS-latest
-            task: r-package
-            compiler: gcc
-            subtitle: gcc
-          - os: macOS-latest
-            task: r-package
-            compiler: clang
-            subtitle: clang
+          # - os: ubuntu-latest
+          #   task: r-package
+          #   compiler: gcc
+          #   subtitle: gcc
+          # - os: ubuntu-latest
+          #   task: r-package
+          #   compiler: clang
+          #   subtitle: clang
+          # - os: macOS-latest
+          #   task: r-package
+          #   compiler: gcc
+          #   subtitle: gcc
+          # - os: macOS-latest
+          #   task: r-package
+          #   compiler: clang
+          #   subtitle: clang
           - os: windows-latest
             task: r-package
             compiler: MINGW
             subtitle: MINGW
-          - os: windows-latest
-            task: r-package
-            compiler: MSVC
-            subtitle: MSVC
-          - os: ubuntu-latest
-            task: lint
+          # - os: windows-latest
+          #   task: r-package
+          #   compiler: MSVC
+          #   subtitle: MSVC
+          # - os: ubuntu-latest
+          #   task: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,17 +24,25 @@ jobs:
             task: r-package
             compiler: MSVC
             subtitle: MSVC
-          # - os: ubuntu-latest
-          #   task: lint
+          - os: ubuntu-latest
+            task: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
         with:
-          fetch-depth: 1
+          fetch-depth: 5
           submodules: true
       - name: Setup and run tests on Linux and macOS
         if: matrix.os != 'windows-latest'
         shell: bash
+        # export AMDAPPSDK_PATH=$HOME/AMDAPPSDK
+        # export LD_LIBRARY_PATH="$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH"
+        # export HOME_DIRECTORY="$HOME"
+        env:
+          COMPILER: "${{ matrix.compiler }}"
+          CONDA_ENV: "test-env"
+          GITHUB_ACTIONS: "true"
+          TASK: "${{ matrix.task }}"
         run: |
           if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
               export OS_NAME="macos"
@@ -48,23 +56,10 @@ jobs:
           if [ -z ${{ matrix.compiler }} ]; then
               export COMPILER=${{ matrix.compiler }}
           fi
-          export TASK="${{ matrix.task }}"
-          export HOME_DIRECTORY="$HOME"
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
-          if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
-              export OS_NAME="macos"
-              export COMPILER="gcc"
-          elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-              export OS_NAME="linux"
-              export COMPILER="clang"
-          fi
-          export GITHUB_ACTIONS="true"
           export CONDA="$HOME/miniconda"
           export PATH="$CONDA/bin:${HOME}/.local/bin:$PATH"
-          export CONDA_ENV="test-env"
           export LGB_VER=$(head -n 1 VERSION.txt)
-          export AMDAPPSDK_PATH=$HOME/AMDAPPSDK
-          export LD_LIBRARY_PATH="$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH"
           $GITHUB_WORKSPACE/.ci/setup.sh
           $GITHUB_WORKSPACE/.ci/test.sh
       #  https://github.com/marketplace/actions/setup-miniconda
@@ -93,9 +88,6 @@ jobs:
         #   $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
         #   cmd /c "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
         run: |
-          if ("${{ matrix.compiler }}" -ne "") {
-            $env:COMPILER = "${{ matrix.compiler }}"
-          }
           $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         # have to use 'pwsh' because with 'powershell', anything writing to
         # stderr causes the job to fail
-        shell: pwsh -NonInteractive -ExecutionPolicy Bypass -File {0}
+        shell: powershell -NonInteractive -ExecutionPolicy Bypass -File {0}
         env:
           COMPILER: "${{ matrix.compiler }}"
           GITHUB_ACTIONS: "true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,13 +74,12 @@ jobs:
           auto-update-conda: false
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
-        shell: powershell
+        shell: pwsh
         env:
           COMPILER: "${{ matrix.compiler }}"
           GITHUB_ACTIONS: "true"
           TASK: "${{ matrix.task }}"
         run: |
-          $ErrorActionPreference = "Continue"
           $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
           conda init powershell
           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
@@ -96,3 +95,4 @@ jobs:
 # * https://stackoverflow.com/a/11826589/3986677
 # * https://github.com/marketplace/actions/setup-miniconda
 # * https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
+# * see "fail-fast behavior" in https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,10 +86,10 @@ jobs:
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
         shell: cmd
+        env:
+          GITHUB_ACTIONS: "true"
+          TASK: "r-package"
         run: |
-          set HOME_DIRECTORY=%HOME%
-          set GITHUB_ACTIONS="true"
-          set TASK="r-package"
           powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
 
 # links

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         # have to use 'pwsh' because with 'powershell', anything writing to
         # stderr causes the job to fail
-        shell: pwsh -File {0}
+        shell: pwsh -NonInteractive -ExecutionPolicy Bypass -File {0}
         env:
           COMPILER: "${{ matrix.compiler }}"
           GITHUB_ACTIONS: "true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
           GITHUB_ACTIONS: "true"
           TASK: "r-package"
         run: |
-          powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
+          powershell.exe -ExecutionPolicy Bypass ErrorActionPreference Continue -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
 
 # links
 # * https://github.com/microsoft/LightGBM/issues/2353
@@ -98,4 +98,4 @@ jobs:
 # * https://github.com/marketplace/actions/setup-miniconda
 # * https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
 # * https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
-# * 
+# * https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,16 @@ jobs:
       matrix:
         task: [lint, r-package]
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            task: r-package
+          - os: macOS-latest
+            task: r-package
+          - os: windows-latest
+            task: r-package
+            compiler: MINGW
+          - os: ubuntu-latest
+            task: lint
         exclude:
           - os: macOS-latest
             task: lint
@@ -37,6 +47,9 @@ jobs:
               export COMPILER="clang"
               export R_TRAVIS_LINUX_VERSION=3.6.3-1bionic;
           fi
+          if [ -z ${{ matrix.compiler }} ]; then
+              export COMPILER=${{ matrix.compiler }}
+          fi
           export TASK="${{ matrix.task }}"
           export HOME_DIRECTORY="$HOME"
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
@@ -56,3 +69,12 @@ jobs:
           export LD_LIBRARY_PATH="$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH"
           $GITHUB_WORKSPACE/.ci/setup.sh
           $GITHUB_WORKSPACE/.ci/test.sh
+      - name: Setup and run tests on Windows
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $env:HOME_DIRECTORY=$env:HOME
+          $env:GITHUB_ACTIONS="true"
+          $env:CONDA_ENV="test-env"
+          & "conda init powershell"
+          & "powershell -ExecutionPolicy Bypass -File %BUILD_DIRECTORY%/.ci/test_windows.ps1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           fi
           export GITHUB_ACTIONS="true"
           export CONDA="$HOME/miniconda"
-          export PATH="$CONDA/bin:$PATH"
+          export PATH="$CONDA/bin:${HOME}/.local/bin:$PATH"
           export CONDA_ENV="test-env"
           export LGB_VER=$(head -n 1 VERSION.txt)
           export AMDAPPSDK_PATH=$HOME/AMDAPPSDK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,11 +79,15 @@ jobs:
         env:
           GITHUB_ACTIONS: "true"
           TASK: "r-package"
+        # https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide
+        # https://stackoverflow.com/a/11826589/3986677
         run: |
           if ("${{ matrix.compiler }}" -ne "") {
             $env:COMPILER = "${{ matrix.compiler }}"
           }
           $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
+          Write-Output "CI default for Errors: $ErrorActionPreference"
+          $ErrorActionPreference = "Continue"
           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
 
 # links

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
           conda init powershell
-          & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1 2&>1"
+          & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
 
 # links
 # * https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,17 @@ jobs:
         if: matrix.os != 'windows-latest'
         shell: bash
         run: |
+          export HOME_DIRECTORY="$HOME"
+          export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
+          if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
+              export OS_NAME="macos"
+              export COMPILER="gcc"
+              export R_MAC_VERSION=3.6.3
+          elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+              export OS_NAME="linux"
+              export COMPILER="clang"
+              export R_TRAVIS_LINUX_VERSION=3.6.3-1bionic;
+          fi
           export TASK="${{ matrix.task }}"
           export HOME_DIRECTORY="$HOME"
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,8 @@ jobs:
           auto-update-conda: false
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
+        # have to use 'pwsh' because with 'powershell', anything writing to
+        # stderr causes the job to fail
         shell: pwsh -File {0}
         env:
           COMPILER: "${{ matrix.compiler }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,10 +79,9 @@ jobs:
         run: conda init powershell
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
-        shell: pwsh
+        shell: cmd
         env:
           GITHUB_ACTIONS: "true"
-          TASK: "r-package"
         # https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide
         # https://stackoverflow.com/a/11826589/3986677
         # run: |
@@ -94,6 +93,7 @@ jobs:
         run: |
           set COMPILER="${{ matrix.compiler }}"
           set BUILD_SOURCESDIRECTORY=%GITHUB_WORKSPACE%
+          set TASK="{{ matrix.task }}"
           powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,11 @@ jobs:
           - os: windows-latest
             task: r-package
             compiler: MINGW
+          - os: windows-latest
+            task: r-package
+            compiler: MSVC
           # - os: ubuntu-latest
           #   task: lint
-        # exclude:
-        #   - os: macOS-latest
-        #     task: lint
-        #   - os: windows-latest
-        #     task: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,12 +83,12 @@ jobs:
         run: conda init powershell
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
-        shell: cmd
+        shell: pwsh
         env:
           GITHUB_ACTIONS: "true"
           TASK: "r-package"
         run: |
-          powershell.exe -ExecutionPolicy Bypass ErrorActionPreference Continue -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
+          & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
 
 # links
 # * https://github.com/microsoft/LightGBM/issues/2353

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,23 +9,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [lint, r-package]
-        os: [windows-latest] # ubuntu-latest, macOS-latest, 
         include:
-          - os: ubuntu-latest
-            task: r-package
-          - os: macOS-latest
-            task: r-package
+          # - os: ubuntu-latest
+          #   task: r-package
+          # - os: macOS-latest
+          #   task: r-package
           - os: windows-latest
             task: r-package
             compiler: MINGW
-          - os: ubuntu-latest
-            task: lint
-        exclude:
-          - os: macOS-latest
-            task: lint
-          - os: windows-latest
-            task: lint
+          # - os: ubuntu-latest
+          #   task: lint
+        # exclude:
+        #   - os: macOS-latest
+        #     task: lint
+        #   - os: windows-latest
+        #     task: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
@@ -81,4 +79,5 @@ jobs:
         run: |
           $env:HOME_DIRECTORY=$env:HOME
           $env:GITHUB_ACTIONS="true"
+          conda init powershell
           powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,16 +10,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            task: r-package
-            subtitle: ""
-          - os: macOS-latest
-            task: r-package
-            subtitle: ""
-          - os: windows-latest
-            task: r-package
-            compiler: MINGW
-            subtitle: MINGW
+          # - os: ubuntu-latest
+          #   task: r-package
+          #   subtitle: ""
+          # - os: macOS-latest
+          #   task: r-package
+          #   subtitle: ""
+          # - os: windows-latest
+          #   task: r-package
+          #   compiler: MINGW
+          #   subtitle: MINGW
           - os: windows-latest
             task: r-package
             compiler: MSVC
@@ -79,7 +79,7 @@ jobs:
         run: conda init powershell
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
-        shell: cmd
+        shell: pwsh
         env:
           COMPILER: "${{ matrix.compiler }}"
           GITHUB_ACTIONS: "true"
@@ -93,9 +93,14 @@ jobs:
         #   $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
         #   cmd /c "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
         run: |
-          set BUILD_SOURCESDIRECTORY=%GITHUB_WORKSPACE%
-          powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
+          if ("${{ matrix.compiler }}" -ne "") {
+            $env:COMPILER = "${{ matrix.compiler }}"
+          }
+          $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
+          & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
 
+# set BUILD_SOURCESDIRECTORY=%GITHUB_WORKSPACE%
+# powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
 
 # Write-Output "CI default for Errors: $ErrorActionPreference"
 # $ErrorActionPreference = "Continue"
@@ -107,3 +112,5 @@ jobs:
 # * https://github.com/marketplace/actions/setup-miniconda
 # * https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
 # * https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
+# * https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide/2095623#2095623
+# 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
           auto-update-conda: false
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
-        shell: pwsh
+        shell: pwsh -File {0}
         env:
           COMPILER: "${{ matrix.compiler }}"
           GITHUB_ACTIONS: "true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
           auto-update-conda: false
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
-        shell: powershell -File {0}
+        shell: pwsh -File {0}
         env:
           COMPILER: "${{ matrix.compiler }}"
           GITHUB_ACTIONS: "true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         task: [lint, r-package]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [windows-latest] # ubuntu-latest, macOS-latest, 
         include:
           - os: ubuntu-latest
             task: r-package
@@ -69,6 +69,12 @@ jobs:
           export LD_LIBRARY_PATH="$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH"
           $GITHUB_WORKSPACE/.ci/setup.sh
           $GITHUB_WORKSPACE/.ci/test.sh
+      # reference: https://github.com/marketplace/actions/setup-conda
+      - name: Use conda on Windows
+        if: matrix.os == 'windows-latest'
+        uses: s-weigand/setup-conda@v1
+        with:
+          activate-conda: true
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
         shell: cmd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
           auto-update-conda: false
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
-        shell: pwsh -File {0}
+        shell: powershell -File {0}
         env:
           COMPILER: "${{ matrix.compiler }}"
           GITHUB_ACTIONS: "true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,5 +85,6 @@ jobs:
         run: |
           $env:HOME_DIRECTORY=$env:HOME
           $env:GITHUB_ACTIONS="true"
+          $env:TASK="r-package"
           conda init powershell
           powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,17 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: cmd
         run: |
-          $env:HOME_DIRECTORY=$env:HOME
-          $env:GITHUB_ACTIONS="true"
-          $env:TASK="r-package"
+          set HOME_DIRECTORY=%HOME%
+          set GITHUB_ACTIONS="true"
+          set TASK="r-package"
           powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
+
+# links
+# * https://github.com/microsoft/LightGBM/issues/2353
+# *  https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun
+# * https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
+# * https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+# * https://github.com/marketplace/actions/setup-miniconda
+# * https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
+# * https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
+# * 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,32 +10,32 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - os: ubuntu-latest
-          #   task: r-package
-          #   compiler: gcc
-          #   subtitle: gcc
-          # - os: ubuntu-latest
-          #   task: r-package
-          #   compiler: clang
-          #   subtitle: clang
-          # - os: macOS-latest
-          #   task: r-package
-          #   compiler: gcc
-          #   subtitle: gcc
-          # - os: macOS-latest
-          #   task: r-package
-          #   compiler: clang
-          #   subtitle: clang
+          - os: ubuntu-latest
+            task: r-package
+            compiler: gcc
+            subtitle: gcc
+          - os: ubuntu-latest
+            task: r-package
+            compiler: clang
+            subtitle: clang
+          - os: macOS-latest
+            task: r-package
+            compiler: gcc
+            subtitle: gcc
+          - os: macOS-latest
+            task: r-package
+            compiler: clang
+            subtitle: clang
           - os: windows-latest
             task: r-package
             compiler: MINGW
             subtitle: MINGW
-          # - os: windows-latest
-          #   task: r-package
-          #   compiler: MSVC
-          #   subtitle: MSVC
-          # - os: ubuntu-latest
-          #   task: lint
+          - os: windows-latest
+            task: r-package
+            compiler: MSVC
+            subtitle: MSVC
+          - os: ubuntu-latest
+            task: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
@@ -74,8 +74,8 @@ jobs:
           auto-update-conda: false
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
-        # have to use 'pwsh' because with 'powershell', anything writing to
-        # stderr causes the job to fail
+        # have to use this explicit command to override the GitHub Actions
+        # default, where any command writing to stderr causes build failures
         shell: pwsh -NonInteractive -ExecutionPolicy Bypass -Command "& '{0}'"
         env:
           COMPILER: "${{ matrix.compiler }}"
@@ -86,7 +86,7 @@ jobs:
           conda init powershell
           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
 
-# links
+# references
 # * https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun
 # * https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
 # * https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set COMPILER="${{ matrix.compiler }}"
           set BUILD_SOURCESDIRECTORY=%GITHUB_WORKSPACE%
-          set TASK="{{ matrix.task }}"
+          set TASK="${{ matrix.task }}"
           powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   test:
-    name: ${{ matrix.task }} (${{ matrix.os }})
+    name: ${{ matrix.task }} (${{ matrix.os }}, ${{ matrix.subtitle }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -12,14 +12,18 @@ jobs:
         include:
           - os: ubuntu-latest
             task: r-package
+            subtitle: ""
           - os: macOS-latest
             task: r-package
+            subtitle: ""
           - os: windows-latest
             task: r-package
             compiler: MINGW
+            subtitle: MINGW
           - os: windows-latest
             task: r-package
             compiler: MSVC
+            subtitle: MSVC
           - os: ubuntu-latest
             task: lint
     steps:
@@ -81,14 +85,20 @@ jobs:
           TASK: "r-package"
         # https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide
         # https://stackoverflow.com/a/11826589/3986677
+        # run: |
+        #   if ("${{ matrix.compiler }}" -ne "") {
+        #     $env:COMPILER = "${{ matrix.compiler }}"
+        #   }
+        #   $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
+        #   cmd /c "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
         run: |
-          if ("${{ matrix.compiler }}" -ne "") {
-            $env:COMPILER = "${{ matrix.compiler }}"
-          }
-          $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
-          Write-Output "CI default for Errors: $ErrorActionPreference"
-          $ErrorActionPreference = "Continue"
-          & cmd /c "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1 2>&1"
+          set COMPILER="${{ matrix.compiler }}"
+          set BUILD_SOURCESDIRECTORY=%GITHUB_WORKSPACE%
+          powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
+
+
+# Write-Output "CI default for Errors: $ErrorActionPreference"
+# $ErrorActionPreference = "Continue"
 
 # links
 # * https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,4 +75,4 @@ jobs:
         run: |
           $env:HOME_DIRECTORY=$env:HOME
           $env:GITHUB_ACTIONS="true"
-          & "powershell -ExecutionPolicy Bypass -File %BUILD_DIRECTORY%/.ci/test_windows.ps1"
+          powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,20 @@ jobs:
         include:
           - os: ubuntu-latest
             task: r-package
-            subtitle: ""
-          # - os: macOS-latest
-          #   task: r-package
-          #   subtitle: ""
+            compiler: gcc
+            subtitle: gcc
+          - os: ubuntu-latest
+            task: r-package
+            compiler: clang
+            subtitle: clang
+          - os: macOS-latest
+            task: r-package
+            compiler: gcc
+            subtitle: gcc
+          - os: macOS-latest
+            task: r-package
+            compiler: clang
+            subtitle: clang
           - os: windows-latest
             task: r-package
             compiler: MINGW
@@ -43,11 +53,9 @@ jobs:
         run: |
           if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
               export OS_NAME="macos"
-              export COMPILER="gcc"
               export R_MAC_VERSION=3.6.3
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
               export OS_NAME="linux"
-              export COMPILER="clang"
               export R_TRAVIS_LINUX_VERSION=3.6.3-1bionic;
           fi
           if [ -z ${{ matrix.compiler }} ]; then
@@ -59,16 +67,11 @@ jobs:
           export LGB_VER=$(head -n 1 VERSION.txt)
           $GITHUB_WORKSPACE/.ci/setup.sh
           $GITHUB_WORKSPACE/.ci/test.sh
-      #  https://github.com/marketplace/actions/setup-miniconda
       - name: Use conda on Windows
         if: matrix.os == 'windows-latest'
         uses: goanpeca/setup-miniconda@v1
         with:
           auto-update-conda: false
-      # - name: conda init powershell
-      #   if: matrix.os == 'windows-latest'
-      #   shell: cmd
-      #   run: conda init powershell
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
         shell: pwsh
@@ -79,10 +82,7 @@ jobs:
         run: |
           $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
           conda init powershell
-          & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
-
-# set BUILD_SOURCESDIRECTORY=%GITHUB_WORKSPACE%
-# powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
+          & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1 2&>1"
 
 # links
 # * https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun
@@ -93,3 +93,4 @@ jobs:
 # * https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
 # * https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide/2095623#2095623
 # * https://stackoverflow.com/a/11826589/3986677
+# * https://github.com/marketplace/actions/setup-miniconda

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,12 +67,18 @@ jobs:
           export LD_LIBRARY_PATH="$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH"
           $GITHUB_WORKSPACE/.ci/setup.sh
           $GITHUB_WORKSPACE/.ci/test.sh
-      # reference: https://github.com/marketplace/actions/setup-conda
+      # # reference: https://github.com/marketplace/actions/setup-conda
+      # - name: Use conda on Windows
+      #   if: matrix.os == 'windows-latest'
+      #   uses: s-weigand/setup-conda@v1
+      #   with:
+      #     activate-conda: true
+      #  https://github.com/marketplace/actions/setup-miniconda
       - name: Use conda on Windows
         if: matrix.os == 'windows-latest'
-        uses: s-weigand/setup-conda@v1
+        uses: goanpeca/setup-miniconda@v1
         with:
-          activate-conda: true
+          auto-update-conda: false
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
         shell: cmd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,9 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: cmd
         env:
+          COMPILER: "${{ matrix.compiler }}"
           GITHUB_ACTIONS: "true"
+          TASK: "${{ matrix.task }}"
         # https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide
         # https://stackoverflow.com/a/11826589/3986677
         # run: |
@@ -91,9 +93,7 @@ jobs:
         #   $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
         #   cmd /c "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
         run: |
-          set COMPILER="${{ matrix.compiler }}"
           set BUILD_SOURCESDIRECTORY=%GITHUB_WORKSPACE%
-          set TASK="${{ matrix.task }}"
           powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,18 +10,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - os: ubuntu-latest
-          #   task: r-package
-          # - os: macOS-latest
-          #   task: r-package
+          - os: ubuntu-latest
+            task: r-package
+          - os: macOS-latest
+            task: r-package
           - os: windows-latest
             task: r-package
             compiler: MINGW
-          # - os: windows-latest
-          #   task: r-package
-          #   compiler: MSVC
-          # - os: ubuntu-latest
-          #   task: lint
+          - os: windows-latest
+            task: r-package
+            compiler: MSVC
+          - os: ubuntu-latest
+            task: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
@@ -83,6 +83,7 @@ jobs:
           if ("${{ matrix.compiler }}" -ne "") {
             $env:COMPILER = "${{ matrix.compiler }}"
           }
+          $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
 
 # links

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         # have to use 'pwsh' because with 'powershell', anything writing to
         # stderr causes the job to fail
-        shell: powershell -NonInteractive -ExecutionPolicy Bypass -File {0}
+        shell: pwsh -NonInteractive -ExecutionPolicy Bypass -Command "& '{0}'"
         env:
           COMPILER: "${{ matrix.compiler }}"
           GITHUB_ACTIONS: "true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,16 +16,16 @@ jobs:
           # - os: macOS-latest
           #   task: r-package
           #   subtitle: ""
-          # - os: windows-latest
-          #   task: r-package
-          #   compiler: MINGW
-          #   subtitle: MINGW
+          - os: windows-latest
+            task: r-package
+            compiler: MINGW
+            subtitle: MINGW
           - os: windows-latest
             task: r-package
             compiler: MSVC
             subtitle: MSVC
-          - os: ubuntu-latest
-            task: lint
+          # - os: ubuntu-latest
+          #   task: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,16 +85,3 @@ jobs:
           $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
           conda init powershell
           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
-
-# references
-# * https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun
-# * https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
-# * https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-# * https://github.com/marketplace/actions/setup-miniconda
-# * https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
-# * https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
-# * https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide/2095623#2095623
-# * https://stackoverflow.com/a/11826589/3986677
-# * https://github.com/marketplace/actions/setup-miniconda
-# * https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
-# * see "fail-fast behavior" in https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
           $GITHUB_WORKSPACE/.ci/test.sh
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
-        shell: pwsh
+        shell: cmd
         run: |
           $env:HOME_DIRECTORY=$env:HOME
           $env:GITHUB_ACTIONS="true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,10 @@ jobs:
         uses: goanpeca/setup-miniconda@v1
         with:
           auto-update-conda: false
+      - name: conda init powershell
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: conda init powershell
       - name: Setup and run tests on Windows
         if: matrix.os == 'windows-latest'
         shell: cmd
@@ -86,5 +90,4 @@ jobs:
           $env:HOME_DIRECTORY=$env:HOME
           $env:GITHUB_ACTIONS="true"
           $env:TASK="r-package"
-          conda init powershell
           powershell.exe -ExecutionPolicy Bypass -File %GITHUB_WORKSPACE%/.ci/test_windows.ps1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [lint] # r-package
+        task: [lint, r-package]
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
           - os: macOS-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,17 @@ env:
   global:  # default values
     - PYTHON_VERSION=3.8
   matrix:
-    - TASK=regular PYTHON_VERSION=3.6
-    - TASK=sdist PYTHON_VERSION=2.7
-    - TASK=bdist
-    - TASK=if-else
+    # - TASK=regular PYTHON_VERSION=3.6
+    # - TASK=sdist PYTHON_VERSION=2.7
+    # - TASK=bdist
+    # - TASK=if-else
     - TASK=lint
-    - TASK=check-docs
-    - TASK=mpi METHOD=source
-    - TASK=mpi METHOD=pip PYTHON_VERSION=3.7
-    - TASK=gpu METHOD=source PYTHON_VERSION=3.5
-    - TASK=gpu METHOD=pip PYTHON_VERSION=3.6
-    - TASK=r-package
+    # - TASK=check-docs
+    # - TASK=mpi METHOD=source
+    # - TASK=mpi METHOD=pip PYTHON_VERSION=3.7
+    # - TASK=gpu METHOD=source PYTHON_VERSION=3.5
+    # - TASK=gpu METHOD=pip PYTHON_VERSION=3.6
+    # - TASK=r-package
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,16 @@ env:
   global:  # default values
     - PYTHON_VERSION=3.8
   matrix:
-    # - TASK=regular PYTHON_VERSION=3.6
-    # - TASK=sdist PYTHON_VERSION=2.7
-    # - TASK=bdist
-    # - TASK=if-else
-    - TASK=lint
-    # - TASK=check-docs
-    # - TASK=mpi METHOD=source
-    # - TASK=mpi METHOD=pip PYTHON_VERSION=3.7
-    # - TASK=gpu METHOD=source PYTHON_VERSION=3.5
-    # - TASK=gpu METHOD=pip PYTHON_VERSION=3.6
-    # - TASK=r-package
+    - TASK=regular PYTHON_VERSION=3.6
+    - TASK=sdist PYTHON_VERSION=2.7
+    - TASK=bdist
+    - TASK=if-else
+    - TASK=check-docs
+    - TASK=mpi METHOD=source
+    - TASK=mpi METHOD=pip PYTHON_VERSION=3.7
+    - TASK=gpu METHOD=source PYTHON_VERSION=3.5
+    - TASK=gpu METHOD=pip PYTHON_VERSION=3.6
+    - TASK=r-package
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - TASK=mpi METHOD=pip PYTHON_VERSION=3.7
     - TASK=gpu METHOD=source PYTHON_VERSION=3.5
     - TASK=gpu METHOD=pip PYTHON_VERSION=3.6
-    - TASK=r-package
 
 matrix:
   exclude:
@@ -31,8 +30,6 @@ matrix:
       env: TASK=gpu METHOD=source PYTHON_VERSION=3.5
     - os: osx
       env: TASK=gpu METHOD=pip PYTHON_VERSION=3.6
-    - os: osx
-      env: TASK=lint
     - os: osx
       env: TASK=check-docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,9 @@ before_install:
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
         export OS_NAME="macos";
         export COMPILER="gcc";
-        export R_MAC_VERSION=3.6.3;
     else
         export OS_NAME="linux";
         export COMPILER="clang";
-        export R_TRAVIS_LINUX_VERSION=3.6.3-1bionic;
     fi
   - export CONDA="$HOME/miniconda"
   - export PATH="$CONDA/bin:$PATH"

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -22,7 +22,7 @@ jobs:
     vmImage: 'ubuntu-latest'
   container: ubuntu1404
   strategy:
-    maxParallel: 7
+    maxParallel: 6
     matrix:
       regular:
         TASK: regular
@@ -94,7 +94,6 @@ jobs:
       echo "##vso[task.setvariable variable=CONDA]$CONDA"
       echo "##vso[task.prependpath]$CONDA/bin"
       echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_8_X64"
-      echo "##vso[task.setvariable variable=R_MAC_VERSION]3.6.3"
     displayName: 'Set variables'
   - bash: $(Build.SourcesDirectory)/.ci/setup.sh
     displayName: Setup

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -41,8 +41,6 @@ jobs:
         TASK: gpu
         METHOD: source
         PYTHON_VERSION: 3.6
-      r_package:
-        TASK: r-package
   steps:
   - script: |
       echo "##vso[task.setvariable variable=HOME_DIRECTORY]$AGENT_HOMEDIRECTORY"
@@ -75,7 +73,7 @@ jobs:
   pool:
     vmImage: 'macOS-10.14'
   strategy:
-    maxParallel: 4
+    maxParallel: 3
     matrix:
       regular:
         TASK: regular
@@ -85,8 +83,6 @@ jobs:
         PYTHON_VERSION: 3.5
       bdist:
         TASK: bdist
-      r_package:
-        TASK: r-package
   steps:
   - script: |
       echo "##vso[task.setvariable variable=HOME_DIRECTORY]$AGENT_HOMEDIRECTORY"


### PR DESCRIPTION
This PR proposes adding GitHub Actions CI and moving all R jobs to it.

GitHub Actions gives you 20 concurrent jobs for free and access to Mac, Linux, and Windows environments.

See #2353 and discussion in this thread: https://github.com/microsoft/LightGBM/pull/3065#discussion_r428246650

This PR should improve CI times (since AppVeyor runs tasks sequentially and now those tasks will be run concurrently), and should give enough extra CI capacity to test more installation paths for the R package(like R 3.6.x AND R 4.0.0x on #3065 )

## Summary of Changes

* move `lint` job from Travis to GitHub Actions
* remove R Linux and Mac CI jobs from Azure
* remove R jobs from AppVeyor
* remove R jobs from Travis
* add 6 R jobs to GitHub Actions:
    - Windows, MSVC
    - Windows, MINGW
    - Mac, gcc
    - Mac, clang
    - Linux, gcc
    - Linux, clang
* add `.ci/download-miktex.R`, to make `miktexsetup.zip` downloads more reliable

## Notes for reviewers

* I developed this on my fork, and you can look at the build history there: https://github.com/jameslamb/LightGBM/pull/28
* I'd like to keep the Azure Windows `r-package` job, since it gives us access to Visual Studio 2017. GitHub Actions only has Visual Studio 2019 ([reference]( https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources))
* I added `.ci/download-miktex.R` because maybe 1 out of every 8 builds hit this issue: https://github.com/microsoft/LightGBM/pull/3113#issue-422362595
* the conda step comes from here: https://github.com/marketplace/actions/setup-miniconda
* I had an issue where any code that writes too `stderr` causes the build to fail, even if the command itself succeeds. I tracked that down to [this section of the docs](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsrun), which state:

> Fail-fast behavior when possible. For pwsh and powershell built-in shell, we will prepend $ErrorActionPreference = 'stop' to script contents.

## Other references

* https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun
* https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
* https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
* https://github.com/marketplace/actions/setup-miniconda
* https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
* https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
* https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide/2095623#2095623
* https://stackoverflow.com/a/11826589/3986677
* https://github.com/marketplace/actions/setup-miniconda
* https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
* see "fail-fast behavior" in https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
