### PR TITLE
[ci] remove unused environment variable in CI setups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ matrix:
 before_install:
   - test -n $CC  && unset CC
   - test -n $CXX && unset CXX
-  - export HOME_DIRECTORY="$HOME"
   - export BUILD_DIRECTORY="$TRAVIS_BUILD_DIR"
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
         export OS_NAME="macos";

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -45,7 +45,6 @@ jobs:
         TASK: r-package
   steps:
   - script: |
-      echo "##vso[task.setvariable variable=HOME_DIRECTORY]$AGENT_HOMEDIRECTORY"
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
       echo "##vso[task.setvariable variable=OS_NAME]linux"
       echo "##vso[task.setvariable variable=AZURE]true"
@@ -89,7 +88,6 @@ jobs:
         TASK: r-package
   steps:
   - script: |
-      echo "##vso[task.setvariable variable=HOME_DIRECTORY]$AGENT_HOMEDIRECTORY"
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
       echo "##vso[task.setvariable variable=OS_NAME]macos"
       echo "##vso[task.setvariable variable=AZURE]true"


### PR DESCRIPTION
While using `.vsts-ci.yml` and `.travis.yml` as references in #2353 , I noticed that we currently set environment variable `HOME_DIRECTORY`. It doesn't seem to be used anywhere, so I think we can remove it.