### PR TITLE
[ci] remove unnecessary R_CHECK_FORCE_SUGGESTS in CI scripts

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -114,9 +114,6 @@ Rscript build_r.R --skip-install || exit -1
 PKG_TARBALL="lightgbm_${LGB_VER}.tar.gz"
 LOG_FILE_NAME="lightgbm.Rcheck/00check.log"
 
-# suppress R CMD check warning from Suggests dependencies not being available
-export _R_CHECK_FORCE_SUGGESTS_=0
-
 # fails tests if either ERRORs or WARNINGs are thrown by
 # R CMD CHECK
 check_succeeded="yes"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -138,7 +138,6 @@ if ($env:COMPILER -ne "MSVC") {
   $PKG_FILE_NAME = $PKG_FILE_NAME -replace '[\\]', '/'
   $LOG_FILE_NAME = "lightgbm.Rcheck/00check.log"
 
-  $env:_R_CHECK_FORCE_SUGGESTS_ = 0
   Write-Output "Running R CMD check as CRAN"
   Run-R-Code-Redirect-Stderr "result <- processx::run(command = 'R.exe', args = c('CMD', 'check', '--no-multiarch', '--as-cran', '$PKG_FILE_NAME'), echo = TRUE, windows_verbatim_args = FALSE)" ; $check_succeeded = $?
 

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -391,9 +391,7 @@ context("save_model")
 test_that("Saving a model with different feature importance types works", {
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
-    data(agaricus.test, package = "lightgbm")
     train <- agaricus.train
-    test <- agaricus.test
     bst <- lightgbm(
         data = as.matrix(train$data)
         , label = train$label


### PR DESCRIPTION
See https://github.com/microsoft/LightGBM/pull/3224#issuecomment-661125688

#3224 removed the last `Suggests:` dependency for the R package that isn't installed in CI, so we can remove the environment variables set to change the `WARNING` about suggests dependencies into a `NOTE`.