### PR TITLE
create buffer for gradients and hessians with goss and customized objective (fixes #3243)

### DIFF
--- a/src/boosting/goss.hpp
+++ b/src/boosting/goss.hpp
@@ -61,7 +61,7 @@ class GOSS: public GBDT {
       CHECK(hessians != nullptr && objective_function_ == nullptr);
       size_t total_size = static_cast<size_t>(num_data_) * num_tree_per_iteration_;
       #pragma omp parallel for schedule(static)
-      for(size_t i = 0; i < total_size; ++i) {
+      for (size_t i = 0; i < total_size; ++i) {
         gradients_[i] = gradients[i];
         hessians_[i] = hessians[i];
       }

--- a/src/boosting/goss.hpp
+++ b/src/boosting/goss.hpp
@@ -36,6 +36,12 @@ class GOSS: public GBDT {
             const std::vector<const Metric*>& training_metrics) override {
     GBDT::Init(config, train_data, objective_function, training_metrics);
     ResetGoss();
+    if (objective_function_ == nullptr) {
+      // use customized objective function
+      size_t total_size = static_cast<size_t>(num_data_) * num_tree_per_iteration_;
+      gradients_.resize(total_size, 0.0f);
+      hessians_.resize(total_size, 0.0f);
+    }
   }
 
   void ResetTrainingData(const Dataset* train_data, const ObjectiveFunction* objective_function,
@@ -47,6 +53,23 @@ class GOSS: public GBDT {
   void ResetConfig(const Config* config) override {
     GBDT::ResetConfig(config);
     ResetGoss();
+  }
+
+  bool TrainOneIter(const score_t* gradients, const score_t* hessians) override {
+    if (gradients != nullptr) {
+      // use customized objective function
+      CHECK(hessians != nullptr && objective_function_ == nullptr);
+      size_t total_size = static_cast<size_t>(num_data_) * num_tree_per_iteration_;
+      #pragma omp parallel for schedule(static)
+      for(size_t i = 0; i < total_size; ++i) {
+        gradients_[i] = gradients[i];
+        hessians_[i] = hessians[i];
+      }
+      return GBDT::TrainOneIter(gradients_.data(), hessians_.data());
+    } else {
+      CHECK(hessians == nullptr);
+      return GBDT::TrainOneIter(nullptr, nullptr);
+    }
   }
 
   void ResetGoss() {


### PR DESCRIPTION
This is to fix Issue #3243.
The gradients_ and hessians_ of GBDT object is of size 0 if customized objective function is used.
> https://github.com/microsoft/LightGBM/blob/1cf13dbaa433c414b2ec871ac4090bb853eceb1f/src/boosting/gbdt.cpp#L95-L99

However, they are used by the bagging function of GOSS, for example
> https://github.com/microsoft/LightGBM/blob/1cf13dbaa433c414b2ec871ac4090bb853eceb1f/src/boosting/goss.hpp#L103-L106

which causes the segment fault.