### PR TITLE
[ci][docs] explicitly recuire fresh versions of RTD stuff

### DIFF
--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -1,4 +1,5 @@
 sphinx >= 3.0.2,<3.2
 sphinx_rtd_theme >= 0.5
+readthedocs-sphinx-ext > 2.1
 mock; python_version < '3'
 breathe

--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -1,4 +1,4 @@
 sphinx >= 3.0.2,<3.2
-sphinx_rtd_theme >= 0.3
+sphinx_rtd_theme >= 0.5
 mock; python_version < '3'
 breathe


### PR DESCRIPTION
Temp fixes for current `master` docs builds... again.

For some reason RTD by default installs old versions of `sphinx_rtd_theme` and `readthedocs-sphinx-ext` which results in

```
...

WARNING: the readthedocs_ext.readthedocs extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit
WARNING: doing serial read

...

build finished with problems, 2 warnings.
```

![image](https://user-images.githubusercontent.com/25141164/90529676-a9409e00-e17c-11ea-90f4-40d5b455e95a.png)
