### PR TITLE
fix error C3861: '_BitScanReverse': identifier not found

### DIFF
--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -26,6 +26,11 @@
 #include <LightGBM/utils/log.h>
 #include <LightGBM/utils/openmp_wrapper.h>
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#pragma intrinsic(_BitScanReverse)
+#endif
+
 #if defined(_MSC_VER)
 #include <malloc.h>
 #elif MM_MALLOC


### PR DESCRIPTION
Fix compilation error for VS 2017 at Azure NC12 VM.

I have no idea why we haven't seen this error at our CIs...

Refer to https://docs.microsoft.com/ru-ru/cpp/intrinsics/bitscanreverse-bitscanreverse64?view=vs-2019#example.
```
C:\Users\ntitov\Downloads\LightGBM\build>cmake -A x64 ..
-- Building for: Visual Studio 15 2017
-- Selecting Windows SDK version 10.0.16299.0 to target Windows 10.0.14393.
-- The C compiler identification is MSVC 19.12.25835.0
-- The CXX compiler identification is MSVC 19.12.25835.0
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found OpenMP_C: -openmp (found version "2.0")
-- Found OpenMP_CXX: -openmp (found version "2.0")
-- Found OpenMP: TRUE (found version "2.0")
-- Performing Test MM_PREFETCH
-- Performing Test MM_PREFETCH - Failed
-- Performing Test MM_MALLOC
-- Performing Test MM_MALLOC - Failed
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/ntitov/Downloads/LightGBM/build

C:\Users\ntitov\Downloads\LightGBM\build>cmake --build . --target ALL_BUILD --config Release
Microsoft (R) Build Engine version 15.5.180.51428 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  CMake does not need to re-run because C:/Users/ntitov/Downloads/LightGBM/build/CMakeFiles/generate.stamp is up-to-date.
  Building Custom Rule C:/Users/ntitov/Downloads/LightGBM/CMakeLists.txt
  CMake does not need to re-run because C:/Users/ntitov/Downloads/LightGBM/build/CMakeFiles/generate.stamp is up-to-date.
  application.cpp
  boosting.cpp
  gbdt.cpp
  gbdt_model_text.cpp
  gbdt_prediction.cpp
  prediction_early_stop.cpp
  bin.cpp
  config.cpp
  config_auto.cpp
  dataset.cpp
  dataset_loader.cpp
  file_io.cpp
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\boosting\boosting.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\boosting\gbdt_model_text.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\dataset_loader.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\boosting\gbdt.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\application\application.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\config_auto.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\boosting\gbdt_prediction.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\dataset.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\config.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\bin.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
  json11.cpp
  metadata.cpp
  parser.cpp
  tree.cpp
  dcg_calculator.cpp
  metric.cpp
  linker_topo.cpp
  linkers_mpi.cpp
  linkers_socket.cpp
  network.cpp
  objective_function.cpp
  data_parallel_tree_learner.cpp
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\metadata.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
  feature_parallel_tree_learner.cpp
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\tree.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\parser.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\metric\metric.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\network\linkers_socket.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\network\linker_topo.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\network\network.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\metric\dcg_calculator.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\objective\objective_function.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
  gpu_tree_learner.cpp
  serial_tree_learner.cpp
  tree_learner.cpp
  voting_parallel_tree_learner.cpp
  c_api.cpp
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\treelearner\data_parallel_tree_learner.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\treelearner\feature_parallel_tree_learner.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\treelearner\tree_learner.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\treelearner\voting_parallel_tree_learner.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\treelearner\serial_tree_learner.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\c_api.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\_lightgbm.vcxproj]
  Building Custom Rule C:/Users/ntitov/Downloads/LightGBM/CMakeLists.txt
  CMake does not need to re-run because C:/Users/ntitov/Downloads/LightGBM/build/CMakeFiles/generate.stamp is up-to-date.
  main.cpp
  application.cpp
  boosting.cpp
  gbdt.cpp
  gbdt_model_text.cpp
  gbdt_prediction.cpp
  prediction_early_stop.cpp
  bin.cpp
  config.cpp
  config_auto.cpp
  dataset.cpp
  dataset_loader.cpp
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\boosting\gbdt_model_text.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\boosting\boosting.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\config.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\main.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\config_auto.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\dataset_loader.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\boosting\gbdt.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\dataset.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\boosting\gbdt_prediction.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\bin.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\application\application.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
  file_io.cpp
  json11.cpp
  metadata.cpp
  parser.cpp
  tree.cpp
  dcg_calculator.cpp
  metric.cpp
  linker_topo.cpp
  linkers_mpi.cpp
  linkers_socket.cpp
  network.cpp
  objective_function.cpp
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\metadata.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
  data_parallel_tree_learner.cpp
  feature_parallel_tree_learner.cpp
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\parser.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\io\tree.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\metric\dcg_calculator.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\network\linker_topo.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\metric\metric.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
  gpu_tree_learner.cpp
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\network\linkers_socket.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
  serial_tree_learner.cpp
  tree_learner.cpp
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\network\network.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\objective\objective_function.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
  voting_parallel_tree_learner.cpp
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\treelearner\data_parallel_tree_learner.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\treelearner\feature_parallel_tree_learner.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\treelearner\tree_learner.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\treelearner\serial_tree_learner.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
C:\Users\ntitov\Downloads\LightGBM\include\LightGBM/utils/common.h(318): error C3861: '_BitScanReverse': identifier not found (compiling source file C:\Use
rs\ntitov\Downloads\LightGBM\src\treelearner\voting_parallel_tree_learner.cpp) [C:\Users\ntitov\Downloads\LightGBM\build\lightgbm.vcxproj]
```