### PR TITLE
remove unnecessary semicolon

### DIFF
--- a/include/LightGBM/utils/openmp_wrapper.h
+++ b/include/LightGBM/utils/openmp_wrapper.h
@@ -81,7 +81,7 @@ class ThreadExceptionHelper {
   inline int omp_get_thread_num() {return 0;}
   inline int OMP_NUM_THREADS() { return 1; }
 #ifdef __cplusplus
-};  // extern "C"
+}  // extern "C"
 #endif
 
 #define OMP_INIT_EX()


### PR DESCRIPTION
Looking at the logs from https://github.com/microsoft/LightGBM/issues/629#issuecomment-664714892, I noticed many instances of this:

```
In file included from ./include/LightGBM/utils/common.h:9:0,
                 from ./include/LightGBM/config.h:16,
                 from io/config_auto.cpp:8:
./include/LightGBM/utils/openmp_wrapper.h:84:2: warning: extra ‘;’ [-Wpedantic]
 };  // extern "C"
```

Uses of `extern "C" {}` don't need a closing `;`.

This PR proposes removing the trailing `;` in `openmp_wrapper.h` to suppress this compiler warning when using `-pedantic`.

You can see the R Hub logs here: https://builder.r-hub.io/status/original/lightgbm_2.3.2.tar.gz-6d1aa84ffbbd409293c9dcd94714bb47