### PR TITLE
[R-package] remove unused Suggests dependencies

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -26,9 +26,7 @@ NeedsCompilation: yes
 Biarch: false
 Suggests:
     ggplot2 (>= 1.0.1),
-    knitr,
     processx,
-    rmarkdown,
     testthat
 Depends:
     R (>= 3.4),


### PR DESCRIPTION
Today we list `{knitr}` and `{rmarkdown}` as `Suggests` dependencies in the R package. This pull request proposes removing them.

`{knitr}` and `{rmarkdown}` are not used by anything in the R package today. I think removing them will provide a better user experience for anyone who is installing the R package in a way that also installs its `Suggests` dependencies.