### PR TITLE
Store the true split gain (without subtracting min_split_gain) in tree models (fix Issue #3054)

### DIFF
--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -577,7 +577,8 @@ void SerialTreeLearner::SplitInner(Tree* tree, int best_leaf, int* left_leaf,
         static_cast<data_size_t>(best_split_info.right_count),
         static_cast<double>(best_split_info.left_sum_hessian),
         static_cast<double>(best_split_info.right_sum_hessian),
-        static_cast<float>(best_split_info.gain),
+        // store the true split gain in tree model
+        static_cast<float>(best_split_info.gain + config_->min_gain_to_split),
         train_data_->FeatureBinMapper(inner_feature_index)->missing_type(),
         best_split_info.default_left);
   } else {
@@ -613,7 +614,8 @@ void SerialTreeLearner::SplitInner(Tree* tree, int best_leaf, int* left_leaf,
         static_cast<data_size_t>(best_split_info.right_count),
         static_cast<double>(best_split_info.left_sum_hessian),
         static_cast<double>(best_split_info.right_sum_hessian),
-        static_cast<float>(best_split_info.gain),
+        // store the true split gain in tree model
+        static_cast<float>(best_split_info.gain + config_->min_gain_to_split),
         train_data_->FeatureBinMapper(inner_feature_index)->missing_type());
   }
 


### PR DESCRIPTION
This PR is to fix #3054 .
The split_gain_ in Tree is only used by feature importance, apart from being saved into models.  

> https://github.com/microsoft/LightGBM/blob/9f367d11ad52ae8f2f1cf7b3447735723281d820/src/boosting/gbdt_model_text.cpp#L587-L621

Storing the true split gain in trees will also change the feature importance value. Feature importance values without subtracting the min_split_gain should be more meaningful, which reflects the true loss reduction by splitting with the feature.

BTW, is the comparing of split gains with 0 necessary in the code above? I thought split gains in tree models should always be >= 0, even after subtracting min_split_gain. 