### PR TITLE
[R-package] remove xlen_t in custom R-to-C++ interface

### DIFF
--- a/R-package/src/R_object_helper.h
+++ b/R-package/src/R_object_helper.h
@@ -15,8 +15,9 @@
 
 #include <cstdint>
 
-// use .Internal(internalsID()) to uuid
-#define R_INTERNALS_UUID "2fdf6c18-697a-4ba7-b8ef-11c0d92f1327"
+#define R_NO_REMAP
+#define R_USE_C99_IN_CXX
+#include <Rinternals.h>
 
 #define NAMED_BITS 16
 struct lgbm_sxpinfo {
@@ -34,13 +35,6 @@ struct lgbm_sxpinfo {
   unsigned int named : NAMED_BITS;
   unsigned int extra : 32 - NAMED_BITS;
 };
-
-// 64bit pointer
-#if INTPTR_MAX == INT64_MAX
-  typedef int64_t xlen_t;
-#else
-  typedef int xlen_t;
-#endif
 
 struct lgbm_primsxp {
   int offset;
@@ -91,8 +85,8 @@ typedef struct LGBM_SER {
 } LGBM_SER, *LGBM_SE;
 
 struct lgbm_vecsxp {
-  xlen_t length;
-  xlen_t truelength;
+  R_xlen_t length;
+  R_xlen_t truelength;
 };
 
 typedef struct VECTOR_SER {


### PR DESCRIPTION
This PR is a step towards #3016 . Now that we are comfortable using R's provided headers in the R package, we can start to factor out custom things to reduce the maintenance burden for the R package.

This replaces `xlen_t` with `R_xlen_t` from `Rinternals.h`.

You can see the implementation at https://github.com/wch/r-source/blob/trunk/src/include/Rinternals.h#L71-L82