### PR TITLE
[R-package] remove unnecessary comments

### DIFF
--- a/R-package/R/callback.R
+++ b/R-package/R/callback.R
@@ -25,7 +25,6 @@ CB_ENV <- R6::R6Class(
 
 cb.reset.parameters <- function(new_params) {
 
-  # Check for parameter list
   if (!identical(class(new_params), "list")) {
     stop(sQuote("new_params"), " must be a list")
   }
@@ -151,7 +150,6 @@ merge.eval.string <- function(env) {
 
   }
 
-  # Return tabulated separated message
   paste0(msg, collapse = "\t")
 
 }
@@ -188,7 +186,6 @@ cb.print.evaluation <- function(period = 1L) {
   attr(callback, "call") <- match.call()
   attr(callback, "name") <- "cb.print.evaluation"
 
-  # Return callback
   callback
 
 }
@@ -198,7 +195,6 @@ cb.record.evaluation <- function() {
   # Create callback
   callback <- function(env) {
 
-    # Return empty if empty evaluation list
     if (length(env$eval_list) <= 0L) {
       return()
     }
@@ -263,14 +259,12 @@ cb.record.evaluation <- function() {
   attr(callback, "call") <- match.call()
   attr(callback, "name") <- "cb.record.evaluation"
 
-  # Return callback
   callback
 
 }
 
 cb.early.stop <- function(stopping_rounds, first_metric_only = FALSE, verbose = TRUE) {
 
-  # Initialize variables
   factor_to_bigger_better <- NULL
   best_iter <- NULL
   best_score <- NULL
@@ -397,11 +391,9 @@ cb.early.stop <- function(stopping_rounds, first_metric_only = FALSE, verbose = 
     }
   }
 
-  # Set attributes
   attr(callback, "call") <- match.call()
   attr(callback, "name") <- "cb.early.stop"
 
-  # Return callback
   callback
 
 }

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -180,7 +180,6 @@ Booster <- R6::R6Class(
       private$num_dataset <- private$num_dataset + 1L
       private$is_predicted_cur_iter <- c(private$is_predicted_cur_iter, FALSE)
 
-      # Return self
       return(invisible(self))
 
     },
@@ -200,7 +199,6 @@ Booster <- R6::R6Class(
         , params_str
       )
 
-      # Return self
       return(invisible(self))
 
     },
@@ -304,7 +302,6 @@ Booster <- R6::R6Class(
         private$is_predicted_cur_iter[[i]] <- FALSE
       }
 
-      # Return self
       return(invisible(self))
 
     },
@@ -418,7 +415,6 @@ Booster <- R6::R6Class(
         )
       }
 
-      # Return ret
       return(ret)
 
     },
@@ -441,7 +437,6 @@ Booster <- R6::R6Class(
         , lgb.c_str(filename)
       )
 
-      # Return self
       return(invisible(self))
     },
 
@@ -471,7 +466,6 @@ Booster <- R6::R6Class(
         num_iteration <- self$best_iter
       }
 
-      # Return dumped model
       lgb.call.return.str(
         "LGBM_BoosterDumpModel_R"
         , private$handle
@@ -582,7 +576,6 @@ Booster <- R6::R6Class(
         private$is_predicted_cur_iter[[idx]] <- TRUE
       }
 
-      # Return prediction buffer
       return(private$predict_buffer[[data_name]])
     },
 
@@ -614,7 +607,6 @@ Booster <- R6::R6Class(
 
       }
 
-      # Return evaluation names
       return(private$eval_names)
 
     },
@@ -690,7 +682,6 @@ Booster <- R6::R6Class(
         ret <- append(ret, list(res))
       }
 
-      # Return ret
       return(ret)
 
     }
@@ -761,7 +752,6 @@ predict.lgb.Booster <- function(object,
                                 reshape = FALSE,
                                 ...) {
 
-  # Check booster existence
   if (!lgb.is.Booster(object)) {
     stop("predict.lgb.Booster: object should be an ", sQuote("lgb.Booster"))
   }
@@ -874,12 +864,10 @@ lgb.load <- function(filename = NULL, model_str = NULL) {
 #' @export
 lgb.save <- function(booster, filename, num_iteration = NULL) {
 
-  # Check if booster is booster
   if (!lgb.is.Booster(booster)) {
     stop("lgb.save: booster should be an ", sQuote("lgb.Booster"))
   }
 
-  # Check if file name is character
   if (!(is.character(filename) && length(filename) == 1L)) {
     stop("lgb.save: filename should be a string")
   }
@@ -922,7 +910,6 @@ lgb.save <- function(booster, filename, num_iteration = NULL) {
 #' @export
 lgb.dump <- function(booster, num_iteration = NULL) {
 
-  # Check if booster is booster
   if (!lgb.is.Booster(booster)) {
     stop("lgb.save: booster should be an ", sQuote("lgb.Booster"))
   }
@@ -1014,7 +1001,6 @@ lgb.get.eval.result <- function(booster, data_name, eval_name, iters = NULL, is_
     stop("lgb.get.eval.result: wrong eval name")
   }
 
-  # Create result
   result <- booster$record_evals[[data_name]][[eval_name]][[.EVAL_KEY()]]
 
   # Check if error is requested

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -105,7 +105,6 @@ Dataset <- R6::R6Class(
         , ...
       )
 
-      # Return ret
       return(invisible(ret))
 
     },
@@ -312,7 +311,6 @@ Dataset <- R6::R6Class(
         stop("lgb.Dataset.construct: label should be set")
       }
 
-      # Return self
       return(invisible(self))
 
     },
@@ -405,7 +403,6 @@ Dataset <- R6::R6Class(
 
       }
 
-      # Return self
       return(invisible(self))
 
     },
@@ -504,7 +501,6 @@ Dataset <- R6::R6Class(
 
       }
 
-      # Return self
       return(invisible(self))
 
     },
@@ -677,7 +673,6 @@ Dataset <- R6::R6Class(
     # Set predictor
     set_predictor = function(predictor) {
 
-      # Return self is identical predictor
       if (identical(private$predictor, predictor)) {
         return(invisible(self))
       }
@@ -847,7 +842,6 @@ dim.lgb.Dataset <- function(x, ...) {
     stop("dim.lgb.Dataset: input data should be an lgb.Dataset object")
   }
 
-  # Return dimensions
   x$dim()
 
 }
@@ -902,10 +896,8 @@ dimnames.lgb.Dataset <- function(x) {
     stop("lgb.Dataset does not have rownames")
   }
 
-  # Check for second value missing
   if (is.null(value[[2L]])) {
 
-    # No column names
     x$set_colnames(NULL)
     return(x)
 
@@ -1010,7 +1002,6 @@ getinfo.lgb.Dataset <- function(dataset, name, ...) {
     stop("getinfo.lgb.Dataset: input dataset should be an lgb.Dataset object")
   }
 
-  # Return information
   dataset$getinfo(name)
 
 }
@@ -1059,7 +1050,6 @@ setinfo <- function(dataset, ...) {
 #' @export
 setinfo.lgb.Dataset <- function(dataset, name, info, ...) {
 
-  # Check if dataset is not a dataset
   if (!lgb.is.Dataset(dataset)) {
     stop("setinfo.lgb.Dataset: input dataset should be an lgb.Dataset object")
   }
@@ -1092,7 +1082,6 @@ setinfo.lgb.Dataset <- function(dataset, name, info, ...) {
 #' @export
 lgb.Dataset.set.categorical <- function(dataset, categorical_feature) {
 
-  # Check if dataset is not a dataset
   if (!lgb.is.Dataset(dataset)) {
     stop("lgb.Dataset.set.categorical: input dataset should be an lgb.Dataset object")
   }

--- a/R-package/R/lgb.Predictor.R
+++ b/R-package/R/lgb.Predictor.R
@@ -51,7 +51,6 @@ Predictor <- R6::R6Class(
 
       } else {
 
-        # Model file is unknown
         stop("lgb.Predictor: modelfile must be either a character filename or an lgb.Booster.handle")
 
       }
@@ -93,7 +92,6 @@ Predictor <- R6::R6Class(
         start_iteration <- 0L
       }
 
-      # Set temporary variable
       num_row <- 0L
 
       # Check if data is a file name and not a matrix
@@ -149,10 +147,7 @@ Predictor <- R6::R6Class(
 
         # Check if data is a matrix
         if (is.matrix(data)) {
-          # Check whether matrix is the correct type first ("double")
-          if (storage.mode(data) != "double") {
-            storage.mode(data) <- "double"
-          }
+          storage.mode(data) <- "double"
           preds <- lgb.call(
             "LGBM_BoosterPredictForMat_R"
             , ret = preds
@@ -193,7 +188,6 @@ Predictor <- R6::R6Class(
 
         } else {
 
-          # Cannot predict on unknown class
           stop("predict: cannot predict on data of class ", sQuote(class(data)))
 
         }
@@ -227,7 +221,6 @@ Predictor <- R6::R6Class(
 
       }
 
-      # Return predictions
       return(preds)
 
     }

--- a/R-package/R/lgb.Predictor.R
+++ b/R-package/R/lgb.Predictor.R
@@ -147,7 +147,11 @@ Predictor <- R6::R6Class(
 
         # Check if data is a matrix
         if (is.matrix(data)) {
-          storage.mode(data) <- "double"
+          # this if() prevents the memory and computational costs
+          # of converting something that is already "double" to "double"
+          if (storage.mode(data) != "double") {
+            storage.mode(data) <- "double"
+          }
           preds <- lgb.call(
             "LGBM_BoosterPredictForMat_R"
             , ret = preds

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -91,7 +91,6 @@ lgb.cv <- function(params = list()
                    , ...
                    ) {
 
-  # validate parameters
   if (nrounds <= 0L) {
     stop("nrounds should be greater than zero")
   }
@@ -276,7 +275,6 @@ lgb.cv <- function(params = list()
     )
   }
 
-  # Categorize callbacks
   cb <- categorize.callbacks(callbacks)
 
   # Construct booster for each fold. The data.table() code below is used to
@@ -354,7 +352,6 @@ lgb.cv <- function(params = list()
     env$iteration <- i
     env$eval_list <- list()
 
-    # Loop through "pre_iter" element
     for (f in cb$pre_iter) {
       f(env)
     }
@@ -430,7 +427,6 @@ lgb.cv <- function(params = list()
     })
   }
 
-  # Return booster
   return(cv_booster)
 
 }
@@ -493,7 +489,6 @@ generate.cv.folds <- function(nfold, nrows, stratified, label, group, params) {
 
   }
 
-  # Return folds
   return(folds)
 
 }
@@ -564,7 +559,6 @@ lgb.stratified.folds <- function(y, k = 10L) {
 
   }
 
-  # Return data
   out <- split(seq(along = y), foldVector)
   names(out) <- NULL
   out
@@ -600,7 +594,6 @@ lgb.merge.cv.result <- function(msg, showsd = TRUE) {
     ret_eval[[j]]$value <- mean(eval_result[[j]])
   }
 
-  # Preinit evaluation error
   ret_eval_err <- NULL
 
   # Check for standard deviation

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -117,9 +117,10 @@ lgb.cv <- function(params = list()
     params$objective <- "NONE"
   }
 
-  # If loss is a single function, store it as a 1-element list
+  # If eval is a single function, store it as a 1-element list
   # (for backwards compatibility). If it is a list of functions, store
-  # all of them
+  # all of them. This makes it possible to pass any mix of strings like "auc"
+  # and custom functions to eval
   if (is.function(eval)) {
     eval_functions <- list(eval)
   }
@@ -586,7 +587,7 @@ lgb.merge.cv.result <- function(msg, showsd = TRUE) {
   })
 
   # Get evaluation. Just taking the first element here to
-  # get structture (name, higher_bettter, data_name)
+  # get structure (name, higher_better, data_name)
   ret_eval <- msg[[1L]]
 
   # Go through evaluation length items

--- a/R-package/R/lgb.importance.R
+++ b/R-package/R/lgb.importance.R
@@ -75,7 +75,6 @@ lgb.importance <- function(model, percentage = TRUE) {
     )]
   }
 
-  # Return importance table
   return(tree_imp_dt)
 
 }

--- a/R-package/R/lgb.interprete.R
+++ b/R-package/R/lgb.interprete.R
@@ -88,7 +88,6 @@ lgb.interprete <- function(model,
     )
   }
 
-  # Return interpretation list
   return(tree_interpretation_dt_list)
 
 }
@@ -132,7 +131,6 @@ single.tree.interprete <- function(tree_dt,
   # Perform leaf to root conversion
   leaf_to_root(leaf_dt[["leaf_parent"]], leaf_dt[["leaf_value"]])
 
-  # Return formatted data.table
   data.table::data.table(
     Feature = feature_seq
     , Contribution = diff.default(value_seq)
@@ -233,6 +231,5 @@ single.row.interprete <- function(tree_dt, num_class, tree_index_mat, leaf_index
 
   }
 
-  # Return interpretation tree
   return(tree_interpretation_dt)
 }

--- a/R-package/R/lgb.model.dt.tree.R
+++ b/R-package/R/lgb.model.dt.tree.R
@@ -79,7 +79,6 @@ lgb.model.dt.tree <- function(model, num_iteration = NULL) {
   feature_names <- parsed_json_model$feature_names[split_feature_indx]
   tree_dt[, split_feature := feature_names]
 
-  # Return tree
   return(tree_dt)
 
 }
@@ -171,7 +170,6 @@ single.tree.parse <- function(lgb_tree) {
   # Store index
   single_tree_dt[, tree_index := lgb_tree$tree_index]
 
-  # Return tree
   return(single_tree_dt)
 
 }

--- a/R-package/R/lgb.plot.importance.R
+++ b/R-package/R/lgb.plot.importance.R
@@ -79,7 +79,6 @@ lgb.plot.importance <- function(tree_imp,
     )
   )
 
-  # Do plot
   tree_imp[.N:1L,
            graphics::barplot(
                height = get(measure)
@@ -92,7 +91,6 @@ lgb.plot.importance <- function(tree_imp,
                , las = 1L
            )]
 
-  # Return invisibly
   invisible(tree_imp)
 
 }

--- a/R-package/R/lgb.plot.interpretation.R
+++ b/R-package/R/lgb.plot.interpretation.R
@@ -155,7 +155,6 @@ multiple.tree.plot.interpretation <- function(tree_interpretation,
                           , las = 1L
                       )]
 
-  # Return invisibly
   return(invisible(NULL))
 
 }

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -246,7 +246,6 @@ lgb.train <- function(params = list(),
     )
   }
 
-  # "Categorize" callbacks
   cb <- categorize.callbacks(callbacks)
 
   # Construct booster with datasets
@@ -371,7 +370,6 @@ lgb.train <- function(params = list(),
 
   }
 
-  # Return booster
   return(booster)
 
 }

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -95,9 +95,10 @@ lgb.train <- function(params = list(),
     params$objective <- "NONE"
   }
 
-  # If loss is a single function, store it as a 1-element list
+  # If eval is a single function, store it as a 1-element list
   # (for backwards compatibility). If it is a list of functions, store
-  # all of them
+  # all of them. This makes it possible to pass any mix of strings like "auc"
+  # and custom functions to eval
   if (is.function(eval)) {
     eval_functions <- list(eval)
   }

--- a/R-package/R/lightgbm.R
+++ b/R-package/R/lightgbm.R
@@ -1,8 +1,7 @@
 #' @name lgb_shared_params
 #' @title Shared parameter docs
 #' @description Parameter docs shared by \code{lgb.train}, \code{lgb.cv}, and \code{lightgbm}
-#' @param callbacks list of callback functions
-#'        List of callback functions that are applied at each iteration.
+#' @param callbacks List of callback functions that are applied at each iteration.
 #' @param data a \code{lgb.Dataset} object, used for training. Some functions, such as \code{\link{lgb.cv}},
 #'             may allow you to pass other types of data like \code{matrix} and then separately supply
 #'             \code{label} as a keyword argument.
@@ -155,7 +154,6 @@ lightgbm <- function(data,
   # Store model under a specific name
   bst$save_model(save_name)
 
-  # Return booster
   return(bst)
 }
 

--- a/R-package/R/readRDS.lgb.Booster.R
+++ b/R-package/R/readRDS.lgb.Booster.R
@@ -33,7 +33,6 @@
 #' @export
 readRDS.lgb.Booster <- function(file = "", refhook = NULL) {
 
-  # Read RDS file
   object <- readRDS(file = file, refhook = refhook)
 
   # Check if object has the model stored

--- a/R-package/R/removed.R
+++ b/R-package/R/removed.R
@@ -1,7 +1,7 @@
 #' @title removed functions
 #' @name lgb.prepare
 #' @description removed functions
-#' @param ... catch-all too match old calls
+#' @param ... catch-all to match old calls
 #' @export
 lgb.prepare <- function(...) {
     stop("lgb.prepare() was removed in LightGBM 3.0.0. Please use lgb.convert_with_rules()")
@@ -10,7 +10,7 @@ lgb.prepare <- function(...) {
 #' @title removed functions
 #' @name lgb.prepare2
 #' @description removed functions
-#' @param ... catch-all too match old calls
+#' @param ... catch-all to match old calls
 #' @export
 lgb.prepare2 <- function(...) {
     stop("lgb.prepare2() was removed in LightGBM 3.0.0. Please use lgb.convert_with_rules()")
@@ -19,7 +19,7 @@ lgb.prepare2 <- function(...) {
 #' @title removed functions
 #' @name lgb.prepare_rules
 #' @description removed functions
-#' @param ... catch-all too match old calls
+#' @param ... catch-all to match old calls
 #' @export
 lgb.prepare_rules <- function(...) {
     stop("lgb.prepare_rules() was removed in LightGBM 3.0.0. Please use lgb.convert_with_rules()")
@@ -28,7 +28,7 @@ lgb.prepare_rules <- function(...) {
 #' @title removed functions
 #' @name lgb.prepare_rules2
 #' @description removed functions
-#' @param ... catch-all too match old calls
+#' @param ... catch-all to match old calls
 #' @export
 lgb.prepare_rules2 <- function(...) {
     stop("lgb.prepare_rules2() was removed in LightGBM 3.0.0. Please use lgb.convert_with_rules()")

--- a/R-package/R/saveRDS.lgb.Booster.R
+++ b/R-package/R/saveRDS.lgb.Booster.R
@@ -52,10 +52,8 @@ saveRDS.lgb.Booster <- function(object,
   # Check if object has a raw value (and if the user wants to store the raw)
   if (is.na(object$raw) && raw) {
 
-    # Save model
     object$save()
 
-    # Save RDS
     saveRDS(
       object
       , file = file
@@ -70,7 +68,6 @@ saveRDS.lgb.Booster <- function(object,
 
   } else {
 
-    # Save as usual
     saveRDS(
       object
       , file = file

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -1,9 +1,9 @@
 lgb.is.Booster <- function(x) {
-  lgb.check.r6.class(x, "lgb.Booster") # Checking if it is of class lgb.Booster or not
+  lgb.check.r6.class(x, "lgb.Booster")
 }
 
 lgb.is.Dataset <- function(x) {
-  lgb.check.r6.class(x, "lgb.Dataset") # Checking if it is of class lgb.Dataset or not
+  lgb.check.r6.class(x, "lgb.Dataset")
 }
 
 lgb.null.handle <- function() {
@@ -53,7 +53,6 @@ lgb.last_error <- function() {
     )
   }
 
-  # Return error
   stop("api error: ", lgb.encode.char(err_msg, act_len))
 }
 
@@ -105,7 +104,6 @@ lgb.call.return.str <- function(fun_name, ...) {
     buf <- lgb.call(fun_name, ret = buf, ..., buf_len, act_len)
   }
 
-  # Return encoded character
   return(lgb.encode.char(buf, act_len))
 
 }
@@ -168,7 +166,6 @@ lgb.params2str <- function(params, ...) {
     return(lgb.c_str(""))
   }
 
-  # Return string separated by a space per element
   return(lgb.c_str(paste0(ret, collapse = " ")))
 
 }
@@ -180,7 +177,6 @@ lgb.check_interaction_constraints <- function(params, column_names) {
 
   if (!is.null(params[["interaction_constraints"]])) {
 
-    # validation
     if (!methods::is(params[["interaction_constraints"]], "list")) {
         stop("interaction_constraints must be a list")
     }
@@ -234,7 +230,6 @@ lgb.check_interaction_constraints <- function(params, column_names) {
 
 lgb.c_str <- function(x) {
 
-  # Perform character to raw conversion
   ret <- charToRaw(as.character(x))
   ret <- c(ret, as.raw(0L))
   ret
@@ -300,19 +295,16 @@ lgb.check.obj <- function(params, obj) {
     # If the objective is a character, check if it is a known objective
     if (!(params$objective %in% OBJECTIVES)) {
 
-      # Interrupt on unknown objective name
       stop("lgb.check.obj: objective name error should be one of (", paste0(OBJECTIVES, collapse = ", "), ")")
 
     }
 
   } else if (!is.function(params$objective)) {
 
-    # If objective is not a character nor a function, then stop
     stop("lgb.check.obj: objective should be a character or a function")
 
   }
 
-  # Return parameters
   return(params)
 
 }

--- a/R-package/man/lgb.prepare.Rd
+++ b/R-package/man/lgb.prepare.Rd
@@ -7,7 +7,7 @@
 lgb.prepare(...)
 }
 \arguments{
-\item{...}{catch-all too match old calls}
+\item{...}{catch-all to match old calls}
 }
 \description{
 removed functions

--- a/R-package/man/lgb.prepare2.Rd
+++ b/R-package/man/lgb.prepare2.Rd
@@ -7,7 +7,7 @@
 lgb.prepare2(...)
 }
 \arguments{
-\item{...}{catch-all too match old calls}
+\item{...}{catch-all to match old calls}
 }
 \description{
 removed functions

--- a/R-package/man/lgb.prepare_rules.Rd
+++ b/R-package/man/lgb.prepare_rules.Rd
@@ -7,7 +7,7 @@
 lgb.prepare_rules(...)
 }
 \arguments{
-\item{...}{catch-all too match old calls}
+\item{...}{catch-all to match old calls}
 }
 \description{
 removed functions

--- a/R-package/man/lgb.prepare_rules2.Rd
+++ b/R-package/man/lgb.prepare_rules2.Rd
@@ -7,7 +7,7 @@
 lgb.prepare_rules2(...)
 }
 \arguments{
-\item{...}{catch-all too match old calls}
+\item{...}{catch-all to match old calls}
 }
 \description{
 removed functions

--- a/R-package/man/lgb_shared_params.Rd
+++ b/R-package/man/lgb_shared_params.Rd
@@ -4,8 +4,7 @@
 \alias{lgb_shared_params}
 \title{Shared parameter docs}
 \arguments{
-\item{callbacks}{list of callback functions
-List of callback functions that are applied at each iteration.}
+\item{callbacks}{List of callback functions that are applied at each iteration.}
 
 \item{data}{a \code{lgb.Dataset} object, used for training. Some functions, such as \code{\link{lgb.cv}},
 may allow you to pass other types of data like \code{matrix} and then separately supply

--- a/R-package/man/lightgbm.Rd
+++ b/R-package/man/lightgbm.Rd
@@ -45,8 +45,7 @@ If early stopping occurs, the model will have 'best_iter' field.}
 
 \item{init_model}{path of model file of \code{lgb.Booster} object, will continue training from this model}
 
-\item{callbacks}{list of callback functions
-List of callback functions that are applied at each iteration.}
+\item{callbacks}{List of callback functions that are applied at each iteration.}
 
 \item{...}{Additional arguments passed to \code{\link{lgb.train}}. For example
 \itemize{

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -13,7 +13,7 @@ set.seed(708L)
 #               This is used to mock the situation where an evaluation
 #               metric increases every iteration
 ACCUMULATOR_NAME <- "INCREASING_METRIC_ACUMULATOR"
-assign(x = "INCREASING_METRIC_ACUMULATOR", value = 0.0, envir = .GlobalEnv)
+assign(x = ACCUMULATOR_NAME, value = 0.0, envir = .GlobalEnv)
 
 .increasing_metric <- function(preds, dtrain) {
   if (!exists(ACCUMULATOR_NAME, envir = .GlobalEnv)) {

--- a/R-package/tests/testthat/test_metrics.R
+++ b/R-package/tests/testthat/test_metrics.R
@@ -1,6 +1,6 @@
 context(".METRICS_HIGHER_BETTER()")
 
-test_that(".METRICS_HIGHER_BETTTER() should be well formed", {
+test_that(".METRICS_HIGHER_BETTER() should be well formed", {
     metrics <- .METRICS_HIGHER_BETTER()
     metric_names <- names(.METRICS_HIGHER_BETTER())
     # should be a logical vector


### PR DESCRIPTION
This PR proposes removing some comments in the R package that I think are unnecessary.

There are a lot of things like this in the R code:

```r
    # return ret
    return(ret)
```

Comments like this don't add any understanding of the code, but they do make it slightly harder to read and possibly lead to false positives when using `git grep` or similar tools to search through the codebase for things.