### PR TITLE
add rules for tests/ in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,14 +9,23 @@
 # catch-all rule (this only gets matched if no rules below match)
 *    @guolinke @StrikerRUS @jameslamb @Laurae2
 
+# other catch-alls that will get matched if specific rules below are not matched
+*.R    @Laurae2 @jameslamb
+*.py    @StrikerRUS @chivee @wxchan @henry0312
+*.cpp    @guolinke @chivee @btrotta
+*.h    @guolinke @chivee @btrotta
+
 # main C++ code
 include/    @guolinke @chivee @btrotta
 src/    @guolinke @chivee @btrotta
 CMakeLists.txt    @guolinke @chivee @Laurae2 @jameslamb @wxchan @henry0312 @StrikerRUS @huanzhang12 @btrotta
+tests/c_api_test/    @guolinke @chivee @btrotta
+tests/cpp_test/    @guolinke @chivee @btrotta
+tests/data/    @guolinke @chivee @btrotta
+windows/    @guolinke @chivee @btrotta @StrikerRUS
 
 # R code
 R-package/    @Laurae2 @jameslamb
-*.R    @Laurae2 @jameslamb
 
 # Python code
 python-package/    @StrikerRUS @chivee @wxchan @henry0312


### PR DESCRIPTION
I've noticed recently that I'm getting automatically added as a reviewer for Python-only PRs like #3222. I think this is because `.github/CODEOWNERS` does not cover the `tests/` directory and my name is in the catch-all rule.

This PR proposes more specific rules for PRs that touch `tests/`, and some language-specific catch-all rules.

When reviewing this, remember that GitHub will use the matching rule that is furthest down in the file. So, for example, if someone touches the code in `helpers/`, the `helpers/` rule will be used, not the `*.py` one.

