### PR TITLE
[ci] remove Azure checks from R CI

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -12,32 +12,24 @@ export PATH="$R_LIB_PATH/R/bin:$PATH"
 export _R_CHECK_SYSTEM_CLOCK_=0
 
 # Get details needed for installing R components
-#
-# NOTES:
-#    * Linux builds on Azure use a container and don't need these details
-if ! { [[ $AZURE == "true" ]] && [[ $OS_NAME == "linux" ]]; }; then
-    R_MAJOR_VERSION=( ${R_VERSION//./ } )
-    if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
-        export R_MAC_VERSION=3.6.3
-        export R_LINUX_VERSION="3.6.3-1bionic"
-        export R_APT_REPO="bionic-cran35/"
-    elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
-        export R_MAC_VERSION=4.0.2
-        export R_LINUX_VERSION="4.0.2-1.1804.0"
-        export R_APT_REPO="bionic-cran40/"
-    else
-        echo "Unrecognized R version: ${R_VERSION}"
-        exit -1
-    fi
+R_MAJOR_VERSION=( ${R_VERSION//./ } )
+if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
+    export R_MAC_VERSION=3.6.3
+    export R_LINUX_VERSION="3.6.3-1bionic"
+    export R_APT_REPO="bionic-cran35/"
+elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
+    export R_MAC_VERSION=4.0.2
+    export R_LINUX_VERSION="4.0.2-1.1804.0"
+    export R_APT_REPO="bionic-cran40/"
+else
+    echo "Unrecognized R version: ${R_VERSION}"
+    exit -1
 fi
 
 # installing precompiled R for Ubuntu
 # https://cran.r-project.org/bin/linux/ubuntu/#installation
 # adding steps from https://stackoverflow.com/a/56378217/3986677 to get latest version
-#
-# This only needs to get run on Travis because R environment for Linux
-# used by Azure pipelines is set up in https://github.com/guolinke/lightgbm-ci-docker
-if [[ $AZURE != "true" ]] && [[ $OS_NAME == "linux" ]]; then
+if [[ $OS_NAME == "linux" ]]; then
     sudo apt-key adv \
         --keyserver keyserver.ubuntu.com \
         --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
@@ -51,7 +43,6 @@ if [[ $AZURE != "true" ]] && [[ $OS_NAME == "linux" ]]; then
             texinfo \
             texlive-latex-recommended \
             texlive-fonts-recommended \
-            texlive-fonts-extra \
             qpdf \
             || exit -1
 

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -43,6 +43,7 @@ if [[ $OS_NAME == "linux" ]]; then
             texinfo \
             texlive-latex-recommended \
             texlive-fonts-recommended \
+            texlive-fonts-extra \
             qpdf \
             || exit -1
 


### PR DESCRIPTION
Now that the R CI seems to be working ok on GitHub Actions (#3119 ) and the R components have been removed from the image used for Azure (https://github.com/guolinke/lightgbm-ci-docker/pull/11), I think we can simplify the CI code for R by removing `if $AZURE == "true"`branches from the code.

I also think it's possible to remove the dependency `texlive-fonts-extra` on Linux. Using this PR to test if that's true.