### PR TITLE
Avoid segment fault in ResetConfig for GBDT in prediction (fix #3317)

### DIFF
--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -20,6 +20,7 @@ namespace LightGBM {
 GBDT::GBDT()
     : iter_(0),
       train_data_(nullptr),
+      config_(nullptr),
       objective_function_(nullptr),
       early_stopping_round_(0),
       es_first_metric_only_(false),
@@ -718,7 +719,7 @@ void GBDT::ResetConfig(const Config* config) {
   if (train_data_ != nullptr) {
     ResetBaggingConfig(new_config.get(), false);
   }
-  if (config_->forcedsplits_filename != new_config->forcedbins_filename) {
+  if (config_.get() != nullptr && config_->forcedsplits_filename != new_config->forcedbins_filename) {
     // load forced_splits file
     if (!new_config->forcedsplits_filename.empty()) {
       std::ifstream forced_splits_file(


### PR DESCRIPTION
This PR is to fix #3317. When a booster is created from model file, its config_ member will be undefined. However, the ResetConfig method of GBDT is not aware of this. As @glarb pointed out.