### PR TITLE
[R-package] Skip tests on 32-bit Windows builds

### DIFF
--- a/R-package/tests/testthat/test_Predictor.R
+++ b/R-package/tests/testthat/test_Predictor.R
@@ -1,6 +1,7 @@
 context("Predictor")
 
 test_that("predictions do not fail for integer input", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     X <- as.matrix(as.integer(iris[, "Species"]), ncol = 1L)
     y <- iris[["Sepal.Length"]]
     dtrain <- lgb.Dataset(X, label = y)
@@ -19,6 +20,7 @@ test_that("predictions do not fail for integer input", {
 })
 
 test_that("start_iteration works correctly", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")

--- a/R-package/tests/testthat/test_Predictor.R
+++ b/R-package/tests/testthat/test_Predictor.R
@@ -1,7 +1,7 @@
 context("Predictor")
 
 test_that("predictions do not fail for integer input", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     X <- as.matrix(as.integer(iris[, "Species"]), ncol = 1L)
     y <- iris[["Sepal.Length"]]
     dtrain <- lgb.Dataset(X, label = y)
@@ -20,7 +20,7 @@ test_that("predictions do not fail for integer input", {
 })
 
 test_that("start_iteration works correctly", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -8,6 +8,7 @@ test <- agaricus.test
 TOLERANCE <- 1e-6
 
 test_that("train and predict binary classification", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   nrounds <- 10L
   bst <- lightgbm(
     data = train$data
@@ -34,6 +35,7 @@ test_that("train and predict binary classification", {
 
 
 test_that("train and predict softmax", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   lb <- as.numeric(iris$Species) - 1L
 
@@ -61,6 +63,7 @@ test_that("train and predict softmax", {
 
 
 test_that("use of multiple eval metrics works", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   metrics <- list("binary_error", "auc", "binary_logloss")
   bst <- lightgbm(
     data = train$data
@@ -82,6 +85,7 @@ test_that("use of multiple eval metrics works", {
 })
 
 test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expected for binary classification", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   nrounds <- 10L
   bst <- lightgbm(
@@ -98,6 +102,7 @@ test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expec
 })
 
 test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expected for regression", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   nrounds <- 10L
   bst <- lightgbm(
@@ -114,6 +119,7 @@ test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expec
 })
 
 test_that("lightgbm() rejects negative or 0 value passed to nrounds", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression", metric = "l2,l1")
   for (nround_value in c(-10L, 0L)) {
@@ -129,6 +135,7 @@ test_that("lightgbm() rejects negative or 0 value passed to nrounds", {
 })
 
 test_that("lightgbm() performs evaluation on validation sets if they are provided", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   dvalid1 <- lgb.Dataset(
     data = train$data
@@ -210,6 +217,7 @@ test_that("training continuation works", {
 context("lgb.cv()")
 
 test_that("cv works", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression", metric = "l2,l1")
   bst <- lgb.cv(
@@ -225,6 +233,7 @@ test_that("cv works", {
 })
 
 test_that("lgb.cv() rejects negative or 0 value passed to nrounds", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression", metric = "l2,l1")
   for (nround_value in c(-10L, 0L)) {
@@ -241,6 +250,7 @@ test_that("lgb.cv() rejects negative or 0 value passed to nrounds", {
 })
 
 test_that("lgb.cv() throws an informative error is 'data' is not an lgb.Dataset and labels are not given", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   bad_values <- list(
     4L
     , "hello"
@@ -263,6 +273,7 @@ test_that("lgb.cv() throws an informative error is 'data' is not an lgb.Dataset 
 })
 
 test_that("lightgbm.cv() gives the correct best_score and best_iter for a metric where higher values are better", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   dtrain <- lgb.Dataset(
     data = as.matrix(runif(n = 500L, min = 0.0, max = 15.0), drop = FALSE)
@@ -296,6 +307,7 @@ test_that("lightgbm.cv() gives the correct best_score and best_iter for a metric
 context("lgb.train()")
 
 test_that("lgb.train() works as expected with multiple eval metrics", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   metrics <- c("binary_error", "auc", "binary_logloss")
   bst <- lgb.train(
     data = lgb.Dataset(
@@ -325,6 +337,7 @@ test_that("lgb.train() works as expected with multiple eval metrics", {
 })
 
 test_that("lgb.train() rejects negative or 0 value passed to nrounds", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression", metric = "l2,l1")
   for (nround_value in c(-10L, 0L)) {
@@ -339,6 +352,7 @@ test_that("lgb.train() rejects negative or 0 value passed to nrounds", {
 })
 
 test_that("lgb.train() throws an informative error if 'data' is not an lgb.Dataset", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   bad_values <- list(
     4L
     , "hello"
@@ -359,6 +373,7 @@ test_that("lgb.train() throws an informative error if 'data' is not an lgb.Datas
 })
 
 test_that("lgb.train() throws an informative error if 'valids' is not a list of lgb.Dataset objects", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   valids <- list(
     "valid1" = data.frame(x = rnorm(5L), y = rnorm(5L))
     , "valid2" = data.frame(x = rnorm(5L), y = rnorm(5L))
@@ -374,6 +389,7 @@ test_that("lgb.train() throws an informative error if 'valids' is not a list of 
 })
 
 test_that("lgb.train() errors if 'valids' is a list of lgb.Dataset objects but some do not have names", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   valids <- list(
     "valid1" = lgb.Dataset(matrix(rnorm(10L), 5L, 2L))
     , lgb.Dataset(matrix(rnorm(10L), 2L, 5L))
@@ -389,6 +405,7 @@ test_that("lgb.train() errors if 'valids' is a list of lgb.Dataset objects but s
 })
 
 test_that("lgb.train() throws an informative error if 'valids' contains lgb.Dataset objects but none have names", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   valids <- list(
     lgb.Dataset(matrix(rnorm(10L), 5L, 2L))
     , lgb.Dataset(matrix(rnorm(10L), 2L, 5L))
@@ -404,6 +421,7 @@ test_that("lgb.train() throws an informative error if 'valids' contains lgb.Data
 })
 
 test_that("lgb.train() works with force_col_wise and force_row_wise", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(1234L)
   nrounds <- 10L
   dtrain <- lgb.Dataset(
@@ -447,6 +465,7 @@ test_that("lgb.train() works with force_col_wise and force_row_wise", {
 })
 
 test_that("lgb.train() works as expected with sparse features", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   num_obs <- 70000L
   trainDF <- data.frame(
@@ -478,6 +497,7 @@ test_that("lgb.train() works as expected with sparse features", {
 })
 
 test_that("lgb.train() works with early stopping for classification", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   trainDF <- data.frame(
     "feat1" = rep(c(5.0, 10.0), 500L)
     , "target" = rep(c(0L, 1L), 500L)
@@ -546,6 +566,7 @@ test_that("lgb.train() works with early stopping for classification", {
 })
 
 test_that("lgb.train() treats early_stopping_rounds<=0 as disabling early stopping", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   trainDF <- data.frame(
     "feat1" = rep(c(5.0, 10.0), 500L)
@@ -614,6 +635,7 @@ test_that("lgb.train() treats early_stopping_rounds<=0 as disabling early stoppi
 })
 
 test_that("lgb.train() works with early stopping for classification with a metric that should be maximized", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   dtrain <- lgb.Dataset(
     data = train$data
@@ -681,6 +703,7 @@ test_that("lgb.train() works with early stopping for classification with a metri
 })
 
 test_that("lgb.train() works with early stopping for regression", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   trainDF <- data.frame(
     "feat1" = rep(c(10.0, 100.0), 500L)
@@ -751,6 +774,7 @@ test_that("lgb.train() works with early stopping for regression", {
 })
 
 test_that("lgb.train() works with early stopping for regression with a metric that should be minimized", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   trainDF <- data.frame(
     "feat1" = rep(c(10.0, 100.0), 500L)
@@ -836,6 +860,7 @@ test_that("lgb.train() supports non-ASCII feature names", {
 })
 
 test_that("when early stopping is not activated, best_iter and best_score come from valids and not training data", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   trainDF <- data.frame(
     "feat1" = rep(c(10.0, 100.0), 500L)
@@ -997,6 +1022,7 @@ test_that("when early stopping is not activated, best_iter and best_score come f
 })
 
 test_that("lightgbm.train() gives the correct best_score and best_iter for a metric where higher values are better", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   trainDF <- data.frame(
     "feat1" = runif(n = 500L, min = 0.0, max = 15.0)
@@ -1044,6 +1070,7 @@ test_that("lightgbm.train() gives the correct best_score and best_iter for a met
 })
 
 test_that("using lightgbm() without early stopping, best_iter and best_score come from valids and not training data", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   # example: train second (called "something-random-we-would-not-hardcode"), two valids,
   #          and a metric where higher values are better ("auc")
@@ -1113,6 +1140,7 @@ test_that("lgb.train() throws an informative error if interaction_constraints is
 
 test_that(paste0("lgb.train() throws an informative error if the members of interaction_constraints ",
                  "are not character or numeric vectors"), {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression", interaction_constraints = list(list(1L, 2L), list(3L)))
     expect_error({
@@ -1125,6 +1153,7 @@ test_that(paste0("lgb.train() throws an informative error if the members of inte
 })
 
 test_that("lgb.train() throws an informative error if interaction_constraints contains a too large index", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression",
                  interaction_constraints = list(c(1L, length(colnames(train$data)) + 1L), 3L))
@@ -1139,6 +1168,7 @@ test_that("lgb.train() throws an informative error if interaction_constraints co
 
 test_that(paste0("lgb.train() gives same result when interaction_constraints is specified as a list of ",
                  "character vectors, numeric vectors, or a combination"), {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(1L)
   dtrain <- lgb.Dataset(train$data, label = train$label)
 
@@ -1173,6 +1203,7 @@ test_that(paste0("lgb.train() gives same result when interaction_constraints is 
 })
 
 test_that(paste0("lgb.train() gives same results when using interaction_constraints and specifying colnames"), {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(1L)
   dtrain <- lgb.Dataset(train$data, label = train$label)
 

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -8,7 +8,7 @@ test <- agaricus.test
 TOLERANCE <- 1e-6
 
 test_that("train and predict binary classification", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   nrounds <- 10L
   bst <- lightgbm(
     data = train$data
@@ -35,7 +35,7 @@ test_that("train and predict binary classification", {
 
 
 test_that("train and predict softmax", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   lb <- as.numeric(iris$Species) - 1L
 
@@ -63,7 +63,7 @@ test_that("train and predict softmax", {
 
 
 test_that("use of multiple eval metrics works", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   metrics <- list("binary_error", "auc", "binary_logloss")
   bst <- lightgbm(
     data = train$data
@@ -85,7 +85,7 @@ test_that("use of multiple eval metrics works", {
 })
 
 test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expected for binary classification", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   nrounds <- 10L
   bst <- lightgbm(
@@ -102,7 +102,7 @@ test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expec
 })
 
 test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expected for regression", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   nrounds <- 10L
   bst <- lightgbm(
@@ -119,7 +119,7 @@ test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expec
 })
 
 test_that("lightgbm() rejects negative or 0 value passed to nrounds", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression", metric = "l2,l1")
   for (nround_value in c(-10L, 0L)) {
@@ -135,7 +135,7 @@ test_that("lightgbm() rejects negative or 0 value passed to nrounds", {
 })
 
 test_that("lightgbm() performs evaluation on validation sets if they are provided", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   dvalid1 <- lgb.Dataset(
     data = train$data
@@ -217,7 +217,7 @@ test_that("training continuation works", {
 context("lgb.cv()")
 
 test_that("cv works", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression", metric = "l2,l1")
   bst <- lgb.cv(
@@ -233,7 +233,7 @@ test_that("cv works", {
 })
 
 test_that("lgb.cv() rejects negative or 0 value passed to nrounds", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression", metric = "l2,l1")
   for (nround_value in c(-10L, 0L)) {
@@ -250,7 +250,7 @@ test_that("lgb.cv() rejects negative or 0 value passed to nrounds", {
 })
 
 test_that("lgb.cv() throws an informative error is 'data' is not an lgb.Dataset and labels are not given", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   bad_values <- list(
     4L
     , "hello"
@@ -273,7 +273,7 @@ test_that("lgb.cv() throws an informative error is 'data' is not an lgb.Dataset 
 })
 
 test_that("lightgbm.cv() gives the correct best_score and best_iter for a metric where higher values are better", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   dtrain <- lgb.Dataset(
     data = as.matrix(runif(n = 500L, min = 0.0, max = 15.0), drop = FALSE)
@@ -307,7 +307,7 @@ test_that("lightgbm.cv() gives the correct best_score and best_iter for a metric
 context("lgb.train()")
 
 test_that("lgb.train() works as expected with multiple eval metrics", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   metrics <- c("binary_error", "auc", "binary_logloss")
   bst <- lgb.train(
     data = lgb.Dataset(
@@ -337,7 +337,7 @@ test_that("lgb.train() works as expected with multiple eval metrics", {
 })
 
 test_that("lgb.train() rejects negative or 0 value passed to nrounds", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression", metric = "l2,l1")
   for (nround_value in c(-10L, 0L)) {
@@ -352,7 +352,7 @@ test_that("lgb.train() rejects negative or 0 value passed to nrounds", {
 })
 
 test_that("lgb.train() throws an informative error if 'data' is not an lgb.Dataset", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   bad_values <- list(
     4L
     , "hello"
@@ -373,7 +373,7 @@ test_that("lgb.train() throws an informative error if 'data' is not an lgb.Datas
 })
 
 test_that("lgb.train() throws an informative error if 'valids' is not a list of lgb.Dataset objects", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   valids <- list(
     "valid1" = data.frame(x = rnorm(5L), y = rnorm(5L))
     , "valid2" = data.frame(x = rnorm(5L), y = rnorm(5L))
@@ -389,7 +389,7 @@ test_that("lgb.train() throws an informative error if 'valids' is not a list of 
 })
 
 test_that("lgb.train() errors if 'valids' is a list of lgb.Dataset objects but some do not have names", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   valids <- list(
     "valid1" = lgb.Dataset(matrix(rnorm(10L), 5L, 2L))
     , lgb.Dataset(matrix(rnorm(10L), 2L, 5L))
@@ -405,7 +405,7 @@ test_that("lgb.train() errors if 'valids' is a list of lgb.Dataset objects but s
 })
 
 test_that("lgb.train() throws an informative error if 'valids' contains lgb.Dataset objects but none have names", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   valids <- list(
     lgb.Dataset(matrix(rnorm(10L), 5L, 2L))
     , lgb.Dataset(matrix(rnorm(10L), 2L, 5L))
@@ -421,7 +421,7 @@ test_that("lgb.train() throws an informative error if 'valids' contains lgb.Data
 })
 
 test_that("lgb.train() works with force_col_wise and force_row_wise", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(1234L)
   nrounds <- 10L
   dtrain <- lgb.Dataset(
@@ -465,7 +465,7 @@ test_that("lgb.train() works with force_col_wise and force_row_wise", {
 })
 
 test_that("lgb.train() works as expected with sparse features", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   num_obs <- 70000L
   trainDF <- data.frame(
@@ -497,7 +497,7 @@ test_that("lgb.train() works as expected with sparse features", {
 })
 
 test_that("lgb.train() works with early stopping for classification", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   trainDF <- data.frame(
     "feat1" = rep(c(5.0, 10.0), 500L)
     , "target" = rep(c(0L, 1L), 500L)
@@ -566,7 +566,7 @@ test_that("lgb.train() works with early stopping for classification", {
 })
 
 test_that("lgb.train() treats early_stopping_rounds<=0 as disabling early stopping", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   trainDF <- data.frame(
     "feat1" = rep(c(5.0, 10.0), 500L)
@@ -635,7 +635,7 @@ test_that("lgb.train() treats early_stopping_rounds<=0 as disabling early stoppi
 })
 
 test_that("lgb.train() works with early stopping for classification with a metric that should be maximized", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   dtrain <- lgb.Dataset(
     data = train$data
@@ -703,7 +703,7 @@ test_that("lgb.train() works with early stopping for classification with a metri
 })
 
 test_that("lgb.train() works with early stopping for regression", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   trainDF <- data.frame(
     "feat1" = rep(c(10.0, 100.0), 500L)
@@ -774,7 +774,7 @@ test_that("lgb.train() works with early stopping for regression", {
 })
 
 test_that("lgb.train() works with early stopping for regression with a metric that should be minimized", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   trainDF <- data.frame(
     "feat1" = rep(c(10.0, 100.0), 500L)
@@ -860,7 +860,7 @@ test_that("lgb.train() supports non-ASCII feature names", {
 })
 
 test_that("when early stopping is not activated, best_iter and best_score come from valids and not training data", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   trainDF <- data.frame(
     "feat1" = rep(c(10.0, 100.0), 500L)
@@ -1022,7 +1022,7 @@ test_that("when early stopping is not activated, best_iter and best_score come f
 })
 
 test_that("lightgbm.train() gives the correct best_score and best_iter for a metric where higher values are better", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   trainDF <- data.frame(
     "feat1" = runif(n = 500L, min = 0.0, max = 15.0)
@@ -1070,7 +1070,7 @@ test_that("lightgbm.train() gives the correct best_score and best_iter for a met
 })
 
 test_that("using lightgbm() without early stopping, best_iter and best_score come from valids and not training data", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   # example: train second (called "something-random-we-would-not-hardcode"), two valids,
   #          and a metric where higher values are better ("auc")
@@ -1140,7 +1140,7 @@ test_that("lgb.train() throws an informative error if interaction_constraints is
 
 test_that(paste0("lgb.train() throws an informative error if the members of interaction_constraints ",
                  "are not character or numeric vectors"), {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression", interaction_constraints = list(list(1L, 2L), list(3L)))
     expect_error({
@@ -1153,7 +1153,7 @@ test_that(paste0("lgb.train() throws an informative error if the members of inte
 })
 
 test_that("lgb.train() throws an informative error if interaction_constraints contains a too large index", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression",
                  interaction_constraints = list(c(1L, length(colnames(train$data)) + 1L), 3L))
@@ -1168,7 +1168,7 @@ test_that("lgb.train() throws an informative error if interaction_constraints co
 
 test_that(paste0("lgb.train() gives same result when interaction_constraints is specified as a list of ",
                  "character vectors, numeric vectors, or a combination"), {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(1L)
   dtrain <- lgb.Dataset(train$data, label = train$label)
 
@@ -1203,7 +1203,7 @@ test_that(paste0("lgb.train() gives same result when interaction_constraints is 
 })
 
 test_that(paste0("lgb.train() gives same results when using interaction_constraints and specifying colnames"), {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(1L)
   dtrain <- lgb.Dataset(train$data, label = train$label)
 

--- a/R-package/tests/testthat/test_custom_objective.R
+++ b/R-package/tests/testthat/test_custom_objective.R
@@ -1,10 +1,12 @@
 context("Test models with custom objective")
 
-data(agaricus.train, package = "lightgbm")
-data(agaricus.test, package = "lightgbm")
-dtrain <- lgb.Dataset(agaricus.train$data, label = agaricus.train$label)
-dtest <- lgb.Dataset(agaricus.test$data, label = agaricus.test$label)
-watchlist <- list(eval = dtest, train = dtrain)
+if (Sys.getenv("R_ARCH") != "i386/") {
+  data(agaricus.train, package = "lightgbm")
+  data(agaricus.test, package = "lightgbm")
+  dtrain <- lgb.Dataset(agaricus.train$data, label = agaricus.train$label)
+  dtest <- lgb.Dataset(agaricus.test$data, label = agaricus.test$label)
+  watchlist <- list(eval = dtest, train = dtrain)
+}
 
 TOLERANCE <- 1e-6
 
@@ -40,11 +42,13 @@ param <- list(
 num_round <- 10L
 
 test_that("custom objective works", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   bst <- lgb.train(param, dtrain, num_round, watchlist, eval = evalerror)
   expect_false(is.null(bst$record_evals))
 })
 
 test_that("using a custom objective, custom eval, and no other metrics works", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   set.seed(708L)
   bst <- lgb.train(
     params = list(

--- a/R-package/tests/testthat/test_custom_objective.R
+++ b/R-package/tests/testthat/test_custom_objective.R
@@ -1,6 +1,6 @@
 context("Test models with custom objective")
 
-if (Sys.getenv("R_ARCH") != "i386/") {
+if (Sys.getenv("R_ARCH") != "/i386") {
   data(agaricus.train, package = "lightgbm")
   data(agaricus.test, package = "lightgbm")
   dtrain <- lgb.Dataset(agaricus.train$data, label = agaricus.train$label)
@@ -42,13 +42,13 @@ param <- list(
 num_round <- 10L
 
 test_that("custom objective works", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   bst <- lgb.train(param, dtrain, num_round, watchlist, eval = evalerror)
   expect_false(is.null(bst$record_evals))
 })
 
 test_that("using a custom objective, custom eval, and no other metrics works", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   set.seed(708L)
   bst <- lgb.train(
     params = list(

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -8,7 +8,7 @@ test_data <- agaricus.test$data[1L:100L, ]
 test_label <- agaricus.test$label[1L:100L]
 
 test_that("lgb.Dataset: basic construction, saving, loading", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   # from sparse matrix
   dtest1 <- lgb.Dataset(test_data, label = test_label)
   # from dense matrix
@@ -26,7 +26,7 @@ test_that("lgb.Dataset: basic construction, saving, loading", {
 })
 
 test_that("lgb.Dataset: getinfo & setinfo", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   dtest <- lgb.Dataset(test_data)
   dtest$construct()
 
@@ -42,7 +42,7 @@ test_that("lgb.Dataset: getinfo & setinfo", {
 })
 
 test_that("lgb.Dataset: slice, dim", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   dtest <- lgb.Dataset(test_data, label = test_label)
   lgb.Dataset.construct(dtest)
   expect_equal(dim(dtest), dim(test_data))
@@ -53,7 +53,7 @@ test_that("lgb.Dataset: slice, dim", {
 })
 
 test_that("lgb.Dataset: colnames", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   dtest <- lgb.Dataset(test_data, label = test_label)
   expect_equal(colnames(dtest), colnames(test_data))
   lgb.Dataset.construct(dtest)
@@ -67,7 +67,7 @@ test_that("lgb.Dataset: colnames", {
 })
 
 test_that("lgb.Dataset: nrow is correct for a very sparse matrix", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   nr <- 1000L
   x <- Matrix::rsparsematrix(nr, 100L, density = 0.0005)
   # we want it very sparse, so that last rows are empty
@@ -77,7 +77,7 @@ test_that("lgb.Dataset: nrow is correct for a very sparse matrix", {
 })
 
 test_that("lgb.Dataset: Dataset should be able to construct from matrix and return non-null handle", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   rawData <- matrix(runif(1000L), ncol = 10L)
   handle <- NA_real_
   ref_handle <- NULL
@@ -94,7 +94,7 @@ test_that("lgb.Dataset: Dataset should be able to construct from matrix and retu
 })
 
 test_that("lgb.Dataset$setinfo() should convert 'group' to integer", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   ds <- lgb.Dataset(
     data = matrix(rnorm(100L), nrow = 50L, ncol = 2L)
     , label = sample(c(0L, 1L), size = 50L, replace = TRUE)
@@ -108,7 +108,7 @@ test_that("lgb.Dataset$setinfo() should convert 'group' to integer", {
 })
 
 test_that("lgb.Dataset should throw an error if 'reference' is provided but of the wrong format", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   data(agaricus.test, package = "lightgbm")
   test_data <- agaricus.test$data[1L:100L, ]
   test_label <- agaricus.test$label[1L:100L]
@@ -123,7 +123,7 @@ test_that("lgb.Dataset should throw an error if 'reference' is provided but of t
 })
 
 test_that("Dataset$new() should throw an error if 'predictor' is provided but of the wrong format", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   data(agaricus.test, package = "lightgbm")
   test_data <- agaricus.test$data[1L:100L, ]
   test_label <- agaricus.test$label[1L:100L]
@@ -137,7 +137,7 @@ test_that("Dataset$new() should throw an error if 'predictor' is provided but of
 })
 
 test_that("Dataset$get_params() successfully returns parameters if you passed them", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   # note that this list uses one "main" parameter (feature_pre_filter) and one that
   # is an alias (is_sparse), to check that aliases are handled correctly
   params <- list(
@@ -159,7 +159,7 @@ test_that("Dataset$get_params() successfully returns parameters if you passed th
 })
 
 test_that("Dataset$get_params() ignores irrelevant parameters", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   params <- list(
     "feature_pre_filter" = TRUE
     , "is_sparse" = FALSE
@@ -175,7 +175,7 @@ test_that("Dataset$get_params() ignores irrelevant parameters", {
 })
 
 test_that("Dataset$update_parameters() does nothing for empty inputs", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   ds <- lgb.Dataset(
     test_data
     , label = test_label
@@ -194,7 +194,7 @@ test_that("Dataset$update_parameters() does nothing for empty inputs", {
 })
 
 test_that("Dataset$update_params() works correctly for recognized Dataset parameters", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   ds <- lgb.Dataset(
     test_data
     , label = test_label

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -8,6 +8,7 @@ test_data <- agaricus.test$data[1L:100L, ]
 test_label <- agaricus.test$label[1L:100L]
 
 test_that("lgb.Dataset: basic construction, saving, loading", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   # from sparse matrix
   dtest1 <- lgb.Dataset(test_data, label = test_label)
   # from dense matrix
@@ -25,6 +26,7 @@ test_that("lgb.Dataset: basic construction, saving, loading", {
 })
 
 test_that("lgb.Dataset: getinfo & setinfo", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   dtest <- lgb.Dataset(test_data)
   dtest$construct()
 
@@ -40,6 +42,7 @@ test_that("lgb.Dataset: getinfo & setinfo", {
 })
 
 test_that("lgb.Dataset: slice, dim", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   dtest <- lgb.Dataset(test_data, label = test_label)
   lgb.Dataset.construct(dtest)
   expect_equal(dim(dtest), dim(test_data))
@@ -50,6 +53,7 @@ test_that("lgb.Dataset: slice, dim", {
 })
 
 test_that("lgb.Dataset: colnames", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   dtest <- lgb.Dataset(test_data, label = test_label)
   expect_equal(colnames(dtest), colnames(test_data))
   lgb.Dataset.construct(dtest)
@@ -63,6 +67,7 @@ test_that("lgb.Dataset: colnames", {
 })
 
 test_that("lgb.Dataset: nrow is correct for a very sparse matrix", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   nr <- 1000L
   x <- Matrix::rsparsematrix(nr, 100L, density = 0.0005)
   # we want it very sparse, so that last rows are empty
@@ -72,6 +77,7 @@ test_that("lgb.Dataset: nrow is correct for a very sparse matrix", {
 })
 
 test_that("lgb.Dataset: Dataset should be able to construct from matrix and return non-null handle", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   rawData <- matrix(runif(1000L), ncol = 10L)
   handle <- NA_real_
   ref_handle <- NULL
@@ -88,6 +94,7 @@ test_that("lgb.Dataset: Dataset should be able to construct from matrix and retu
 })
 
 test_that("lgb.Dataset$setinfo() should convert 'group' to integer", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   ds <- lgb.Dataset(
     data = matrix(rnorm(100L), nrow = 50L, ncol = 2L)
     , label = sample(c(0L, 1L), size = 50L, replace = TRUE)
@@ -101,6 +108,7 @@ test_that("lgb.Dataset$setinfo() should convert 'group' to integer", {
 })
 
 test_that("lgb.Dataset should throw an error if 'reference' is provided but of the wrong format", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   data(agaricus.test, package = "lightgbm")
   test_data <- agaricus.test$data[1L:100L, ]
   test_label <- agaricus.test$label[1L:100L]
@@ -115,6 +123,7 @@ test_that("lgb.Dataset should throw an error if 'reference' is provided but of t
 })
 
 test_that("Dataset$new() should throw an error if 'predictor' is provided but of the wrong format", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   data(agaricus.test, package = "lightgbm")
   test_data <- agaricus.test$data[1L:100L, ]
   test_label <- agaricus.test$label[1L:100L]
@@ -128,6 +137,7 @@ test_that("Dataset$new() should throw an error if 'predictor' is provided but of
 })
 
 test_that("Dataset$get_params() successfully returns parameters if you passed them", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   # note that this list uses one "main" parameter (feature_pre_filter) and one that
   # is an alias (is_sparse), to check that aliases are handled correctly
   params <- list(
@@ -149,6 +159,7 @@ test_that("Dataset$get_params() successfully returns parameters if you passed th
 })
 
 test_that("Dataset$get_params() ignores irrelevant parameters", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   params <- list(
     "feature_pre_filter" = TRUE
     , "is_sparse" = FALSE
@@ -164,6 +175,7 @@ test_that("Dataset$get_params() ignores irrelevant parameters", {
 })
 
 test_that("Dataset$update_parameters() does nothing for empty inputs", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   ds <- lgb.Dataset(
     test_data
     , label = test_label
@@ -182,6 +194,7 @@ test_that("Dataset$update_parameters() does nothing for empty inputs", {
 })
 
 test_that("Dataset$update_params() works correctly for recognized Dataset parameters", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   ds <- lgb.Dataset(
     test_data
     , label = test_label

--- a/R-package/tests/testthat/test_learning_to_rank.R
+++ b/R-package/tests/testthat/test_learning_to_rank.R
@@ -4,6 +4,7 @@ context("Learning to rank")
 TOLERANCE <- 1e-06
 
 test_that("learning-to-rank with lgb.train() works as expected", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     # just keep a few features,to generate an model with imperfect fit
@@ -51,6 +52,7 @@ test_that("learning-to-rank with lgb.train() works as expected", {
 })
 
 test_that("learning-to-rank with lgb.cv() works as expected", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     # just keep a few features,to generate an model with imperfect fit

--- a/R-package/tests/testthat/test_learning_to_rank.R
+++ b/R-package/tests/testthat/test_learning_to_rank.R
@@ -4,7 +4,7 @@ context("Learning to rank")
 TOLERANCE <- 1e-06
 
 test_that("learning-to-rank with lgb.train() works as expected", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     # just keep a few features,to generate an model with imperfect fit
@@ -52,7 +52,7 @@ test_that("learning-to-rank with lgb.train() works as expected", {
 })
 
 test_that("learning-to-rank with lgb.cv() works as expected", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     # just keep a few features,to generate an model with imperfect fit

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -1,7 +1,7 @@
 context("lgb.get.eval.result")
 
 test_that("lgb.get.eval.result() should throw an informative error if booster is not an lgb.Booster", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     bad_inputs <- list(
         matrix(1.0:10.0, 2L, 5L)
         , TRUE
@@ -25,7 +25,7 @@ test_that("lgb.get.eval.result() should throw an informative error if booster is
 })
 
 test_that("lgb.get.eval.result() should throw an informative error for incorrect data_name", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
     dtrain <- lgb.Dataset(
@@ -59,7 +59,7 @@ test_that("lgb.get.eval.result() should throw an informative error for incorrect
 })
 
 test_that("lgb.get.eval.result() should throw an informative error for incorrect eval_name", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
     dtrain <- lgb.Dataset(
@@ -95,7 +95,7 @@ test_that("lgb.get.eval.result() should throw an informative error for incorrect
 context("lgb.load()")
 
 test_that("lgb.load() gives the expected error messages given different incorrect inputs", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
@@ -140,7 +140,7 @@ test_that("lgb.load() gives the expected error messages given different incorrec
 })
 
 test_that("Loading a Booster from a file works", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
@@ -174,7 +174,7 @@ test_that("Loading a Booster from a file works", {
 })
 
 test_that("Loading a Booster from a string works", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
@@ -207,7 +207,7 @@ test_that("Loading a Booster from a string works", {
 })
 
 test_that("If a string and a file are both passed to lgb.load() the file is used model_str is totally ignored", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
@@ -244,7 +244,7 @@ test_that("If a string and a file are both passed to lgb.load() the file is used
 context("Booster")
 
 test_that("Creating a Booster from a Dataset should work", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
@@ -265,7 +265,7 @@ test_that("Creating a Booster from a Dataset should work", {
 })
 
 test_that("Creating a Booster from a Dataset with an existing predictor should work", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     nrounds <- 2L
@@ -297,7 +297,7 @@ test_that("Creating a Booster from a Dataset with an existing predictor should w
 })
 
 test_that("Booster$rollback_one_iter() should work as expected", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
@@ -331,7 +331,7 @@ test_that("Booster$rollback_one_iter() should work as expected", {
 })
 
 test_that("Booster$update() passing a train_set works as expected", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     nrounds <- 2L
@@ -376,7 +376,7 @@ test_that("Booster$update() passing a train_set works as expected", {
 })
 
 test_that("Booster$update() throws an informative error if you provide a non-Dataset to update()", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     nrounds <- 2L
@@ -401,7 +401,7 @@ test_that("Booster$update() throws an informative error if you provide a non-Dat
 context("save_model")
 
 test_that("Saving a model with different feature importance types works", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -1,6 +1,7 @@
 context("lgb.get.eval.result")
 
 test_that("lgb.get.eval.result() should throw an informative error if booster is not an lgb.Booster", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     bad_inputs <- list(
         matrix(1.0:10.0, 2L, 5L)
         , TRUE
@@ -24,6 +25,7 @@ test_that("lgb.get.eval.result() should throw an informative error if booster is
 })
 
 test_that("lgb.get.eval.result() should throw an informative error for incorrect data_name", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
     dtrain <- lgb.Dataset(
@@ -57,6 +59,7 @@ test_that("lgb.get.eval.result() should throw an informative error for incorrect
 })
 
 test_that("lgb.get.eval.result() should throw an informative error for incorrect eval_name", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
     dtrain <- lgb.Dataset(
@@ -92,6 +95,7 @@ test_that("lgb.get.eval.result() should throw an informative error for incorrect
 context("lgb.load()")
 
 test_that("lgb.load() gives the expected error messages given different incorrect inputs", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
@@ -136,6 +140,7 @@ test_that("lgb.load() gives the expected error messages given different incorrec
 })
 
 test_that("Loading a Booster from a file works", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
@@ -169,6 +174,7 @@ test_that("Loading a Booster from a file works", {
 })
 
 test_that("Loading a Booster from a string works", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
@@ -201,6 +207,7 @@ test_that("Loading a Booster from a string works", {
 })
 
 test_that("If a string and a file are both passed to lgb.load() the file is used model_str is totally ignored", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
@@ -237,6 +244,7 @@ test_that("If a string and a file are both passed to lgb.load() the file is used
 context("Booster")
 
 test_that("Creating a Booster from a Dataset should work", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
@@ -257,6 +265,7 @@ test_that("Creating a Booster from a Dataset should work", {
 })
 
 test_that("Creating a Booster from a Dataset with an existing predictor should work", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     nrounds <- 2L
@@ -288,6 +297,7 @@ test_that("Creating a Booster from a Dataset with an existing predictor should w
 })
 
 test_that("Booster$rollback_one_iter() should work as expected", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     data(agaricus.test, package = "lightgbm")
@@ -321,6 +331,7 @@ test_that("Booster$rollback_one_iter() should work as expected", {
 })
 
 test_that("Booster$update() passing a train_set works as expected", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     nrounds <- 2L
@@ -365,6 +376,7 @@ test_that("Booster$update() passing a train_set works as expected", {
 })
 
 test_that("Booster$update() throws an informative error if you provide a non-Dataset to update()", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     nrounds <- 2L
@@ -389,6 +401,7 @@ test_that("Booster$update() throws an informative error if you provide a non-Dat
 context("save_model")
 
 test_that("Saving a model with different feature importance types works", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train

--- a/R-package/tests/testthat/test_lgb.convert_with_rules.R
+++ b/R-package/tests/testthat/test_lgb.convert_with_rules.R
@@ -1,7 +1,7 @@
 context("lgb.convert_with_rules()")
 
 test_that("lgb.convert_with_rules() rejects inputs that are not a data.table or data.frame", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     bad_inputs <- list(
         matrix(1.0:10.0, 2L, 5L)
         , TRUE
@@ -21,7 +21,7 @@ test_that("lgb.convert_with_rules() rejects inputs that are not a data.table or 
 })
 
 test_that("lgb.convert_with_rules() should work correctly for a dataset with only character columns", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     testDF <- data.frame(
         col1 = c("a", "b", "c")
         , col2 =  c("green", "green", "red")
@@ -47,7 +47,7 @@ test_that("lgb.convert_with_rules() should work correctly for a dataset with onl
 })
 
 test_that("lgb.convert_with_rules() should work correctly for a dataset with only factor columns", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     testDF <- data.frame(
         col1 = as.factor(c("a", "b", "c"))
         , col2 =  as.factor(c("green", "green", "red"))
@@ -73,7 +73,7 @@ test_that("lgb.convert_with_rules() should work correctly for a dataset with onl
 })
 
 test_that("lgb.convert_with_rules() should not change a dataset with only integer columns", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     testDF <- data.frame(
         col1 = 11L:15L
         , col2 = 16L:20L
@@ -92,7 +92,7 @@ test_that("lgb.convert_with_rules() should not change a dataset with only intege
 })
 
 test_that("lgb.convert_with_rules() should work correctly for a dataset with numeric, factor, and character columns", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     testDF <- data.frame(
         character_col = c("a", "b", "c")
         , numeric_col = c(1.0, 9.0, 10.0)
@@ -123,7 +123,7 @@ test_that("lgb.convert_with_rules() should work correctly for a dataset with num
 })
 
 test_that("lgb.convert_with_rules() should convert missing values to the expected value", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     testDF <- data.frame(
         character_col = c("a", NA_character_, "c")
         , na_col = rep(NA, 3L)
@@ -179,7 +179,7 @@ test_that("lgb.convert_with_rules() should convert missing values to the expecte
 })
 
 test_that("lgb.convert_with_rules() should work correctly if you provide your own well-formed rules", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     testDF <- data.frame(
         character_col = c("a", NA_character_, "c", "a", "a", "c")
         , na_col = rep(NA, 6L)
@@ -239,7 +239,7 @@ test_that("lgb.convert_with_rules() should work correctly if you provide your ow
 })
 
 test_that("lgb.convert_with_rules() should modify data.tables in-place", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     testDT <- data.table::data.table(
         character_col = c("a", NA_character_, "c")
         , na_col = rep(NA, 3L)

--- a/R-package/tests/testthat/test_lgb.convert_with_rules.R
+++ b/R-package/tests/testthat/test_lgb.convert_with_rules.R
@@ -1,6 +1,7 @@
 context("lgb.convert_with_rules()")
 
 test_that("lgb.convert_with_rules() rejects inputs that are not a data.table or data.frame", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     bad_inputs <- list(
         matrix(1.0:10.0, 2L, 5L)
         , TRUE
@@ -20,6 +21,7 @@ test_that("lgb.convert_with_rules() rejects inputs that are not a data.table or 
 })
 
 test_that("lgb.convert_with_rules() should work correctly for a dataset with only character columns", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     testDF <- data.frame(
         col1 = c("a", "b", "c")
         , col2 =  c("green", "green", "red")
@@ -45,6 +47,7 @@ test_that("lgb.convert_with_rules() should work correctly for a dataset with onl
 })
 
 test_that("lgb.convert_with_rules() should work correctly for a dataset with only factor columns", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     testDF <- data.frame(
         col1 = as.factor(c("a", "b", "c"))
         , col2 =  as.factor(c("green", "green", "red"))
@@ -70,6 +73,7 @@ test_that("lgb.convert_with_rules() should work correctly for a dataset with onl
 })
 
 test_that("lgb.convert_with_rules() should not change a dataset with only integer columns", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     testDF <- data.frame(
         col1 = 11L:15L
         , col2 = 16L:20L
@@ -88,6 +92,7 @@ test_that("lgb.convert_with_rules() should not change a dataset with only intege
 })
 
 test_that("lgb.convert_with_rules() should work correctly for a dataset with numeric, factor, and character columns", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     testDF <- data.frame(
         character_col = c("a", "b", "c")
         , numeric_col = c(1.0, 9.0, 10.0)
@@ -118,6 +123,7 @@ test_that("lgb.convert_with_rules() should work correctly for a dataset with num
 })
 
 test_that("lgb.convert_with_rules() should convert missing values to the expected value", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     testDF <- data.frame(
         character_col = c("a", NA_character_, "c")
         , na_col = rep(NA, 3L)
@@ -173,6 +179,7 @@ test_that("lgb.convert_with_rules() should convert missing values to the expecte
 })
 
 test_that("lgb.convert_with_rules() should work correctly if you provide your own well-formed rules", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     testDF <- data.frame(
         character_col = c("a", NA_character_, "c", "a", "a", "c")
         , na_col = rep(NA, 6L)
@@ -232,6 +239,7 @@ test_that("lgb.convert_with_rules() should work correctly if you provide your ow
 })
 
 test_that("lgb.convert_with_rules() should modify data.tables in-place", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     testDT <- data.table::data.table(
         character_col = c("a", NA_character_, "c")
         , na_col = rep(NA, 3L)

--- a/R-package/tests/testthat/test_lgb.importance.R
+++ b/R-package/tests/testthat/test_lgb.importance.R
@@ -1,6 +1,7 @@
 context("lgb.importance")
 
 test_that("lgb.importance() should reject bad inputs", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     bad_inputs <- list(
         .Machine$integer.max
         , Inf

--- a/R-package/tests/testthat/test_lgb.importance.R
+++ b/R-package/tests/testthat/test_lgb.importance.R
@@ -1,7 +1,7 @@
 context("lgb.importance")
 
 test_that("lgb.importance() should reject bad inputs", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     bad_inputs <- list(
         .Machine$integer.max
         , Inf

--- a/R-package/tests/testthat/test_lgb.interprete.R
+++ b/R-package/tests/testthat/test_lgb.interprete.R
@@ -8,7 +8,7 @@ context("lgb.interpete")
 }
 
 test_that("lgb.intereprete works as expected for binary classification", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -61,7 +61,7 @@ test_that("lgb.intereprete works as expected for binary classification", {
 })
 
 test_that("lgb.intereprete works as expected for multiclass classification", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     data(iris)
 
     # We must convert factors to numeric

--- a/R-package/tests/testthat/test_lgb.interprete.R
+++ b/R-package/tests/testthat/test_lgb.interprete.R
@@ -8,6 +8,7 @@ context("lgb.interpete")
 }
 
 test_that("lgb.intereprete works as expected for binary classification", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -60,6 +61,7 @@ test_that("lgb.intereprete works as expected for binary classification", {
 })
 
 test_that("lgb.intereprete works as expected for multiclass classification", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     data(iris)
 
     # We must convert factors to numeric

--- a/R-package/tests/testthat/test_lgb.plot.importance.R
+++ b/R-package/tests/testthat/test_lgb.plot.importance.R
@@ -1,7 +1,7 @@
 context("lgb.plot.importance()")
 
 test_that("lgb.plot.importance() should run without error for well-formed inputs", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)

--- a/R-package/tests/testthat/test_lgb.plot.importance.R
+++ b/R-package/tests/testthat/test_lgb.plot.importance.R
@@ -1,6 +1,7 @@
 context("lgb.plot.importance()")
 
 test_that("lgb.plot.importance() should run without error for well-formed inputs", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)

--- a/R-package/tests/testthat/test_lgb.plot.interpretation.R
+++ b/R-package/tests/testthat/test_lgb.plot.interpretation.R
@@ -8,6 +8,7 @@ context("lgb.plot.interpretation")
 }
 
 test_that("lgb.plot.interepretation works as expected for binary classification", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -58,6 +59,7 @@ test_that("lgb.plot.interepretation works as expected for binary classification"
 })
 
 test_that("lgb.plot.interepretation works as expected for multiclass classification", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     data(iris)
 
     # We must convert factors to numeric

--- a/R-package/tests/testthat/test_lgb.plot.interpretation.R
+++ b/R-package/tests/testthat/test_lgb.plot.interpretation.R
@@ -8,7 +8,7 @@ context("lgb.plot.interpretation")
 }
 
 test_that("lgb.plot.interepretation works as expected for binary classification", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -59,7 +59,7 @@ test_that("lgb.plot.interepretation works as expected for binary classification"
 })
 
 test_that("lgb.plot.interepretation works as expected for multiclass classification", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     data(iris)
 
     # We must convert factors to numeric

--- a/R-package/tests/testthat/test_lgb.unloader.R
+++ b/R-package/tests/testthat/test_lgb.unloader.R
@@ -1,6 +1,7 @@
 context("lgb.unloader")
 
 test_that("lgb.unloader works as expected", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -21,6 +22,7 @@ test_that("lgb.unloader works as expected", {
 })
 
 test_that("lgb.unloader finds all boosters and removes them", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)

--- a/R-package/tests/testthat/test_lgb.unloader.R
+++ b/R-package/tests/testthat/test_lgb.unloader.R
@@ -1,7 +1,7 @@
 context("lgb.unloader")
 
 test_that("lgb.unloader works as expected", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -22,7 +22,7 @@ test_that("lgb.unloader works as expected", {
 })
 
 test_that("lgb.unloader finds all boosters and removes them", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)

--- a/R-package/tests/testthat/test_parameters.R
+++ b/R-package/tests/testthat/test_parameters.R
@@ -7,6 +7,7 @@ train <- agaricus.train
 test <- agaricus.test
 
 test_that("Feature penalties work properly", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   # Fit a series of models with varying penalty on most important variable
   var_name <- "odor=none"
   var_index <- which(train$data@Dimnames[[2L]] == var_name)
@@ -48,6 +49,7 @@ test_that("Feature penalties work properly", {
 context("parameter aliases")
 
 test_that(".PARAMETER_ALIASES() returns a named list of character vectors, where names are unique", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   param_aliases <- .PARAMETER_ALIASES()
   expect_identical(class(param_aliases), "list")
   expect_true(is.character(names(param_aliases)))
@@ -61,6 +63,7 @@ test_that(".PARAMETER_ALIASES() returns a named list of character vectors, where
 })
 
 test_that("training should warn if you use 'dart' boosting, specified with 'boosting' or aliases", {
+  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
   for (boosting_param in .PARAMETER_ALIASES()[["boosting"]]) {
     expect_warning({
       result <- lightgbm(

--- a/R-package/tests/testthat/test_parameters.R
+++ b/R-package/tests/testthat/test_parameters.R
@@ -7,7 +7,7 @@ train <- agaricus.train
 test <- agaricus.test
 
 test_that("Feature penalties work properly", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   # Fit a series of models with varying penalty on most important variable
   var_name <- "odor=none"
   var_index <- which(train$data@Dimnames[[2L]] == var_name)
@@ -49,7 +49,7 @@ test_that("Feature penalties work properly", {
 context("parameter aliases")
 
 test_that(".PARAMETER_ALIASES() returns a named list of character vectors, where names are unique", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   param_aliases <- .PARAMETER_ALIASES()
   expect_identical(class(param_aliases), "list")
   expect_true(is.character(names(param_aliases)))
@@ -63,7 +63,7 @@ test_that(".PARAMETER_ALIASES() returns a named list of character vectors, where
 })
 
 test_that("training should warn if you use 'dart' boosting, specified with 'boosting' or aliases", {
-  testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+  testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
   for (boosting_param in .PARAMETER_ALIASES()[["boosting"]]) {
     expect_warning({
       result <- lightgbm(

--- a/R-package/tests/testthat/test_utils.R
+++ b/R-package/tests/testthat/test_utils.R
@@ -1,7 +1,7 @@
 context("lgb.encode.char")
 
 test_that("lgb.encode.char throws an informative error if it is passed a non-raw input", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     x <- "some-string"
     expect_error({
         lgb.encode.char(x)
@@ -11,19 +11,19 @@ test_that("lgb.encode.char throws an informative error if it is passed a non-raw
 context("lgb.check.r6.class")
 
 test_that("lgb.check.r6.class() should return FALSE for NULL input", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     expect_false(lgb.check.r6.class(NULL, "lgb.Dataset"))
 })
 
 test_that("lgb.check.r6.class() should return FALSE for non-R6 inputs", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     x <- 5L
     class(x) <- "lgb.Dataset"
     expect_false(lgb.check.r6.class(x, "lgb.Dataset"))
 })
 
 test_that("lgb.check.r6.class() should correctly identify lgb.Dataset", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     data("agaricus.train", package = "lightgbm")
     train <- agaricus.train
     ds <- lgb.Dataset(train$data, label = train$label)
@@ -35,7 +35,7 @@ test_that("lgb.check.r6.class() should correctly identify lgb.Dataset", {
 context("lgb.params2str")
 
 test_that("lgb.params2str() works as expected for empty lists", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     out_str <- lgb.params2str(
         params = list()
     )
@@ -44,7 +44,7 @@ test_that("lgb.params2str() works as expected for empty lists", {
 })
 
 test_that("lgb.params2str() works as expected for a key in params with multiple different-length elements", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     metrics <- c("a", "ab", "abc", "abcdefg")
     params <- list(
         objective = "magic"
@@ -66,14 +66,14 @@ test_that("lgb.params2str() works as expected for a key in params with multiple 
 context("lgb.last_error")
 
 test_that("lgb.last_error() throws an error if there are no errors", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     expect_error({
         lgb.last_error()
     }, regexp = "Everything is fine")
 })
 
 test_that("lgb.last_error() correctly returns errors from the C++ side", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dvalid1 <- lgb.Dataset(
@@ -88,7 +88,7 @@ test_that("lgb.last_error() correctly returns errors from the C++ side", {
 context("lgb.check.eval")
 
 test_that("lgb.check.eval works as expected with no metric", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     params <- lgb.check.eval(
         params = list(device = "cpu")
         , eval = "binary_error"
@@ -98,7 +98,7 @@ test_that("lgb.check.eval works as expected with no metric", {
 })
 
 test_that("lgb.check.eval adds eval to metric in params", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     params <- lgb.check.eval(
         params = list(metric = "auc")
         , eval = "binary_error"
@@ -117,7 +117,7 @@ test_that("lgb.check.eval adds eval to metric in params if two evaluation names 
 })
 
 test_that("lgb.check.eval adds eval to metric in params if a list is provided", {
-    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
+    testthat::skip_if(Sys.getenv("R_ARCH") == "/i386", message = "skipping tests on 32-bit R")
     params <- lgb.check.eval(
         params = list(metric = "auc")
         , eval = list("binary_error", "binary_logloss")

--- a/R-package/tests/testthat/test_utils.R
+++ b/R-package/tests/testthat/test_utils.R
@@ -1,6 +1,7 @@
 context("lgb.encode.char")
 
 test_that("lgb.encode.char throws an informative error if it is passed a non-raw input", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     x <- "some-string"
     expect_error({
         lgb.encode.char(x)
@@ -10,17 +11,19 @@ test_that("lgb.encode.char throws an informative error if it is passed a non-raw
 context("lgb.check.r6.class")
 
 test_that("lgb.check.r6.class() should return FALSE for NULL input", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     expect_false(lgb.check.r6.class(NULL, "lgb.Dataset"))
 })
 
 test_that("lgb.check.r6.class() should return FALSE for non-R6 inputs", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     x <- 5L
     class(x) <- "lgb.Dataset"
     expect_false(lgb.check.r6.class(x, "lgb.Dataset"))
 })
 
 test_that("lgb.check.r6.class() should correctly identify lgb.Dataset", {
-
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     data("agaricus.train", package = "lightgbm")
     train <- agaricus.train
     ds <- lgb.Dataset(train$data, label = train$label)
@@ -32,6 +35,7 @@ test_that("lgb.check.r6.class() should correctly identify lgb.Dataset", {
 context("lgb.params2str")
 
 test_that("lgb.params2str() works as expected for empty lists", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     out_str <- lgb.params2str(
         params = list()
     )
@@ -40,6 +44,7 @@ test_that("lgb.params2str() works as expected for empty lists", {
 })
 
 test_that("lgb.params2str() works as expected for a key in params with multiple different-length elements", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     metrics <- c("a", "ab", "abc", "abcdefg")
     params <- list(
         objective = "magic"
@@ -61,12 +66,14 @@ test_that("lgb.params2str() works as expected for a key in params with multiple 
 context("lgb.last_error")
 
 test_that("lgb.last_error() throws an error if there are no errors", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     expect_error({
         lgb.last_error()
     }, regexp = "Everything is fine")
 })
 
 test_that("lgb.last_error() correctly returns errors from the C++ side", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dvalid1 <- lgb.Dataset(
@@ -81,6 +88,7 @@ test_that("lgb.last_error() correctly returns errors from the C++ side", {
 context("lgb.check.eval")
 
 test_that("lgb.check.eval works as expected with no metric", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     params <- lgb.check.eval(
         params = list(device = "cpu")
         , eval = "binary_error"
@@ -90,6 +98,7 @@ test_that("lgb.check.eval works as expected with no metric", {
 })
 
 test_that("lgb.check.eval adds eval to metric in params", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     params <- lgb.check.eval(
         params = list(metric = "auc")
         , eval = "binary_error"
@@ -108,6 +117,7 @@ test_that("lgb.check.eval adds eval to metric in params if two evaluation names 
 })
 
 test_that("lgb.check.eval adds eval to metric in params if a list is provided", {
+    testthat::skip_if(Sys.getenv("R_ARCH") == "i386/", message = "skipping tests on 32-bit R")
     params <- lgb.check.eval(
         params = list(metric = "auc")
         , eval = list("binary_error", "binary_logloss")


### PR DESCRIPTION
This PR proposes skipping all of the R-package tests on 32-bit Windows builds. See the lengthy discussion on #3187, especially this proposal: https://github.com/microsoft/LightGBM/issues/3187#issuecomment-673219806.

This PR is an attempt to petition CRAN to allow LightGBM's R package onto CRAN without support for 32-bit Windows, in pursuit of #629 .

I've built this branch and submitted it to win-builder. It passes all automated pre-checks!

This link will work for 72 hours: https://win-builder.r-project.org/YAnUD23bbYGR/

<details><summary>install logs (no issues)</summary>

```text
* installing *source* package 'lightgbm' ...
** using staged installation
checking whether MM_PREFETCH works...yes
checking whether MM_MALLOC works...yes
** libs

*** arch - i386
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c application/application.cpp -o application/application.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c boosting/boosting.cpp -o boosting/boosting.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c boosting/gbdt.cpp -o boosting/gbdt.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c boosting/gbdt_model_text.cpp -o boosting/gbdt_model_text.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c boosting/gbdt_prediction.cpp -o boosting/gbdt_prediction.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c boosting/prediction_early_stop.cpp -o boosting/prediction_early_stop.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/bin.cpp -o io/bin.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/config.cpp -o io/config.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/config_auto.cpp -o io/config_auto.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/dataset.cpp -o io/dataset.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/dataset_loader.cpp -o io/dataset_loader.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/file_io.cpp -o io/file_io.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/json11.cpp -o io/json11.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/metadata.cpp -o io/metadata.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/parser.cpp -o io/parser.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/tree.cpp -o io/tree.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c metric/dcg_calculator.cpp -o metric/dcg_calculator.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c metric/metric.cpp -o metric/metric.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c objective/objective_function.cpp -o objective/objective_function.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c network/linker_topo.cpp -o network/linker_topo.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c network/linkers_mpi.cpp -o network/linkers_mpi.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c network/linkers_socket.cpp -o network/linkers_socket.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c network/network.cpp -o network/network.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c treelearner/data_parallel_tree_learner.cpp -o treelearner/data_parallel_tree_learner.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c treelearner/feature_parallel_tree_learner.cpp -o treelearner/feature_parallel_tree_learner.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c treelearner/gpu_tree_learner.cpp -o treelearner/gpu_tree_learner.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c treelearner/serial_tree_learner.cpp -o treelearner/serial_tree_learner.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c treelearner/tree_learner.cpp -o treelearner/tree_learner.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c treelearner/voting_parallel_tree_learner.cpp -o treelearner/voting_parallel_tree_learner.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c c_api.cpp -o c_api.o
d:/Compiler/rtools40/mingw32/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c lightgbm_R.cpp -o lightgbm_R.o
d:/Compiler/rtools40/mingw32/bin/g++ -shared -s -static-libgcc -o lightgbm.dll tmp.def application/application.o boosting/boosting.o boosting/gbdt.o boosting/gbdt_model_text.o boosting/gbdt_prediction.o boosting/prediction_early_stop.o io/bin.o io/config.o io/config_auto.o io/dataset.o io/dataset_loader.o io/file_io.o io/json11.o io/metadata.o io/parser.o io/tree.o metric/dcg_calculator.o metric/metric.o objective/objective_function.o network/linker_topo.o network/linkers_mpi.o network/linkers_socket.o network/network.o treelearner/data_parallel_tree_learner.o treelearner/feature_parallel_tree_learner.o treelearner/gpu_tree_learner.o treelearner/serial_tree_learner.o treelearner/tree_learner.o treelearner/voting_parallel_tree_learner.o c_api.o lightgbm_R.o -fopenmp -pthread -lws2_32 -lIphlpapi -Ld:/Compiler/gcc-4.9.3/local330/lib/i386 -Ld:/Compiler/gcc-4.9.3/local330/lib -LD:/RCompile/recent/R-4.0.2/bin/i386 -lR
installing to d:/RCompile/CRANguest/R-release/lib/00LOCK-lightgbm/00new/lightgbm/libs/i386

*** arch - x64
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c application/application.cpp -o application/application.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c boosting/boosting.cpp -o boosting/boosting.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c boosting/gbdt.cpp -o boosting/gbdt.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c boosting/gbdt_model_text.cpp -o boosting/gbdt_model_text.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c boosting/gbdt_prediction.cpp -o boosting/gbdt_prediction.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c boosting/prediction_early_stop.cpp -o boosting/prediction_early_stop.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/bin.cpp -o io/bin.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/config.cpp -o io/config.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/config_auto.cpp -o io/config_auto.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/dataset.cpp -o io/dataset.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/dataset_loader.cpp -o io/dataset_loader.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/file_io.cpp -o io/file_io.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/json11.cpp -o io/json11.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/metadata.cpp -o io/metadata.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/parser.cpp -o io/parser.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c io/tree.cpp -o io/tree.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c metric/dcg_calculator.cpp -o metric/dcg_calculator.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c metric/metric.cpp -o metric/metric.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c objective/objective_function.cpp -o objective/objective_function.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c network/linker_topo.cpp -o network/linker_topo.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c network/linkers_mpi.cpp -o network/linkers_mpi.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c network/linkers_socket.cpp -o network/linkers_socket.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c network/network.cpp -o network/network.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c treelearner/data_parallel_tree_learner.cpp -o treelearner/data_parallel_tree_learner.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c treelearner/feature_parallel_tree_learner.cpp -o treelearner/feature_parallel_tree_learner.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c treelearner/gpu_tree_learner.cpp -o treelearner/gpu_tree_learner.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c treelearner/serial_tree_learner.cpp -o treelearner/serial_tree_learner.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c treelearner/tree_learner.cpp -o treelearner/tree_learner.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c treelearner/voting_parallel_tree_learner.cpp -o treelearner/voting_parallel_tree_learner.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c c_api.cpp -o c_api.o
d:/Compiler/rtools40/mingw64/bin/g++  -std=gnu++11 -I"D:/RCompile/recent/R-4.0.2/include" -DNDEBUG -I./include -DMM_PREFETCH=1 -DMM_MALLOC=1 -DUSE_SOCKET -DLGB_R_BUILD    -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp -pthread   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign -c lightgbm_R.cpp -o lightgbm_R.o
d:/Compiler/rtools40/mingw64/bin/g++ -shared -s -static-libgcc -o lightgbm.dll tmp.def application/application.o boosting/boosting.o boosting/gbdt.o boosting/gbdt_model_text.o boosting/gbdt_prediction.o boosting/prediction_early_stop.o io/bin.o io/config.o io/config_auto.o io/dataset.o io/dataset_loader.o io/file_io.o io/json11.o io/metadata.o io/parser.o io/tree.o metric/dcg_calculator.o metric/metric.o objective/objective_function.o network/linker_topo.o network/linkers_mpi.o network/linkers_socket.o network/network.o treelearner/data_parallel_tree_learner.o treelearner/feature_parallel_tree_learner.o treelearner/gpu_tree_learner.o treelearner/serial_tree_learner.o treelearner/tree_learner.o treelearner/voting_parallel_tree_learner.o c_api.o lightgbm_R.o -fopenmp -pthread -lws2_32 -lIphlpapi -Ld:/Compiler/gcc-4.9.3/local330/lib/x64 -Ld:/Compiler/gcc-4.9.3/local330/lib -LD:/RCompile/recent/R-4.0.2/bin/x64 -lR
installing to d:/RCompile/CRANguest/R-release/lib/00LOCK-lightgbm/00new/lightgbm/libs/x64
** R
** data
** demo
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** testing if installed package can be loaded from temporary location
*** arch - i386
*** arch - x64
** testing if installed package can be loaded from final location
*** arch - i386
*** arch - x64
** testing if installed package keeps a record of temporary installation path
* MD5 sums
packaged installation of 'lightgbm' as lightgbm_3.0.0-1.zip
* DONE (lightgbm)
```

</details>


<details><summary>check logs (1 NOTE)</summary>

```text
* using log directory 'd:/RCompile/CRANguest/R-release/lightgbm.Rcheck'
* using R version 4.0.2 (2020-06-22)
* using platform: x86_64-w64-mingw32 (64-bit)
* using session charset: ISO8859-1
* checking for file 'lightgbm/DESCRIPTION' ... OK
* checking extension type ... Package
* this is package 'lightgbm' version '3.0.0-1'
* package encoding: UTF-8
* checking CRAN incoming feasibility ... NOTE
Maintainer: 'Guolin Ke <jaylamb20@gmail.com>'

New submission

License components with restrictions and base license permitting such:
  MIT + file LICENSE
File 'LICENSE':
  The MIT License (MIT)
  
  Copyright (c) Microsoft Corporation
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
  
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
  
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
* checking package namespace information ... OK
* checking package dependencies ... OK
* checking if this is a source package ... OK
* checking if there is a namespace ... OK
* checking for hidden files and directories ... OK
* checking for portable file names ... OK
* checking whether package 'lightgbm' can be installed ... OK
* checking installed package size ... OK
* checking package directory ... OK
* checking for future file timestamps ... OK
* checking DESCRIPTION meta-information ... OK
* checking top-level files ... OK
* checking for left-over files ... OK
* checking index information ... OK
* checking package subdirectories ... OK
* checking R files for non-ASCII characters ... OK
* checking R files for syntax errors ... OK
* loading checks for arch 'i386'
** checking whether the package can be loaded ... OK
** checking whether the package can be loaded with stated dependencies ... OK
** checking whether the package can be unloaded cleanly ... OK
** checking whether the namespace can be loaded with stated dependencies ... OK
** checking whether the namespace can be unloaded cleanly ... OK
** checking loading without being on the library search path ... OK
** checking use of S3 registration ... OK
* loading checks for arch 'x64'
** checking whether the package can be loaded ... OK
** checking whether the package can be loaded with stated dependencies ... OK
** checking whether the package can be unloaded cleanly ... OK
** checking whether the namespace can be loaded with stated dependencies ... OK
** checking whether the namespace can be unloaded cleanly ... OK
** checking loading without being on the library search path ... OK
** checking use of S3 registration ... OK
* checking dependencies in R code ... OK
* checking S3 generic/method consistency ... OK
* checking replacement functions ... OK
* checking foreign function calls ... OK
* checking R code for possible problems ... [12s] OK
* checking Rd files ... OK
* checking Rd metadata ... OK
* checking Rd line widths ... OK
* checking Rd cross-references ... OK
* checking for missing documentation entries ... OK
* checking for code/documentation mismatches ... OK
* checking Rd \usage sections ... OK
* checking Rd contents ... OK
* checking for unstated dependencies in examples ... OK
* checking contents of 'data' directory ... OK
* checking data for non-ASCII characters ... OK
* checking data for ASCII and uncompressed saves ... OK
* checking line endings in shell scripts ... OK
* checking line endings in C/C++/Fortran sources/headers ... OK
* checking line endings in Makefiles ... OK
* checking compilation flags in Makevars ... OK
* checking for GNU extensions in Makefiles ... OK
* checking for portable use of $(BLAS_LIBS) and $(LAPACK_LIBS) ... OK
* checking use of PKG_*FLAGS in Makefiles ... OK
* checking use of SHLIB_OPENMP_*FLAGS in Makefiles ... OK
* checking pragmas in C/C++ headers and code ... OK
* checking compiled code ... OK
* checking examples ...
** running examples for arch 'i386' ... [6s] OK
** running examples for arch 'x64' ... [7s] OK
* checking for unstated dependencies in 'tests' ... OK
* checking tests ...
** running tests for arch 'i386' ... [4s] OK
  Running 'testthat.R' [4s]
** running tests for arch 'x64' ... [20s] OK
  Running 'testthat.R' [19s]
* checking PDF version of manual ... OK
* checking for detritus in the temp directory ... OK
* DONE
Status: 1 NOTE
```

<details>


@guolinke could you try submitting this version to CRAN, with something like the proposed text in https://github.com/microsoft/LightGBM/issues/3187#issuecomment-673219806?
