### PR TITLE
[Python] Refactors scikit-learn API to allow a list of evaluation metrics

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3096,6 +3096,8 @@ class Booster(object):
         """Evaluate training or validation data."""
         if data_idx >= self.__num_dataset:
             raise ValueError("Data_idx should be smaller than number of dataset")
+        if callable(feval):
+            feval = [feval]
         self.__get_eval_info()
         ret = []
         if self.__num_inner_eval > 0:
@@ -3116,13 +3118,16 @@ class Booster(object):
                 cur_data = self.train_set
             else:
                 cur_data = self.valid_sets[data_idx - 1]
-            feval_ret = feval(self.__inner_predict(data_idx), cur_data)
-            if isinstance(feval_ret, list):
-                for eval_name, val, is_higher_better in feval_ret:
+            for eval_function in feval:
+                if eval_function is None:
+                    continue
+                feval_ret = eval_function(self.__inner_predict(data_idx), cur_data)
+                if isinstance(feval_ret, list):
+                    for eval_name, val, is_higher_better in feval_ret:
+                        ret.append((data_name, eval_name, val, is_higher_better))
+                else:
+                    eval_name, val, is_higher_better = feval_ret
                     ret.append((data_name, eval_name, val, is_higher_better))
-            else:
-                eval_name, val, is_higher_better = feval_ret
-                ret.append((data_name, eval_name, val, is_higher_better))
         return ret
 
     def __inner_predict(self, data_idx):

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3096,8 +3096,6 @@ class Booster(object):
         """Evaluate training or validation data."""
         if data_idx >= self.__num_dataset:
             raise ValueError("Data_idx should be smaller than number of dataset")
-        if callable(feval):
-            feval = [feval]
         self.__get_eval_info()
         ret = []
         if self.__num_inner_eval > 0:
@@ -3113,6 +3111,8 @@ class Booster(object):
             for i in range_(self.__num_inner_eval):
                 ret.append((data_name, self.__name_inner_eval[i],
                             result[i], self.__higher_better_inner_eval[i]))
+        if callable(feval):
+            feval = [feval]
         if feval is not None:
             if data_idx == 0:
                 cur_data = self.train_set

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -55,7 +55,7 @@ def train(params, train_set, num_boost_round=100,
         If you want to get i-th row preds in j-th class, the access way is score[j * num_data + i]
         and you should group grad and hess in this way as well.
 
-    feval : callable, list of callable functions, or None, optional (default=None)
+    feval : callable, list of callable functions or None, optional (default=None)
         Customized evaluation function.
         Each evaluation function should accept two parameters: preds, train_data,
         and return (eval_name, eval_result, is_higher_better) or list of such tuples.
@@ -443,7 +443,7 @@ def cv(params, train_set, num_boost_round=100,
         If you want to get i-th row preds in j-th class, the access way is score[j * num_data + i]
         and you should group grad and hess in this way as well.
 
-    feval : callable, list of callable functions, or None, optional (default=None)
+    feval : callable, list of callable functions or None, optional (default=None)
         Customized evaluation function.
         Each evaluation function should accept two parameters: preds, train_data,
         and return (eval_name, eval_result, is_higher_better) or list of such tuples.

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -55,9 +55,9 @@ def train(params, train_set, num_boost_round=100,
         If you want to get i-th row preds in j-th class, the access way is score[j * num_data + i]
         and you should group grad and hess in this way as well.
 
-    feval : callable or None, optional (default=None)
+    feval : callable, list of callable functions, or None, optional (default=None)
         Customized evaluation function.
-        Should accept two parameters: preds, train_data,
+        Each evaluation function should accept two parameters: preds, train_data,
         and return (eval_name, eval_result, is_higher_better) or list of such tuples.
 
             preds : list or numpy 1-D array
@@ -443,9 +443,9 @@ def cv(params, train_set, num_boost_round=100,
         If you want to get i-th row preds in j-th class, the access way is score[j * num_data + i]
         and you should group grad and hess in this way as well.
 
-    feval : callable or None, optional (default=None)
+    feval : callable, list of callable functions, or None, optional (default=None)
         Customized evaluation function.
-        Should accept two parameters: preds, train_data,
+        Each evaluation function should accept two parameters: preds, train_data,
         and return (eval_name, eval_result, is_higher_better) or list of such tuples.
 
             preds : list or numpy 1-D array

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -388,7 +388,7 @@ class LGBMModel(_LGBMModelBase):
             Init score of eval data.
         eval_group : list of arrays or None, optional (default=None)
             Group data of eval data.
-        eval_metric : string, callable, list, or None, optional (default=None)
+        eval_metric : string, callable, list or None, optional (default=None)
             If string, it should be a built-in evaluation metric to use.
             If callable, it should be a custom evaluation metric, see note below for more details.
             If list, it can be a list of built-in metrics, a list of custom evaluation metrics, or a mix of both.

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -501,7 +501,7 @@ class LGBMModel(_LGBMModelBase):
         if self._fobj:
             params['objective'] = 'None'  # objective = nullptr for unknown objective
 
-        if isinstance(eval_metric, (string_type, type(None))) or callable(eval_metric):
+        if not isinstance(eval_metric, list):
             eval_metric = [eval_metric]
 
         # Separate built-in from callable evaluation metrics

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -388,9 +388,10 @@ class LGBMModel(_LGBMModelBase):
             Init score of eval data.
         eval_group : list of arrays or None, optional (default=None)
             Group data of eval data.
-        eval_metric : string, list of strings, callable or None, optional (default=None)
+        eval_metric : string, callable, list, or None, optional (default=None)
             If string, it should be a built-in evaluation metric to use.
             If callable, it should be a custom evaluation metric, see note below for more details.
+            If list, it can be a list of built-in metrics, a list of custom evaluation metrics, or a mix of both.
             In either case, the ``metric`` from the model parameters will be evaluated and used as well.
             Default: 'l2' for LGBMRegressor, 'logloss' for LGBMClassifier, 'ndcg' for LGBMRanker.
         early_stopping_rounds : int or None, optional (default=None)
@@ -500,29 +501,33 @@ class LGBMModel(_LGBMModelBase):
         if self._fobj:
             params['objective'] = 'None'  # objective = nullptr for unknown objective
 
-        if callable(eval_metric):
-            feval = _EvalFunctionWrapper(eval_metric)
-        else:
-            feval = None
-            # register default metric for consistency with callable eval_metric case
-            original_metric = self._objective if isinstance(self._objective, string_type) else None
-            if original_metric is None:
-                # try to deduce from class instance
-                if isinstance(self, LGBMRegressor):
-                    original_metric = "l2"
-                elif isinstance(self, LGBMClassifier):
-                    original_metric = "multi_logloss" if self._n_classes > 2 else "binary_logloss"
-                elif isinstance(self, LGBMRanker):
-                    original_metric = "ndcg"
-            # overwrite default metric by explicitly set metric
-            for metric_alias in _ConfigAliases.get("metric"):
-                if metric_alias in params:
-                    original_metric = params.pop(metric_alias)
-            # concatenate metric from params (or default if not provided in params) and eval_metric
-            original_metric = [original_metric] if isinstance(original_metric, (string_type, type(None))) else original_metric
-            eval_metric = [eval_metric] if isinstance(eval_metric, (string_type, type(None))) else eval_metric
-            params['metric'] = [e for e in eval_metric if e not in original_metric] + original_metric
-            params['metric'] = [metric for metric in params['metric'] if metric is not None]
+        if isinstance(eval_metric, (string_type, type(None))) or callable(eval_metric):
+            eval_metric = [eval_metric]
+
+        # Separate built-in from callable evaluation metrics
+        eval_metrics_callable = [_EvalFunctionWrapper(f) for f in eval_metric if callable(f)]
+        eval_metrics_builtin = [m for m in eval_metric if isinstance(m, string_type)]
+
+        # register default metric for consistency with callable eval_metric case
+        original_metric = self._objective if isinstance(self._objective, string_type) else None
+        if original_metric is None:
+            # try to deduce from class instance
+            if isinstance(self, LGBMRegressor):
+                original_metric = "l2"
+            elif isinstance(self, LGBMClassifier):
+                original_metric = "multi_logloss" if self._n_classes > 2 else "binary_logloss"
+            elif isinstance(self, LGBMRanker):
+                original_metric = "ndcg"
+
+        # overwrite default metric by explicitly set metric
+        for metric_alias in _ConfigAliases.get("metric"):
+            if metric_alias in params:
+                original_metric = params.pop(metric_alias)
+
+        # concatenate metric from params (or default if not provided in params) and eval_metric
+        original_metric = [original_metric] if isinstance(original_metric, (string_type, type(None))) else original_metric
+        params['metric'] = [e for e in eval_metrics_builtin if e not in original_metric] + original_metric
+        params['metric'] = [metric for metric in params['metric'] if metric is not None]
 
         if not isinstance(X, (DataFrame, DataTable)):
             _X, _y = _LGBMCheckXY(X, y, accept_sparse=True, force_all_finite=False, ensure_min_samples=2)
@@ -595,7 +600,7 @@ class LGBMModel(_LGBMModelBase):
         self._Booster = train(params, train_set,
                               self.n_estimators, valid_sets=valid_sets, valid_names=eval_names,
                               early_stopping_rounds=early_stopping_rounds,
-                              evals_result=evals_result, fobj=self._fobj, feval=feval,
+                              evals_result=evals_result, fobj=self._fobj, feval=eval_metrics_callable,
                               verbose_eval=verbose, feature_name=feature_name,
                               callbacks=callbacks, init_model=init_model)
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1813,7 +1813,7 @@ class TestEngine(unittest.TestCase):
         train_dataset = lgb.Dataset(data=X_train, label=y_train, silent=True)
         validation_dataset = lgb.Dataset(data=X_validation, label=y_validation, reference=train_dataset, silent=True)
         evals_result = {}
-        _ = lgb.train(
+        lgb.train(
             params=params,
             train_set=train_dataset,
             valid_sets=validation_dataset,

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -12,7 +12,8 @@ import numpy as np
 from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_csc
 from sklearn.datasets import (load_boston, load_breast_cancer, load_digits,
                               load_iris, load_svmlight_file, make_multilabel_classification)
-from sklearn.metrics import log_loss, mean_absolute_error, mean_squared_error, roc_auc_score
+from sklearn.metrics import (log_loss, mean_absolute_error, mean_squared_error, roc_auc_score,
+                             recall_score, precision_score)
 from sklearn.model_selection import train_test_split, TimeSeriesSplit, GroupKFold
 
 try:
@@ -49,6 +50,15 @@ def decreasing_metric(preds, train_data):
 
 def categorize(continuous_x):
     return np.digitize(continuous_x, bins=np.arange(0, 1, 0.01))
+
+def custom_recall(preds, train_data):
+    y_true = train_data.get_label()
+    return 'custom_recall', recall_score(y_true, preds > 0.5), True
+
+
+def custom_precision(preds, train_data):
+    y_true = train_data.get_label()
+    return 'custom_precision', precision_score(y_true, preds > 0.5), True
 
 
 class TestEngine(unittest.TestCase):
@@ -1802,6 +1812,51 @@ class TestEngine(unittest.TestCase):
         # binary metric with non-default num_class for custom objective
         self.assertRaises(lgb.basic.LightGBMError, get_cv_result,
                           params_class_3_verbose, metrics='binary_error', fobj=dummy_obj)
+
+    def test_multiple_feval_train(self):
+        X, y = load_breast_cancer(True)
+
+        params = {'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
+
+        X_train, X_validation, y_train, y_validation = train_test_split(X, y, test_size=0.2)
+
+        train_dataset = lgb.Dataset(data=X_train, label=y_train, silent=True)
+        validation_dataset = lgb.Dataset(data=X_validation, label=y_validation, reference=train_dataset, silent=True)
+        evals_result = {}
+        _ = lgb.train(
+            params=params,
+            train_set=train_dataset,
+            valid_sets=validation_dataset,
+            num_boost_round=5,
+            feval=[custom_recall, custom_precision],
+            evals_result=evals_result)
+
+        self.assertEqual(len(evals_result['valid_0']), 3)
+        self.assertIn('binary_logloss', evals_result['valid_0'])
+        self.assertIn('custom_recall', evals_result['valid_0'])
+        self.assertIn('custom_precision', evals_result['valid_0'])
+
+    def test_multiple_feval_cv(self):
+        X, y = load_breast_cancer(True)
+
+        params = {'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
+
+        train_dataset = lgb.Dataset(data=X, label=y, silent=True)
+
+        cv_results = lgb.cv(
+            params=params,
+            train_set=train_dataset,
+            num_boost_round=5,
+            feval=[custom_recall, custom_precision])
+
+        # Expect three metrics but mean and stdv for each metric
+        self.assertEqual(len(cv_results), 6)
+        self.assertIn('binary_logloss-mean', cv_results)
+        self.assertIn('custom_recall-mean', cv_results)
+        self.assertIn('custom_precision-mean', cv_results)
+        self.assertIn('binary_logloss-stdv', cv_results)
+        self.assertIn('custom_recall-stdv', cv_results)
+        self.assertIn('custom_precision-stdv', cv_results)
 
     @unittest.skipIf(psutil.virtual_memory().available / 1024 / 1024 / 1024 < 3, 'not enough RAM')
     def test_model_size(self):

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1804,7 +1804,7 @@ class TestEngine(unittest.TestCase):
                           params_class_3_verbose, metrics='binary_error', fobj=dummy_obj)
 
     def test_multiple_feval_train(self):
-        X, y = load_breast_cancer(True)
+        X, y = load_breast_cancer(return_X_y=True)
 
         params = {'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
 
@@ -1827,7 +1827,7 @@ class TestEngine(unittest.TestCase):
         self.assertIn('decreasing_metric', evals_result['valid_0'])
 
     def test_multiple_feval_cv(self):
-        X, y = load_breast_cancer(True)
+        X, y = load_breast_cancer(return_X_y=True)
 
         params = {'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
 

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -922,7 +922,7 @@ class TestSklearn(unittest.TestCase):
         self.assertEqual(len(gbm.evals_result_['training']), 1)
         self.assertIn('binary_logloss', gbm.evals_result_['training'])
 
-    def test_lgbmclassifier_multiple_eval_metrics(self):
+    def test_multiple_eval_metrics(self):
 
         X, y = load_breast_cancer(return_X_y=True)
 
@@ -958,99 +958,6 @@ class TestSklearn(unittest.TestCase):
         gbm = lgb.LGBMClassifier(**params).fit(eval_metric=['fair', 'error', None], **params_fit)
         self.assertEqual(len(gbm.evals_result_['training']), 3)
         self.assertIn('binary_logloss', gbm.evals_result_['training'])
-
-    def test_lgbmregressor_multiple_eval_metrics(self):
-
-        X, y = load_boston(True)
-
-        params = {'n_estimators': 2, 'verbose': -1, 'metric': 'rmse'}
-        params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
-
-        # Verify that can receive a list of metrics, only callable
-        gbm = lgb.LGBMRegressor(**params).fit(eval_metric=[mse, decreasing_metric], **params_fit)
-        self.assertEqual(len(gbm.evals_result_['training']), 3)
-        self.assertIn('custom MSE', gbm.evals_result_['training'])
-        self.assertIn('decreasing_metric', gbm.evals_result_['training'])
-        self.assertIn('rmse', gbm.evals_result_['training'])
-
-        # Verify that can receive a list of custom and built-in metrics
-        gbm = lgb.LGBMRegressor(**params).fit(eval_metric=[mse, decreasing_metric, 'mape'], **params_fit)
-        self.assertEqual(len(gbm.evals_result_['training']), 4)
-        self.assertIn('custom MSE', gbm.evals_result_['training'])
-        self.assertIn('decreasing_metric', gbm.evals_result_['training'])
-        self.assertIn('mape', gbm.evals_result_['training'])
-        self.assertIn('rmse', gbm.evals_result_['training'])
-
-        # Verify that works as expected when eval_metric is empty
-        gbm = lgb.LGBMRegressor(**params).fit(eval_metric=[], **params_fit)
-        self.assertEqual(len(gbm.evals_result_['training']), 1)
-        self.assertIn('rmse', gbm.evals_result_['training'])
-
-        # Verify that can receive a list of metrics, only built-in
-        gbm = lgb.LGBMRegressor(**params).fit(eval_metric=['mape', 'mae'], **params_fit)
-        self.assertEqual(len(gbm.evals_result_['training']), 3)
-        self.assertIn('mape', gbm.evals_result_['training'])
-        self.assertIn('l1', gbm.evals_result_['training'])
-        self.assertIn('rmse', gbm.evals_result_['training'])
-
-        # Verify that eval_metric is robust to receiving a list with None
-        gbm = lgb.LGBMRegressor(**params).fit(eval_metric=['mape', 'mae', None], **params_fit)
-        self.assertEqual(len(gbm.evals_result_['training']), 3)
-        self.assertIn('mape', gbm.evals_result_['training'])
-        self.assertIn('l1', gbm.evals_result_['training'])
-        self.assertIn('rmse', gbm.evals_result_['training'])
-
-    def test_lgbmranker_multiple_eval_metrics(self):
-
-        X, y = load_svmlight_file(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                               '../../examples/lambdarank/rank.train'))
-
-        q = np.loadtxt(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                    '../../examples/lambdarank/rank.train.query'))
-
-        params = {'n_estimators': 2, 'verbose': -1, 'metric': 'lambdarank'}
-        params_fit = {'X': X, 'y': y, 'eval_set': [(X, y)], 'verbose': False, 'group': q, 'eval_group': [q],
-                      'eval_at': [1, 3]}
-
-        # Verify that can receive a list of metrics, only callable
-        gbm = lgb.LGBMRanker(**params).fit(eval_metric=[constant_metric, decreasing_metric], **params_fit)
-        self.assertEqual(len(gbm.evals_result_['training']), 4)
-        self.assertIn('error', gbm.evals_result_['training'])
-        self.assertIn('decreasing_metric', gbm.evals_result_['training'])
-        self.assertIn('ndcg@1', gbm.evals_result_['training'])
-        self.assertIn('ndcg@3', gbm.evals_result_['training'])
-
-        # Verify that can receive a list of custom and built-in metrics
-        gbm = lgb.LGBMRanker(**params).fit(eval_metric=[constant_metric, decreasing_metric, 'map'], **params_fit)
-        self.assertEqual(len(gbm.evals_result_['training']), 6)
-        self.assertIn('error', gbm.evals_result_['training'])
-        self.assertIn('decreasing_metric', gbm.evals_result_['training'])
-        self.assertIn('map@1', gbm.evals_result_['training'])
-        self.assertIn('map@3', gbm.evals_result_['training'])
-        self.assertIn('ndcg@1', gbm.evals_result_['training'])
-        self.assertIn('ndcg@3', gbm.evals_result_['training'])
-
-        # Verify that works as expected when eval_metric is empty
-        gbm = lgb.LGBMRanker(**params).fit(eval_metric=[], **params_fit)
-        self.assertEqual(len(gbm.evals_result_['training']), 2)
-        self.assertIn('ndcg@1', gbm.evals_result_['training'])
-        self.assertIn('ndcg@3', gbm.evals_result_['training'])
-
-        # Verify that can receive a list of metrics, only built-in
-        gbm = lgb.LGBMRanker(**params).fit(eval_metric=['map'], **params_fit)
-        self.assertEqual(len(gbm.evals_result_['training']), 4)
-        self.assertIn('map@1', gbm.evals_result_['training'])
-        self.assertIn('map@3', gbm.evals_result_['training'])
-        self.assertIn('ndcg@1', gbm.evals_result_['training'])
-        self.assertIn('ndcg@3', gbm.evals_result_['training'])
-
-        # Verify that eval_metric is robust to receiving a list with None
-        gbm = lgb.LGBMRanker(**params).fit(eval_metric=['map', None], **params_fit)
-        self.assertEqual(len(gbm.evals_result_['training']), 4)
-        self.assertIn('map@1', gbm.evals_result_['training'])
-        self.assertIn('map@3', gbm.evals_result_['training'])
-        self.assertIn('ndcg@1', gbm.evals_result_['training'])
-        self.assertIn('ndcg@3', gbm.evals_result_['training'])
 
     def test_inf_handle(self):
         nrows = 100

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -924,7 +924,7 @@ class TestSklearn(unittest.TestCase):
 
     def test_lgbmclassifier_multiple_eval_metrics(self):
 
-        X, y = load_breast_cancer(True)
+        X, y = load_breast_cancer(return_X_y=True)
 
         params = {'n_estimators': 2, 'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
         params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -73,13 +73,6 @@ def multi_error(y_true, y_pred):
 def multi_logloss(y_true, y_pred):
     return np.mean([-math.log(y_pred[i][y]) for i, y in enumerate(y_true)])
 
-def custom_recall(y_true, y_pred):
-    return 'custom_recall', recall_score(y_true, y_pred > 0.5), True
-
-
-def custom_precision(y_true, y_pred):
-    return 'custom_precision', precision_score(y_true, y_pred > 0.5), True
-
 
 class TestSklearn(unittest.TestCase):
 
@@ -937,17 +930,17 @@ class TestSklearn(unittest.TestCase):
         params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
 
         # Verify that can receive a list of metrics, only callable
-        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=[custom_recall, custom_precision], **params_fit)
+        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=[constant_metric, decreasing_metric], **params_fit)
         self.assertEqual(len(gbm.evals_result_['training']), 3)
-        self.assertIn('custom_recall', gbm.evals_result_['training'])
-        self.assertIn('custom_precision', gbm.evals_result_['training'])
+        self.assertIn('error', gbm.evals_result_['training'])
+        self.assertIn('decreasing_metric', gbm.evals_result_['training'])
         self.assertIn('binary_logloss', gbm.evals_result_['training'])
 
         # Verify that can receive a list of custom and built-in metrics
-        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=[custom_recall, custom_precision, 'fair'], **params_fit)
+        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=[constant_metric, decreasing_metric, 'fair'], **params_fit)
         self.assertEqual(len(gbm.evals_result_['training']), 4)
-        self.assertIn('custom_recall', gbm.evals_result_['training'])
-        self.assertIn('custom_precision', gbm.evals_result_['training'])
+        self.assertIn('error', gbm.evals_result_['training'])
+        self.assertIn('decreasing_metric', gbm.evals_result_['training'])
         self.assertIn('binary_logloss', gbm.evals_result_['training'])
         self.assertIn('fair', gbm.evals_result_['training'])
 

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -73,6 +73,13 @@ def multi_error(y_true, y_pred):
 def multi_logloss(y_true, y_pred):
     return np.mean([-math.log(y_pred[i][y]) for i, y in enumerate(y_true)])
 
+def custom_recall(y_true, y_pred):
+    return 'custom_recall', recall_score(y_true, y_pred > 0.5), True
+
+
+def custom_precision(y_true, y_pred):
+    return 'custom_precision', precision_score(y_true, y_pred > 0.5), True
+
 
 class TestSklearn(unittest.TestCase):
 
@@ -862,7 +869,7 @@ class TestSklearn(unittest.TestCase):
         # custom metric for custom objective
         gbm = lgb.LGBMRegressor(objective=custom_dummy_obj,
                                 **params).fit(eval_metric=constant_metric, **params_fit)
-        self.assertEqual(len(gbm.evals_result_['training']), 1)
+        self.assertEqual(len(gbm.evals_result_['training']), 2)
         self.assertIn('error', gbm.evals_result_['training'])
 
         # non-default regression metric with custom metric for custom objective
@@ -921,6 +928,136 @@ class TestSklearn(unittest.TestCase):
                                  **params).fit(eval_metric='multi_logloss', **params_fit)
         self.assertEqual(len(gbm.evals_result_['training']), 1)
         self.assertIn('binary_logloss', gbm.evals_result_['training'])
+
+    def test_lgbmclassifier_multiple_eval_metrics(self):
+
+        X, y = load_breast_cancer(True)
+
+        params = {'n_estimators': 2, 'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
+        params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
+
+        # Verify that can receive a list of metrics, only callable
+        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=[custom_recall, custom_precision], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 3)
+        self.assertIn('custom_recall', gbm.evals_result_['training'])
+        self.assertIn('custom_precision', gbm.evals_result_['training'])
+        self.assertIn('binary_logloss', gbm.evals_result_['training'])
+
+        # Verify that can receive a list of custom and built-in metrics
+        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=[custom_recall, custom_precision, 'fair'], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 4)
+        self.assertIn('custom_recall', gbm.evals_result_['training'])
+        self.assertIn('custom_precision', gbm.evals_result_['training'])
+        self.assertIn('binary_logloss', gbm.evals_result_['training'])
+        self.assertIn('fair', gbm.evals_result_['training'])
+
+        # Verify that works as expected when eval_metric is empty
+        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=[], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 1)
+        self.assertIn('binary_logloss', gbm.evals_result_['training'])
+
+        # Verify that can receive a list of metrics, only built-in
+        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=['fair', 'error'], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 3)
+        self.assertIn('binary_logloss', gbm.evals_result_['training'])
+
+        # Verify that eval_metric is robust to receiving a list with None
+        gbm = lgb.LGBMClassifier(**params).fit(eval_metric=['fair', 'error', None], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 3)
+        self.assertIn('binary_logloss', gbm.evals_result_['training'])
+
+    def test_lgbmregressor_multiple_eval_metrics(self):
+
+        X, y = load_boston(True)
+
+        params = {'n_estimators': 2, 'verbose': -1, 'metric': 'rmse'}
+        params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
+
+        # Verify that can receive a list of metrics, only callable
+        gbm = lgb.LGBMRegressor(**params).fit(eval_metric=[mse, decreasing_metric], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 3)
+        self.assertIn('custom MSE', gbm.evals_result_['training'])
+        self.assertIn('decreasing_metric', gbm.evals_result_['training'])
+        self.assertIn('rmse', gbm.evals_result_['training'])
+
+        # Verify that can receive a list of custom and built-in metrics
+        gbm = lgb.LGBMRegressor(**params).fit(eval_metric=[mse, decreasing_metric, 'mape'], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 4)
+        self.assertIn('custom MSE', gbm.evals_result_['training'])
+        self.assertIn('decreasing_metric', gbm.evals_result_['training'])
+        self.assertIn('mape', gbm.evals_result_['training'])
+        self.assertIn('rmse', gbm.evals_result_['training'])
+
+        # Verify that works as expected when eval_metric is empty
+        gbm = lgb.LGBMRegressor(**params).fit(eval_metric=[], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 1)
+        self.assertIn('rmse', gbm.evals_result_['training'])
+
+        # Verify that can receive a list of metrics, only built-in
+        gbm = lgb.LGBMRegressor(**params).fit(eval_metric=['mape', 'mae'], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 3)
+        self.assertIn('mape', gbm.evals_result_['training'])
+        self.assertIn('l1', gbm.evals_result_['training'])
+        self.assertIn('rmse', gbm.evals_result_['training'])
+
+        # Verify that eval_metric is robust to receiving a list with None
+        gbm = lgb.LGBMRegressor(**params).fit(eval_metric=['mape', 'mae', None], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 3)
+        self.assertIn('mape', gbm.evals_result_['training'])
+        self.assertIn('l1', gbm.evals_result_['training'])
+        self.assertIn('rmse', gbm.evals_result_['training'])
+
+    def test_lgbmranker_multiple_eval_metrics(self):
+
+        X, y = load_svmlight_file(os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                               '../../examples/lambdarank/rank.train'))
+
+        q = np.loadtxt(os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                    '../../examples/lambdarank/rank.train.query'))
+
+        params = {'n_estimators': 2, 'verbose': -1, 'metric': 'lambdarank'}
+        params_fit = {'X': X, 'y': y, 'eval_set': [(X, y)], 'verbose': False, 'group': q, 'eval_group': [q],
+                      'eval_at': [1, 3]}
+
+        # Verify that can receive a list of metrics, only callable
+        gbm = lgb.LGBMRanker(**params).fit(eval_metric=[constant_metric, decreasing_metric], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 4)
+        self.assertIn('error', gbm.evals_result_['training'])
+        self.assertIn('decreasing_metric', gbm.evals_result_['training'])
+        self.assertIn('ndcg@1', gbm.evals_result_['training'])
+        self.assertIn('ndcg@3', gbm.evals_result_['training'])
+
+        # Verify that can receive a list of custom and built-in metrics
+        gbm = lgb.LGBMRanker(**params).fit(eval_metric=[constant_metric, decreasing_metric, 'map'], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 6)
+        self.assertIn('error', gbm.evals_result_['training'])
+        self.assertIn('decreasing_metric', gbm.evals_result_['training'])
+        self.assertIn('map@1', gbm.evals_result_['training'])
+        self.assertIn('map@3', gbm.evals_result_['training'])
+        self.assertIn('ndcg@1', gbm.evals_result_['training'])
+        self.assertIn('ndcg@3', gbm.evals_result_['training'])
+
+        # Verify that works as expected when eval_metric is empty
+        gbm = lgb.LGBMRanker(**params).fit(eval_metric=[], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 2)
+        self.assertIn('ndcg@1', gbm.evals_result_['training'])
+        self.assertIn('ndcg@3', gbm.evals_result_['training'])
+
+        # Verify that can receive a list of metrics, only built-in
+        gbm = lgb.LGBMRanker(**params).fit(eval_metric=['map'], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 4)
+        self.assertIn('map@1', gbm.evals_result_['training'])
+        self.assertIn('map@3', gbm.evals_result_['training'])
+        self.assertIn('ndcg@1', gbm.evals_result_['training'])
+        self.assertIn('ndcg@3', gbm.evals_result_['training'])
+
+        # Verify that eval_metric is robust to receiving a list with None
+        gbm = lgb.LGBMRanker(**params).fit(eval_metric=['map', None], **params_fit)
+        self.assertEqual(len(gbm.evals_result_['training']), 4)
+        self.assertIn('map@1', gbm.evals_result_['training'])
+        self.assertIn('map@3', gbm.evals_result_['training'])
+        self.assertIn('ndcg@1', gbm.evals_result_['training'])
+        self.assertIn('ndcg@3', gbm.evals_result_['training'])
 
     def test_inf_handle(self):
         nrows = 100


### PR DESCRIPTION
This PR refactors the code in LGBM's scikit-learn API to allow the user to pass a list of evaluation metrics to the parameter `eval_metric` in the `fit` method of `LGBMModel` and its subclasses.

The snippet bellow shows an example of the possible uses of this functionality:

```python
import ...

def custom_recall_sklearn(y_true, y_pred):
    return 'recall', recall_score(y_true, y_pred > 0.5), True


def custom_precision_sklearn(y_true, y_pred):
    return 'precision', precision_score(y_true, y_pred > 0.5), True

parameters = {
    "objective": "binary",
    "metric": "binary_logloss",
}

model = lightgbm.LGBMClassifier(**parameters)

model.fit(
    X=train,
    y=train_label,
    eval_set=(validation, validation_label),
    eval_metric=[custom_recall_sklearn, custom_precision_sklearn, "auc"])
```

Where `eval_metric` receives a list that can combine custom and built-in evaluation functions. The output looks like this:

```python
[1]	valid_0's auc: 0.951963	valid_0's binary_logloss: 0.620274	valid_0's recall: 0.963916	valid_0's precision: 0.932162
[2]	valid_0's auc: 0.972375	valid_0's binary_logloss: 0.558293	valid_0's recall: 0.971234	valid_0's precision: 0.93151
[3]	valid_0's auc: 0.975112	valid_0's binary_logloss: 0.507648	valid_0's recall: 0.967701	valid_0's precision: 0.935594
[4]	valid_0's auc: 0.975005	valid_0's binary_logloss: 0.463648	valid_0's recall: 0.96644	valid_0's precision: 0.938495
[5]	valid_0's auc: 0.975215	valid_0's binary_logloss: 0.426748	valid_0's recall: 0.966944	valid_0's precision: 0.939676
```

The user can monitor during training as many metrics as needed.

@StrikerRUS rightly mentioned in PR [3165](https://github.com/microsoft/LightGBM/pull/3165) and in issue [2182](https://github.com/microsoft/LightGBM/issues/2182) that it is possible to monitor multiple metrics already. This PR leverages that functionality to make it a bit more intuitive.

This PR is backwards compatible.

 