### PR TITLE
[R-package] DESCRIPTION changes to address CRAN feedback

### DIFF
--- a/R-package/.Rbuildignore
+++ b/R-package/.Rbuildignore
@@ -2,6 +2,7 @@
 \.gitkeep$
 ^docs$
 ^pkgdown$
+^cran-comments\.md$
 
 # Objects created by compilation
 ^.*\.o

--- a/R-package/.Rbuildignore
+++ b/R-package/.Rbuildignore
@@ -2,7 +2,7 @@
 \.gitkeep$
 ^docs$
 ^pkgdown$
-cran-comments.md
+^cran-comments\.md$
 
 # Objects created by compilation
 ^.*\.o

--- a/R-package/.Rbuildignore
+++ b/R-package/.Rbuildignore
@@ -2,7 +2,7 @@
 \.gitkeep$
 ^docs$
 ^pkgdown$
-^cran-comments\.md$
+^cran-comments.md$
 
 # Objects created by compilation
 ^.*\.o

--- a/R-package/.Rbuildignore
+++ b/R-package/.Rbuildignore
@@ -2,7 +2,7 @@
 \.gitkeep$
 ^docs$
 ^pkgdown$
-^cran-comments.md$
+cran-comments.md
 
 # Objects created by compilation
 ^.*\.o

--- a/R-package/.Rbuildignore
+++ b/R-package/.Rbuildignore
@@ -1,6 +1,6 @@
 ^build_r.R$
 \.gitkeep$
-^docs$
+^docs/.*$
 ^pkgdown$
 ^cran-comments\.md$
 

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -9,21 +9,20 @@ Authors@R: c(
     person("Yachen", "Yan", role = c("ctb")),
     person("James", "Lamb", email="jaylamb20@gmail.com", role = c("ctb"))
     )
-Description: Tree based algorithms can be improved by introducing boosting frameworks. LightGBM is one such framework, and this package offers an R interface to work with it.
+Description: Tree based algorithms can be improved by introducing boosting frameworks. "LightGBM" is one such framework, and this package offers an R interface to work with it.
     It is designed to be distributed and efficient with the following advantages:
         1. Faster training speed and higher efficiency.
         2. Lower memory usage.
         3. Better accuracy.
         4. Parallel learning supported.
         5. Capable of handling large-scale data.
-    In recognition of these advantages, LightGBM has been widely-used in many winning solutions of machine learning competitions.
-    Comparison experiments on public datasets suggest that LightGBM can outperform existing boosting frameworks on both efficiency and accuracy, with significantly lower memory consumption. In addition, parallel experiments suggest that in certain circumstances, LightGBM can achieve a linear speed-up in training time by using multiple machines.
+    In recognition of these advantages, "LightGBM" has been widely-used in many winning solutions of machine learning competitions.
+    Comparison experiments on public datasets suggest that "LightGBM" can outperform existing boosting frameworks on both efficiency and accuracy, with significantly lower memory consumption. In addition, parallel experiments suggest that in certain circumstances, "LightGBM" can achieve a linear speed-up in training time by using multiple machines.
 Encoding: UTF-8
 License: MIT + file LICENSE
 URL: https://github.com/Microsoft/LightGBM
 BugReports: https://github.com/Microsoft/LightGBM/issues
 NeedsCompilation: yes
-Biarch: false
 Suggests:
     processx,
     testthat

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -23,6 +23,7 @@ License: MIT + file LICENSE
 URL: https://github.com/Microsoft/LightGBM
 BugReports: https://github.com/Microsoft/LightGBM/issues
 NeedsCompilation: yes
+Biarch: true
 Suggests:
     processx,
     testthat

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -9,15 +9,15 @@ Authors@R: c(
     person("Yachen", "Yan", role = c("ctb")),
     person("James", "Lamb", email="jaylamb20@gmail.com", role = c("ctb"))
     )
-Description: Tree based algorithms can be improved by introducing boosting frameworks. "LightGBM" is one such framework, and this package offers an R interface to work with it.
+Description: Tree based algorithms can be improved by introducing boosting frameworks. 'LightGBM' is one such framework, and this package offers an R interface to work with it.
     It is designed to be distributed and efficient with the following advantages:
         1. Faster training speed and higher efficiency.
         2. Lower memory usage.
         3. Better accuracy.
         4. Parallel learning supported.
         5. Capable of handling large-scale data.
-    In recognition of these advantages, "LightGBM" has been widely-used in many winning solutions of machine learning competitions.
-    Comparison experiments on public datasets suggest that "LightGBM" can outperform existing boosting frameworks on both efficiency and accuracy, with significantly lower memory consumption. In addition, parallel experiments suggest that in certain circumstances, "LightGBM" can achieve a linear speed-up in training time by using multiple machines.
+    In recognition of these advantages, 'LightGBM' has been widely-used in many winning solutions of machine learning competitions.
+    Comparison experiments on public datasets suggest that 'LightGBM' can outperform existing boosting frameworks on both efficiency and accuracy, with significantly lower memory consumption. In addition, parallel experiments suggest that in certain circumstances, 'LightGBM' can achieve a linear speed-up in training time by using multiple machines.
 Encoding: UTF-8
 License: MIT + file LICENSE
 URL: https://github.com/Microsoft/LightGBM

--- a/R-package/cran-comments.md
+++ b/R-package/cran-comments.md
@@ -1,5 +1,62 @@
 # CRAN Submission History
 
+## v3.0.0-1 - Submission 3 - (August 13, 2020)
+
+### CRAN response
+
+Failing pre-checks.
+
+### `R CMD check` results
+
+* Debian: 1 NOTE
+
+    ```text
+    * checking CRAN incoming feasibility ... NOTE
+    Maintainer: ‘Guolin Ke <guolin.ke@microsoft.com>’
+
+    New submission
+
+    License components with restrictions and base license permitting such:
+      MIT + file LICENSE
+    ```
+
+* Windows: 1 ERROR, 1 NOTE
+
+    ```text
+    * checking CRAN incoming feasibility ... NOTE
+    Maintainer: ‘Guolin Ke <guolin.ke@microsoft.com>’
+
+    New submission
+
+    License components with restrictions and base license permitting such:
+      MIT + file LICENSE
+
+    ** running tests for arch 'i386' ... [9s] ERROR
+      Running 'testthat.R' [8s]
+    Running the tests in 'tests/testthat.R' failed.
+    Complete output:
+      > library(testthat)
+      > library(lightgbm)
+      Loading required package: R6
+      >
+      > test_check(
+      +     package = "lightgbm"
+      +     , stop_on_failure = TRUE
+      +     , stop_on_warning = FALSE
+      + )
+      -- 1. Error: predictions do not fail for integer input (@test_Predictor.R#7)  --
+      lgb.Dataset.construct: cannot create Dataset handle
+      Backtrace:
+       1. lightgbm::lgb.train(...)
+       2. data$construct()
+    ```
+
+### Maintainer Notes
+
+The "checking CRAN incoming feasibility" NOTE can be safely ignored. It only shows up the first time you submit a package to CRAN.
+
+So the only thing I see broken right now is the test error on 32-bit Windows. This is documented in https://github.com/microsoft/LightGBM/issues/3187.
+
 ## v3.0.0-1 - Submission 2 - (August 10, 2020)
 
 ### CRAN response

--- a/R-package/cran-comments.md
+++ b/R-package/cran-comments.md
@@ -1,0 +1,25 @@
+# CRAN Submission History
+
+## v3.0.0-1 - Submission 1 - (August 9, 2020)
+
+### CRAN Response
+
+* Debian: 1 NOTE
+
+    ```text
+    Possibly mis-spelled words in DESCRIPTION:
+      LightGBM (12:88, 19:41, 20:60, 20:264)
+    ```
+
+* Windows: 1 ERROR, 1 NOTE
+
+    ```text
+    Possibly mis-spelled words in DESCRIPTION:
+      LightGBM (12:88, 19:41, 20:60, 20:264)
+
+    ** checking whether the package can be loaded ... ERROR
+    Loading this package had a fatal error status code 1
+    Loading log:
+    Error: package 'lightgbm' is not installed for 'arch = i386'
+    Execution halted
+    ```

--- a/R-package/cran-comments.md
+++ b/R-package/cran-comments.md
@@ -1,8 +1,67 @@
 # CRAN Submission History
 
+## v3.0.0-1 - Submission 2 - (August 10, 2020)
+
+### CRAN response
+
+Failing pre-checks.
+
+### `R CMD check` results
+
+* Debian: 2 NOTEs
+
+    ```text
+    * checking CRAN incoming feasibility ... NOTE
+    Maintainer: ‘Guolin Ke <guolin.ke@microsoft.com>’
+
+    New submission
+
+    License components with restrictions and base license permitting such:
+      MIT + file LICENSE
+
+    Non-standard files/directories found at top level:
+    ‘cran-comments.md’ ‘docs’
+    ```
+
+* Windows: 1 ERROR, 2 NOTEs
+
+    ```text
+    * checking CRAN incoming feasibility ... NOTE
+    Maintainer: 'Guolin Ke <guolin.ke@microsoft.com>'
+
+    New submission
+
+    License components with restrictions and base license permitting such:
+      MIT + file LICENSE
+
+    * checking top-level files ... NOTE
+    Non-standard files/directories found at top level:
+      'cran-comments.md' 'docs'
+
+    ** checking whether the package can be loaded ... ERROR
+    Loading this package had a fatal error status code 1
+    Loading log:
+    Error: package 'lightgbm' is not installed for 'arch = i386'
+    Execution halted
+    ```
+
+### Maintainer Notes
+
+Seems removing `Biarch` field did't work. Noticed this in the install logs:
+
+> Warning: this package has a non-empty 'configure.win' file, so building only the main architecture
+
+Tried adding `Biarch: true` to `DESCRIPTION` to overcome this.
+
+NOTE about non-standard files was the result of a mistake in `.Rbuildignore` syntax, and something strange with how `cran-comments.md` line in `.Rbuildignore`  was treated. Updated `.Rbuildignore` and added an `rm cran-comments.md` to `build-cran-package.sh`.
+
 ## v3.0.0-1 - Submission 1 - (August 9, 2020)
 
-### CRAN Response
+### CRAN response
+
+Failing pre-checks.
+
+### `R CMD check` results
 
 * Debian: 1 NOTE
 
@@ -23,3 +82,9 @@
     Error: package 'lightgbm' is not installed for 'arch = i386'
     Execution halted
     ```
+
+### Maintainer Notes
+
+Thought the issue on Windows was caused by `Biarch: false` in `DESCRIPTION`. Removed `Biarch` field.
+
+Thought the "misspellings" issue could be resolved by adding single quotes around LightGBM, like `'LightGBM'`.

--- a/R-package/cran-comments.md
+++ b/R-package/cran-comments.md
@@ -1,6 +1,6 @@
 # CRAN Submission History
 
-## v3.0.0-1 - Submission 3 - (August 13, 2020)
+## v3.0.0-1 - Submission 3 - (August 12, 2020)
 
 ### CRAN response
 

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -30,6 +30,7 @@ cd ${TEMP_R_DIR}
     rm -r src/cmake/
     rm -r inst/
     rm -r pkgdown/
+    rm cran-comments.md
     rm AUTOCONF_UBUNTU_VERSION
     rm recreate-configure.sh
 

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -2,7 +2,6 @@
 """Setup lightgbm package."""
 from __future__ import absolute_import
 
-import distutils
 import io
 import logging
 import os
@@ -16,6 +15,8 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 from setuptools.command.install_lib import install_lib
 from setuptools.command.sdist import sdist
+from distutils.dir_util import copy_tree
+from distutils.file_util import copy_file
 
 
 def find_lib():
@@ -35,7 +36,7 @@ def copy_files(use_gpu=False):
         if os.path.exists(src):
             dst = os.path.join(CURRENT_DIR, 'compile', folder_name)
             shutil.rmtree(dst, ignore_errors=True)
-            distutils.dir_util.copy_tree(src, dst, verbose=0)
+            copy_tree(src, dst, verbose=0)
         else:
             raise Exception('Cannot copy {0} folder'.format(src))
 
@@ -44,20 +45,20 @@ def copy_files(use_gpu=False):
         copy_files_helper('src')
         if not os.path.exists(os.path.join(CURRENT_DIR, "compile", "windows")):
             os.makedirs(os.path.join(CURRENT_DIR, "compile", "windows"))
-        distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.sln"),
-                                      os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.sln"),
-                                      verbose=0)
-        distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.vcxproj"),
-                                      os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.vcxproj"),
-                                      verbose=0)
+        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.sln"),
+                  os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.sln"),
+                  verbose=0)
+        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.vcxproj"),
+                  os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.vcxproj"),
+                  verbose=0)
         if use_gpu:
             copy_files_helper('compute')
-        distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "CMakeLists.txt"),
-                                      os.path.join(CURRENT_DIR, "compile", "CMakeLists.txt"),
-                                      verbose=0)
-        distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "LICENSE"),
-                                      os.path.join(CURRENT_DIR, "LICENSE"),
-                                      verbose=0)
+        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "CMakeLists.txt"),
+                  os.path.join(CURRENT_DIR, "compile", "CMakeLists.txt"),
+                  verbose=0)
+        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "LICENSE"),
+                  os.path.join(CURRENT_DIR, "LICENSE"),
+                  verbose=0)
 
 
 def clear_path(path):
@@ -258,9 +259,9 @@ if __name__ == "__main__":
     LOG_PATH = os.path.join(os.path.expanduser('~'), 'LightGBM_compilation.log')
     LOG_NOTICE = "The full version of error log was saved into {0}".format(LOG_PATH)
     if os.path.isfile(os.path.join(CURRENT_DIR, os.path.pardir, 'VERSION.txt')):
-        distutils.file_util.copy_file(os.path.join(CURRENT_DIR, os.path.pardir, 'VERSION.txt'),
-                                      os.path.join(CURRENT_DIR, 'lightgbm', 'VERSION.txt'),
-                                      verbose=0)
+        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, 'VERSION.txt'),
+                  os.path.join(CURRENT_DIR, 'lightgbm', 'VERSION.txt'),
+                  verbose=0)
     version = io.open(os.path.join(CURRENT_DIR, 'lightgbm', 'VERSION.txt'), encoding='utf-8').read().strip()
     readme = io.open(os.path.join(CURRENT_DIR, 'README.rst'), encoding='utf-8').read()
 


### PR DESCRIPTION
This addresses feedback from our first ever submission to CRAN!

https://github.com/microsoft/LightGBM/issues/629#issuecomment-671648923

* The note about "possible misspellings" can be fixed by putting `LightGBM` in quotes. I remember we had to do this when we first submitted [`uptasticsearch`](https://github.com/uptake/uptasticsearch/blob/master/r-pkg/DESCRIPTION#L17)
* the error from "not installed on i386" is from setting `Biarch: false` in `DESCRIPTION`. I thought that flag could be a way to publish a package that doesn't support 32-bit, but I don't think that works. Let's remove that field and we'll get a better error on CRAN 32-bit checks.

This also proposes adding a `cran-comments.md` to track feedback from CRAN. Since the CRAN upload process involves back-and-forth with humans (not just automated checks), a lot of projects keep this type of file to hold a record of the things CRAN has asked them to do in the past. We do this in [`uptasticsearch`](https://github.com/uptake/uptasticsearch/blob/master/cran-comments.md).