### PR TITLE
[ci][docs] temporarily pin Sphinx version

### DIFF
--- a/docs/requirements_base.txt
+++ b/docs/requirements_base.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx == 3.0.2
 sphinx_rtd_theme >= 0.3
 mock; python_version < '3'

--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -1,4 +1,4 @@
-sphinx >= 3.0.2
+sphinx == 3.0.2
 sphinx_rtd_theme >= 0.3
 mock; python_version < '3'
 breathe


### PR DESCRIPTION
Refer to https://github.com/sphinx-doc/sphinx/issues/7817.

Avoid
```
Warning, treated as error:
/home/travis/build/microsoft/LightGBM/docs/../python-package/lightgbm/sklearn.py:docstring of lightgbm.LGBMClassifier.best_iteration_:1:duplicate object description of lightgbm.LGBMClassifier.best_iteration_, other instance in pythonapi/lightgbm.LGBMClassifier, use :noindex: for one of them
Makefile:20: recipe for target 'html' failed
make: *** [html] Error 2
```
in `master`.