### PR TITLE
[R-package] add some R build files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,8 +400,10 @@ python-package/lightgbm/VERSION.txt
 
 # R build artefacts
 **/autom4te.cache/
+R-package/config.status
 R-package/docs
 R-package/src/CMakeLists.txt
+R-package/src/Makevars
 R-package/src/lib_lightgbm.so.dSYM/
 R-package/src/src/
 R-package/src-x64
@@ -410,6 +412,7 @@ R-package/**/VERSION.txt
 **/Makevars.win
 lightgbm_r/*
 lightgbm*.tar.gz
+lightgbm*.tgz
 lightgbm.Rcheck/
 miktex*.zip
 *.def


### PR DESCRIPTION
This PR adds a few files to `.gitignore` that I've seen generated while working on the R package.

* `.tgz` --> the default when using `R CMD INSTALL --build` to create precompiled binaries
* `config.status` --> running `cd R-package && Rscript -e "pkgdown::build_site()"` now creates this, I don't know why
* `R-package/src/Makevars` --> this is generated at build time of the CRAN package but should never be checked in since its values will changed based on the system you install the package on