### PR TITLE
Fix integer overflow in auc_mu (fixes #3201)

### DIFF
--- a/src/metric/multiclass_metric.hpp
+++ b/src/metric/multiclass_metric.hpp
@@ -286,10 +286,10 @@ class AucMuMetric : public Metric {
     double ans = 0;
     for (int i = 0; i < num_class_; ++i) {
       for (int j = i + 1; j < num_class_; ++j) {
-        ans += S[i][j] / (class_sizes[i] * class_sizes[j]);
+        ans += (S[i][j] / class_sizes[i]) / class_sizes[j];
       }
     }
-    ans = 2 * ans / (num_class_ * (num_class_ - 1));
+    ans = (2 * ans / num_class_) / (num_class_ - 1);
     return std::vector<double>(1, ans);
   }
 


### PR DESCRIPTION
Fixes #3201. Auc-mu was giving wrong values for large training sets, due to an integer overflow error when multiplying class sizes. This PR rewrites the calculation to avoid this multiplication.