### PR TITLE
[ci] bump gcc version for macOS

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -9,6 +9,7 @@ if [[ $OS_NAME == "macos" ]]; then
     else  # gcc
         if [[ $TASK != "mpi" ]]; then
             brew install gcc
+            brew upgrade gcc
         fi
     fi
     if [[ $TASK == "mpi" ]]; then

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -9,7 +9,12 @@ if [[ $OS_NAME == "macos" ]]; then
     else  # gcc
         if [[ $TASK != "mpi" ]]; then
             brew install gcc
-            brew upgrade gcc
+            if [[ $GITHUB_ACTIONS == "true" ]]; then
+                brew update
+            fi
+            if [[ $TRAVIS == "true" ]] || [[ $GITHUB_ACTIONS == "true" ]]; then
+                brew upgrade gcc
+            fi
         fi
     fi
     if [[ $TASK == "mpi" ]]; then

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "gcc" ]]; then
-    export CXX=g++-9
-    export CC=gcc-9
+    export CXX=g++-10
+    export CC=gcc-10
 elif [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "clang" ]]; then
     export CXX=clang++
     export CC=clang


### PR DESCRIPTION
Refer to https://github.com/Homebrew/homebrew-core/pull/54364#issuecomment-653448513.

Fix current MPI jobs failures.