### PR TITLE
Revert "re-order includes (fixes #3132) (#3133)"

### DIFF
--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -5,19 +5,19 @@
 
 #include "lightgbm_R.h"
 
-#include <string>
-#include <cstdio>
-#include <cstring>
-#include <memory>
-#include <utility>
-#include <vector>
-
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/log.h>
 #include <LightGBM/utils/openmp_wrapper.h>
 #include <LightGBM/utils/text_reader.h>
 
 #include <R_ext/Rdynload.h>
+
+#include <string>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #define COL_MAJOR (0)
 

--- a/include/LightGBM/application.h
+++ b/include/LightGBM/application.h
@@ -5,11 +5,11 @@
 #ifndef LIGHTGBM_APPLICATION_H_
 #define LIGHTGBM_APPLICATION_H_
 
-#include <memory>
-#include <vector>
-
 #include <LightGBM/config.h>
 #include <LightGBM/meta.h>
+
+#include <memory>
+#include <vector>
 
 namespace LightGBM {
 

--- a/include/LightGBM/bin.h
+++ b/include/LightGBM/bin.h
@@ -5,16 +5,16 @@
 #ifndef LIGHTGBM_BIN_H_
 #define LIGHTGBM_BIN_H_
 
+#include <LightGBM/meta.h>
+#include <LightGBM/utils/common.h>
+#include <LightGBM/utils/file_io.h>
+
 #include <limits>
 #include <string>
 #include <functional>
 #include <sstream>
 #include <unordered_map>
 #include <vector>
-
-#include <LightGBM/meta.h>
-#include <LightGBM/utils/common.h>
-#include <LightGBM/utils/file_io.h>
 
 namespace LightGBM {
 

--- a/include/LightGBM/boosting.h
+++ b/include/LightGBM/boosting.h
@@ -5,13 +5,13 @@
 #ifndef LIGHTGBM_BOOSTING_H_
 #define LIGHTGBM_BOOSTING_H_
 
+#include <LightGBM/config.h>
+#include <LightGBM/meta.h>
+
 #include <string>
 #include <map>
 #include <unordered_map>
 #include <vector>
-
-#include <LightGBM/config.h>
-#include <LightGBM/meta.h>
 
 namespace LightGBM {
 

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -13,11 +13,11 @@
 #ifndef LIGHTGBM_C_API_H_
 #define LIGHTGBM_C_API_H_
 
+#include <LightGBM/export.h>
+
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-
-#include <LightGBM/export.h>
 
 
 typedef void* DatasetHandle;  /*!< \brief Handle of dataset. */

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -11,17 +11,17 @@
 #ifndef LIGHTGBM_CONFIG_H_
 #define LIGHTGBM_CONFIG_H_
 
+#include <LightGBM/export.h>
+#include <LightGBM/meta.h>
+#include <LightGBM/utils/common.h>
+#include <LightGBM/utils/log.h>
+
 #include <string>
 #include <algorithm>
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#include <LightGBM/export.h>
-#include <LightGBM/meta.h>
-#include <LightGBM/utils/common.h>
-#include <LightGBM/utils/log.h>
 
 namespace LightGBM {
 

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -5,6 +5,13 @@
 #ifndef LIGHTGBM_DATASET_H_
 #define LIGHTGBM_DATASET_H_
 
+#include <LightGBM/config.h>
+#include <LightGBM/feature_group.h>
+#include <LightGBM/meta.h>
+#include <LightGBM/utils/openmp_wrapper.h>
+#include <LightGBM/utils/random.h>
+#include <LightGBM/utils/text_reader.h>
+
 #include <string>
 #include <functional>
 #include <memory>
@@ -12,13 +19,6 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
-
-#include <LightGBM/config.h>
-#include <LightGBM/feature_group.h>
-#include <LightGBM/meta.h>
-#include <LightGBM/utils/openmp_wrapper.h>
-#include <LightGBM/utils/random.h>
-#include <LightGBM/utils/text_reader.h>
 
 namespace LightGBM {
 

--- a/include/LightGBM/dataset_loader.h
+++ b/include/LightGBM/dataset_loader.h
@@ -5,11 +5,11 @@
 #ifndef LIGHTGBM_DATASET_LOADER_H_
 #define LIGHTGBM_DATASET_LOADER_H_
 
+#include <LightGBM/dataset.h>
+
 #include <string>
 #include <unordered_set>
 #include <vector>
-
-#include <LightGBM/dataset.h>
 
 namespace LightGBM {
 

--- a/include/LightGBM/feature_group.h
+++ b/include/LightGBM/feature_group.h
@@ -5,13 +5,13 @@
 #ifndef LIGHTGBM_FEATURE_GROUP_H_
 #define LIGHTGBM_FEATURE_GROUP_H_
 
-#include <cstdio>
-#include <memory>
-#include <vector>
-
 #include <LightGBM/bin.h>
 #include <LightGBM/meta.h>
 #include <LightGBM/utils/random.h>
+
+#include <cstdio>
+#include <memory>
+#include <vector>
 
 namespace LightGBM {
 

--- a/include/LightGBM/metric.h
+++ b/include/LightGBM/metric.h
@@ -5,15 +5,15 @@
 #ifndef LIGHTGBM_METRIC_H_
 #define LIGHTGBM_METRIC_H_
 
-#include <string>
-#include <vector>
-
 #include <LightGBM/config.h>
 #include <LightGBM/dataset.h>
 #include <LightGBM/meta.h>
 #include <LightGBM/objective_function.h>
 #include <LightGBM/utils/log.h>
 #include <LightGBM/utils/common.h>
+
+#include <string>
+#include <vector>
 
 namespace LightGBM {
 

--- a/include/LightGBM/network.h
+++ b/include/LightGBM/network.h
@@ -5,13 +5,13 @@
 #ifndef LIGHTGBM_NETWORK_H_
 #define LIGHTGBM_NETWORK_H_
 
-#include <functional>
-#include <memory>
-#include <vector>
-
 #include <LightGBM/config.h>
 #include <LightGBM/meta.h>
 #include <LightGBM/utils/log.h>
+
+#include <functional>
+#include <memory>
+#include <vector>
 
 namespace LightGBM {
 

--- a/include/LightGBM/objective_function.h
+++ b/include/LightGBM/objective_function.h
@@ -5,12 +5,12 @@
 #ifndef LIGHTGBM_OBJECTIVE_FUNCTION_H_
 #define LIGHTGBM_OBJECTIVE_FUNCTION_H_
 
-#include <string>
-#include <functional>
-
 #include <LightGBM/config.h>
 #include <LightGBM/dataset.h>
 #include <LightGBM/meta.h>
+
+#include <string>
+#include <functional>
 
 namespace LightGBM {
 /*!

--- a/include/LightGBM/prediction_early_stop.h
+++ b/include/LightGBM/prediction_early_stop.h
@@ -5,10 +5,10 @@
 #ifndef LIGHTGBM_PREDICTION_EARLY_STOP_H_
 #define LIGHTGBM_PREDICTION_EARLY_STOP_H_
 
+#include <LightGBM/export.h>
+
 #include <string>
 #include <functional>
-
-#include <LightGBM/export.h>
 
 namespace LightGBM {
 

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -5,14 +5,14 @@
 #ifndef LIGHTGBM_TREE_H_
 #define LIGHTGBM_TREE_H_
 
+#include <LightGBM/dataset.h>
+#include <LightGBM/meta.h>
+
 #include <string>
 #include <map>
 #include <memory>
 #include <unordered_map>
 #include <vector>
-
-#include <LightGBM/dataset.h>
-#include <LightGBM/meta.h>
 
 namespace LightGBM {
 

--- a/include/LightGBM/tree_learner.h
+++ b/include/LightGBM/tree_learner.h
@@ -5,12 +5,12 @@
 #ifndef LIGHTGBM_TREE_LEARNER_H_
 #define LIGHTGBM_TREE_LEARNER_H_
 
-#include <string>
-#include <vector>
-
 #include <LightGBM/config.h>
 #include <LightGBM/meta.h>
 #include <LightGBM/utils/json11.h>
+
+#include <string>
+#include <vector>
 
 namespace LightGBM {
 

--- a/include/LightGBM/utils/array_args.h
+++ b/include/LightGBM/utils/array_args.h
@@ -5,12 +5,12 @@
 #ifndef LIGHTGBM_UTILS_ARRAY_AGRS_H_
 #define LIGHTGBM_UTILS_ARRAY_AGRS_H_
 
+#include <LightGBM/utils/openmp_wrapper.h>
+#include <LightGBM/utils/threading.h>
+
 #include <algorithm>
 #include <utility>
 #include <vector>
-
-#include <LightGBM/utils/openmp_wrapper.h>
-#include <LightGBM/utils/threading.h>
 
 namespace LightGBM {
 

--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -5,6 +5,9 @@
 #ifndef LIGHTGBM_UTILS_COMMON_FUN_H_
 #define LIGHTGBM_UTILS_COMMON_FUN_H_
 
+#include <LightGBM/utils/log.h>
+#include <LightGBM/utils/openmp_wrapper.h>
+
 #include <limits>
 #include <string>
 #include <algorithm>
@@ -22,9 +25,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <LightGBM/utils/log.h>
-#include <LightGBM/utils/openmp_wrapper.h>
 
 #if defined(_MSC_VER)
 #include <malloc.h>

--- a/include/LightGBM/utils/openmp_wrapper.h
+++ b/include/LightGBM/utils/openmp_wrapper.h
@@ -6,15 +6,15 @@
 #define LIGHTGBM_OPENMP_WRAPPER_H_
 #ifdef _OPENMP
 
+#include <LightGBM/utils/log.h>
+
+#include <omp.h>
+
 #include <exception>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <vector>
-
-#include <omp.h>
-
-#include <LightGBM/utils/log.h>
 
 inline int OMP_NUM_THREADS() {
   int ret = 1;

--- a/include/LightGBM/utils/pipeline_reader.h
+++ b/include/LightGBM/utils/pipeline_reader.h
@@ -5,6 +5,9 @@
 #ifndef LIGHTGBM_UTILS_PIPELINE_READER_H_
 #define LIGHTGBM_UTILS_PIPELINE_READER_H_
 
+#include <LightGBM/utils/file_io.h>
+#include <LightGBM/utils/log.h>
+
 #include <algorithm>
 #include <cstdio>
 #include <functional>
@@ -12,9 +15,6 @@
 #include <thread>
 #include <utility>
 #include <vector>
-
-#include <LightGBM/utils/file_io.h>
-#include <LightGBM/utils/log.h>
 
 namespace LightGBM {
 

--- a/include/LightGBM/utils/text_reader.h
+++ b/include/LightGBM/utils/text_reader.h
@@ -5,15 +5,15 @@
 #ifndef LIGHTGBM_UTILS_TEXT_READER_H_
 #define LIGHTGBM_UTILS_TEXT_READER_H_
 
+#include <LightGBM/utils/log.h>
+#include <LightGBM/utils/pipeline_reader.h>
+#include <LightGBM/utils/random.h>
+
 #include <string>
 #include <cstdio>
 #include <functional>
 #include <sstream>
 #include <vector>
-
-#include <LightGBM/utils/log.h>
-#include <LightGBM/utils/pipeline_reader.h>
-#include <LightGBM/utils/random.h>
 
 namespace LightGBM {
 

--- a/include/LightGBM/utils/threading.h
+++ b/include/LightGBM/utils/threading.h
@@ -6,13 +6,13 @@
 #ifndef LIGHTGBM_UTILS_THREADING_H_
 #define LIGHTGBM_UTILS_THREADING_H_
 
-#include <algorithm>
-#include <functional>
-#include <vector>
-
 #include <LightGBM/meta.h>
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/openmp_wrapper.h>
+
+#include <algorithm>
+#include <functional>
+#include <vector>
 
 namespace LightGBM {
 

--- a/src/application/application.cpp
+++ b/src/application/application.cpp
@@ -2,15 +2,6 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
-
-#include <string>
-#include <chrono>
-#include <cstdio>
-#include <ctime>
-#include <fstream>
-#include <sstream>
-#include <utility>
-
 #include <LightGBM/application.h>
 
 #include <LightGBM/boosting.h>
@@ -23,6 +14,14 @@
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/openmp_wrapper.h>
 #include <LightGBM/utils/text_reader.h>
+
+#include <string>
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+#include <fstream>
+#include <sstream>
+#include <utility>
 
 #include "predictor.hpp"
 

--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -5,6 +5,12 @@
 #ifndef LIGHTGBM_PREDICTOR_HPP_
 #define LIGHTGBM_PREDICTOR_HPP_
 
+#include <LightGBM/boosting.h>
+#include <LightGBM/dataset.h>
+#include <LightGBM/meta.h>
+#include <LightGBM/utils/openmp_wrapper.h>
+#include <LightGBM/utils/text_reader.h>
+
 #include <string>
 #include <cstdio>
 #include <cstring>
@@ -14,12 +20,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <LightGBM/boosting.h>
-#include <LightGBM/dataset.h>
-#include <LightGBM/meta.h>
-#include <LightGBM/utils/openmp_wrapper.h>
-#include <LightGBM/utils/text_reader.h>
 
 namespace LightGBM {
 

--- a/src/boosting/dart.hpp
+++ b/src/boosting/dart.hpp
@@ -5,13 +5,13 @@
 #ifndef LIGHTGBM_BOOSTING_DART_H_
 #define LIGHTGBM_BOOSTING_DART_H_
 
+#include <LightGBM/boosting.h>
+
 #include <string>
 #include <algorithm>
 #include <cstdio>
 #include <fstream>
 #include <vector>
-
-#include <LightGBM/boosting.h>
 
 #include "gbdt.h"
 #include "score_updater.hpp"

--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -2,12 +2,7 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
-
 #include "gbdt.h"
-
-#include <chrono>
-#include <ctime>
-#include <sstream>
 
 #include <LightGBM/metric.h>
 #include <LightGBM/network.h>
@@ -15,6 +10,10 @@
 #include <LightGBM/prediction_early_stop.h>
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/openmp_wrapper.h>
+
+#include <chrono>
+#include <ctime>
+#include <sstream>
 
 namespace LightGBM {
 

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -5,6 +5,12 @@
 #ifndef LIGHTGBM_BOOSTING_GBDT_H_
 #define LIGHTGBM_BOOSTING_GBDT_H_
 
+#include <LightGBM/boosting.h>
+#include <LightGBM/objective_function.h>
+#include <LightGBM/prediction_early_stop.h>
+#include <LightGBM/utils/json11.h>
+#include <LightGBM/utils/threading.h>
+
 #include <string>
 #include <algorithm>
 #include <cstdio>
@@ -15,12 +21,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <LightGBM/boosting.h>
-#include <LightGBM/objective_function.h>
-#include <LightGBM/prediction_early_stop.h>
-#include <LightGBM/utils/json11.h>
-#include <LightGBM/utils/threading.h>
 
 #include "score_updater.hpp"
 

--- a/src/boosting/gbdt_model_text.cpp
+++ b/src/boosting/gbdt_model_text.cpp
@@ -2,16 +2,15 @@
  * Copyright (c) 2017 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
-
-#include <string>
-#include <sstream>
-#include <vector>
-
 #include <LightGBM/config.h>
 #include <LightGBM/metric.h>
 #include <LightGBM/objective_function.h>
 #include <LightGBM/utils/array_args.h>
 #include <LightGBM/utils/common.h>
+
+#include <string>
+#include <sstream>
+#include <vector>
 
 #include "gbdt.h"
 

--- a/src/boosting/gbdt_prediction.cpp
+++ b/src/boosting/gbdt_prediction.cpp
@@ -2,11 +2,11 @@
  * Copyright (c) 2017 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
-#include "gbdt.h"
-
 #include <LightGBM/objective_function.h>
 #include <LightGBM/prediction_early_stop.h>
 #include <LightGBM/utils/openmp_wrapper.h>
+
+#include "gbdt.h"
 
 namespace LightGBM {
 

--- a/src/boosting/goss.hpp
+++ b/src/boosting/goss.hpp
@@ -5,16 +5,16 @@
 #ifndef LIGHTGBM_BOOSTING_GOSS_H_
 #define LIGHTGBM_BOOSTING_GOSS_H_
 
+#include <LightGBM/boosting.h>
+#include <LightGBM/utils/array_args.h>
+#include <LightGBM/utils/log.h>
+
 #include <string>
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <fstream>
 #include <vector>
-
-#include <LightGBM/boosting.h>
-#include <LightGBM/utils/array_args.h>
-#include <LightGBM/utils/log.h>
 
 #include "gbdt.h"
 #include "score_updater.hpp"

--- a/src/boosting/prediction_early_stop.cpp
+++ b/src/boosting/prediction_early_stop.cpp
@@ -2,15 +2,14 @@
  * Copyright (c) 2017 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
+#include <LightGBM/prediction_early_stop.h>
+
+#include <LightGBM/utils/log.h>
 
 #include <limits>
 #include <algorithm>
 #include <cmath>
 #include <vector>
-
-#include <LightGBM/prediction_early_stop.h>
-
-#include <LightGBM/utils/log.h>
 
 namespace LightGBM {
 

--- a/src/boosting/rf.hpp
+++ b/src/boosting/rf.hpp
@@ -5,15 +5,15 @@
 #ifndef LIGHTGBM_BOOSTING_RF_H_
 #define LIGHTGBM_BOOSTING_RF_H_
 
+#include <LightGBM/boosting.h>
+#include <LightGBM/metric.h>
+
 #include <string>
 #include <cstdio>
 #include <fstream>
 #include <memory>
 #include <utility>
 #include <vector>
-
-#include <LightGBM/boosting.h>
-#include <LightGBM/metric.h>
 
 #include "gbdt.h"
 #include "score_updater.hpp"

--- a/src/boosting/score_updater.hpp
+++ b/src/boosting/score_updater.hpp
@@ -5,14 +5,14 @@
 #ifndef LIGHTGBM_BOOSTING_SCORE_UPDATER_HPP_
 #define LIGHTGBM_BOOSTING_SCORE_UPDATER_HPP_
 
-#include <cstring>
-#include <vector>
-
 #include <LightGBM/dataset.h>
 #include <LightGBM/meta.h>
 #include <LightGBM/tree.h>
 #include <LightGBM/tree_learner.h>
 #include <LightGBM/utils/openmp_wrapper.h>
+
+#include <cstring>
+#include <vector>
 
 namespace LightGBM {
 /*!

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -2,15 +2,6 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
-
-#include <string>
-#include <cstdio>
-#include <functional>
-#include <memory>
-#include <mutex>
-#include <stdexcept>
-#include <vector>
-
 #include <LightGBM/c_api.h>
 
 #include <LightGBM/boosting.h>
@@ -26,6 +17,14 @@
 #include <LightGBM/utils/openmp_wrapper.h>
 #include <LightGBM/utils/random.h>
 #include <LightGBM/utils/threading.h>
+
+#include <string>
+#include <cstdio>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <vector>
 
 #include "application/predictor.hpp"
 

--- a/src/io/bin.cpp
+++ b/src/io/bin.cpp
@@ -2,17 +2,16 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
-
-#include <algorithm>
-#include <cmath>
-#include <cstdint>
-#include <cstring>
-
 #include <LightGBM/bin.h>
 
 #include <LightGBM/utils/array_args.h>
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/file_io.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
 
 #include "dense_bin.hpp"
 #include "multi_val_dense_bin.hpp"

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -2,14 +2,13 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
-
-#include <limits>
-
 #include <LightGBM/config.h>
 
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/log.h>
 #include <LightGBM/utils/random.h>
+
+#include <limits>
 
 namespace LightGBM {
 

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -3,19 +3,18 @@
  * Licensed under the MIT License. See LICENSE file in the project root for
  * license information.
  */
-
-#include <chrono>
-#include <cstdio>
-#include <limits>
-#include <sstream>
-#include <unordered_map>
-
 #include <LightGBM/dataset.h>
 
 #include <LightGBM/feature_group.h>
 #include <LightGBM/utils/array_args.h>
 #include <LightGBM/utils/openmp_wrapper.h>
 #include <LightGBM/utils/threading.h>
+
+#include <chrono>
+#include <cstdio>
+#include <limits>
+#include <sstream>
+#include <unordered_map>
 
 namespace LightGBM {
 

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -2,9 +2,6 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
-
-#include <fstream>
-
 #include <LightGBM/dataset_loader.h>
 
 #include <LightGBM/network.h>
@@ -12,6 +9,8 @@
 #include <LightGBM/utils/json11.h>
 #include <LightGBM/utils/log.h>
 #include <LightGBM/utils/openmp_wrapper.h>
+
+#include <fstream>
 
 namespace LightGBM {
 

--- a/src/io/dense_bin.hpp
+++ b/src/io/dense_bin.hpp
@@ -6,11 +6,11 @@
 #ifndef LIGHTGBM_IO_DENSE_BIN_HPP_
 #define LIGHTGBM_IO_DENSE_BIN_HPP_
 
+#include <LightGBM/bin.h>
+
 #include <cstdint>
 #include <cstring>
 #include <vector>
-
-#include <LightGBM/bin.h>
 
 namespace LightGBM {
 

--- a/src/io/file_io.cpp
+++ b/src/io/file_io.cpp
@@ -3,14 +3,13 @@
  * Licensed under the MIT License. See LICENSE file in the project root for
  * license information.
  */
+#include <LightGBM/utils/file_io.h>
+
+#include <LightGBM/utils/log.h>
 
 #include <algorithm>
 #include <sstream>
 #include <unordered_map>
-
-#include <LightGBM/utils/file_io.h>
-
-#include <LightGBM/utils/log.h>
 
 #ifdef USE_HDFS
 #include <hdfs.h>

--- a/src/io/json11.cpp
+++ b/src/io/json11.cpp
@@ -18,15 +18,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <LightGBM/utils/json11.h>
+
+#include <LightGBM/utils/log.h>
 
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <limits>
-
-#include <LightGBM/utils/json11.h>
-
-#include <LightGBM/utils/log.h>
 
 namespace json11 {
 

--- a/src/io/metadata.cpp
+++ b/src/io/metadata.cpp
@@ -2,12 +2,11 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
+#include <LightGBM/dataset.h>
+#include <LightGBM/utils/common.h>
 
 #include <string>
 #include <vector>
-
-#include <LightGBM/dataset.h>
-#include <LightGBM/utils/common.h>
 
 namespace LightGBM {
 

--- a/src/io/multi_val_dense_bin.hpp
+++ b/src/io/multi_val_dense_bin.hpp
@@ -5,13 +5,13 @@
 #ifndef LIGHTGBM_IO_MULTI_VAL_DENSE_BIN_HPP_
 #define LIGHTGBM_IO_MULTI_VAL_DENSE_BIN_HPP_
 
+#include <LightGBM/bin.h>
+#include <LightGBM/utils/openmp_wrapper.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <vector>
-
-#include <LightGBM/bin.h>
-#include <LightGBM/utils/openmp_wrapper.h>
 
 namespace LightGBM {
 

--- a/src/io/multi_val_sparse_bin.hpp
+++ b/src/io/multi_val_sparse_bin.hpp
@@ -5,13 +5,13 @@
 #ifndef LIGHTGBM_IO_MULTI_VAL_SPARSE_BIN_HPP_
 #define LIGHTGBM_IO_MULTI_VAL_SPARSE_BIN_HPP_
 
+#include <LightGBM/bin.h>
+#include <LightGBM/utils/openmp_wrapper.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <vector>
-
-#include <LightGBM/bin.h>
-#include <LightGBM/utils/openmp_wrapper.h>
 
 namespace LightGBM {
 

--- a/src/io/parser.cpp
+++ b/src/io/parser.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
+#include "parser.hpp"
 
 #include <string>
 #include <algorithm>
@@ -9,8 +10,6 @@
 #include <functional>
 #include <iostream>
 #include <memory>
-
-#include "parser.hpp"
 
 namespace LightGBM {
 

--- a/src/io/parser.hpp
+++ b/src/io/parser.hpp
@@ -5,13 +5,13 @@
 #ifndef LIGHTGBM_IO_PARSER_HPP_
 #define LIGHTGBM_IO_PARSER_HPP_
 
-#include <unordered_map>
-#include <utility>
-#include <vector>
-
 #include <LightGBM/dataset.h>
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/log.h>
+
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace LightGBM {
 

--- a/src/io/sparse_bin.hpp
+++ b/src/io/sparse_bin.hpp
@@ -6,16 +6,16 @@
 #ifndef LIGHTGBM_IO_SPARSE_BIN_HPP_
 #define LIGHTGBM_IO_SPARSE_BIN_HPP_
 
+#include <LightGBM/bin.h>
+#include <LightGBM/utils/log.h>
+#include <LightGBM/utils/openmp_wrapper.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <limits>
 #include <utility>
 #include <vector>
-
-#include <LightGBM/bin.h>
-#include <LightGBM/utils/log.h>
-#include <LightGBM/utils/openmp_wrapper.h>
 
 namespace LightGBM {
 

--- a/src/io/tree.cpp
+++ b/src/io/tree.cpp
@@ -2,16 +2,15 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
-
-#include <functional>
-#include <iomanip>
-#include <sstream>
-
 #include <LightGBM/tree.h>
 
 #include <LightGBM/dataset.h>
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/threading.h>
+
+#include <functional>
+#include <iomanip>
+#include <sstream>
 
 namespace LightGBM {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,10 +2,9 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
+#include <LightGBM/application.h>
 
 #include <iostream>
-
-#include <LightGBM/application.h>
 
 #include "network/linkers.h"
 

--- a/src/metric/binary_metric.hpp
+++ b/src/metric/binary_metric.hpp
@@ -5,14 +5,14 @@
 #ifndef LIGHTGBM_METRIC_BINARY_METRIC_HPP_
 #define LIGHTGBM_METRIC_BINARY_METRIC_HPP_
 
+#include <LightGBM/metric.h>
+#include <LightGBM/utils/common.h>
+#include <LightGBM/utils/log.h>
+
 #include <string>
 #include <algorithm>
 #include <sstream>
 #include <vector>
-
-#include <LightGBM/metric.h>
-#include <LightGBM/utils/common.h>
-#include <LightGBM/utils/log.h>
 
 namespace LightGBM {
 

--- a/src/metric/dcg_calculator.cpp
+++ b/src/metric/dcg_calculator.cpp
@@ -2,13 +2,12 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
+#include <LightGBM/metric.h>
+#include <LightGBM/utils/log.h>
 
 #include <algorithm>
 #include <cmath>
 #include <vector>
-
-#include <LightGBM/metric.h>
-#include <LightGBM/utils/log.h>
 
 namespace LightGBM {
 

--- a/src/metric/map_metric.hpp
+++ b/src/metric/map_metric.hpp
@@ -5,15 +5,15 @@
 #ifndef LIGHTGBM_METRIC_MAP_METRIC_HPP_
 #define LIGHTGBM_METRIC_MAP_METRIC_HPP_
 
-#include <string>
-#include <algorithm>
-#include <sstream>
-#include <vector>
-
 #include <LightGBM/metric.h>
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/log.h>
 #include <LightGBM/utils/openmp_wrapper.h>
+
+#include <string>
+#include <algorithm>
+#include <sstream>
+#include <vector>
 
 namespace LightGBM {
 

--- a/src/metric/multiclass_metric.hpp
+++ b/src/metric/multiclass_metric.hpp
@@ -5,13 +5,13 @@
 #ifndef LIGHTGBM_METRIC_MULTICLASS_METRIC_HPP_
 #define LIGHTGBM_METRIC_MULTICLASS_METRIC_HPP_
 
+#include <LightGBM/metric.h>
+#include <LightGBM/utils/log.h>
+
 #include <string>
 #include <cmath>
 #include <utility>
 #include <vector>
-
-#include <LightGBM/metric.h>
-#include <LightGBM/utils/log.h>
 
 namespace LightGBM {
 /*!

--- a/src/metric/rank_metric.hpp
+++ b/src/metric/rank_metric.hpp
@@ -5,14 +5,14 @@
 #ifndef LIGHTGBM_METRIC_RANK_METRIC_HPP_
 #define LIGHTGBM_METRIC_RANK_METRIC_HPP_
 
-#include <string>
-#include <sstream>
-#include <vector>
-
 #include <LightGBM/metric.h>
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/log.h>
 #include <LightGBM/utils/openmp_wrapper.h>
+
+#include <string>
+#include <sstream>
+#include <vector>
 
 namespace LightGBM {
 

--- a/src/metric/regression_metric.hpp
+++ b/src/metric/regression_metric.hpp
@@ -5,13 +5,13 @@
 #ifndef LIGHTGBM_METRIC_REGRESSION_METRIC_HPP_
 #define LIGHTGBM_METRIC_REGRESSION_METRIC_HPP_
 
+#include <LightGBM/metric.h>
+#include <LightGBM/utils/log.h>
+
 #include <string>
 #include <algorithm>
 #include <cmath>
 #include <vector>
-
-#include <LightGBM/metric.h>
-#include <LightGBM/utils/log.h>
 
 namespace LightGBM {
 /*!

--- a/src/metric/xentropy_metric.hpp
+++ b/src/metric/xentropy_metric.hpp
@@ -5,15 +5,15 @@
 #ifndef LIGHTGBM_METRIC_XENTROPY_METRIC_HPP_
 #define LIGHTGBM_METRIC_XENTROPY_METRIC_HPP_
 
-#include <string>
-#include <algorithm>
-#include <sstream>
-#include <vector>
-
 #include <LightGBM/meta.h>
 #include <LightGBM/metric.h>
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/log.h>
+
+#include <string>
+#include <algorithm>
+#include <sstream>
+#include <vector>
 
 /*
  * Implements three related metrics:

--- a/src/network/linker_topo.cpp
+++ b/src/network/linker_topo.cpp
@@ -2,14 +2,13 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
+#include <LightGBM/network.h>
+#include <LightGBM/utils/common.h>
+#include <LightGBM/utils/log.h>
 
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include <LightGBM/network.h>
-#include <LightGBM/utils/common.h>
-#include <LightGBM/utils/log.h>
 
 namespace LightGBM {
 

--- a/src/network/linkers.h
+++ b/src/network/linkers.h
@@ -5,6 +5,11 @@
 #ifndef LIGHTGBM_NETWORK_LINKERS_H_
 #define LIGHTGBM_NETWORK_LINKERS_H_
 
+#include <LightGBM/config.h>
+#include <LightGBM/meta.h>
+#include <LightGBM/network.h>
+#include <LightGBM/utils/common.h>
+
 #include <string>
 #include <algorithm>
 #include <chrono>
@@ -12,11 +17,6 @@
 #include <memory>
 #include <thread>
 #include <vector>
-
-#include <LightGBM/config.h>
-#include <LightGBM/meta.h>
-#include <LightGBM/network.h>
-#include <LightGBM/utils/common.h>
 
 #ifdef USE_SOCKET
 #include "socket_wrapper.hpp"

--- a/src/network/linkers_socket.cpp
+++ b/src/network/linkers_socket.cpp
@@ -4,6 +4,10 @@
  */
 #ifdef USE_SOCKET
 
+#include <LightGBM/config.h>
+#include <LightGBM/utils/common.h>
+#include <LightGBM/utils/text_reader.h>
+
 #include <string>
 #include <chrono>
 #include <cstring>
@@ -11,10 +15,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#include <LightGBM/config.h>
-#include <LightGBM/utils/common.h>
-#include <LightGBM/utils/text_reader.h>
 
 #include "linkers.h"
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -2,13 +2,12 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
-
-#include <cstdlib>
-#include <cstring>
-
 #include <LightGBM/network.h>
 
 #include <LightGBM/utils/common.h>
+
+#include <cstdlib>
+#include <cstring>
 
 #include "linkers.h"
 

--- a/src/network/socket_wrapper.hpp
+++ b/src/network/socket_wrapper.hpp
@@ -6,12 +6,12 @@
 #define LIGHTGBM_NETWORK_SOCKET_WRAPPER_HPP_
 #ifdef USE_SOCKET
 
+#include <LightGBM/utils/log.h>
+
 #include <string>
 #include <cerrno>
 #include <cstdlib>
 #include <unordered_set>
-
-#include <LightGBM/utils/log.h>
 
 #if defined(_WIN32)
 

--- a/src/objective/binary_objective.hpp
+++ b/src/objective/binary_objective.hpp
@@ -5,14 +5,14 @@
 #ifndef LIGHTGBM_OBJECTIVE_BINARY_OBJECTIVE_HPP_
 #define LIGHTGBM_OBJECTIVE_BINARY_OBJECTIVE_HPP_
 
+#include <LightGBM/network.h>
+#include <LightGBM/objective_function.h>
+
 #include <string>
 #include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <vector>
-
-#include <LightGBM/network.h>
-#include <LightGBM/objective_function.h>
 
 namespace LightGBM {
 /*!

--- a/src/objective/multiclass_objective.hpp
+++ b/src/objective/multiclass_objective.hpp
@@ -5,15 +5,15 @@
 #ifndef LIGHTGBM_OBJECTIVE_MULTICLASS_OBJECTIVE_HPP_
 #define LIGHTGBM_OBJECTIVE_MULTICLASS_OBJECTIVE_HPP_
 
+#include <LightGBM/network.h>
+#include <LightGBM/objective_function.h>
+
 #include <string>
 #include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <memory>
 #include <vector>
-
-#include <LightGBM/network.h>
-#include <LightGBM/objective_function.h>
 
 #include "binary_objective.hpp"
 

--- a/src/objective/rank_objective.hpp
+++ b/src/objective/rank_objective.hpp
@@ -6,6 +6,9 @@
 #ifndef LIGHTGBM_OBJECTIVE_RANK_OBJECTIVE_HPP_
 #define LIGHTGBM_OBJECTIVE_RANK_OBJECTIVE_HPP_
 
+#include <LightGBM/metric.h>
+#include <LightGBM/objective_function.h>
+
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
@@ -13,9 +16,6 @@
 #include <limits>
 #include <string>
 #include <vector>
-
-#include <LightGBM/metric.h>
-#include <LightGBM/objective_function.h>
 
 namespace LightGBM {
 

--- a/src/objective/regression_objective.hpp
+++ b/src/objective/regression_objective.hpp
@@ -5,13 +5,13 @@
 #ifndef LIGHTGBM_OBJECTIVE_REGRESSION_OBJECTIVE_HPP_
 #define LIGHTGBM_OBJECTIVE_REGRESSION_OBJECTIVE_HPP_
 
-#include <string>
-#include <algorithm>
-#include <vector>
-
 #include <LightGBM/meta.h>
 #include <LightGBM/objective_function.h>
 #include <LightGBM/utils/array_args.h>
+
+#include <string>
+#include <algorithm>
+#include <vector>
 
 namespace LightGBM {
 

--- a/src/objective/xentropy_objective.hpp
+++ b/src/objective/xentropy_objective.hpp
@@ -5,15 +5,15 @@
 #ifndef LIGHTGBM_OBJECTIVE_XENTROPY_OBJECTIVE_HPP_
 #define LIGHTGBM_OBJECTIVE_XENTROPY_OBJECTIVE_HPP_
 
+#include <LightGBM/meta.h>
+#include <LightGBM/objective_function.h>
+#include <LightGBM/utils/common.h>
+
 #include <string>
 #include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <vector>
-
-#include <LightGBM/meta.h>
-#include <LightGBM/objective_function.h>
-#include <LightGBM/utils/common.h>
 
 /*
  * Implements gradients and hessians for the following point losses.

--- a/src/treelearner/col_sampler.hpp
+++ b/src/treelearner/col_sampler.hpp
@@ -6,14 +6,14 @@
 #ifndef LIGHTGBM_TREELEARNER_COL_SAMPLER_HPP_
 #define LIGHTGBM_TREELEARNER_COL_SAMPLER_HPP_
 
-#include <algorithm>
-#include <vector>
-
 #include <LightGBM/dataset.h>
 #include <LightGBM/meta.h>
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/openmp_wrapper.h>
 #include <LightGBM/utils/random.h>
+
+#include <algorithm>
+#include <vector>
 
 namespace LightGBM {
 class ColSampler {

--- a/src/treelearner/cost_effective_gradient_boosting.hpp
+++ b/src/treelearner/cost_effective_gradient_boosting.hpp
@@ -5,12 +5,12 @@
 #ifndef LIGHTGBM_TREELEARNER_COST_EFFECTIVE_GRADIENT_BOOSTING_HPP_
 #define LIGHTGBM_TREELEARNER_COST_EFFECTIVE_GRADIENT_BOOSTING_HPP_
 
-#include <vector>
-
 #include <LightGBM/config.h>
 #include <LightGBM/dataset.h>
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/log.h>
+
+#include <vector>
 
 #include "data_partition.hpp"
 #include "serial_tree_learner.h"

--- a/src/treelearner/data_partition.hpp
+++ b/src/treelearner/data_partition.hpp
@@ -5,14 +5,14 @@
 #ifndef LIGHTGBM_TREELEARNER_DATA_PARTITION_HPP_
 #define LIGHTGBM_TREELEARNER_DATA_PARTITION_HPP_
 
-#include <algorithm>
-#include <cstring>
-#include <vector>
-
 #include <LightGBM/dataset.h>
 #include <LightGBM/meta.h>
 #include <LightGBM/utils/openmp_wrapper.h>
 #include <LightGBM/utils/threading.h>
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
 
 namespace LightGBM {
 /*!

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -6,16 +6,16 @@
 #ifndef LIGHTGBM_TREELEARNER_FEATURE_HISTOGRAM_HPP_
 #define LIGHTGBM_TREELEARNER_FEATURE_HISTOGRAM_HPP_
 
+#include <LightGBM/bin.h>
+#include <LightGBM/dataset.h>
+#include <LightGBM/utils/array_args.h>
+
 #include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <memory>
 #include <utility>
 #include <vector>
-
-#include <LightGBM/bin.h>
-#include <LightGBM/dataset.h>
-#include <LightGBM/utils/array_args.h>
 
 #include "monotone_constraints.hpp"
 #include "split_info.hpp"

--- a/src/treelearner/gpu_tree_learner.cpp
+++ b/src/treelearner/gpu_tree_learner.cpp
@@ -6,11 +6,11 @@
 
 #include "gpu_tree_learner.h"
 
-#include <algorithm>
-
 #include <LightGBM/bin.h>
 #include <LightGBM/network.h>
 #include <LightGBM/utils/array_args.h>
+
+#include <algorithm>
 
 #include "../io/dense_bin.hpp"
 

--- a/src/treelearner/gpu_tree_learner.h
+++ b/src/treelearner/gpu_tree_learner.h
@@ -5,18 +5,18 @@
 #ifndef LIGHTGBM_TREELEARNER_GPU_TREE_LEARNER_H_
 #define LIGHTGBM_TREELEARNER_GPU_TREE_LEARNER_H_
 
+#include <LightGBM/dataset.h>
+#include <LightGBM/feature_group.h>
+#include <LightGBM/tree.h>
+#include <LightGBM/utils/array_args.h>
+#include <LightGBM/utils/random.h>
+
 #include <string>
 #include <cmath>
 #include <cstdio>
 #include <memory>
 #include <random>
 #include <vector>
-
-#include <LightGBM/dataset.h>
-#include <LightGBM/feature_group.h>
-#include <LightGBM/tree.h>
-#include <LightGBM/utils/array_args.h>
-#include <LightGBM/utils/random.h>
 
 #include "data_partition.hpp"
 #include "feature_histogram.hpp"

--- a/src/treelearner/leaf_splits.hpp
+++ b/src/treelearner/leaf_splits.hpp
@@ -5,10 +5,10 @@
 #ifndef LIGHTGBM_TREELEARNER_LEAF_SPLITS_HPP_
 #define LIGHTGBM_TREELEARNER_LEAF_SPLITS_HPP_
 
+#include <LightGBM/meta.h>
+
 #include <limits>
 #include <vector>
-
-#include <LightGBM/meta.h>
 
 #include "data_partition.hpp"
 

--- a/src/treelearner/parallel_tree_learner.h
+++ b/src/treelearner/parallel_tree_learner.h
@@ -5,12 +5,12 @@
 #ifndef LIGHTGBM_TREELEARNER_PARALLEL_TREE_LEARNER_H_
 #define LIGHTGBM_TREELEARNER_PARALLEL_TREE_LEARNER_H_
 
+#include <LightGBM/network.h>
+#include <LightGBM/utils/array_args.h>
+
 #include <cstring>
 #include <memory>
 #include <vector>
-
-#include <LightGBM/network.h>
-#include <LightGBM/utils/array_args.h>
 
 #include "gpu_tree_learner.h"
 #include "serial_tree_learner.h"

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -4,15 +4,15 @@
  */
 #include "serial_tree_learner.h"
 
-#include <algorithm>
-#include <queue>
-#include <unordered_map>
-#include <utility>
-
 #include <LightGBM/network.h>
 #include <LightGBM/objective_function.h>
 #include <LightGBM/utils/array_args.h>
 #include <LightGBM/utils/common.h>
+
+#include <algorithm>
+#include <queue>
+#include <unordered_map>
+#include <utility>
 
 #include "cost_effective_gradient_boosting.hpp"
 

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -5,19 +5,19 @@
 #ifndef LIGHTGBM_TREELEARNER_SERIAL_TREE_LEARNER_H_
 #define LIGHTGBM_TREELEARNER_SERIAL_TREE_LEARNER_H_
 
-#include <string>
-#include <cmath>
-#include <cstdio>
-#include <memory>
-#include <random>
-#include <vector>
-
 #include <LightGBM/dataset.h>
 #include <LightGBM/tree.h>
 #include <LightGBM/tree_learner.h>
 #include <LightGBM/utils/array_args.h>
 #include <LightGBM/utils/json11.h>
 #include <LightGBM/utils/random.h>
+
+#include <string>
+#include <cmath>
+#include <cstdio>
+#include <memory>
+#include <random>
+#include <vector>
 
 #include "col_sampler.hpp"
 #include "data_partition.hpp"

--- a/src/treelearner/split_info.hpp
+++ b/src/treelearner/split_info.hpp
@@ -5,14 +5,14 @@
 #ifndef LIGHTGBM_TREELEARNER_SPLIT_INFO_HPP_
 #define LIGHTGBM_TREELEARNER_SPLIT_INFO_HPP_
 
+#include <LightGBM/meta.h>
+
 #include <limits>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <functional>
 #include <vector>
-
-#include <LightGBM/meta.h>
 
 namespace LightGBM {
 

--- a/src/treelearner/voting_parallel_tree_learner.cpp
+++ b/src/treelearner/voting_parallel_tree_learner.cpp
@@ -2,12 +2,11 @@
  * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
+#include <LightGBM/utils/common.h>
 
 #include <cstring>
 #include <tuple>
 #include <vector>
-
-#include <LightGBM/utils/common.h>
 
 #include "parallel_tree_learner.h"
 


### PR DESCRIPTION
This reverts commit 656d2676c2174781c91747ba158cb6d27f4cacbd.

Refer to https://github.com/microsoft/LightGBM/issues/3132#issuecomment-639347710.