### PR TITLE
[ci] run Travis and Azure Pipelines only for master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+if: branch = master
+
 language: cpp
 
 git:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,10 +1,12 @@
 trigger:
   branches:
     include:
-    - '*'
+    - master
   tags:
     include:
     - v*
+pr:
+- master
 variables:
   PYTHON_VERSION: 3.8
   CONDA_ENV: test-env


### PR DESCRIPTION
This removes remained duplicated runs of CI for PRs from the original repo and now is in consistency with Appveyor and GitHub Actions configs.

Refer to #3096.