### PR TITLE
[docs] Fix repetition of `tree_method` hyper-parameter in xgboost_hist

### DIFF
--- a/docs/Experiments.rst
+++ b/docs/Experiments.rst
@@ -73,7 +73,6 @@ We set up total 3 settings for experiments. The parameters of these settings are
        eta = 0.1
        num_round = 500
        nthread = 16
-       tree_method = approx
        min_child_weight = 100
        tree_method = hist
        grow_policy = lossguide


### PR DESCRIPTION
Fixes #3290, by removing the duplicated `tree_method = approx` from hyper-parameter setting of `xgboost_hist`.