### PR TITLE
[R-package] factor out {ggplot2}

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -148,7 +148,7 @@ if grep -q -R "WARNING" "$LOG_FILE_NAME"; then
     exit -1
 fi
 
-ALLOWED_CHECK_NOTES=3
+ALLOWED_CHECK_NOTES=2
 NUM_CHECK_NOTES=$(
     cat ${LOG_FILE_NAME} \
         | grep -e '^Status: .* NOTE.*' \

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -157,7 +157,7 @@ if ($env:COMPILER -ne "MSVC") {
   $note_str = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern '.*Status.* NOTE' | Out-String ; Check-Output $?
   $relevant_line = $note_str -match '(\d+) NOTE'
   $NUM_CHECK_NOTES = $matches[1]
-  $ALLOWED_CHECK_NOTES = 3
+  $ALLOWED_CHECK_NOTES = 2
   if ([int]$NUM_CHECK_NOTES -gt $ALLOWED_CHECK_NOTES) {
       Write-Output "Found ${NUM_CHECK_NOTES} NOTEs from R CMD check. Only ${ALLOWED_CHECK_NOTES} are allowed"
       Check-Output $False

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -25,7 +25,6 @@ BugReports: https://github.com/Microsoft/LightGBM/issues
 NeedsCompilation: yes
 Biarch: false
 Suggests:
-    ggplot2 (>= 1.0.1),
     processx,
     testthat
 Depends:

--- a/R-package/demo/leaf_stability.R
+++ b/R-package/demo/leaf_stability.R
@@ -2,9 +2,7 @@
 # Obviously, we are in a controlled environment, without issues (real rules).
 # Do not do this in a real scenario.
 
-# First, we load our libraries
 library(lightgbm)
-library(ggplot2)
 
 # Second, we load our data
 data(agaricus.train, package = "lightgbm")

--- a/R-package/demo/leaf_stability.R
+++ b/R-package/demo/leaf_stability.R
@@ -59,7 +59,6 @@ new_data$binned <- .bincode(
     , include.lowest = TRUE
 )
 new_data$binned[is.na(new_data$binned)] <- 0L
-new_data$binned <- as.factor(new_data$binned)
 
 # We can check the binned content
 table(new_data$binned)
@@ -67,18 +66,54 @@ table(new_data$binned)
 # We can plot the binned content
 # On the second plot, we clearly notice the lower the bin (the lower the leaf value), the higher the loss
 # On the third plot, it is smooth!
+.plot_binned <- function(new_data){
+  .diverging_palette <- c(
+    "#A50026"
+    , "#D73027"
+    , "#F46D43"
+    , "#FDAE61"
+    , "#FEE08B"
+    , "#D9EF8B"
+    , "#A6D96A"
+    , "#66BD63"
+    , "#1A9850"
+    , "#006837"
+  )
+  plot(
+    x = new_data$X
+    , y = new_data$Y
+    , type = "p"
+    , main = "Prediction Depth"
+    , xlab = "Leaf Bin"
+    , ylab = "Prediction Probability"
+    , pch = 19
+    , col = .diverging_palette[new_data$binned + 1]
+  )
+  legend(
+    "topright"
+    , legend = sort(unique(new_data$binned))
+    , pch = 19
+    , col = .diverging_palette[sort(unique(new_data$binned + 1))]
+    , cex = 0.7
+  )
+}
+
 ggplot(
     data = new_data
     , mapping = aes(x = X, y = Y, color = binned)
 ) + geom_point() +
   theme_bw() +
   labs(title = "Prediction Depth", x = "Leaf Bin", y = "Prediction Probability")
+
+
+
 ggplot(
     data = new_data
     , mapping = aes(x = binned, y = Z, fill = binned, group = binned)
 ) + geom_boxplot() +
   theme_bw() +
   labs(title = "Prediction Depth Spread", x = "Leaf Bin", y = "Logloss")
+
 ggplot(
     data = new_data
     , mapping = aes(x = Y, y = ..count.., fill = binned)

--- a/R-package/demo/leaf_stability.R
+++ b/R-package/demo/leaf_stability.R
@@ -66,37 +66,34 @@ table(new_data$binned)
 # We can plot the binned content
 # On the second plot, we clearly notice the lower the bin (the lower the leaf value), the higher the loss
 # On the third plot, it is smooth!
-.plot_binned <- function(new_data){
-  .diverging_palette <- c(
-    "#A50026"
-    , "#D73027"
-    , "#F46D43"
-    , "#FDAE61"
-    , "#FEE08B"
-    , "#D9EF8B"
-    , "#A6D96A"
-    , "#66BD63"
-    , "#1A9850"
-    , "#006837"
-  )
+.diverging_palette <- c(
+  "#A50026", "#D73027", "#F46D43", "#FDAE61", "#FEE08B"
+  , "#D9EF8B", "#A6D96A", "#66BD63", "#1A9850", "#006837"
+)
+
+.prediction_depth_plot <- function(df){
   plot(
-    x = new_data$X
-    , y = new_data$Y
+    x = df$X
+    , y = df$Y
     , type = "p"
     , main = "Prediction Depth"
     , xlab = "Leaf Bin"
     , ylab = "Prediction Probability"
     , pch = 19
-    , col = .diverging_palette[new_data$binned + 1]
+    , col = .diverging_palette[df$binned + 1]
   )
   legend(
     "topright"
-    , legend = sort(unique(new_data$binned))
+    , title = "bin"
+    , legend = sort(unique(df$binned))
     , pch = 19
-    , col = .diverging_palette[sort(unique(new_data$binned + 1))]
+    , col = .diverging_palette[sort(unique(df$binned + 1))]
     , cex = 0.7
   )
 }
+
+
+.prediction_depth_plot(df = new_data)
 
 ggplot(
     data = new_data
@@ -106,7 +103,30 @@ ggplot(
   labs(title = "Prediction Depth", x = "Leaf Bin", y = "Prediction Probability")
 
 
+.prediction_depth_spread_plot <- function(df){
+  plot(
+    x = df$binned
+    , xlim = c(0, 9)
+    , y = df$Z
+    , type = "p"
+    , main = "Prediction Depth Spread"
+    , xlab = "Leaf Bin"
+    , ylab = "Logloss"
+    , pch = 19
+    , col = .diverging_palette[df$binned + 1]
+  )
+  legend(
+    "topright"
+    , title = "bin"
+    , legend = sort(unique(df$binned))
+    , pch = 19
+    , col = .diverging_palette[sort(unique(df$binned + 1))]
+    , cex = 0.7
+  )
+}
 
+
+.prediction_depth_spread_plot(df = new_data)
 ggplot(
     data = new_data
     , mapping = aes(x = binned, y = Z, fill = binned, group = binned)
@@ -114,6 +134,30 @@ ggplot(
   theme_bw() +
   labs(title = "Prediction Depth Spread", x = "Leaf Bin", y = "Logloss")
 
+.depth_density_plot <- function(df){
+  plot(
+    x = density(df$Y)
+    , xlim = c(min(df$Y), max(df$Y))
+    , type = "p"
+    , main = "Depth Density"
+    , xlab = "Prediction Probability"
+    , ylab = "Bin Density"
+    , pch = 19
+    , col = .diverging_palette[df$binned + 1]
+  )
+  legend(
+    "topright"
+    , title = "bin"
+    , legend = sort(unique(df$binned))
+    , pch = 19
+    , pt.cex = 0.1
+    , col = .diverging_palette[sort(unique(df$binned + 1))]
+    , cex = 0.7
+  )
+}
+
+
+.depth_density_plot(df = new_data)
 ggplot(
     data = new_data
     , mapping = aes(x = Y, y = ..count.., fill = binned)
@@ -161,7 +205,6 @@ new_data2$binned <- .bincode(
     , include.lowest = TRUE
 )
 new_data2$binned[is.na(new_data2$binned)] <- 0L
-new_data2$binned <- as.factor(new_data2$binned)
 
 # We can check the binned content
 table(new_data2$binned)
@@ -171,18 +214,23 @@ table(new_data2$binned)
 # On the third plot, it is clearly not smooth! We are severely overfitting the data, but the rules are
 # real thus it is not an issue
 # However, if the rules were not true, the loss would explode.
+.prediction_depth_plot(df = new_data2)
 ggplot(
     data = new_data2
     , mapping = aes(x = X, y = Y, color = binned)
 ) + geom_point() +
   theme_bw() +
   labs(title = "Prediction Depth", x = "Leaf Bin", y = "Prediction Probability")
+
+.prediction_depth_spread_plot(df = new_data2)
 ggplot(
     data = new_data2
     , mapping = aes(x = binned, y = Z, fill = binned, group = binned)
 ) + geom_boxplot() +
   theme_bw() +
   labs(title = "Prediction Depth Spread", x = "Leaf Bin", y = "Logloss")
+
+.depth_density_plot(df = new_data2)
 ggplot(
     data = new_data2
     , mapping = aes(x = Y, y = ..count.., fill = binned)
@@ -230,7 +278,6 @@ new_data3$binned <- .bincode(
     , include.lowest = TRUE
 )
 new_data3$binned[is.na(new_data3$binned)] <- 0L
-new_data3$binned <- as.factor(new_data3$binned)
 
 # We can check the binned content
 table(new_data3$binned)
@@ -239,6 +286,7 @@ table(new_data3$binned)
 # On the third plot, it is clearly not smooth! We are severely overfitting the data, but the rules
 # are real thus it is not an issue.
 # However, if the rules were not true, the loss would explode. See the sudden spikes?
+.depth_density_plot(df = new_data3)
 ggplot(
     data = new_data3
     , mapping = aes(x = Y, y = ..count.., fill = binned)
@@ -248,6 +296,7 @@ ggplot(
   labs(title = "Depth Density", x = "Prediction Probability", y = "Bin Density")
 
 # Compare with our second model, the difference is severe. This is smooth.
+.depth_density_plot(df = new_data2)
 ggplot(
     data = new_data2
     , mapping = aes(x = Y, y = ..count.., fill = binned)


### PR DESCRIPTION
Today the R package has a `Suggests` dependency on `{ggplot2}`.  This is only for one demo, `demo/leaf_stability.R`. This pull request proposes factoring it out and replacing it with `base` R code.

This will allow us to cut out this `R CMD check` NOTE:

> * checking package dependencies ... NOTE
Package suggested but not available for checking: ‘ggplot2’

More importantly, it's an expensive dependency that anyone installing the `Suggests` dependencies of `{lightgbm}`has to pay for.

Some of these plots look different from the comments around them, but this PR does not address that...it can be addressed in #1944 . This PR is limited to just factoring out `{ggplot2}`, to make the package as lightweight as possible when it goes to CRAN (work-in-progress, #629 ).

## Comparisons

I've included before and after screenshots for each plot below. The "Depth Density" plots look noticeably different, I think because of changes in how `geom_density()` works in `{ggplot2}`. `demo/leaf_stability.R` was written more than 3 years ago.

Thanks to @alistaire47 for helping me with `{ggplot2}` stuff 😀 

<details><summary>plot 1</summary>

**before**
![image](https://user-images.githubusercontent.com/7608904/87268001-e4b9bf80-c48e-11ea-831e-55c0fa4b4a1a.png)

**after**

![image](https://user-images.githubusercontent.com/7608904/87268186-66115200-c48f-11ea-8dda-83f7a5d3e5b7.png)

</details>

<details><summary>plot 2</summary>

**before**

![image](https://user-images.githubusercontent.com/7608904/87268216-7cb7a900-c48f-11ea-8650-f31aed3d77dc.png)

**after**

![image](https://user-images.githubusercontent.com/7608904/87268239-88a36b00-c48f-11ea-9595-5a2eb4054629.png)

</details>

<details><summary>plot 3</summary>

**before**

![image](https://user-images.githubusercontent.com/7608904/87268311-a83a9380-c48f-11ea-8f53-a48a11b3ed4f.png)

**after**

![image](https://user-images.githubusercontent.com/7608904/87268334-b8eb0980-c48f-11ea-9e15-a5294631ef20.png)

</details>

<details><summary>plot 4</summary>

**before**

![image](https://user-images.githubusercontent.com/7608904/87268358-c86a5280-c48f-11ea-9b81-51d7f213eace.png)

**after**

![image](https://user-images.githubusercontent.com/7608904/87268378-d28c5100-c48f-11ea-9689-90e5bcb94a88.png)

</details>

<details><summary>plot 5</summary>

**before**

![image](https://user-images.githubusercontent.com/7608904/87268429-f485d380-c48f-11ea-9519-a50b8cb7ec01.png)

**after**

![image](https://user-images.githubusercontent.com/7608904/87268411-e768e480-c48f-11ea-894b-c21d4dab6546.png)

</details>

<details><summary>plot 6</summary>

**before**

![image](https://user-images.githubusercontent.com/7608904/87268453-09626700-c490-11ea-9a5b-0f2bf0596049.png)

**after**

![image](https://user-images.githubusercontent.com/7608904/87268478-154e2900-c490-11ea-9490-9cdd4507385a.png)

</details>

<details><summary>plot 7</summary>

**before**

![image](https://user-images.githubusercontent.com/7608904/87268542-4595c780-c490-11ea-907a-bb874486e933.png)

**after**

![image](https://user-images.githubusercontent.com/7608904/87268529-3d3d8c80-c490-11ea-801b-03436c9910fd.png)

</details>

<details><summary>plot 8</summary>

**before**

![image](https://user-images.githubusercontent.com/7608904/87268578-5cd4b500-c490-11ea-99ba-24ded24ee298.png)


**after**

![image](https://user-images.githubusercontent.com/7608904/87268563-52b2b680-c490-11ea-9107-0111bc9a2f7e.png)

</details>
