### PR TITLE
[ci] Move R Windows CI to GitHub Actions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,15 +13,6 @@ branches:
 
 environment:
   matrix:
-    - COMPILER: MINGW
-      TASK: r-package
-      R_VERSION: 3.6
-      TOOLCHAIN: MINGW
-    - COMPILER: MSVC 
-      TASK: r-package
-      R_VERSION: 4.0
-      TOOLCHAIN: MSVC
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - COMPILER: MSVC
       TASK: python
     - COMPILER: MINGW

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -33,7 +33,7 @@ function Download-Miktex-Setup {
 # status information) can cause failures in GitHub Actions PowerShell jobs.
 # See https://github.community/t/powershell-steps-fail-nondeterministically/115496
 #
-# Using standard Powershell redirection does not work to avoid these errors.
+# Using standard PowerShell redirection does not work to avoid these errors.
 # This function uses R's built-in redirection mechanism, sink(). Any place where
 # this function is used is a command that writes harmless messages to stderr
 function Run-R-Code-Redirect-Stderr {
@@ -140,7 +140,7 @@ if ($env:COMPILER -ne "MSVC") {
 
   $env:_R_CHECK_FORCE_SUGGESTS_ = 0
   Write-Output "Running R CMD check as CRAN"
-  Run-R-Code-Redirect-Stderr "processx::run(command = 'R.exe', args = c('CMD', 'check', '--no-multiarch', '--as-cran', '$PKG_FILE_NAME'), windows_verbatim_args = FALSE)" ; $check_succeeded=$?
+  Run-R-Code-Redirect-Stderr "processx::run(command = 'R.exe', args = c('CMD', 'check', '--no-multiarch', '--as-cran', '$PKG_FILE_NAME'), windows_verbatim_args = FALSE)" ; $check_succeeded = $?
 
   Write-Output "R CMD check build logs:"
   $INSTALL_LOG_FILE_NAME = "$env:BUILD_SOURCESDIRECTORY\lightgbm.Rcheck\00install.out"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,28 @@ jobs:
             task: r-package
             compiler: clang
             r_version: 4.0
+          - os: windows-latest
+            task: r-package
+            compiler: MINGW
+            toolchain: MINGW
+            r_version: 3.6
+          - os: windows-latest
+            task: r-package
+            compiler: MINGW
+            toolchain: MSYS
+            r_version: 4.0
+          # Visual Studio 2017
+          - os: windows-2016
+            task: r-package
+            compiler: MSVC
+            toolchain: MSVC
+            r_version: 3.6
+          # Visual Studio 2019
+          - os: windows-2019
+            task: r-package
+            compiler: MSVC
+            toolchain: MSVC
+            r_version: 4.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
@@ -76,3 +98,20 @@ jobs:
           export R_VERSION="${{ matrix.r_version }}"
           $GITHUB_WORKSPACE/.ci/setup.sh
           $GITHUB_WORKSPACE/.ci/test.sh
+      - name: Use conda on Windows
+        if: matrix.os == 'windows-latest' || matrix.os == 'windows-2016' || matrix.os == 'windows-2019'
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: false
+      - name: Setup and run tests on Windows
+        if: matrix.os == 'windows-latest' || matrix.os == 'windows-2016' || matrix.os == 'windows-2019'
+        shell: pwsh -command ". {0}"
+        run: |
+          $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
+          $env:TOOLCHAIN = "${{ matrix.toolchain }}"
+          $env:R_VERSION = "${{ matrix.r_version }}"
+          $env:COMPILER = "${{ matrix.compiler }}"
+          $env:GITHUB_ACTIONS = "true"
+          $env:TASK = "${{ matrix.task }}"
+          conda init powershell
+          & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
           fetch-depth: 5
           submodules: true
       - name: Setup and run tests on Linux and macOS
-        if: matrix.os != 'windows-latest'
+        if: matrix.os == 'macOS-latest' || matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
           export TASK="${{ matrix.task }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
               export R_MAC_VERSION=3.6.3
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
               export OS_NAME="linux"
-              export R_LINUX_VERSION=3.6.3-1bionic;
+              export R_LINUX_VERSION=3.6.3-1bionic
           fi
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           export CONDA_ENV="test-env"

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -109,18 +109,8 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   strategy:
-    maxParallel: 5
+    maxParallel: 3
     matrix:
-      r_package_msvc:
-        TASK: r-package
-        COMPILER: MSVC
-        R_VERSION: 3.6
-        TOOLCHAIN: MSVC
-      r_package_msys:
-        TASK: r-package
-        COMPILER: MINGW
-        R_VERSION: 4.0
-        TOOLCHAIN: MSYS
       regular:
         TASK: regular
         PYTHON_VERSION: 3.6


### PR DESCRIPTION
This PR addresses https://github.com/microsoft/LightGBM/pull/3065#pullrequestreview-429217760, moving all Windows R CI jobs to GitHub Actions.

##  Why this is important

This should reduce the total runtime of CI for this project. GitHub Actions allows 20 concurrent builds...AppVeyor (which we currently use) allows 1 😬 

While testing [on my fork](https://github.com/jameslamb/LightGBM/actions/runs/136691678), I found that thanks to this concurrency, all 12 jobs for R run in 12-13 minutes!!!

![image](https://user-images.githubusercontent.com/7608904/84727608-0047ae00-af55-11ea-9b1a-edca7a7e899a.png)

As of this PR, we will have four R Windows jobs all in GitHub Actions:

* R 4.0 + `MSYS2` toolchain
* R 4.0 + Visual Studio 2019
* R 3.6 + `MINGW` toolchain
* R 3.6 + Visual Studio 2017

You can see the full details of software versions for the GitHub Actions environments [here](https://github.com/actions/virtual-environments).

## What I Changed

We didn't move R jobs into GitHub Actions in #3119 because of the issues with Powershell jobs on GitHub Actions (https://github.community/t/powershell-steps-fail-nondeterministically/115496) / Powershell itself (https://github.com/PowerShell/PowerShell/issues/12823).

`R`, `Rscript`, and `initexmf` all produce harmless messages to `stderr`, which could trigger the issues linked above. I tried many approaches to fix this, including:

* redirecting to `$null`
* setting `$ErrorActionPreference = "SilentlyContinue"`
* using `-ErrorAction` flag
* piping to `Out-Null` with `|`
* piping to `Out-String` with `|`
* redirecting to a file

None of these approaches worked, but the one in this PR did: calling these commands with `R` and using R's built-in redirection, [`sink()`](https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/sink).
