### PR TITLE
[python][scikit-learn] Fixes a bug that prevented using multiple eval_metrics in LGBMClassifier

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -782,20 +782,28 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
 
         self._classes = self._le.classes_
         self._n_classes = len(self._classes)
+
         if self._n_classes > 2:
             # Switch to using a multiclass objective in the underlying LGBM instance
             ova_aliases = {"multiclassova", "multiclass_ova", "ova", "ovr"}
             if self._objective not in ova_aliases and not callable(self._objective):
                 self._objective = "multiclass"
-            if eval_metric in {'logloss', 'binary_logloss'}:
-                eval_metric = "multi_logloss"
-            elif eval_metric in {'error', 'binary_error'}:
-                eval_metric = "multi_error"
-        else:
-            if eval_metric in {'logloss', 'multi_logloss'}:
-                eval_metric = 'binary_logloss'
-            elif eval_metric in {'error', 'multi_error'}:
-                eval_metric = 'binary_error'
+
+        if not callable(eval_metric):
+            if isinstance(eval_metric, (string_type, type(None))):
+                eval_metric = [eval_metric]
+            if self._n_classes > 2:
+                for index, metric in enumerate(eval_metric):
+                    if metric in {'logloss', 'binary_logloss'}:
+                        eval_metric[index] = "multi_logloss"
+                    elif metric in {'error', 'binary_error'}:
+                        eval_metric[index] = "multi_error"
+            else:
+                for index, metric in enumerate(eval_metric):
+                    if metric in {'logloss', 'multi_logloss'}:
+                        eval_metric[index] = 'binary_logloss'
+                    elif metric in {'error', 'multi_error'}:
+                        eval_metric[index] = 'binary_error'
 
         # do not modify args, as it causes errors in model selection tools
         valid_sets = None

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -540,6 +540,17 @@ class TestSklearn(unittest.TestCase):
         self.assertIn('l2', gbm.evals_result_['training'])
         self.assertIn('mape', gbm.evals_result_['training'])
 
+        # non-default metric with multiple metrics in eval_metric for LGBMClassifier
+        X_classification, y_classification = load_breast_cancer(True)
+        params = {'n_estimators': 2, 'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
+        params_fit = {'X': X_classification, 'y': y_classification,
+                      'eval_set': (X_classification, y_classification), 'verbose': False}
+        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=['fair', 'error'], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 3)
+        self.assertIn('fair', gbm.evals_result_['training'])
+        self.assertIn('binary_error', gbm.evals_result_['training'])
+        self.assertIn('binary_logloss', gbm.evals_result_['training'])
+
         # default metric for non-default objective
         gbm = lgb.LGBMRegressor(objective='regression_l1', **params).fit(**params_fit)
         self.assertEqual(len(gbm.evals_result_['training']), 1)
@@ -922,14 +933,3 @@ class TestSklearn(unittest.TestCase):
         self.assertEqual(len(init_gbm.evals_result_['valid_0']['multi_logloss']), 5)
         self.assertLess(gbm.evals_result_['valid_0']['multi_logloss'][-1],
                         init_gbm.evals_result_['valid_0']['multi_logloss'][-1])
-
-    def test_eval_metrics_lgbmclassifier(self):
-        X, y = load_breast_cancer(True)
-        params = {'n_estimators': 2, 'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
-        params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
-
-        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=['fair', 'error'], **params_fit)
-        self.assertEqual(len(gbm.evals_result_['training']), 3)
-        self.assertIn('fair', gbm.evals_result_['training'])
-        self.assertIn('binary_error', gbm.evals_result_['training'])
-        self.assertIn('binary_logloss', gbm.evals_result_['training'])

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -542,10 +542,13 @@ class TestSklearn(unittest.TestCase):
 
         # non-default metric with multiple metrics in eval_metric for LGBMClassifier
         X_classification, y_classification = load_breast_cancer(True)
-        params_classification = {'n_estimators': 2, 'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
+        params_classification = {'n_estimators': 2, 'verbose': -1,
+                                 'objective': 'binary', 'metric': 'binary_logloss'}
         params_fit_classification = {'X': X_classification, 'y': y_classification,
-                      'eval_set': (X_classification, y_classification), 'verbose': False}
-        gbm = lgb.LGBMClassifier(**params_classification).fit(eval_metric=['fair', 'error'], **params_fit_classification)
+                                     'eval_set': (X_classification, y_classification),
+                                     'verbose': False}
+        gbm = lgb.LGBMClassifier(**params_classification).fit(eval_metric=['fair', 'error'],
+                                                              **params_fit_classification)
         self.assertEqual(len(gbm.evals_result_['training']), 3)
         self.assertIn('fair', gbm.evals_result_['training'])
         self.assertIn('binary_error', gbm.evals_result_['training'])

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -542,10 +542,10 @@ class TestSklearn(unittest.TestCase):
 
         # non-default metric with multiple metrics in eval_metric for LGBMClassifier
         X_classification, y_classification = load_breast_cancer(True)
-        params = {'n_estimators': 2, 'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
-        params_fit = {'X': X_classification, 'y': y_classification,
+        params_classification = {'n_estimators': 2, 'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
+        params_fit_classification = {'X': X_classification, 'y': y_classification,
                       'eval_set': (X_classification, y_classification), 'verbose': False}
-        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=['fair', 'error'], **params_fit)
+        gbm = lgb.LGBMClassifier(**params_classification).fit(eval_metric=['fair', 'error'], **params_fit_classification)
         self.assertEqual(len(gbm.evals_result_['training']), 3)
         self.assertIn('fair', gbm.evals_result_['training'])
         self.assertIn('binary_error', gbm.evals_result_['training'])

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -922,3 +922,14 @@ class TestSklearn(unittest.TestCase):
         self.assertEqual(len(init_gbm.evals_result_['valid_0']['multi_logloss']), 5)
         self.assertLess(gbm.evals_result_['valid_0']['multi_logloss'][-1],
                         init_gbm.evals_result_['valid_0']['multi_logloss'][-1])
+
+    def test_eval_metrics_lgbmclassifier(self):
+        X, y = load_breast_cancer(True)
+        params = {'n_estimators': 2, 'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
+        params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
+
+        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=['fair', 'error'], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 3)
+        self.assertIn('fair', gbm.evals_result_['training'])
+        self.assertIn('binary_error', gbm.evals_result_['training'])
+        self.assertIn('binary_logloss', gbm.evals_result_['training'])


### PR DESCRIPTION
This PR fixes a bug in the LGBMClassifier class. The code as-is breaks when eval_metric is a list of strings. This is meant to work (as referenced in the documentation) and does work on all derived classes of LGBMModel except LGBMClassifier. The issue is in the following code in the master branch:

https://github.com/microsoft/LightGBM/blob/1e2013a306c0ca719fa076a733796a6372e5b77e/python-package/lightgbm/sklearn.py#L785-L798

with the fix the following line works as expected (see tests in PR):

`gbm = lgb.LGBMClassifier(**params).fit(eval_metric=['fair', 'error'], **params_fit)`