### PR TITLE
[docs][scikit-learn] removed duplicated docstrings

### DIFF
--- a/docs/requirements_base.txt
+++ b/docs/requirements_base.txt
@@ -1,3 +1,3 @@
-sphinx == 3.0.2
+sphinx
 sphinx_rtd_theme >= 0.3
 mock; python_version < '3'

--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -1,4 +1,4 @@
-sphinx == 3.0.2
+sphinx >= 3.0.2
 sphinx_rtd_theme >= 0.3
 mock; python_version < '3'
 breathe

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -255,28 +255,8 @@ class LGBMModel(_LGBMModelBase):
 
         Attributes
         ----------
-        n_features_ : int
-            The number of features of fitted model.
         n_features_in_ : int
             The number of features of fitted model.
-        classes_ : array of shape = [n_classes]
-            The class label array (only for classification problem).
-        n_classes_ : int
-            The number of classes (only for classification problem).
-        best_score_ : dict or None
-            The best score of fitted model.
-        best_iteration_ : int or None
-            The best iteration of fitted model if ``early_stopping_rounds`` has been specified.
-        objective_ : string or callable
-            The concrete objective used while fitting this model.
-        booster_ : Booster
-            The underlying Booster of this model.
-        evals_result_ : dict or None
-            The evaluation results if ``early_stopping_rounds`` has been specified.
-        feature_importances_ : array of shape = [n_features]
-            The feature importances (the higher, the more important the feature).
-        feature_name_ : array of shape = [n_features]
-            The names of features.
 
         Note
         ----
@@ -690,49 +670,49 @@ class LGBMModel(_LGBMModelBase):
 
     @property
     def n_features_(self):
-        """Get the number of features of fitted model."""
+        """:obj:`int`: The number of features of fitted model."""
         if self._n_features is None:
             raise LGBMNotFittedError('No n_features found. Need to call fit beforehand.')
         return self._n_features
 
     @property
     def best_score_(self):
-        """Get the best score of fitted model."""
+        """:obj:`dict` or :obj:`None`: The best score of fitted model."""
         if self._n_features is None:
             raise LGBMNotFittedError('No best_score found. Need to call fit beforehand.')
         return self._best_score
 
     @property
     def best_iteration_(self):
-        """Get the best iteration of fitted model."""
+        """:obj:`int` or :obj:`None`: The best iteration of fitted model if ``early_stopping_rounds`` has been specified."""
         if self._n_features is None:
             raise LGBMNotFittedError('No best_iteration found. Need to call fit with early_stopping_rounds beforehand.')
         return self._best_iteration
 
     @property
     def objective_(self):
-        """Get the concrete objective used while fitting this model."""
+        """:obj:`string` or :obj:`callable`: The concrete objective used while fitting this model."""
         if self._n_features is None:
             raise LGBMNotFittedError('No objective found. Need to call fit beforehand.')
         return self._objective
 
     @property
     def booster_(self):
-        """Get the underlying lightgbm Booster of this model."""
+        """Booster: The underlying Booster of this model."""
         if self._Booster is None:
             raise LGBMNotFittedError('No booster found. Need to call fit beforehand.')
         return self._Booster
 
     @property
     def evals_result_(self):
-        """Get the evaluation results."""
+        """:obj:`dict` or :obj:`None`: The evaluation results if ``early_stopping_rounds`` has been specified."""
         if self._n_features is None:
             raise LGBMNotFittedError('No results found. Need to call fit with eval_set beforehand.')
         return self._evals_result
 
     @property
     def feature_importances_(self):
-        """Get feature importances.
+        """:obj:`array` of shape = [n_features]: The feature importances (the higher, the more important).
 
         .. note::
 
@@ -745,7 +725,7 @@ class LGBMModel(_LGBMModelBase):
 
     @property
     def feature_name_(self):
-        """Get feature name."""
+        """:obj:`array` of shape = [n_features]: The names of features."""
         if self._n_features is None:
             raise LGBMNotFittedError('No feature_name found. Need to call fit beforehand.')
         return self._Booster.feature_name()
@@ -907,14 +887,14 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
 
     @property
     def classes_(self):
-        """Get the class label array."""
+        """:obj:`array` of shape = [n_classes]: The class label array."""
         if self._classes is None:
             raise LGBMNotFittedError('No classes found. Need to call fit beforehand.')
         return self._classes
 
     @property
     def n_classes_(self):
-        """Get the number of classes."""
+        """:obj:`int`: The number of classes."""
         if self._n_classes is None:
             raise LGBMNotFittedError('No classes found. Need to call fit beforehand.')
         return self._n_classes


### PR DESCRIPTION
Refer to https://github.com/sphinx-doc/sphinx/issues/7817#issuecomment-643295015.


Completely remove attribute names from `__init__` docstring because new Sphinx version doesn't fully comply with `numpy` docstring guide in terms of
> Attributes that are properties and have their own docstrings can be simply listed by name:
  https://numpydoc.readthedocs.io/en/latest/format.html#class-docstring

Ugly constructions like ```:obj:``` are needed to workaround pydocstyle test:
```
./python-package/lightgbm/sklearn.py:680 in public method `best_score_`:
        D401: First line should be in imperative mood; try rephrasing (found 'dict')
./python-package/lightgbm/sklearn.py:680 in public method `best_score_`:
        D403: First word of the first line should be properly capitalized ('Dict', not 'dict')
./python-package/lightgbm/sklearn.py:687 in public method `best_iteration_`:
        D403: First word of the first line should be properly capitalized ('Int', not 'int')
./python-package/lightgbm/sklearn.py:694 in public method `objective_`:
        D401: First line should be in imperative mood; try rephrasing (found 'string')
./python-package/lightgbm/sklearn.py:694 in public method `objective_`:
        D403: First word of the first line should be properly capitalized ('String', not 'string')
./python-package/lightgbm/sklearn.py:708 in public method `evals_result_`:
        D401: First line should be in imperative mood; try rephrasing (found 'dict')
./python-package/lightgbm/sklearn.py:708 in public method `evals_result_`:
        D403: First word of the first line should be properly capitalized ('Dict', not 'dict')
./python-package/lightgbm/sklearn.py:715 in public method `feature_importances_`:
        D205: 1 blank line required between summary line and description (found 0)
./python-package/lightgbm/sklearn.py:715 in public method `feature_importances_`:
        D400: First line should end with a period (not 's')
./python-package/lightgbm/sklearn.py:715 in public method `feature_importances_`:
        D403: First word of the first line should be properly capitalized ('Array', not 'array')
./python-package/lightgbm/sklearn.py:729 in public method `feature_name_`:
        D403: First word of the first line should be properly capitalized ('Array', not 'array')
./python-package/lightgbm/sklearn.py:891 in public method `classes_`:
        D403: First word of the first line should be properly capitalized ('Array', not 'array')
```