### PR TITLE
[python] try to use bundled distutils to setuptools during setup

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -2,7 +2,6 @@
 """Setup lightgbm package."""
 from __future__ import absolute_import
 
-import distutils
 import io
 import logging
 import os
@@ -16,6 +15,8 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 from setuptools.command.install_lib import install_lib
 from setuptools.command.sdist import sdist
+from distutils.dir_util import copy_tree
+from distutils.file_util import copy_file
 
 
 def find_lib():
@@ -35,7 +36,7 @@ def copy_files(use_gpu=False):
         if os.path.exists(src):
             dst = os.path.join(CURRENT_DIR, 'compile', folder_name)
             shutil.rmtree(dst, ignore_errors=True)
-            distutils.dir_util.copy_tree(src, dst, verbose=0)
+            copy_tree(src, dst, verbose=0)
         else:
             raise Exception('Cannot copy {0} folder'.format(src))
 
@@ -44,20 +45,20 @@ def copy_files(use_gpu=False):
         copy_files_helper('src')
         if not os.path.exists(os.path.join(CURRENT_DIR, "compile", "windows")):
             os.makedirs(os.path.join(CURRENT_DIR, "compile", "windows"))
-        distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.sln"),
-                                      os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.sln"),
-                                      verbose=0)
-        distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.vcxproj"),
-                                      os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.vcxproj"),
-                                      verbose=0)
+        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.sln"),
+                  os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.sln"),
+                  verbose=0)
+        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.vcxproj"),
+                  os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.vcxproj"),
+                  verbose=0)
         if use_gpu:
             copy_files_helper('compute')
-        distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "CMakeLists.txt"),
-                                      os.path.join(CURRENT_DIR, "compile", "CMakeLists.txt"),
-                                      verbose=0)
-        distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "LICENSE"),
-                                      os.path.join(CURRENT_DIR, "LICENSE"),
-                                      verbose=0)
+        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "CMakeLists.txt"),
+                  os.path.join(CURRENT_DIR, "compile", "CMakeLists.txt"),
+                  verbose=0)
+        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "LICENSE"),
+                  os.path.join(CURRENT_DIR, "LICENSE"),
+                  verbose=0)
 
 
 def clear_path(path):
@@ -258,9 +259,9 @@ if __name__ == "__main__":
     LOG_PATH = os.path.join(os.path.expanduser('~'), 'LightGBM_compilation.log')
     LOG_NOTICE = "The full version of error log was saved into {0}".format(LOG_PATH)
     if os.path.isfile(os.path.join(CURRENT_DIR, os.path.pardir, 'VERSION.txt')):
-        distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, 'VERSION.txt'),
-                                      os.path.join(CURRENT_DIR, 'lightgbm', 'VERSION.txt'),
-                                      verbose=0)
+        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, 'VERSION.txt'),
+                  os.path.join(CURRENT_DIR, 'lightgbm', 'VERSION.txt'),
+                  verbose=0)
     version = io.open(os.path.join(CURRENT_DIR, 'lightgbm', 'VERSION.txt'), encoding='utf-8').read().strip()
     readme = io.open(os.path.join(CURRENT_DIR, 'README.rst'), encoding='utf-8').read()
 


### PR DESCRIPTION
Eliminate warning:
```
C:\Miniconda37-x64\envs\test-env\lib\site-packages\setuptools\distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  "Distutils was imported before Setuptools. This usage is discouraged "
```

Refer to https://github.com/pypa/setuptools/pull/2143, https://github.com/pypa/setuptools/issues/2259.