### PR TITLE
[ci] [R-package] catch builds that have not updated docs

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -69,7 +69,7 @@ if [[ $TASK == "if-else" ]]; then
     exit 0
 fi
 
-if [[ $TASK == "r-package" ]]; then
+if [[ $TASK == "r-package" ]] || [[ $TASK == "check-r-docs" ]]; then
     bash ${BUILD_DIRECTORY}/.ci/test_r_package.sh || exit -1
     exit 0
 fi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -69,7 +69,7 @@ if [[ $TASK == "if-else" ]]; then
     exit 0
 fi
 
-if [[ $TASK == "r-package" ]] || [[ $TASK == "check-r-docs" ]]; then
+if [[ "${TASK:0:9}" == "r-package" ]]; then
     bash ${BUILD_DIRECTORY}/.ci/test_r_package.sh || exit -1
     exit 0
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -4,7 +4,7 @@
 CRAN_MIRROR="https://cloud.r-project.org/"
 R_LIB_PATH=~/Rlib
 mkdir -p $R_LIB_PATH
-echo "R_LIBS=$R_LIB_PATH" > ${HOME}/.Renviron
+export R_LIBS=$R_LIB_PATH
 export PATH="$R_LIB_PATH/R/bin:$PATH"
 
 # Get details needed for installing R components

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -90,7 +90,7 @@ if [[ $OS_NAME == "macos" ]]; then
 fi
 Rscript --vanilla -e "install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
 
-if [[ $TASK == "check-r-docs" ]]; then
+if [[ $TASK == "r-package-check-docs" ]]; then
     Rscript build_r.R || exit -1
     Rscript --vanilla -e "install.packages('roxygen2', repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
     Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit -1

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -91,7 +91,7 @@ fi
 Rscript --vanilla -e "install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
 
 if [[ $TASK == "check-r-docs" ]]; then
-    Rscript build_r.R
+    Rscript build_r.R || exit -1
     Rscript --vanilla -e "install.packages('roxygen2', repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
     Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit -1
     num_doc_files_changed=$(

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -103,7 +103,7 @@ if [[ $TASK == "check-r-docs" ]]; then
         echo "    Rscript build_r.R"
         echo "    Rscript -e \"roxygen2::roxygenize('R-package/', load = 'installed')\""
         echo ""
-        exit  -1
+        exit -1
     fi
     exit 0
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -90,6 +90,24 @@ if [[ $OS_NAME == "macos" ]]; then
 fi
 Rscript --vanilla -e "install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
 
+if [[ $TASK == "check-r-docs" ]]; then
+    Rscript build_r.R
+    Rscript --vanilla -e "install.packages('roxygen2', repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
+    Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit -1
+    num_doc_files_changed=$(
+        git diff --name-only | grep -E "\.Rd|NAMESPACE" | wc -l
+    )
+    if [[ ${num_doc_files_changed} -gt 0 ]]; then
+        echo "Some R documentation files have changed. Please re-generate them and commit those changes."
+        echo ""
+        echo "    Rscript build_r.R"
+        echo "    Rscript -e \"roxygen2::roxygenize('R-package/', load = 'installed')\""
+        echo ""
+        exit  -1
+    fi
+    exit 0
+fi
+
 cd ${BUILD_DIRECTORY}
 Rscript build_r.R --skip-install || exit -1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
             compiler: clang
             r_version: 4.0
           - os: ubuntu-latest
-            task: check-r-docs
+            task: r-package-check-docs
             compiler: gcc
             r_version: 4.0
           - os: macOS-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,10 @@ jobs:
             task: r-package
             compiler: clang
             r_version: 4.0
+          - os: ubuntu-latest
+            task: check-r-docs
+            compiler: gcc
+            r_version: 4.0
           - os: macOS-latest
             task: r-package
             compiler: gcc

--- a/R-package/R/lgb.importance.R
+++ b/R-package/R/lgb.importance.R
@@ -1,5 +1,5 @@
 #' @name lgb.importance
-#' @title Compute feature importance in a model
+#' @title Compute feature importance in a model (testing)
 #' @description Creates a \code{data.table} of feature importances in a model.
 #' @param model object of class \code{lgb.Booster}.
 #' @param percentage whether to show importance in relative percentage.

--- a/R-package/R/lgb.importance.R
+++ b/R-package/R/lgb.importance.R
@@ -1,5 +1,5 @@
 #' @name lgb.importance
-#' @title Compute feature importance in a model (testing)
+#' @title Compute feature importance in a model
 #' @description Creates a \code{data.table} of feature importances in a model.
 #' @param model object of class \code{lgb.Booster}.
 #' @param percentage whether to show importance in relative percentage.


### PR DESCRIPTION
From @StrikerRUS 's suggestion in https://github.com/microsoft/LightGBM/pull/3188#discussion_r449203929, this pull request proposes adding a new R CI jobs called `check-r-docs`. This job regenerates the documentation for the R package and checks if there are any changes that have not been committed to the repo.

In R, the process for builds the docs in the `R-package/man/` folder is like this:

1. change files in `R-package/R/`
2. install the liibrary
3. run `roxygen2::roxygenize(load = 'installed')`

Because this process relies on installing the library, I think it makes sense to add into `./.ci/test_r_package.sh`. It requires installing one additional somewhat-expensive dependency (`roxygen2`) and the documentation is not dependent on operating system so I think it makes sense to do this in a single new TASK instead of running it in all of the R CI jobs.