### PR TITLE
Pr4 advanced method monotone constraints

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -472,6 +472,8 @@ Learning Control Parameters
 
       -  ``intermediate``, a `more advanced method <https://github.com/microsoft/LightGBM/files/3457826/PR-monotone-constraints-report.pdf>`__, which may slow the library very slightly. However, this method is much less constraining than the basic method and should significantly improve the results
 
+      -  ``advanced``, an `even more advanced method <https://github.com/microsoft/LightGBM/files/3457826/PR-monotone-constraints-report.pdf>`__, which may slow the library. However, this method is even less constraining than the intermediate method and should again significantly improve the results
+
 -  ``monotone_penalty`` :raw-html:`<a id="monotone_penalty" title="Permalink to this parameter" href="#monotone_penalty">&#x1F517;&#xFE0E;</a>`, default = ``0.0``, type = double, aliases: ``monotone_splits_penalty``, ``ms_penalty``, ``mc_penalty``, constraints: ``monotone_penalty >= 0.0``
 
    -  used only if ``monotone_constraints`` is set

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -462,7 +462,7 @@ Learning Control Parameters
 
    -  you need to specify all features in order. For example, ``mc=-1,0,1`` means decreasing for 1st feature, non-constraint for 2nd feature and increasing for the 3rd feature
 
--  ``monotone_constraints_method`` :raw-html:`<a id="monotone_constraints_method" title="Permalink to this parameter" href="#monotone_constraints_method">&#x1F517;&#xFE0E;</a>`, default = ``basic``, type = enum, options: ``basic``, ``intermediate``, aliases: ``monotone_constraining_method``, ``mc_method``
+-  ``monotone_constraints_method`` :raw-html:`<a id="monotone_constraints_method" title="Permalink to this parameter" href="#monotone_constraints_method">&#x1F517;&#xFE0E;</a>`, default = ``basic``, type = enum, options: ``basic``, ``intermediate``, ``advanced``, aliases: ``monotone_constraining_method``, ``mc_method``
 
    -  used only if ``monotone_constraints`` is set
 

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -443,7 +443,7 @@ struct Config {
 
   // type = enum
   // alias = monotone_constraining_method, mc_method
-  // options = basic, intermediate
+  // options = basic, intermediate, advanced
   // desc = used only if ``monotone_constraints`` is set
   // desc = monotone constraints method
   // descl2 = ``basic``, the most basic monotone constraints method. It does not slow the library at all, but over-constrains the predictions

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -448,6 +448,7 @@ struct Config {
   // desc = monotone constraints method
   // descl2 = ``basic``, the most basic monotone constraints method. It does not slow the library at all, but over-constrains the predictions
   // descl2 = ``intermediate``, a `more advanced method <https://github.com/microsoft/LightGBM/files/3457826/PR-monotone-constraints-report.pdf>`__, which may slow the library very slightly. However, this method is much less constraining than the basic method and should significantly improve the results
+  // descl2 = ``advanced``, an `even more advanced method <https://github.com/microsoft/LightGBM/files/3457826/PR-monotone-constraints-report.pdf>`__, which may slow the library. However, this method is even less constraining than the intermediate method and should again significantly improve the results
   std::string monotone_constraints_method = "basic";
 
   // alias = monotone_splits_penalty, ms_penalty, mc_penalty

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -347,13 +347,13 @@ void Config::CheckParamConflict() {
   }
   if (is_parallel && monotone_constraints_method == std::string("intermediate")) {
     // In distributed mode, local node doesn't have histograms on all features, cannot perform "intermediate" monotone constraints.
-    Log::Warning("Cannot use \"intermediate\" monotone constraints in parallel learning, auto set to \"basic\" method.");
+    Log::Warning("Cannot use \"intermediate\" or \"advanced\" monotone constraints in parallel learning, auto set to \"basic\" method.");
     monotone_constraints_method = "basic";
   }
   if (feature_fraction_bynode != 1.0 && monotone_constraints_method == std::string("intermediate")) {
     // "intermediate" monotone constraints need to recompute splits. If the features are sampled when computing the
     // split initially, then the sampling needs to be recorded or done once again, which is currently not supported
-    Log::Warning("Cannot use \"intermediate\" monotone constraints with feature fraction different from 1, auto set monotone constraints to \"basic\" method.");
+    Log::Warning("Cannot use \"intermediate\" or \"advanced\" monotone constraints with feature fraction different from 1, auto set monotone constraints to \"basic\" method.");
     monotone_constraints_method = "basic";
   }
   if (max_depth > 0 && monotone_penalty >= max_depth) {

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -345,12 +345,12 @@ void Config::CheckParamConflict() {
     min_data_in_leaf = 2;
     Log::Warning("min_data_in_leaf has been increased to 2 because this is required when path smoothing is active.");
   }
-  if (is_parallel && monotone_constraints_method == std::string("intermediate")) {
+  if (is_parallel && (monotone_constraints_method == std::string("intermediate") || monotone_constraints_method == std::string("intermediate"))) {
     // In distributed mode, local node doesn't have histograms on all features, cannot perform "intermediate" monotone constraints.
     Log::Warning("Cannot use \"intermediate\" or \"advanced\" monotone constraints in parallel learning, auto set to \"basic\" method.");
     monotone_constraints_method = "basic";
   }
-  if (feature_fraction_bynode != 1.0 && monotone_constraints_method == std::string("intermediate")) {
+  if (feature_fraction_bynode != 1.0 && (monotone_constraints_method == std::string("intermediate") || monotone_constraints_method == std::string("advanced"))) {
     // "intermediate" monotone constraints need to recompute splits. If the features are sampled when computing the
     // split initially, then the sampling needs to be recorded or done once again, which is currently not supported
     Log::Warning("Cannot use \"intermediate\" or \"advanced\" monotone constraints with feature fraction different from 1, auto set monotone constraints to \"basic\" method.");

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -345,7 +345,7 @@ void Config::CheckParamConflict() {
     min_data_in_leaf = 2;
     Log::Warning("min_data_in_leaf has been increased to 2 because this is required when path smoothing is active.");
   }
-  if (is_parallel && (monotone_constraints_method == std::string("intermediate") || monotone_constraints_method == std::string("intermediate"))) {
+  if (is_parallel && (monotone_constraints_method == std::string("intermediate") || monotone_constraints_method == std::string("advanced"))) {
     // In distributed mode, local node doesn't have histograms on all features, cannot perform "intermediate" monotone constraints.
     Log::Warning("Cannot use \"intermediate\" or \"advanced\" monotone constraints in parallel learning, auto set to \"basic\" method.");
     monotone_constraints_method = "basic";

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -951,8 +951,8 @@ class FeatureHistogram {
           best_threshold = static_cast<uint32_t>(t - 1 + offset);
           best_gain = current_gain;
           if (USE_MC) {
-            best_right_constraints = (constraints->RightToBasicConstraint());
-            best_left_constraints = (constraints->LeftToBasicConstraint());
+            best_right_constraints = constraints->RightToBasicConstraint();
+            best_left_constraints = constraints->LeftToBasicConstraint();
           }
         }
       }
@@ -1039,8 +1039,8 @@ class FeatureHistogram {
           best_threshold = static_cast<uint32_t>(t + offset);
           best_gain = current_gain;
           if (USE_MC) {
-            best_right_constraints = (constraints->RightToBasicConstraint());
-            best_left_constraints = (constraints->LeftToBasicConstraint());
+            best_right_constraints = constraints->RightToBasicConstraint();
+            best_left_constraints = constraints->LeftToBasicConstraint();
           }
         }
       }

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -84,7 +84,7 @@ class FeatureHistogram {
 
   void FindBestThreshold(double sum_gradient, double sum_hessian,
                          data_size_t num_data,
-                         FeatureConstraint* constraints,
+                         const FeatureConstraint* constraints,
                          double parent_output,
                          SplitInfo* output) {
     output->default_left = true;
@@ -158,7 +158,7 @@ class FeatureHistogram {
 #define TEMPLATE_PREFIX USE_RAND, USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING
 #define LAMBDA_ARGUMENTS                                         \
   double sum_gradient, double sum_hessian, data_size_t num_data, \
-      FeatureConstraint* constraints, double parent_output, SplitInfo *output
+      const FeatureConstraint* constraints, double parent_output, SplitInfo *output
 #define BEFORE_ARGUMENTS sum_gradient, sum_hessian, parent_output, num_data, output, &rand_threshold
 #define FUNC_ARGUMENTS                                                      \
   sum_gradient, sum_hessian, num_data, constraints, min_gain_shift, \
@@ -278,7 +278,7 @@ class FeatureHistogram {
   void FindBestThresholdCategoricalInner(double sum_gradient,
                                          double sum_hessian,
                                          data_size_t num_data,
-                                         FeatureConstraint* constraints,
+                                         const FeatureConstraint* constraints,
                                          double parent_output,
                                          SplitInfo* output) {
     is_splittable_ = false;
@@ -787,7 +787,7 @@ class FeatureHistogram {
                               double sum_right_gradients,
                               double sum_right_hessians, double l1, double l2,
                               double max_delta_step,
-                              FeatureConstraint* constraints,
+                              const FeatureConstraint* constraints,
                               int8_t monotone_constraint,
                               double smoothing,
                               data_size_t left_count,
@@ -853,12 +853,11 @@ class FeatureHistogram {
     }
   }
 
-  // FIXME Make constraints const again and have the cumulative constraints outside of it?
   template <bool USE_RAND, bool USE_MC, bool USE_L1, bool USE_MAX_OUTPUT, bool USE_SMOOTHING,
             bool REVERSE, bool SKIP_DEFAULT_BIN, bool NA_AS_MISSING>
   void FindBestThresholdSequentially(double sum_gradient, double sum_hessian,
                                      data_size_t num_data,
-                                     FeatureConstraint* constraints,
+                                     const FeatureConstraint* constraints,
                                      double min_gain_shift, SplitInfo* output,
                                      int rand_threshold, double parent_output) {
     const int8_t offset = meta_->offset;
@@ -1080,7 +1079,7 @@ class FeatureHistogram {
   hist_t* data_;
   bool is_splittable_ = true;
 
-  std::function<void(double, double, data_size_t, FeatureConstraint*,
+  std::function<void(double, double, data_size_t, const FeatureConstraint*,
                      double, SplitInfo*)>
       find_best_threshold_fun_;
 };

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -764,7 +764,7 @@ class FeatureHistogram {
   template <bool USE_MC, bool USE_L1, bool USE_MAX_OUTPUT, bool USE_SMOOTHING>
   static double CalculateSplittedLeafOutput(
       double sum_gradients, double sum_hessians, double l1, double l2,
-      double max_delta_step, const BasicConstraint constraints,
+      double max_delta_step, const BasicConstraint& constraints,
       double smoothing, data_size_t num_data, double parent_output) {
     double ret = CalculateSplittedLeafOutput<USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
         sum_gradients, sum_hessians, l1, l2, max_delta_step, smoothing, num_data, parent_output);

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -84,7 +84,7 @@ class FeatureHistogram {
 
   void FindBestThreshold(double sum_gradient, double sum_hessian,
                          data_size_t num_data,
-                         const ConstraintEntry& constraints,
+                         FeatureConstraint* constraints,
                          double parent_output,
                          SplitInfo* output) {
     output->default_left = true;
@@ -158,7 +158,7 @@ class FeatureHistogram {
 #define TEMPLATE_PREFIX USE_RAND, USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING
 #define LAMBDA_ARGUMENTS                                         \
   double sum_gradient, double sum_hessian, data_size_t num_data, \
-      const ConstraintEntry &constraints, double parent_output, SplitInfo *output
+      FeatureConstraint* constraints, double parent_output, SplitInfo *output
 #define BEFORE_ARGUMENTS sum_gradient, sum_hessian, parent_output, num_data, output, &rand_threshold
 #define FUNC_ARGUMENTS                                                      \
   sum_gradient, sum_hessian, num_data, constraints, min_gain_shift, \
@@ -278,7 +278,7 @@ class FeatureHistogram {
   void FindBestThresholdCategoricalInner(double sum_gradient,
                                          double sum_hessian,
                                          data_size_t num_data,
-                                         const ConstraintEntry& constraints,
+                                         FeatureConstraint* constraints,
                                          double parent_output,
                                          SplitInfo* output) {
     is_splittable_ = false;
@@ -288,6 +288,7 @@ class FeatureHistogram {
     double best_sum_left_gradient = 0;
     double best_sum_left_hessian = 0;
     double gain_shift;
+    constraints->InitCumulativeConstraints(true);
     if (USE_SMOOTHING) {
       gain_shift = GetLeafGainGivenOutput<USE_L1>(
           sum_gradient, sum_hessian, meta_->config->lambda_l1, meta_->config->lambda_l2, parent_output);
@@ -474,14 +475,14 @@ class FeatureHistogram {
       output->left_output = CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
           best_sum_left_gradient, best_sum_left_hessian,
           meta_->config->lambda_l1, l2, meta_->config->max_delta_step,
-          constraints, meta_->config->path_smooth, best_left_count, parent_output);
+          constraints->LeftToBasicConstraint(), meta_->config->path_smooth, best_left_count, parent_output);
       output->left_count = best_left_count;
       output->left_sum_gradient = best_sum_left_gradient;
       output->left_sum_hessian = best_sum_left_hessian - kEpsilon;
       output->right_output = CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
           sum_gradient - best_sum_left_gradient,
           sum_hessian - best_sum_left_hessian, meta_->config->lambda_l1, l2,
-          meta_->config->max_delta_step, constraints, meta_->config->path_smooth,
+          meta_->config->max_delta_step, constraints->RightToBasicConstraint(), meta_->config->path_smooth,
           num_data - best_left_count, parent_output);
       output->right_count = num_data - best_left_count;
       output->right_sum_gradient = sum_gradient - best_sum_left_gradient;
@@ -763,7 +764,7 @@ class FeatureHistogram {
   template <bool USE_MC, bool USE_L1, bool USE_MAX_OUTPUT, bool USE_SMOOTHING>
   static double CalculateSplittedLeafOutput(
       double sum_gradients, double sum_hessians, double l1, double l2,
-      double max_delta_step, const ConstraintEntry& constraints,
+      double max_delta_step, const BasicConstraint constraints,
       double smoothing, data_size_t num_data, double parent_output) {
     double ret = CalculateSplittedLeafOutput<USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
         sum_gradients, sum_hessians, l1, l2, max_delta_step, smoothing, num_data, parent_output);
@@ -784,7 +785,7 @@ class FeatureHistogram {
                               double sum_right_gradients,
                               double sum_right_hessians, double l1, double l2,
                               double max_delta_step,
-                              const ConstraintEntry& constraints,
+                              FeatureConstraint* constraints,
                               int8_t monotone_constraint,
                               double smoothing,
                               data_size_t left_count,
@@ -803,11 +804,11 @@ class FeatureHistogram {
       double left_output =
           CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
               sum_left_gradients, sum_left_hessians, l1, l2, max_delta_step,
-              constraints, smoothing, left_count, parent_output);
+              constraints->LeftToBasicConstraint(), smoothing, left_count, parent_output);
       double right_output =
           CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
               sum_right_gradients, sum_right_hessians, l1, l2, max_delta_step,
-              constraints, smoothing, right_count, parent_output);
+              constraints->RightToBasicConstraint(), smoothing, right_count, parent_output);
       if (((monotone_constraint > 0) && (left_output > right_output)) ||
           ((monotone_constraint < 0) && (left_output < right_output))) {
         return 0;
@@ -850,11 +851,12 @@ class FeatureHistogram {
     }
   }
 
+  // FIXME Make constraints const again and have the cumulative constraints outside of it?
   template <bool USE_RAND, bool USE_MC, bool USE_L1, bool USE_MAX_OUTPUT, bool USE_SMOOTHING,
             bool REVERSE, bool SKIP_DEFAULT_BIN, bool NA_AS_MISSING>
   void FindBestThresholdSequentially(double sum_gradient, double sum_hessian,
                                      data_size_t num_data,
-                                     const ConstraintEntry& constraints,
+                                     FeatureConstraint* constraints,
                                      double min_gain_shift, SplitInfo* output,
                                      int rand_threshold, double parent_output) {
     const int8_t offset = meta_->offset;
@@ -864,6 +866,13 @@ class FeatureHistogram {
     data_size_t best_left_count = 0;
     uint32_t best_threshold = static_cast<uint32_t>(meta_->num_bin);
     const double cnt_factor = num_data / sum_hessian;
+    BasicConstraint best_right_constraints;
+    BasicConstraint best_left_constraints;
+
+    bool constraint_update_necessary =
+        constraints->ConstraintDifferentDependingOnThreshold();
+    constraints->InitCumulativeConstraints(REVERSE);
+
     if (REVERSE) {
       double sum_right_gradient = 0.0f;
       double sum_right_hessian = kEpsilon;
@@ -910,6 +919,11 @@ class FeatureHistogram {
             continue;
           }
         }
+
+        if (constraint_update_necessary) {
+          constraints->Update(t + offset);
+        }
+
         // current split gain
         double current_gain = GetSplitGains<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
             sum_left_gradient, sum_left_hessian, sum_right_gradient,
@@ -932,6 +946,8 @@ class FeatureHistogram {
           // left is <= threshold, right is > threshold.  so this is t-1
           best_threshold = static_cast<uint32_t>(t - 1 + offset);
           best_gain = current_gain;
+          best_right_constraints = (constraints->RightToBasicConstraint());
+          best_left_constraints = (constraints->LeftToBasicConstraint());
         }
       }
     } else {
@@ -1016,6 +1032,8 @@ class FeatureHistogram {
           best_sum_left_hessian = sum_left_hessian;
           best_threshold = static_cast<uint32_t>(t + offset);
           best_gain = current_gain;
+          best_right_constraints = (constraints->RightToBasicConstraint());
+          best_left_constraints = (constraints->LeftToBasicConstraint());
         }
       }
     }
@@ -1027,7 +1045,7 @@ class FeatureHistogram {
           CalculateSplittedLeafOutput<USE_MC, USE_L1, USE_MAX_OUTPUT, USE_SMOOTHING>(
               best_sum_left_gradient, best_sum_left_hessian,
               meta_->config->lambda_l1, meta_->config->lambda_l2,
-              meta_->config->max_delta_step, constraints, meta_->config->path_smooth,
+              meta_->config->max_delta_step, best_left_constraints, meta_->config->path_smooth,
               best_left_count, parent_output);
       output->left_count = best_left_count;
       output->left_sum_gradient = best_sum_left_gradient;
@@ -1037,7 +1055,7 @@ class FeatureHistogram {
               sum_gradient - best_sum_left_gradient,
               sum_hessian - best_sum_left_hessian, meta_->config->lambda_l1,
               meta_->config->lambda_l2, meta_->config->max_delta_step,
-              constraints, meta_->config->path_smooth, num_data - best_left_count,
+              best_right_constraints, meta_->config->path_smooth, num_data - best_left_count,
               parent_output);
       output->right_count = num_data - best_left_count;
       output->right_sum_gradient = sum_gradient - best_sum_left_gradient;
@@ -1053,7 +1071,7 @@ class FeatureHistogram {
   hist_t* data_;
   bool is_splittable_ = true;
 
-  std::function<void(double, double, data_size_t, const ConstraintEntry&,
+  std::function<void(double, double, data_size_t, FeatureConstraint*,
                      double, SplitInfo*)>
       find_best_threshold_fun_;
 };

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -986,11 +986,10 @@ class AdvancedLeafConstraints : public IntermediateLeafConstraints {
     if ((monotone_type == -1 && min_constraints_to_be_updated) ||
         (monotone_type == 1 && !min_constraints_to_be_updated)) {
       return std::pair<bool, bool>(true, false);
-    }
-//    Same as
-//    if ((monotone_type == 1 && min_constraints_to_be_updated) ||
-//        (monotone_type == -1 && !min_constraints_to_be_updated))
-    else {
+    } else {
+      //    Same as
+      //    if ((monotone_type == 1 && min_constraints_to_be_updated) ||
+      //        (monotone_type == -1 && !min_constraints_to_be_updated))
       return std::pair<bool, bool>(false, true);
     }
   }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -28,8 +28,8 @@ struct BasicConstraint {
 };
 
 struct FeatureConstraint {
-  virtual void InitCumulativeConstraints(bool) {}
-  virtual void Update(int) {}
+  virtual void InitCumulativeConstraints(bool) const {}
+  virtual void Update(int) const {}
   virtual BasicConstraint LeftToBasicConstraint() const = 0;
   virtual BasicConstraint RightToBasicConstraint() const = 0;
   virtual bool ConstraintDifferentDependingOnThreshold() const = 0;
@@ -258,16 +258,16 @@ struct CumulativeFeatureConstraint {
 struct AdvancedFeatureConstraints : FeatureConstraint {
   FeatureMinOrMaxConstraints min_constraints;
   FeatureMinOrMaxConstraints max_constraints;
-  CumulativeFeatureConstraint cumulative_feature_constraint;
+  mutable CumulativeFeatureConstraint cumulative_feature_constraint;
   bool min_constraints_to_be_recomputed = false;
   bool max_constraints_to_be_recomputed = false;
 
-  void InitCumulativeConstraints(bool REVERSE) final {
+  void InitCumulativeConstraints(bool REVERSE) const final {
     cumulative_feature_constraint =
         CumulativeFeatureConstraint(min_constraints, max_constraints, REVERSE);
   }
 
-  void Update(int threshold) final {
+  void Update(int threshold) const final {
     cumulative_feature_constraint.Update(threshold);
   }
 

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -852,7 +852,7 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
 };
 
 class AdvancedLeafConstraints : public IntermediateLeafConstraints {
-public:
+ public:
   AdvancedLeafConstraints(const Config *config, int num_leaves,
                           int num_features)
       : IntermediateLeafConstraints(config, num_leaves) {

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -413,7 +413,7 @@ struct AdvancedConstraintEntry : ConstraintEntry {
   }
 
   // for each feature, an array of constraints needs to be stored
-  explicit AdvancedConstraintEntry(unsigned int num_features) {
+  explicit AdvancedConstraintEntry(int num_features) {
     constraints.resize(num_features);
   }
 

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -461,7 +461,7 @@ struct AdvancedConstraintEntry : ConstraintEntry {
 class BasicLeafConstraints : public LeafConstraintsBase {
  public:
   explicit BasicLeafConstraints(int num_leaves) : num_leaves_(num_leaves) {
-    for (int i = 0; i < num_leaves; i++) {
+    for (int i = 0; i < num_leaves; ++i) {
       entries_.push_back(new BasicConstraintEntry());
     }
   }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -430,7 +430,7 @@ struct AdvancedConstraintEntry : ConstraintEntry {
   }
 
   void UpdateMax(double new_max) final {
-    for (unsigned int i = 0; i < constraints.size(); i++) {
+    for (size_t i = 0; i < constraints.size(); ++i) {
       constraints[i].UpdateMax(new_max, false);
     }
   }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -146,10 +146,10 @@ struct CumulativeFeatureConstraint {
   std::vector<double> cumulative_min_constraints_right_to_left;
   std::vector<double> cumulative_max_constraints_left_to_right;
   std::vector<double> cumulative_max_constraints_right_to_left;
-  unsigned int index_min_constraints_left_to_right;
-  unsigned int index_min_constraints_right_to_left;
-  unsigned int index_max_constraints_left_to_right;
-  unsigned int index_max_constraints_right_to_left;
+  size_t index_min_constraints_left_to_right;
+  size_t index_min_constraints_right_to_left;
+  size_t index_max_constraints_left_to_right;
+  size_t index_max_constraints_right_to_left;
 
   static void CumulativeExtremum(
       const double &(*extremum_function)(const double &, const double &),

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -131,7 +131,7 @@ struct FeatureMinOrMaxConstraints {
   }
 
   void UpdateMax(double max) {
-    for (unsigned int j = 0; j < constraints.size(); j++) {
+    for (size_t j = 0; j < constraints.size(); ++j) {
       if (max < constraints[j]) {
         constraints[j] = max;
       }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -878,7 +878,7 @@ class AdvancedLeafConstraints : public IntermediateLeafConstraints {
     // the previous constraint that still applies needs to be recorded
     double previous_constraint;
     double current_constraint;
-    for (unsigned int i = 0; i < feature_constraint->thresholds.size();) {
+    for (size_t i = 0; i < feature_constraint->thresholds.size();) {
       current_constraint = feature_constraint->constraints[i];
       // easy case when the thresholds match
       if (feature_constraint->thresholds[i] == it_start) {

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -436,7 +436,7 @@ struct AdvancedConstraintEntry : ConstraintEntry {
   }
 
   bool UpdateMinAndReturnBoolIfChanged(double new_min) final {
-    for (unsigned int i = 0; i < constraints.size(); i++) {
+    for (size_t i = 0; i < constraints.size(); ++i) {
       constraints[i].UpdateMin(new_min, true);
     }
     // even if nothing changed, this could have been unconstrained so it needs

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -424,7 +424,7 @@ struct AdvancedConstraintEntry : ConstraintEntry {
   }
 
   void UpdateMin(double new_min) final {
-    for (unsigned int i = 0; i < constraints.size(); i++) {
+    for (size_t i = 0; i < constraints.size(); ++i) {
       constraints[i].UpdateMin(new_min, false);
     }
   }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -880,7 +880,7 @@ class AdvancedLeafConstraints : public IntermediateLeafConstraints {
       ? -std::numeric_limits<double>::max()
       : std::numeric_limits<double>::max();
     double current_constraint;
-    for (size_t i = 0; i < feature_constraint->thresholds.size();) {
+    for (size_t i = 0; i < feature_constraint->thresholds.size(); ++i) {
       current_constraint = feature_constraint->constraints[i];
       // easy case when the thresholds match
       if (feature_constraint->thresholds[i] == it_start) {
@@ -908,14 +908,13 @@ class AdvancedLeafConstraints : public IntermediateLeafConstraints {
                 feature_constraint->constraints.begin() + i, extremum);
             feature_constraint->thresholds.insert(
                 feature_constraint->thresholds.begin() + i, it_start);
-            i += 1;
+            ++i;
           }
         }
       }
       // easy case when the end thresholds match
       if (feature_constraint->thresholds[i] == it_end) {
         end_done = true;
-        i += 1;
         break;
       }
       // if they don't then, the previous constraint needs to be added back
@@ -929,7 +928,6 @@ class AdvancedLeafConstraints : public IntermediateLeafConstraints {
               feature_constraint->thresholds.begin() + i, it_end);
         }
         end_done = true;
-        i += 1;
         break;
       }
       // If 2 successive constraints are the same then the second one may as
@@ -941,10 +939,9 @@ class AdvancedLeafConstraints : public IntermediateLeafConstraints {
         feature_constraint->thresholds.erase(
             feature_constraint->thresholds.begin() + i);
         previous_constraint = current_constraint;
-        i -= 1;
+        --i;
       }
       previous_constraint = current_constraint;
-      i += 1;
     }
     // if the loop didn't get to an index greater than it_start, it needs to be
     // added at the end

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -445,7 +445,7 @@ struct AdvancedConstraintEntry : ConstraintEntry {
   }
 
   bool UpdateMaxAndReturnBoolIfChanged(double new_max) final {
-    for (unsigned int i = 0; i < constraints.size(); i++) {
+    for (size_t i = 0; i < constraints.size(); ++i) {
       constraints[i].UpdateMax(new_max, true);
     }
     // even if nothing changed, this could have been unconstrained so it needs

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -856,7 +856,7 @@ class AdvancedLeafConstraints : public IntermediateLeafConstraints {
   AdvancedLeafConstraints(const Config *config, int num_leaves,
                           int num_features)
       : IntermediateLeafConstraints(config, num_leaves) {
-    for (int i = 0; i < num_leaves; i++) {
+    for (int i = 0; i < num_leaves; ++i) {
       entries_[i] = new AdvancedConstraintEntry(num_features);
     }
   }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -418,7 +418,7 @@ struct AdvancedConstraintEntry : ConstraintEntry {
   }
 
   void Reset() final {
-    for (unsigned int i = 0; i < constraints.size(); i++) {
+    for (size_t i = 0; i < constraints.size(); ++i) {
       constraints[i].Reset();
     }
   }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -474,7 +474,7 @@ class BasicLeafConstraints : public LeafConstraintsBase {
 
   void RecomputeConstraintsIfNeeded(
       LeafConstraintsBase* constraints_,
-      int feature_for_constraint, int leaf_idx, uint32_t it_end) {
+      int feature_for_constraint, int leaf_idx, uint32_t it_end) override{
     entries_[~leaf_idx]->RecomputeConstraintsIfNeeded(constraints_, feature_for_constraint, leaf_idx, it_end);
   }
 

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -28,8 +28,8 @@ struct BasicConstraint {
 };
 
 struct FeatureConstraint {
-  virtual void InitCumulativeConstraints(bool) {};
-  virtual void Update(int) {};
+  virtual void InitCumulativeConstraints(bool) {}
+  virtual void Update(int) {}
   virtual BasicConstraint LeftToBasicConstraint() const = 0;
   virtual BasicConstraint RightToBasicConstraint() const = 0;
   virtual bool ConstraintDifferentDependingOnThreshold() const = 0;
@@ -44,7 +44,7 @@ struct ConstraintEntry {
   virtual ConstraintEntry *clone() const = 0;
 
   virtual void RecomputeConstraintsIfNeeded(LeafConstraintsBase *, int, int,
-                                            uint32_t) {};
+                                            uint32_t) {}
 
   virtual FeatureConstraint *GetFeatureConstraint(int feature_index) = 0;
 };
@@ -53,7 +53,6 @@ struct ConstraintEntry {
 struct BasicConstraintEntry : ConstraintEntry,
                               FeatureConstraint,
                               BasicConstraint {
-
   bool ConstraintDifferentDependingOnThreshold() const final { return false; }
 
   BasicConstraintEntry *clone() const final {
@@ -107,7 +106,7 @@ struct FeatureMinOrMaxConstraints {
 
   size_t Size() const { return thresholds.size(); }
 
-  FeatureMinOrMaxConstraints(double extremum) {
+  explicit FeatureMinOrMaxConstraints(double extremum) {
     constraints.reserve(32);
     thresholds.reserve(32);
 
@@ -160,7 +159,7 @@ struct CumulativeFeatureConstraint {
     }
 
 #ifdef DEBUG
-    CHECK(cumulative_extremum.size() != 0);
+    CHECK_NE(cumulative_extremum.size(), 0);
 #endif
 
     std::size_t n_exts = cumulative_extremum.size();
@@ -413,7 +412,7 @@ struct AdvancedConstraintEntry : ConstraintEntry {
   }
 
   // for each feature, an array of constraints needs to be stored
-  AdvancedConstraintEntry(unsigned int num_features) {
+  explicit AdvancedConstraintEntry(unsigned int num_features) {
     constraints.resize(num_features);
   }
 
@@ -474,7 +473,7 @@ class BasicLeafConstraints : public LeafConstraintsBase {
 
   void RecomputeConstraintsIfNeeded(
       LeafConstraintsBase* constraints_,
-      int feature_for_constraint, int leaf_idx, uint32_t it_end) override{
+      int feature_for_constraint, int leaf_idx, uint32_t it_end) override {
     entries_[~leaf_idx]->RecomputeConstraintsIfNeeded(constraints_, feature_for_constraint, leaf_idx, it_end);
   }
 
@@ -1014,7 +1013,7 @@ public:
 #endif
       UpdateConstraints(feature_constraint, extremum, it_start, it_end,
                         min_constraints_to_be_updated, last_threshold);
-    } else { // if node, keep going down the tree
+    } else {  // if node, keep going down the tree
       // check if the children are contiguous to the original leaf and therefore
       // potentially constraining
       std::pair<bool, bool> keep_going_left_right = ShouldKeepGoingLeftRight(

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -123,7 +123,7 @@ struct FeatureMinOrMaxConstraints {
   }
 
   void UpdateMin(double min) {
-    for (unsigned int j = 0; j < constraints.size(); j++) {
+    for (size_t j = 0; j < constraints.size(); ++j) {
       if (min > constraints[j]) {
         constraints[j] = min;
       }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -33,6 +33,7 @@ struct FeatureConstraint {
   virtual BasicConstraint LeftToBasicConstraint() const = 0;
   virtual BasicConstraint RightToBasicConstraint() const = 0;
   virtual bool ConstraintDifferentDependingOnThreshold() const = 0;
+  virtual ~FeatureConstraint() {}
 };
 
 struct ConstraintEntry {

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -499,7 +499,7 @@ class BasicLeafConstraints : public LeafConstraintsBase {
 
   const ConstraintEntry* Get(int leaf_idx) override { return entries_[leaf_idx]; }
 
-  FeatureConstraint* GetFeatureConstraint(int leaf_idx, int feature_index) {
+  FeatureConstraint* GetFeatureConstraint(int leaf_idx, int feature_index) final {
     return entries_[leaf_idx]->GetFeatureConstraint(feature_index);
   }
 

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -610,8 +610,7 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
         }
       }
       return true;
-    }
-    else {
+    } else {
       return false;
     }
   }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -988,8 +988,10 @@ public:
         (monotone_type == 1 && !min_constraints_to_be_updated)) {
       return std::pair<bool, bool>(true, false);
     }
-    if ((monotone_type == 1 && min_constraints_to_be_updated) ||
-        (monotone_type == -1 && !min_constraints_to_be_updated)) {
+//    Same as
+//    if ((monotone_type == 1 && min_constraints_to_be_updated) ||
+//        (monotone_type == -1 && !min_constraints_to_be_updated))
+    else {
       return std::pair<bool, bool>(false, true);
     }
   }

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -590,7 +590,6 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
       int inner_feature,
       const std::vector<bool>& was_original_leaf_right_child_of_split,
       bool is_in_right_child) {
-
     // if the split is categorical, it is not handled by this optimisation,
     // so the code will have to go down in the other child subtree to see if
     // there are leaves to update

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -202,7 +202,6 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
       int inner_feature,
       const std::vector<bool>& was_original_leaf_right_child_of_split,
       bool is_in_right_child) {
-    bool opposite_child_should_be_updated = true;
 
     // if the split is categorical, it is not handled by this optimisation,
     // so the code will have to go down in the other child subtree to see if
@@ -220,12 +219,14 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
                 inner_feature &&
             (was_original_leaf_right_child_of_split[split_idx] ==
              is_in_right_child)) {
-          opposite_child_should_be_updated = false;
-          break;
+          return false;
         }
       }
+      return true;
     }
-    return opposite_child_should_be_updated;
+    else {
+      return false;
+    }
   }
 
   // Recursive function that goes up the tree, and then down to find leaves that
@@ -248,7 +249,7 @@ class IntermediateLeafConstraints : public BasicLeafConstraints {
       int feature = tree_->split_feature(parent_idx);
       int8_t monotone_type = config_->monotone_constraints[feature];
       bool is_in_right_child = tree_->right_child(parent_idx) == node_idx;
-      bool is_split_numerical = tree_->IsNumericalSplit(node_idx);
+      bool is_split_numerical = tree_->IsNumericalSplit(parent_idx);
 
       // this is just an optimisation not to waste time going down in subtrees
       // where there won't be any leaf to update

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -876,7 +876,9 @@ class AdvancedLeafConstraints : public IntermediateLeafConstraints {
     // [0, 1, 2] and  [cstr1, cstr2, cstr1]
     // so since we loop through thresholds only once,
     // the previous constraint that still applies needs to be recorded
-    double previous_constraint;
+    double previous_constraint = use_max_operator
+      ? -std::numeric_limits<double>::max()
+      : std::numeric_limits<double>::max();
     double current_constraint;
     for (size_t i = 0; i < feature_constraint->thresholds.size();) {
       current_constraint = feature_constraint->constraints[i];

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -163,10 +163,10 @@ struct CumulativeFeatureConstraint {
     CHECK_NE(cumulative_extremum->size(), 0);
 #endif
 
-    std::size_t n_exts = cumulative_extremum->size();
+    size_t n_exts = cumulative_extremum->size();
     int step = is_direction_from_left_to_right ? 1 : -1;
-    std::size_t start = is_direction_from_left_to_right ? 0 : n_exts - 1;
-    std::size_t end = is_direction_from_left_to_right ? n_exts - 1 : 0;
+    size_t start = is_direction_from_left_to_right ? 0 : n_exts - 1;
+    size_t end = is_direction_from_left_to_right ? n_exts - 1 : 0;
 
     for (auto i = start; i != end; i = i + step) {
       (*cumulative_extremum)[i + step] = extremum_function(

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -714,7 +714,7 @@ void SerialTreeLearner::ComputeBestSplitForFeature(
 
   bool is_feature_numerical = train_data_->FeatureBinMapper(feature_index)
                                   ->bin_type() == BinType::NumericalBin;
-  if (is_feature_numerical) {
+  if (is_feature_numerical & !config_->monotone_constraints.empty()) {
     constraints_->RecomputeConstraintsIfNeeded(
         constraints_.get(), feature_index, ~(leaf_splits->leaf_index()),
         train_data_->FeatureNumBin(feature_index));

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -719,7 +719,7 @@ void SerialTreeLearner::ComputeBestSplitForFeature(
         constraints_.get(), feature_index, ~(leaf_splits->leaf_index()),
         train_data_->FeatureNumBin(feature_index));
   }
-  
+
   SplitInfo new_split;
   double parent_output;
   if (leaf_splits->leaf_index() == 0) {

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -715,9 +715,9 @@ void SerialTreeLearner::ComputeBestSplitForFeature(
   double parent_output;
   if (leaf_splits->leaf_index() == 0) {
     // for root leaf the "parent" output is its own output because we don't apply any smoothing to the root
-    parent_output = FeatureHistogram::CalculateSplittedLeafOutput<true, true, true, false>(
+    parent_output = FeatureHistogram::CalculateSplittedLeafOutput<false, true, true, false>(
         leaf_splits->sum_gradients(), leaf_splits->sum_hessians(), config_->lambda_l1,
-        config_->lambda_l2, config_->max_delta_step, constraints_->Get(leaf_splits->leaf_index()),
+        config_->lambda_l2, config_->max_delta_step, ConstraintEntry(),
         config_->path_smooth, static_cast<data_size_t>(num_data), 0);
   } else {
     parent_output = leaf_splits->weight();

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -561,7 +561,7 @@ void SerialTreeLearner::SplitInner(Tree* tree, int best_leaf, int* left_leaf,
   auto next_leaf_id = tree->NextLeafId();
 
   // update before tree split
-  constraints_->BeforeSplit(tree, best_leaf, next_leaf_id,
+  constraints_->BeforeSplit(best_leaf, next_leaf_id,
                             best_split_info.monotone_type);
 
   bool is_numerical_split =
@@ -657,7 +657,7 @@ void SerialTreeLearner::SplitInner(Tree* tree, int best_leaf, int* left_leaf,
                               best_split_info.left_output);
   }
   auto leaves_need_update = constraints_->Update(
-      tree, is_numerical_split, *left_leaf, *right_leaf,
+      is_numerical_split, *left_leaf, *right_leaf,
       best_split_info.monotone_type, best_split_info.right_output,
       best_split_info.left_output, inner_feature_index, best_split_info,
       best_split_per_leaf_);

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1202,7 +1202,7 @@ class TestEngine(unittest.TestCase):
 
         for test_with_categorical_variable in [True, False]:
             trainset = self.generate_trainset_for_monotone_constraints_tests(test_with_categorical_variable)
-            for monotone_constraints_method in ["basic", "intermediate"]:
+            for monotone_constraints_method in ["basic", "intermediate", "advanced"]:
                 params = {
                     'min_data': 20,
                     'num_leaves': 20,
@@ -1236,7 +1236,7 @@ class TestEngine(unittest.TestCase):
         monotone_constraints = [1, -1, 0]
         penalization_parameter = 2.0
         trainset = self.generate_trainset_for_monotone_constraints_tests(x3_to_category=False)
-        for monotone_constraints_method in ["basic", "intermediate"]:
+        for monotone_constraints_method in ["basic", "intermediate", "advanced"]:
             params = {
                 'max_depth': max_depth,
                 'monotone_constraints': monotone_constraints,
@@ -1275,7 +1275,7 @@ class TestEngine(unittest.TestCase):
         unconstrained_model_predictions = unconstrained_model.\
             predict(x3_negatively_correlated_with_y.reshape(-1, 1))
 
-        for monotone_constraints_method in ["basic", "intermediate"]:
+        for monotone_constraints_method in ["basic", "intermediate", "advanced"]:
             params_constrained_model["monotone_constraints_method"] = monotone_constraints_method
             # The penalization is so high that the first 2 features should not be used here
             constrained_model = lgb.train(params_constrained_model, trainset_constrained_model, 10)


### PR DESCRIPTION
@aldanor @redditur

@guolinke @jameslamb @StrikerRUS 
Following PRs #2305, #2717, #2770, and #2939 here is the last PR of the series. #2305 was judged to be not merge-able because it was too big. Therefore, in my ultimate comment I said I would split it into smaller PRs easier to merge. #2717 was some refactoring, #2770 was the intermediate method, #2939 was the monotone penalization, and this PR is about the advanced method.

As a reminder, the basic method over-constrains leaves, and creates "unused space" between them. The intermediate method is smarter in updating the constraints and creates less "space" between the leaves, but it doesn't take into account that depending on thresholds, a leaf on the right and on the left of a monotone splits may not have to constrain each other. This advanced method takes it into account, and recomputes leaves constraints from the beginning when needed. This leads in a more expressive model, with a meaningfully better training loss. More details in the original report https://github.com/microsoft/LightGBM/files/3457826/PR-monotone-constraints-report.pdf. Feel free to ask for more details. 

About the code, most changes happen in the monotone_constraints.hpp file, where the new AdvancedLeafConstraints has been added. Tests have been updated to include this new constraining method. 

2 things in the original PR that are missing in here:
- The code was more optimized for time in the original PR, and the method is a bit slower here. Though the optimizations made the code significantly more complicated, and I think the time saved was not much. I can implement the optimization in another PR later, as I think this PR is complicated enough as is.
- In the original PR, once a tree is build, there was a final leaves refitting, that I have not implemented here yet. I can either implement it here or in another PR later. This can slightly improve performance.

I am looking forward to your review. Thanks.