### PR TITLE
[ci] host some artifacts needed by R Windows CI jobs

### DIFF
--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -86,8 +86,6 @@ if ($env:R_BUILD_TYPE -eq "cmake") {
   }
 }
 
-https://github.com/microsoft/LightGBM/releases/download/v2.0.12/rtools35-x86_64.exe
-
 # download R and RTools
 Write-Output "Downloading R and Rtools"
 Download-File-With-Retries -url "https://cran.r-project.org/bin/windows/base/old/$env:R_WINDOWS_VERSION/R-$env:R_WINDOWS_VERSION-win.exe" -destfile "R-win.exe"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -12,23 +12,6 @@ function Download-File-With-Retries {
   } while(!$?);
 }
 
-# mirrors that host miktexsetup.zip do so only with explicitly-named
-# files like miktexsetup-2.4.5.zip, so hard-coding a link to an archive as a
-# way to peg to one mirror does not work
-#
-# this function will find the specific version of miktexsetup.zip at a given
-# mirror and download it
-function Download-Miktex-Setup {
-    param(
-        [string]$archive,
-        [string]$destfile
-    )
-    $PageContent = Invoke-WebRequest -Uri $archive -Method Get
-    $SetupExeFile = $PageContent.Links.href | Select-String -Pattern 'miktexsetup-2.*'
-    $FileToDownload = "${archive}/${SetupExeFile}"
-    Download-File-With-Retries $FileToDownload $destfile
-}
-
 # External utilities like R.exe / Rscript.exe writing to stderr (even for harmless
 # status information) can cause failures in GitHub Actions PowerShell jobs.
 # See https://github.community/t/powershell-steps-fail-nondeterministically/115496
@@ -54,7 +37,7 @@ if ($env:R_MAJOR_VERSION -eq "3") {
   #     * https://stackoverflow.com/a/46619260/3986677
   $RTOOLS_INSTALL_PATH = "C:\Rtools"
   $env:RTOOLS_MINGW_BIN = "$RTOOLS_INSTALL_PATH/mingw_64/bin"
-  $env:RTOOLS_EXE_FILE = "Rtools35.exe"
+  $env:RTOOLS_EXE_FILE = "rtools35-x86_64.exe"
   $env:R_WINDOWS_VERSION = "3.6.3"
 } elseif ($env:R_MAJOR_VERSION -eq "4") {
   $RTOOLS_INSTALL_PATH = "C:\rtools40"
@@ -71,7 +54,6 @@ $env:R_LIBS = "$env:R_LIB_PATH"
 $env:PATH = "$RTOOLS_INSTALL_PATH/bin;" + "$RTOOLS_INSTALL_PATH/usr/bin;" + "$env:R_LIB_PATH/R/bin/x64;" + "$env:R_LIB_PATH/miktex/texmfs/install/miktex/bin/x64;" + $env:PATH
 $env:CRAN_MIRROR = "https://cloud.r-project.org/"
 $env:CTAN_MIRROR = "https://ctan.math.illinois.edu/systems/win32/miktex"
-$env:CTAN_MIKTEX_ARCHIVE = "$env:CTAN_MIRROR/setup/windows-x64/"
 $env:CTAN_PACKAGE_ARCHIVE = "$env:CTAN_MIRROR/tm/packages/"
 
 # hack to get around this:
@@ -104,10 +86,12 @@ if ($env:R_BUILD_TYPE -eq "cmake") {
   }
 }
 
+https://github.com/microsoft/LightGBM/releases/download/v2.0.12/rtools35-x86_64.exe
+
 # download R and RTools
 Write-Output "Downloading R and Rtools"
 Download-File-With-Retries -url "https://cran.r-project.org/bin/windows/base/old/$env:R_WINDOWS_VERSION/R-$env:R_WINDOWS_VERSION-win.exe" -destfile "R-win.exe"
-Download-File-With-Retries -url "https://cran.r-project.org/bin/windows/Rtools/$env:RTOOLS_EXE_FILE" -destfile "Rtools.exe"
+Download-File-With-Retries -url "https://github.com/microsoft/LightGBM/releases/download/v2.0.12/$env:RTOOLS_EXE_FILE" -destfile "Rtools.exe"
 
 # Install R
 Write-Output "Installing R"
@@ -127,7 +111,7 @@ Run-R-Code-Redirect-Stderr "options(install.packages.check.source = 'no'); insta
 #
 # MiKTeX always needs to be built to test a CRAN package.
 if (($env:COMPILER -eq "MINGW") -or ($env:R_BUILD_TYPE -eq "cran")) {
-    Download-Miktex-Setup "$env:CTAN_MIKTEX_ARCHIVE" "miktexsetup-x64.zip"
+    Download-File-With-Retries "https://github.com/microsoft/LightGBM/releases/download/v2.0.12/miktexsetup-4.0-x64.zip" -destfile "miktexsetup-x64.zip"
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     [System.IO.Compression.ZipFile]::ExtractToDirectory("miktexsetup-x64.zip", "miktex")
     Write-Output "Setting up MiKTeX"

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -39,7 +39,7 @@ elseif ($env:TASK -eq "sdist") {
   cd dist; pip install @(Get-ChildItem *.gz) -v ; Check-Output $?
 
   $env:JAVA_HOME = $env:JAVA_HOME_8_X64  # there is pre-installed Zulu OpenJDK-8 somewhere
-  Invoke-WebRequest -Uri "https://sourceforge.net/projects/swig/files/swigwin/swigwin-3.0.12/swigwin-3.0.12.zip/download" -OutFile $env:BUILD_SOURCESDIRECTORY/swig/swigwin.zip -UserAgent "NativeHost"
+  Invoke-WebRequest -Uri "https://github.com/microsoft/LightGBM/releases/download/v2.0.12/swigwin-3.0.12.zip" -OutFile $env:BUILD_SOURCESDIRECTORY/swig/swigwin.zip -UserAgent "NativeHost"
   Add-Type -AssemblyName System.IO.Compression.FileSystem
   [System.IO.Compression.ZipFile]::ExtractToDirectory("$env:BUILD_SOURCESDIRECTORY/swig/swigwin.zip", "$env:BUILD_SOURCESDIRECTORY/swig")
   $env:PATH += ";$env:BUILD_SOURCESDIRECTORY/swig/swigwin-3.0.12"


### PR DESCRIPTION
Today, the Windows CI jobs sometimes fail downloading artifacts like Rtools and mixtexsetup.exe.

For example, see https://github.com/microsoft/LightGBM/pull/2912#issuecomment-686534527

Following the suggestion in https://github.com/microsoft/LightGBM/pull/2912#issuecomment-686556271, I've hosted the artifacts where we see these failures most often on a very old release (https://github.com/microsoft/LightGBM/releases/tag/v2.0.12). I also updated that release to explain that those artifacts are not a part of LightGBM. I think the "right" way to do this is to create a bucket in an object store like Azure Blob Store, but this is free and easier to maintain.

This PR proposes the necessary changes to download these files from GitHub instead of their current sources. I think that this PR will make our R CI jobs on Windows more reliable and reduce the number of times we have to manually re-run GitHub Actions.

## Notes for Reviewers

* I don't think we should do this for R itself yet. I think it's important that we can change the R version just in `.github/workflows/main.yml`. If we hosted R itself, upgrading to a new R version would also mean manually updating the artifacts on that releases page
* this PR also upgrades us from MiKTeX 2.9 to MiKTex 4.0 (the newest version)
