### PR TITLE
[R-package] allow R to pick between -fPIC and -fpic for CRAN package

### DIFF
--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -7,8 +7,6 @@ LGB_CPPFLAGS = \
     -DUSE_SOCKET \
     -DLGB_R_BUILD
 
-CPICFLAGS = -fPIC
-
 PKG_CPPFLAGS = \
     -I$(PKGROOT)/include \
     $(LGB_CPPFLAGS)

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -7,8 +7,6 @@ LGB_CPPFLAGS = \
     -DUSE_SOCKET \
     -DLGB_R_BUILD
 
-CPICFLAGS = -fPIC
-
 PKG_CPPFLAGS = \
     -I$(PKGROOT)/include \
     $(LGB_CPPFLAGS)


### PR DESCRIPTION
I think we can remove setting `CPICFLAGS`  in `Makevars.in` and `Makevars.win.in` in the R package. I noticed in the logs from R Hub (https://github.com/microsoft/LightGBM/issues/629#issuecomment-664714892) that my choioce was being ignored anyway...`-fpic` is used in many of the jobs.

Re-reading ["Writing R Extensions"](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Configure-and-cleanup), I see that I probably should have been using `CXX11PICFLAGS`.

In this PR, I propose just removing `CPICFLAGS` from these Makefiles and using whatever values R chooses based on the environment it is installed in. That should slightly simplify our configuration and reduce the risk of the CRAN package failing checks on the many obscure environments CRAN uses for testing.