### PR TITLE
[R-package] fix typo in R installation instructions

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -25,7 +25,7 @@ To install this package on any operating system:
 3. Copy that link into `PKG_URL` in the code below and run it.
 
 ```r
-PKG_URL <- "https://github.com/microsoft/LightGBM/releases/download/v3.0.0rc1/lightgbm_3.0.0-1-r-cran.tar.gz"
+PKG_URL <- "https://github.com/microsoft/LightGBM/releases/download/v3.0.0/lightgbm-3.0.0-r-cran.tar.gz"
 
 remotes::install_url(PKG_URL)
 ```

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -25,7 +25,7 @@ To install this package on any operating system:
 3. Copy that link into `PKG_URL` in the code below and run it.
 
 ```r
-PKG_URL <- "https://github.com/microsoft/LightGBM/releases/download/v3.0.0rc1/lightgbm-3.0.0-1-r-cran.tar.gz"
+PKG_URL <- "https://github.com/microsoft/LightGBM/releases/download/v3.0.0rc1/lightgbm_3.0.0-1-r-cran.tar.gz"
 
 remotes::install_url(PKG_URL)
 ```


### PR DESCRIPTION
Fixes typo to allow for copy-paste installation of R package.