### PR TITLE
[python] remove unused variable

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2906,7 +2906,7 @@ class Booster(object):
             new_booster.handle,
             predictor.handle))
         leaf_preds = leaf_preds.reshape(-1)
-        ptr_data, type_ptr_data, _ = c_int_array(leaf_preds)
+        ptr_data, _, _ = c_int_array(leaf_preds)
         _safe_call(_LIB.LGBM_BoosterRefit(
             new_booster.handle,
             ptr_data,


### PR DESCRIPTION
I ran `pylint` over the Python package tonight and found a few small things.

This PR sets one unused variable to `_` to make the code a little easier to read and a little more memory-efficient.