### PR TITLE
[ci] Test 32-bit builds for R package

### DIFF
--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -158,8 +158,14 @@ if ($env:COMPILER -ne "MSVC") {
     cd "C:\$R_CMD_CHECK_DIR\"
   }
 
-  Write-Output "Running R CMD check as CRAN"
-  Run-R-Code-Redirect-Stderr "result <- processx::run(command = 'R.exe', args = c('CMD', 'check', '--no-multiarch', '--as-cran', '--run-dontrun', '$PKG_FILE_NAME'), echo = TRUE, windows_verbatim_args = FALSE)" ; $check_succeeded = $?
+  Write-Output "Running R CMD check"
+  if ($env:R_BUILD_TYPE -eq "cran") {
+    # CRAN packages must pass without --no-multiarch (build on 64-bit and 32-bit)
+    $check_args = "c('CMD', 'check', '--as-cran', '--run-dontrun', '$PKG_FILE_NAME')"
+  } else {
+    $check_args = "c('CMD', 'check', '--no-multiarch', '--as-cran', '--run-dontrun', '$PKG_FILE_NAME')"
+  }
+  Run-R-Code-Redirect-Stderr "result <- processx::run(command = 'R.exe', args = $check_args, echo = TRUE, windows_verbatim_args = FALSE)" ; $check_succeeded = $?
 
   Write-Output "R CMD check build logs:"
   $INSTALL_LOG_FILE_NAME = "lightgbm.Rcheck\00install.out"

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -26,7 +26,7 @@ To install this package on any operating system:
 ```r
 PKG_URL <- "https://github.com/microsoft/LightGBM/releases/download/v3.0.0rc1/lightgbm-3.0.0-1-r-cran.tar.gz"
 
-remotes::install_url(PKG_URL, INSTALL_OPTS = "--no-multiarch")
+remotes::install_url(PKG_URL)
 ```
 
 ### Installing Precompiled Binaries


### PR DESCRIPTION
Now that #3307 has ben merged and the R package is passing `R CMD check` for both `x64` and `i386` architectures, this PR proposes testing that in our CI. Since the 32-bit build isn't enable when  building with CMake (and I think we should not enable it), as of this PR `R CMD check` would be run without `--no-multiarch` only for CRAN builds.

This PR also proposes removing the `--no-multiarch` option from the documentation for installing with `{remotes}`. If we do that, I'd want to update the artifact `lightgbm-3.0.0-1-r-cran.tar.gz` on release `3.0.0rc`. @guolinke is that ok? Generally I think it's bad to update artifacts once they're published, but in this case since it's something very new and experimental, since its only a pre-release, and since the new artifact would't have any breaking changes, I think it's worth it to remove the need for that flag from the documentation.