### PR TITLE
fixed a small bug in example/python-guide/advanced_example 

### DIFF
--- a/examples/python-guide/advanced_example.py
+++ b/examples/python-guide/advanced_example.py
@@ -52,7 +52,7 @@ print('Starting training...')
 gbm = lgb.train(params,
                 lgb_train,
                 num_boost_round=10,
-                valid_sets=lgb_train,  # eval training data
+                valid_sets=lgb_eval,  # eval training data
                 feature_name=feature_name,
                 categorical_feature=[21])
 


### PR DESCRIPTION
In `examples/python-guide/advanced_example.py`, the valid_sets for `lgb.train` should be `lgb_eval` instead of `lgb_train`.
It's a small bug :)