### PR TITLE
[ci][docs] fix current master failures for docs test

### DIFF
--- a/docs/Parallel-Learning-Guide.rst
+++ b/docs/Parallel-Learning-Guide.rst
@@ -138,7 +138,7 @@ Example
 
 .. _The following example: https://github.com/Azure/mmlspark/blob/master/notebooks/samples/LightGBM%20-%20Quantile%20Regression%20for%20Drug%20Discovery.ipynb
 
-.. _Kubeflow Fairing: https://www.kubeflow.org/docs/fairing/fairing-overview
+.. _Kubeflow Fairing: https://www.kubeflow.org/docs/components/fairing/fairing-overview
 
 .. _These examples: https://github.com/kubeflow/fairing/tree/master/examples/lightgbm
 

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -5,9 +5,9 @@
  * \note
  * To avoid type conversion on large data, the most of our exposed interface supports both float32 and float64,
  * except the following:
- *   1. gradient and Hessian;
- *   2. current score for training and validation data.
- *   .
+ * 1. gradient and Hessian;
+ * 2. current score for training and validation data.
+ * .
  * The reason is that they are called frequently, and the type conversion on them may be time-cost.
  */
 #ifndef LIGHTGBM_C_API_H_


### PR DESCRIPTION
Fix two errors:

- 404 for `https://www.kubeflow.org/docs/fairing/fairing-overview`;
- `End of list marker found without any preceding list items` error in new Doxygen version.