### PR TITLE
Upcast index to size_t in Refit

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -345,7 +345,7 @@ class Booster {
     std::vector<std::vector<int32_t>> v_leaf_preds(nrow, std::vector<int32_t>(ncol, 0));
     for (int i = 0; i < nrow; ++i) {
       for (int j = 0; j < ncol; ++j) {
-        v_leaf_preds[i][j] = leaf_preds[i * ncol + j];
+        v_leaf_preds[i][j] = leaf_preds[static_cast<size_t>(i) * static_cast<size_t>(ncol) + static_cast<size_t>(j)];
       }
     }
     boosting_->RefitTree(v_leaf_preds);


### PR DESCRIPTION
Closes #3227

Upcast index of `leaf_preds` to size_t. In the current implementation, the index is an int32, which will segfault with large data sets and a large number of estimators.