### PR TITLE
[R-package] [ci] Fix MiKTeX downloads (fixes #3198)

### DIFF
--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -24,7 +24,7 @@ function Download-Miktex-Setup {
         [string]$destfile
     )
     $PageContent = Invoke-WebRequest -Uri $archive -Method Get
-    $SetupExeFile = $PageContent.Links.href | Select-String -Pattern 'miktexsetup.*'
+    $SetupExeFile = $PageContent.Links.href | Select-String -Pattern 'miktexsetup-4.*'
     $FileToDownload = "${archive}/${SetupExeFile}"
     Download-File-With-Retries $FileToDownload $destfile
 }

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -24,7 +24,7 @@ function Download-Miktex-Setup {
         [string]$destfile
     )
     $PageContent = Invoke-WebRequest -Uri $archive -Method Get
-    $SetupExeFile = $PageContent.Links.href | Select-String -Pattern 'miktexsetup-4.*'
+    $SetupExeFile = $PageContent.Links.href | Select-String -Pattern 'miktexsetup-2.*'
     $FileToDownload = "${archive}/${SetupExeFile}"
     Download-File-With-Retries $FileToDownload $destfile
 }

--- a/.gitignore
+++ b/.gitignore
@@ -406,6 +406,7 @@ R-package/src-i386
 lightgbm_r/*
 lightgbm*.tar.gz
 lightgbm.Rcheck/
+miktex*.zip
 *.def
 
 # Files created by R examples and tests


### PR DESCRIPTION
See #3198 for details. Basically, R Windows jobs in CI today have to scrape a TeX archive page to find the name of a `miktexsetup` distribution to download. The scraping logic assumes that only one `miktexsetup` will be found there. That has been true for a while, but `miktexsetup` just had a major version bump (from 2.10.x to 4.0.0).

This PR fixes our CI by looking for a specific version of `miktexsetup`.