### PR TITLE
[ci] fix R CMD check issue 'unable to verify current time'

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -7,6 +7,10 @@ mkdir -p $R_LIB_PATH
 export R_LIBS=$R_LIB_PATH
 export PATH="$R_LIB_PATH/R/bin:$PATH"
 
+# hack to get around this:
+# https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
+export _R_CHECK_SYSTEM_CLOCK_=0
+
 # Get details needed for installing R components
 #
 # NOTES:

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -74,6 +74,10 @@ $env:CTAN_MIRROR = "https://ctan.math.illinois.edu/systems/win32/miktex"
 $env:CTAN_MIKTEX_ARCHIVE = "$env:CTAN_MIRROR/setup/windows-x64/"
 $env:CTAN_PACKAGE_ARCHIVE = "$env:CTAN_MIRROR/tm/packages/"
 
+# hack to get around this:
+# https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
+$env:_R_CHECK_SYSTEM_CLOCK_ = 0
+
 if (($env:COMPILER -eq "MINGW") -and ($env:R_BUILD_TYPE -eq "cmake")) {
   $env:CXX = "$env:RTOOLS_MINGW_BIN/g++.exe"
   $env:CC = "$env:RTOOLS_MINGW_BIN/gcc.exe"


### PR DESCRIPTION
This PR skips this `R CMD check` check that is breaking builds

```text
* checking for future file timestamps ... NOTE
unable to verify current time
```

You can see https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html for details. Essentially `R CMD check` relies on two small web services that provide a global clock, and this NOTE can show up when those services are unavailable. They are experiencing some issues this week 🙃 

I think this hack is better than just bumping `ALLOWED_CHECK_NOTES`, as described here: https://github.com/microsoft/LightGBM/pull/3338#discussion_r479346363

I've added this fix in #3336 and #3298 , but since it's blocking any other PRs, I thought it made sense to pull it out into its own PR we can merge quickly.