### PR TITLE
[R-package] move all examples to dontrun() to fix R CMD CHECK notes

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -173,6 +173,7 @@ check_succeeded="yes"
 (
     R CMD check ${PKG_TARBALL} \
         --as-cran \
+        --run-dontrun \
     || check_succeeded="no"
 ) &
 

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -160,7 +160,7 @@ if ($env:COMPILER -ne "MSVC") {
   }
 
   Write-Output "Running R CMD check as CRAN"
-  Run-R-Code-Redirect-Stderr "result <- processx::run(command = 'R.exe', args = c('CMD', 'check', '--no-multiarch', '--as-cran', '$PKG_FILE_NAME'), echo = TRUE, windows_verbatim_args = FALSE)" ; $check_succeeded = $?
+  Run-R-Code-Redirect-Stderr "result <- processx::run(command = 'R.exe', args = c('CMD', 'check', '--no-multiarch', '--as-cran', '--run-dontrun', '$PKG_FILE_NAME'), echo = TRUE, windows_verbatim_args = FALSE)" ; $check_succeeded = $?
 
   Write-Output "R CMD check build logs:"
   $INSTALL_LOG_FILE_NAME = "lightgbm.Rcheck\00install.out"

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -774,7 +774,7 @@ predict.lgb.Booster <- function(object,
 #' @return lgb.Booster
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -834,7 +834,7 @@ lgb.load <- function(filename = NULL, model_str = NULL) {
 #' @return lgb.Booster
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(lightgbm)
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
@@ -882,7 +882,7 @@ lgb.save <- function(booster, filename, num_iteration = NULL) {
 #' @return json format of model
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(lightgbm)
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
@@ -930,6 +930,7 @@ lgb.dump <- function(booster, num_iteration = NULL) {
 #' @return vector of evaluation result
 #'
 #' @examples
+#' \dontrun{
 #' # train a regression model
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
@@ -956,6 +957,7 @@ lgb.dump <- function(booster, num_iteration = NULL) {
 #'
 #' # Get L2 values for "test" dataset
 #' lgb.get.eval.result(model, "test", "l2")
+#' }
 #' @export
 lgb.get.eval.result <- function(booster, data_name, eval_name, iters = NULL, is_err = FALSE) {
 

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -718,6 +718,7 @@ Booster <- R6::R6Class(
 #'         number of columns corresponding to the number of trees.
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -735,6 +736,7 @@ Booster <- R6::R6Class(
 #'   , learning_rate = 1.0
 #' )
 #' preds <- predict(model, test$data)
+#' }
 #' @export
 predict.lgb.Booster <- function(object,
                                 data,

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -725,6 +725,7 @@ Dataset <- R6::R6Class(
 #' @return constructed dataset
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -732,7 +733,7 @@ Dataset <- R6::R6Class(
 #' lgb.Dataset.save(dtrain, data_file)
 #' dtrain <- lgb.Dataset(data_file)
 #' lgb.Dataset.construct(dtrain)
-#'
+#' }
 #' @export
 lgb.Dataset <- function(data,
                         params = list(),
@@ -770,13 +771,14 @@ lgb.Dataset <- function(data,
 #' @return constructed dataset
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
 #' data(agaricus.test, package = "lightgbm")
 #' test <- agaricus.test
 #' dtest <- lgb.Dataset.create.valid(dtrain, test$data, label = test$label)
-#'
+#' }
 #' @export
 lgb.Dataset.create.valid <- function(dataset, data, info = list(), ...) {
 
@@ -796,11 +798,12 @@ lgb.Dataset.create.valid <- function(dataset, data, info = list(), ...) {
 #' @param dataset Object of class \code{lgb.Dataset}
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
 #' lgb.Dataset.construct(dtrain)
-#'
+#' }
 #' @export
 lgb.Dataset.construct <- function(dataset) {
 
@@ -826,6 +829,7 @@ lgb.Dataset.construct <- function(dataset) {
 #' be directly used with an \code{lgb.Dataset} object.
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -833,7 +837,7 @@ lgb.Dataset.construct <- function(dataset) {
 #' stopifnot(nrow(dtrain) == nrow(train$data))
 #' stopifnot(ncol(dtrain) == ncol(train$data))
 #' stopifnot(all(dim(dtrain) == dim(train$data)))
-#'
+#' }
 #' @rdname dim
 #' @export
 dim.lgb.Dataset <- function(x, ...) {
@@ -860,6 +864,7 @@ dim.lgb.Dataset <- function(x, ...) {
 #' Since row names are irrelevant, it is recommended to use \code{colnames} directly.
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -868,7 +873,7 @@ dim.lgb.Dataset <- function(x, ...) {
 #' colnames(dtrain)
 #' colnames(dtrain) <- make.names(seq_len(ncol(train$data)))
 #' print(dtrain, verbose = TRUE)
-#'
+#' }
 #' @rdname dimnames.lgb.Dataset
 #' @export
 dimnames.lgb.Dataset <- function(x) {
@@ -932,6 +937,7 @@ dimnames.lgb.Dataset <- function(x) {
 #' @return constructed sub dataset
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -939,7 +945,7 @@ dimnames.lgb.Dataset <- function(x) {
 #' dsub <- lightgbm::slice(dtrain, seq_len(42L))
 #' lgb.Dataset.construct(dsub)
 #' labels <- lightgbm::getinfo(dsub, "label")
-#'
+#' }
 #' @export
 slice <- function(dataset, ...) {
   UseMethod("slice")
@@ -978,6 +984,7 @@ slice.lgb.Dataset <- function(dataset, idxset, ...) {
 #' }
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -988,7 +995,7 @@ slice.lgb.Dataset <- function(dataset, idxset, ...) {
 #'
 #' labels2 <- lightgbm::getinfo(dtrain, "label")
 #' stopifnot(all(labels2 == 1 - labels))
-#'
+#' }
 #' @export
 getinfo <- function(dataset, ...) {
   UseMethod("getinfo")
@@ -1031,6 +1038,7 @@ getinfo.lgb.Dataset <- function(dataset, name, ...) {
 #' }
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -1041,7 +1049,7 @@ getinfo.lgb.Dataset <- function(dataset, name, ...) {
 #'
 #' labels2 <- lightgbm::getinfo(dtrain, "label")
 #' stopifnot(all.equal(labels2, 1 - labels))
-#'
+#' }
 #' @export
 setinfo <- function(dataset, ...) {
   UseMethod("setinfo")
@@ -1071,6 +1079,7 @@ setinfo.lgb.Dataset <- function(dataset, name, info, ...) {
 #' @return passed dataset
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -1078,7 +1087,7 @@ setinfo.lgb.Dataset <- function(dataset, name, info, ...) {
 #' lgb.Dataset.save(dtrain, data_file)
 #' dtrain <- lgb.Dataset(data_file)
 #' lgb.Dataset.set.categorical(dtrain, 1L:2L)
-#'
+#' }
 #' @rdname lgb.Dataset.set.categorical
 #' @export
 lgb.Dataset.set.categorical <- function(dataset, categorical_feature) {
@@ -1102,6 +1111,7 @@ lgb.Dataset.set.categorical <- function(dataset, categorical_feature) {
 #' @return passed dataset
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package ="lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -1109,7 +1119,7 @@ lgb.Dataset.set.categorical <- function(dataset, categorical_feature) {
 #' test <- agaricus.test
 #' dtest <- lgb.Dataset(test$data, test = train$label)
 #' lgb.Dataset.set.reference(dtest, dtrain)
-#'
+#' }
 #' @rdname lgb.Dataset.set.reference
 #' @export
 lgb.Dataset.set.reference <- function(dataset, reference) {
@@ -1133,10 +1143,12 @@ lgb.Dataset.set.reference <- function(dataset, reference) {
 #' @return passed dataset
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
 #' lgb.Dataset.save(dtrain, tempfile(fileext = ".bin"))
+#' }
 #' @export
 lgb.Dataset.save <- function(dataset, fname) {
 

--- a/R-package/R/lgb.convert.R
+++ b/R-package/R/lgb.convert.R
@@ -23,7 +23,7 @@
 #' # When lightgbm package is installed, and you do not want to load it
 #' # You can still use the function!
 #' lgb.unloader()
-#' str(lightgbm::lgb.convert(data = iris))
+#' str(lgb.convert(data = iris))
 #' # 'data.frame':	150 obs. of  5 variables:
 #' # $ Sepal.Length: num  5.1 4.9 4.7 4.6 5 5.4 4.6 5 4.4 4.9 ...
 #' # $ Sepal.Width : num  3.5 3 3.2 3.1 3.6 3.9 3.4 3.4 2.9 3.1 ...

--- a/R-package/R/lgb.convert.R
+++ b/R-package/R/lgb.convert.R
@@ -20,7 +20,6 @@
 #' # Convert all factors/chars to integer
 #' str(lgb.convert(data = iris))
 #'
-#' \dontrun{
 #' # When lightgbm package is installed, and you do not want to load it
 #' # You can still use the function!
 #' lgb.unloader()
@@ -31,7 +30,6 @@
 #' # $ Petal.Length: num  1.4 1.4 1.3 1.5 1.4 1.7 1.4 1.5 1.4 1.5 ...
 #' # $ Petal.Width : num  0.2 0.2 0.2 0.2 0.2 0.4 0.3 0.2 0.2 0.1 ...
 #' # $ Species     : int  1 1 1 1 1 1 1 1 1 1 ...
-#' }
 #' }
 #' @export
 lgb.convert <- function(data) {

--- a/R-package/R/lgb.convert.R
+++ b/R-package/R/lgb.convert.R
@@ -12,6 +12,7 @@
 #'         for input in \code{lgb.Dataset}.
 #'
 #' @examples
+#' \dontrun{
 #' data(iris)
 #'
 #' str(iris)
@@ -31,7 +32,7 @@
 #' # $ Petal.Width : num  0.2 0.2 0.2 0.2 0.2 0.4 0.3 0.2 0.2 0.1 ...
 #' # $ Species     : int  1 1 1 1 1 1 1 1 1 1 ...
 #' }
-#'
+#' }
 #' @export
 lgb.convert <- function(data) {
 

--- a/R-package/R/lgb.convert_with_rules.R
+++ b/R-package/R/lgb.convert_with_rules.R
@@ -13,6 +13,7 @@
 #'         \code{lgb.Dataset}.
 #'
 #' @examples
+#' \dontrun{
 #' data(iris)
 #'
 #' str(iris)
@@ -48,7 +49,7 @@
 #' )
 #' newest_iris <- lgb.convert_with_rules(data = iris, rules = personal_rules)
 #' str(newest_iris$data) # SUCCESS!
-#'
+#' }
 #' @importFrom data.table set
 #' @export
 lgb.convert_with_rules <- function(data, rules = NULL) {

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -56,6 +56,7 @@ CVBooster <- R6::R6Class(
 #' @return a trained model \code{lgb.CVBooster}.
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -68,6 +69,7 @@ CVBooster <- R6::R6Class(
 #'   , min_data = 1L
 #'   , learning_rate = 1.0
 #' )
+#' }
 #' @importFrom data.table data.table setorderv
 #' @export
 lgb.cv <- function(params = list()

--- a/R-package/R/lgb.importance.R
+++ b/R-package/R/lgb.importance.R
@@ -13,6 +13,7 @@
 #' }
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -32,7 +33,7 @@
 #'
 #' tree_imp1 <- lgb.importance(model, percentage = TRUE)
 #' tree_imp2 <- lgb.importance(model, percentage = FALSE)
-#'
+#' }
 #' @importFrom data.table := setnames setorderv
 #' @export
 lgb.importance <- function(model, percentage = TRUE) {

--- a/R-package/R/lgb.interprete.R
+++ b/R-package/R/lgb.interprete.R
@@ -16,6 +16,7 @@
 #'         Contribution columns to each class.
 #'
 #' @examples
+#' \dontrun{
 #' Logit <- function(x) log(x / (1.0 - x))
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
@@ -38,7 +39,7 @@
 #' )
 #'
 #' tree_interpretation <- lgb.interprete(model, test$data, 1L:5L)
-#'
+#' }
 #' @importFrom data.table as.data.table
 #' @export
 lgb.interprete <- function(model,

--- a/R-package/R/lgb.model.dt.tree.R
+++ b/R-package/R/lgb.model.dt.tree.R
@@ -28,7 +28,7 @@
 #' }
 #'
 #' @examples
-#'
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -44,7 +44,7 @@
 #' model <- lgb.train(params, dtrain, 10L)
 #'
 #' tree_dt <- lgb.model.dt.tree(model)
-#'
+#' }
 #' @importFrom data.table := rbindlist
 #' @importFrom jsonlite fromJSON
 #' @export

--- a/R-package/R/lgb.plot.importance.R
+++ b/R-package/R/lgb.plot.importance.R
@@ -18,6 +18,7 @@
 #' and silently returns a processed data.table with \code{top_n} features sorted by defined importance.
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -37,6 +38,7 @@
 #'
 #' tree_imp <- lgb.importance(model, percentage = TRUE)
 #' lgb.plot.importance(tree_imp, top_n = 5L, measure = "Gain")
+#' }
 #' @importFrom graphics barplot par
 #' @export
 lgb.plot.importance <- function(tree_imp,

--- a/R-package/R/lgb.plot.interpretation.R
+++ b/R-package/R/lgb.plot.interpretation.R
@@ -15,7 +15,7 @@
 #' The \code{lgb.plot.interpretation} function creates a \code{barplot}.
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' Logit <- function(x) {
 #'   log(x / (1.0 - x))
 #' }

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -29,6 +29,7 @@
 #' @return a trained booster model \code{lgb.Booster}.
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -46,6 +47,7 @@
 #'   , learning_rate = 1.0
 #'   , early_stopping_rounds = 3L
 #' )
+#' }
 #' @export
 lgb.train <- function(params = list(),
                       data,

--- a/R-package/R/lgb.unloader.R
+++ b/R-package/R/lgb.unloader.R
@@ -14,6 +14,7 @@
 #' @return NULL invisibly.
 #'
 #' @examples
+#' \dontrun{
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train
 #' dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -39,7 +40,7 @@
 #' library(lightgbm)
 #' # Do whatever you want again with LightGBM without object clashing
 #' }
-#'
+#' }
 #' @export
 lgb.unloader <- function(restore = TRUE, wipe = FALSE, envir = .GlobalEnv) {
 

--- a/R-package/R/lgb.unloader.R
+++ b/R-package/R/lgb.unloader.R
@@ -32,14 +32,12 @@
 #'   , learning_rate = 1.0
 #' )
 #'
-#' \dontrun{
 #' lgb.unloader(restore = FALSE, wipe = FALSE, envir = .GlobalEnv)
 #' rm(model, dtrain, dtest) # Not needed if wipe = TRUE
 #' gc() # Not needed if wipe = TRUE
 #'
 #' library(lightgbm)
 #' # Do whatever you want again with LightGBM without object clashing
-#' }
 #' }
 #' @export
 lgb.unloader <- function(restore = TRUE, wipe = FALSE, envir = .GlobalEnv) {

--- a/R-package/R/readRDS.lgb.Booster.R
+++ b/R-package/R/readRDS.lgb.Booster.R
@@ -7,7 +7,7 @@
 #' @return \code{lgb.Booster}.
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(lightgbm)
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train

--- a/R-package/R/saveRDS.lgb.Booster.R
+++ b/R-package/R/saveRDS.lgb.Booster.R
@@ -18,7 +18,7 @@
 #' @return NULL invisibly.
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(lightgbm)
 #' data(agaricus.train, package = "lightgbm")
 #' train <- agaricus.train

--- a/R-package/man/dim.Rd
+++ b/R-package/man/dim.Rd
@@ -22,6 +22,7 @@ Note: since \code{nrow} and \code{ncol} internally use \code{dim}, they can also
 be directly used with an \code{lgb.Dataset} object.
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -29,5 +30,5 @@ dtrain <- lgb.Dataset(train$data, label = train$label)
 stopifnot(nrow(dtrain) == nrow(train$data))
 stopifnot(ncol(dtrain) == ncol(train$data))
 stopifnot(all(dim(dtrain) == dim(train$data)))
-
+}
 }

--- a/R-package/man/dimnames.lgb.Dataset.Rd
+++ b/R-package/man/dimnames.lgb.Dataset.Rd
@@ -24,6 +24,7 @@ Generic \code{dimnames} methods are used by \code{colnames}.
 Since row names are irrelevant, it is recommended to use \code{colnames} directly.
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -32,5 +33,5 @@ dimnames(dtrain)
 colnames(dtrain)
 colnames(dtrain) <- make.names(seq_len(ncol(train$data)))
 print(dtrain, verbose = TRUE)
-
+}
 }

--- a/R-package/man/getinfo.Rd
+++ b/R-package/man/getinfo.Rd
@@ -33,6 +33,7 @@ The \code{name} field can be one of the following:
 }
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -43,5 +44,5 @@ lightgbm::setinfo(dtrain, "label", 1 - labels)
 
 labels2 <- lightgbm::getinfo(dtrain, "label")
 stopifnot(all(labels2 == 1 - labels))
-
+}
 }

--- a/R-package/man/lgb.Dataset.Rd
+++ b/R-package/man/lgb.Dataset.Rd
@@ -40,6 +40,7 @@ Construct \code{lgb.Dataset} object from dense matrix, sparse matrix
              or local file (that was created previously by saving an \code{lgb.Dataset}).
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -47,5 +48,5 @@ data_file <- tempfile(fileext = ".data")
 lgb.Dataset.save(dtrain, data_file)
 dtrain <- lgb.Dataset(data_file)
 lgb.Dataset.construct(dtrain)
-
+}
 }

--- a/R-package/man/lgb.Dataset.construct.Rd
+++ b/R-package/man/lgb.Dataset.construct.Rd
@@ -13,9 +13,10 @@ lgb.Dataset.construct(dataset)
 Construct Dataset explicitly
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
 lgb.Dataset.construct(dtrain)
-
+}
 }

--- a/R-package/man/lgb.Dataset.create.valid.Rd
+++ b/R-package/man/lgb.Dataset.create.valid.Rd
@@ -22,11 +22,12 @@ constructed dataset
 Construct validation data according to training data
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
 data(agaricus.test, package = "lightgbm")
 test <- agaricus.test
 dtest <- lgb.Dataset.create.valid(dtrain, test$data, label = test$label)
-
+}
 }

--- a/R-package/man/lgb.Dataset.save.Rd
+++ b/R-package/man/lgb.Dataset.save.Rd
@@ -19,8 +19,10 @@ Please note that \code{init_score} is not saved in binary file.
              If you need it, please set it again after loading Dataset.
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
 lgb.Dataset.save(dtrain, tempfile(fileext = ".bin"))
+}
 }

--- a/R-package/man/lgb.Dataset.set.categorical.Rd
+++ b/R-package/man/lgb.Dataset.set.categorical.Rd
@@ -21,6 +21,7 @@ Set the categorical features of an \code{lgb.Dataset} object. Use this function
              to tell LightGBM which features should be treated as categorical.
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -28,5 +29,5 @@ data_file <- tempfile(fileext = ".data")
 lgb.Dataset.save(dtrain, data_file)
 dtrain <- lgb.Dataset(data_file)
 lgb.Dataset.set.categorical(dtrain, 1L:2L)
-
+}
 }

--- a/R-package/man/lgb.Dataset.set.reference.Rd
+++ b/R-package/man/lgb.Dataset.set.reference.Rd
@@ -18,6 +18,7 @@ passed dataset
 If you want to use validation data, you should set reference to training data
 }
 \examples{
+\dontrun{
 data(agaricus.train, package ="lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -25,5 +26,5 @@ data(agaricus.test, package = "lightgbm")
 test <- agaricus.test
 dtest <- lgb.Dataset(test$data, test = train$label)
 lgb.Dataset.set.reference(dtest, dtrain)
-
+}
 }

--- a/R-package/man/lgb.convert.Rd
+++ b/R-package/man/lgb.convert.Rd
@@ -31,7 +31,6 @@ str(iris)
 # Convert all factors/chars to integer
 str(lgb.convert(data = iris))
 
-\dontrun{
 # When lightgbm package is installed, and you do not want to load it
 # You can still use the function!
 lgb.unloader()
@@ -42,6 +41,5 @@ str(lightgbm::lgb.convert(data = iris))
 # $ Petal.Length: num  1.4 1.4 1.3 1.5 1.4 1.7 1.4 1.5 1.4 1.5 ...
 # $ Petal.Width : num  0.2 0.2 0.2 0.2 0.2 0.4 0.3 0.2 0.2 0.1 ...
 # $ Species     : int  1 1 1 1 1 1 1 1 1 1 ...
-}
 }
 }

--- a/R-package/man/lgb.convert.Rd
+++ b/R-package/man/lgb.convert.Rd
@@ -34,7 +34,7 @@ str(lgb.convert(data = iris))
 # When lightgbm package is installed, and you do not want to load it
 # You can still use the function!
 lgb.unloader()
-str(lightgbm::lgb.convert(data = iris))
+str(lgb.convert(data = iris))
 # 'data.frame':	150 obs. of  5 variables:
 # $ Sepal.Length: num  5.1 4.9 4.7 4.6 5 5.4 4.6 5 4.4 4.9 ...
 # $ Sepal.Width : num  3.5 3 3.2 3.1 3.6 3.9 3.4 3.4 2.9 3.1 ...

--- a/R-package/man/lgb.convert.Rd
+++ b/R-package/man/lgb.convert.Rd
@@ -23,6 +23,7 @@ Attempts to prepare a clean dataset to prepare to put in a \code{lgb.Dataset}.
              NOTE: In previous releases of LightGBM, this function was called \code{lgb.prepare}.
 }
 \examples{
+\dontrun{
 data(iris)
 
 str(iris)
@@ -42,5 +43,5 @@ str(lightgbm::lgb.convert(data = iris))
 # $ Petal.Width : num  0.2 0.2 0.2 0.2 0.2 0.4 0.3 0.2 0.2 0.1 ...
 # $ Species     : int  1 1 1 1 1 1 1 1 1 1 ...
 }
-
+}
 }

--- a/R-package/man/lgb.convert_with_rules.Rd
+++ b/R-package/man/lgb.convert_with_rules.Rd
@@ -25,6 +25,7 @@ Attempts to prepare a clean dataset to prepare to put in a \code{lgb.Dataset}.
              NOTE: In previous releases of LightGBM, this function was called \code{lgb.prepare_rules2}.
 }
 \examples{
+\dontrun{
 data(iris)
 
 str(iris)
@@ -60,5 +61,5 @@ personal_rules <- list(
 )
 newest_iris <- lgb.convert_with_rules(data = iris, rules = personal_rules)
 str(newest_iris$data) # SUCCESS!
-
+}
 }

--- a/R-package/man/lgb.cv.Rd
+++ b/R-package/man/lgb.cv.Rd
@@ -100,6 +100,7 @@ a trained model \code{lgb.CVBooster}.
 Cross validation logic used by LightGBM
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -112,4 +113,5 @@ model <- lgb.cv(
   , min_data = 1L
   , learning_rate = 1.0
 )
+}
 }

--- a/R-package/man/lgb.dump.Rd
+++ b/R-package/man/lgb.dump.Rd
@@ -18,7 +18,7 @@ json format of model
 Dump LightGBM model to json
 }
 \examples{
-\donttest{
+\dontrun{
 library(lightgbm)
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train

--- a/R-package/man/lgb.get.eval.result.Rd
+++ b/R-package/man/lgb.get.eval.result.Rd
@@ -32,6 +32,7 @@ Given a \code{lgb.Booster}, return evaluation results for a
              particular metric on a particular dataset.
 }
 \examples{
+\dontrun{
 # train a regression model
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
@@ -58,4 +59,5 @@ print(names(model$record_evals[["test"]]))
 
 # Get L2 values for "test" dataset
 lgb.get.eval.result(model, "test", "l2")
+}
 }

--- a/R-package/man/lgb.importance.Rd
+++ b/R-package/man/lgb.importance.Rd
@@ -24,6 +24,7 @@ For a tree model, a \code{data.table} with the following columns:
 Creates a \code{data.table} of feature importances in a model.
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -43,5 +44,5 @@ model <- lgb.train(
 
 tree_imp1 <- lgb.importance(model, percentage = TRUE)
 tree_imp2 <- lgb.importance(model, percentage = FALSE)
-
+}
 }

--- a/R-package/man/lgb.interprete.Rd
+++ b/R-package/man/lgb.interprete.Rd
@@ -29,6 +29,7 @@ For regression, binary classification and lambdarank model, a \code{list} of \co
 Computes feature contribution components of rawscore prediction.
 }
 \examples{
+\dontrun{
 Logit <- function(x) log(x / (1.0 - x))
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
@@ -51,5 +52,5 @@ model <- lgb.train(
 )
 
 tree_interpretation <- lgb.interprete(model, test$data, 1L:5L)
-
+}
 }

--- a/R-package/man/lgb.load.Rd
+++ b/R-package/man/lgb.load.Rd
@@ -19,7 +19,7 @@ Load LightGBM takes in either a file path or model string.
               If both are provided, Load will default to loading from file
 }
 \examples{
-\donttest{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)

--- a/R-package/man/lgb.model.dt.tree.Rd
+++ b/R-package/man/lgb.model.dt.tree.Rd
@@ -39,7 +39,7 @@ The columns of the \code{data.table} are:
 Parse a LightGBM model json dump into a \code{data.table} structure.
 }
 \examples{
-
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -55,5 +55,5 @@ params <- list(
 model <- lgb.train(params, dtrain, 10L)
 
 tree_dt <- lgb.model.dt.tree(model)
-
+}
 }

--- a/R-package/man/lgb.plot.importance.Rd
+++ b/R-package/man/lgb.plot.importance.Rd
@@ -37,6 +37,7 @@ The graph represents each feature as a horizontal bar of length proportional to 
 Features are shown ranked in a decreasing importance order.
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -56,4 +57,5 @@ model <- lgb.train(
 
 tree_imp <- lgb.importance(model, percentage = TRUE)
 lgb.plot.importance(tree_imp, top_n = 5L, measure = "Gain")
+}
 }

--- a/R-package/man/lgb.plot.interpretation.Rd
+++ b/R-package/man/lgb.plot.interpretation.Rd
@@ -34,7 +34,7 @@ The graph represents each feature as a horizontal bar of length proportional to 
 contribution of a feature. Features are shown ranked in a decreasing contribution order.
 }
 \examples{
-\donttest{
+\dontrun{
 Logit <- function(x) {
   log(x / (1.0 - x))
 }

--- a/R-package/man/lgb.save.Rd
+++ b/R-package/man/lgb.save.Rd
@@ -20,7 +20,7 @@ lgb.Booster
 Save LightGBM model
 }
 \examples{
-\donttest{
+\dontrun{
 library(lightgbm)
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train

--- a/R-package/man/lgb.train.Rd
+++ b/R-package/man/lgb.train.Rd
@@ -83,6 +83,7 @@ a trained booster model \code{lgb.Booster}.
 Logic to train with LightGBM
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -100,4 +101,5 @@ model <- lgb.train(
   , learning_rate = 1.0
   , early_stopping_rounds = 3L
 )
+}
 }

--- a/R-package/man/lgb.unloader.Rd
+++ b/R-package/man/lgb.unloader.Rd
@@ -26,6 +26,7 @@ Attempts to unload LightGBM packages so you can remove objects cleanly without
              apparent reason and you do not want to restart R to fix the lost object.
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -51,5 +52,5 @@ gc() # Not needed if wipe = TRUE
 library(lightgbm)
 # Do whatever you want again with LightGBM without object clashing
 }
-
+}
 }

--- a/R-package/man/lgb.unloader.Rd
+++ b/R-package/man/lgb.unloader.Rd
@@ -44,13 +44,11 @@ model <- lgb.train(
   , learning_rate = 1.0
 )
 
-\dontrun{
 lgb.unloader(restore = FALSE, wipe = FALSE, envir = .GlobalEnv)
 rm(model, dtrain, dtest) # Not needed if wipe = TRUE
 gc() # Not needed if wipe = TRUE
 
 library(lightgbm)
 # Do whatever you want again with LightGBM without object clashing
-}
 }
 }

--- a/R-package/man/predict.lgb.Booster.Rd
+++ b/R-package/man/predict.lgb.Booster.Rd
@@ -52,6 +52,7 @@ For regression or binary classification, it returns a vector of length \code{nro
 Predicted values based on class \code{lgb.Booster}
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -69,4 +70,5 @@ model <- lgb.train(
   , learning_rate = 1.0
 )
 preds <- predict(model, test$data)
+}
 }

--- a/R-package/man/readRDS.lgb.Booster.Rd
+++ b/R-package/man/readRDS.lgb.Booster.Rd
@@ -18,7 +18,7 @@ readRDS.lgb.Booster(file = "", refhook = NULL)
 Attempts to load a model stored in a \code{.rds} file, using \code{\link[base]{readRDS}}
 }
 \examples{
-\donttest{
+\dontrun{
 library(lightgbm)
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train

--- a/R-package/man/saveRDS.lgb.Booster.Rd
+++ b/R-package/man/saveRDS.lgb.Booster.Rd
@@ -42,7 +42,7 @@ Attempts to save a model using RDS. Has an additional parameter (\code{raw})
              which decides whether to save the raw model or not.
 }
 \examples{
-\donttest{
+\dontrun{
 library(lightgbm)
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train

--- a/R-package/man/setinfo.Rd
+++ b/R-package/man/setinfo.Rd
@@ -38,6 +38,7 @@ The \code{name} field can be one of the following:
 }
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -48,5 +49,5 @@ lightgbm::setinfo(dtrain, "label", 1 - labels)
 
 labels2 <- lightgbm::getinfo(dtrain, "label")
 stopifnot(all.equal(labels2, 1 - labels))
-
+}
 }

--- a/R-package/man/slice.Rd
+++ b/R-package/man/slice.Rd
@@ -24,6 +24,7 @@ Get a new \code{lgb.Dataset} containing the specified rows of
              original \code{lgb.Dataset} object
 }
 \examples{
+\dontrun{
 data(agaricus.train, package = "lightgbm")
 train <- agaricus.train
 dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -31,5 +32,5 @@ dtrain <- lgb.Dataset(train$data, label = train$label)
 dsub <- lightgbm::slice(dtrain, seq_len(42L))
 lgb.Dataset.construct(dsub)
 labels <- lightgbm::getinfo(dsub, "label")
-
+}
 }

--- a/docs/Python-API.rst
+++ b/docs/Python-API.rst
@@ -11,6 +11,7 @@ Data Structure API
 
     Dataset
     Booster
+    CVBooster
 
 Training API
 ------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -247,7 +247,7 @@ def generate_r_docs(app):
             , install = FALSE \
             , devel = FALSE \
             , examples = TRUE \
-            , run_dont_run = FALSE \
+            , run_dont_run = TRUE \
             , seed = 42L \
             , preview = FALSE \
             , new_process = TRUE \

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 from .basic import Booster, Dataset
 from .callback import (early_stopping, print_evaluation, record_evaluation,
                        reset_parameter)
-from .engine import cv, train
+from .engine import cv, train, CVBooster
 
 import os
 
@@ -29,7 +29,7 @@ if os.path.isfile(os.path.join(dir_path, 'VERSION.txt')):
     with open(os.path.join(dir_path, 'VERSION.txt')) as version_file:
         __version__ = version_file.read().strip()
 
-__all__ = ['Dataset', 'Booster',
+__all__ = ['Dataset', 'Booster', 'CVBooster',
            'train', 'cv',
            'LGBMModel', 'LGBMRegressor', 'LGBMClassifier', 'LGBMRanker',
            'print_evaluation', 'record_evaluation', 'reset_parameter', 'early_stopping',

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -276,19 +276,35 @@ def train(params, train_set, num_boost_round=100,
     return booster
 
 
-class _CVBooster(object):
-    """Auxiliary data struct to hold all boosters of CV."""
+class CVBooster(object):
+    """CVBooster in LightGBM.
+
+    Auxiliary data structure to hold and redirect all boosters of ``cv`` function.
+    This class has the same methods as Booster class.
+    All method calls are actually performed for underlying Boosters and then all returned results are returned in a list.
+
+    Attributes
+    ----------
+    boosters : list of Booster
+        The list of underlying fitted models.
+    best_iteration : int
+        The best iteration of fitted model.
+    """
 
     def __init__(self):
+        """Initialize the CVBooster.
+
+        Generally, no need to instantiate manually.
+        """
         self.boosters = []
         self.best_iteration = -1
 
-    def append(self, booster):
-        """Add a booster to _CVBooster."""
+    def _append(self, booster):
+        """Add a booster to CVBooster."""
         self.boosters.append(booster)
 
     def __getattr__(self, name):
-        """Redirect methods call of _CVBooster."""
+        """Redirect methods call of CVBooster."""
         def handler_function(*args, **kwargs):
             """Call methods with each booster, and concatenate their results."""
             ret = []
@@ -341,7 +357,7 @@ def _make_n_folds(full_data, folds, nfold, params, seed, fpreproc=None, stratifi
             train_id = [np.concatenate([test_id[i] for i in range_(nfold) if k != i]) for k in range_(nfold)]
             folds = zip_(train_id, test_id)
 
-    ret = _CVBooster()
+    ret = CVBooster()
     for train_idx, test_idx in folds:
         train_set = full_data.subset(sorted(train_idx))
         valid_set = full_data.subset(sorted(test_idx))
@@ -354,7 +370,7 @@ def _make_n_folds(full_data, folds, nfold, params, seed, fpreproc=None, stratifi
         if eval_train_metric:
             cvbooster.add_valid(train_set, 'train')
         cvbooster.add_valid(valid_set, 'valid')
-        ret.append(cvbooster)
+        ret._append(cvbooster)
     return ret
 
 
@@ -380,7 +396,8 @@ def cv(params, train_set, num_boost_round=100,
        feature_name='auto', categorical_feature='auto',
        early_stopping_rounds=None, fpreproc=None,
        verbose_eval=None, show_stdv=True, seed=0,
-       callbacks=None, eval_train_metric=False):
+       callbacks=None, eval_train_metric=False,
+       return_cvbooster=False):
     """Perform the cross-validation with given paramaters.
 
     Parameters
@@ -486,6 +503,8 @@ def cv(params, train_set, num_boost_round=100,
     eval_train_metric : bool, optional (default=False)
         Whether to display the train metric in progress.
         The score of the metric is calculated again after each training step, so there is some impact on performance.
+    return_cvbooster : bool, optional (default=False)
+        Whether to return Booster models trained on each fold through ``CVBooster``.
 
     Returns
     -------
@@ -495,6 +514,7 @@ def cv(params, train_set, num_boost_round=100,
         {'metric1-mean': [values], 'metric1-stdv': [values],
         'metric2-mean': [values], 'metric2-stdv': [values],
         ...}.
+        If ``return_cvbooster=True``, also returns trained boosters via ``cvbooster`` key.
     """
     if not isinstance(train_set, Dataset):
         raise TypeError("Training only accepts Dataset object")
@@ -586,4 +606,8 @@ def cv(params, train_set, num_boost_round=100,
             for k in results:
                 results[k] = results[k][:cvfolds.best_iteration]
             break
+
+    if return_cvbooster:
+        results['cvbooster'] = cvfolds
+
     return dict(results)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -735,6 +735,50 @@ class TestEngine(unittest.TestCase):
                                    verbose_eval=False)
         np.testing.assert_allclose(cv_res_lambda['ndcg@3-mean'], cv_res_lambda_obj['ndcg@3-mean'])
 
+    def test_cvbooster(self):
+        X, y = load_breast_cancer(True)
+        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+        params = {
+            'objective': 'binary',
+            'metric': 'binary_logloss',
+            'verbose': -1,
+        }
+        lgb_train = lgb.Dataset(X_train, y_train)
+        # with early stopping
+        cv_res = lgb.cv(params, lgb_train,
+                        num_boost_round=25,
+                        early_stopping_rounds=5,
+                        verbose_eval=False,
+                        nfold=3,
+                        return_cvbooster=True)
+        self.assertIn('cvbooster', cv_res)
+        cvb = cv_res['cvbooster']
+        self.assertIsInstance(cvb, lgb.CVBooster)
+        self.assertIsInstance(cvb.boosters, list)
+        self.assertEqual(len(cvb.boosters), 3)
+        self.assertTrue(all(isinstance(bst, lgb.Booster) for bst in cvb.boosters))
+        self.assertGreater(cvb.best_iteration, 0)
+        # predict by each fold booster
+        preds = cvb.predict(X_test, num_iteration=cvb.best_iteration)
+        self.assertIsInstance(preds, list)
+        self.assertEqual(len(preds), 3)
+        # fold averaging
+        avg_pred = np.mean(preds, axis=0)
+        ret = log_loss(y_test, avg_pred)
+        self.assertLess(ret, 0.13)
+        # without early stopping
+        cv_res = lgb.cv(params, lgb_train,
+                        num_boost_round=20,
+                        verbose_eval=False,
+                        nfold=3,
+                        return_cvbooster=True)
+        cvb = cv_res['cvbooster']
+        self.assertEqual(cvb.best_iteration, -1)
+        preds = cvb.predict(X_test)
+        avg_pred = np.mean(preds, axis=0)
+        ret = log_loss(y_test, avg_pred)
+        self.assertLess(ret, 0.15)
+
     def test_feature_name(self):
         X_train, y_train = load_boston(True)
         params = {'verbose': -1}


### PR DESCRIPTION
In the R Hub checks I ran in https://github.com/microsoft/LightGBM/issues/629#issuecomment-664714892, builds on several linux systems had this `R CMD CHECK` note:

```text
* checking examples ... NOTE
Examples with CPU (user + system) or elapsed time > 5s
                      user system elapsed
lgb.cv              23.612  0.098  66.864
lgb.model.dt.tree   12.887  0.039  35.043
lgb.importance       7.528  0.051  19.835
lgb.plot.importance  7.190  0.028  20.008
lgb.interprete       5.828  0.031  16.085
lgb.get.eval.result  4.639  0.012  13.082
predict.lgb.Booster  4.547  0.038  12.532
lgb.unloader         4.558  0.017  12.948
lgb.train            4.512  0.049  12.857
```

My first idea to fix these issues was to move all examples to vignettes (https://github.com/microsoft/LightGBM/issues/629#issuecomment-667566850), but tonight I had another idea that I think is a lot easier.

1. Wrap all examples in `\dontrun{}` so by default they aren't run
2. In CI, use `R CMD CHECK --run-dontrun` so that in CI, we still test that all the examples work. We can ignore the example-timing NOTE if it comes up, because the `\dontrun{}` means it will never come up on CRAN

This PR also replaces uses of `\donttest{}` with `\dontrun{}`. As of R 4.02, `\donttest{}` examples  will be run by `R CMD CHECK` ([release notes](https://cran.r-project.org/doc/manuals/r-release/NEWS.pdf))

>  R CMD check --as-cran now runs \donttest examples (which are run by example())
instead of instructing the tester to do so. This can be temporarily circumvented during
development by setting environment variable _R_CHECK_DONTTEST_EXAMPLES_ to a
false value.

@StrikerRUS I made this a LightGBM branch so we could test readthedocs. Could you enable readthedocs build temporarily for this branch?