### PR TITLE
[ci] avoid VS warning for R builds

### DIFF
--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -121,6 +121,7 @@ if ($env:COMPILER -ne "MSVC") {
       Check-Output $False
   }
 } else {
+  $env:TMPDIR = $env:USERPROFILE  # to avoid warnings about incremental builds inside a temp directory
   $INSTALL_LOG_FILE_NAME = "$env:BUILD_SOURCESDIRECTORY\00install_out.txt"
   Rscript build_r.R *> $INSTALL_LOG_FILE_NAME ; $install_succeeded = $?
   Write-Output "----- build and install logs -----"


### PR DESCRIPTION
Fixed #3088.

Refer to
> Some parts of the operation of INSTALL depend on the R temporary directory (see tempdir, usually under /tmp) having both write and execution access to the account running R. This is usually the case, but if /tmp has been mounted as noexec, environment variable TMPDIR may need to be set to a directory from which execution is allowed.
  https://www.rdocumentation.org/packages/utils/versions/3.6.2/topics/INSTALL