### PR TITLE
[R-package] remove blank lines and not-really-comments from .Rbuildignore

### DIFF
--- a/R-package/.Rbuildignore
+++ b/R-package/.Rbuildignore
@@ -1,27 +1,19 @@
-^build_r.R$
-\.gitkeep$
-^docs/.*$
-^pkgdown$
-^cran-comments\.md$
-
-# Objects created by compilation
-^.*\.o
-^.*\.so
-^.*\.dll
-^.*\.out
-^.*\.bin
-
-# Code copied in at build time
-^src/CMakeLists.txt$
-^Makefile$
-^src/build/.*$
-^autom4te.cache/.*$
-
-# files only used during development
 AUTOCONF_UBUNTU_VERSION
+^autom4te.cache/.*$
+^.*\.bin
+^build_r.R$
+^cran-comments\.md$
+^docs/.*$
+^.*\.dll
+\.gitkeep$
+^Makefile$
+^.*\.o
+^.*\.out
+^pkgdown$
 ^recreate-configure\.sh$
-
-# unnecessary files from submodules
+^.*\.so
+^src/build/.*$
+^src/CMakeLists.txt$
 ^src/compute/.appveyor.yml$
 ^src/compute/.coveralls.yml$
 ^src/compute/.travis.yml$


### PR DESCRIPTION
I saw this really interesting discussion on the `r-pkg-devel` mailing list: https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005894.html

Basically, the `.Rbuildignore` file does not support comments. Lines that start with `#` will be evaluated as patterns that could match a file.

It also does not skip blank lines, so having blank lines just increases the time it takes to build a package.

This PR should slightly reduce the build time for the R package, and should avoid the unlikely but not impossible case where one of the "commented" lines matches and ignores a file that should not be ignored.

Since I'm touching this file, I also took the opportunity to rearrange it so that it is in alphabetical order (ignoring non-alphanumeric characters).