### PR TITLE
[ci] bump R 4 version

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -18,8 +18,8 @@ if ! { [[ $AZURE == "true" ]] && [[ $OS_NAME == "linux" ]]; }; then
         export R_LINUX_VERSION="3.6.3-1bionic"
         export R_APT_REPO="bionic-cran35/"
     elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
-        export R_MAC_VERSION=4.0.0
-        export R_LINUX_VERSION="4.0.0-1.1804.0"
+        export R_MAC_VERSION=4.0.2
+        export R_LINUX_VERSION="4.0.2-1.1804.0"
         export R_APT_REPO="bionic-cran40/"
     else
         echo "Unrecognized R version: ${R_VERSION}"


### PR DESCRIPTION
Should fix current `master` failures for R-package tests (https://github.com/microsoft/LightGBM/pull/2760#issuecomment-657538134).
```
Found the following significant warnings:
  Warning: package ‘R6’ was built under R version 4.0.1
```

Extracted from #3188 because we need this change right now.