### PR TITLE
[ci] fix flaky R CMD check test about library size

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -199,11 +199,7 @@ if grep -q -R "WARNING" "$LOG_FILE_NAME"; then
     exit -1
 fi
 
-if [[ $OS_NAME == "linux" ]] && [[ $R_BUILD_TYPE == "cran" ]]; then
-    ALLOWED_CHECK_NOTES=2
-else
-    ALLOWED_CHECK_NOTES=1
-fi
+ALLOWED_CHECK_NOTES=2
 NUM_CHECK_NOTES=$(
     cat ${LOG_FILE_NAME} \
         | grep -e '^Status: .* NOTE.*' \


### PR DESCRIPTION
We now have two PRs hitting CI failures on R builds for this issue:

```text
* checking installed package size ... NOTE
  installed size is  5.2Mb
  sub-directories of 1Mb or more:
    libs   4.5Mb
```

https://github.com/microsoft/LightGBM/pull/3305#issuecomment-674348634, https://github.com/microsoft/LightGBM/pull/3264#issuecomment-671509757

That note is very unpredictable and likely to be allowed by CRAN. This PR proposes allowing it in CI jobs.