### PR TITLE
[R-package] use keyword arguments in internal function calls

### DIFF
--- a/R-package/R/lightgbm.R
+++ b/R-package/R/lightgbm.R
@@ -121,7 +121,7 @@ lightgbm <- function(data,
 
   # Check whether data is lgb.Dataset, if not then create lgb.Dataset manually
   if (!lgb.is.Dataset(dtrain)) {
-    dtrain <- lgb.Dataset(data, label = label, weight = weight)
+    dtrain <- lgb.Dataset(data = data, label = label, weight = weight)
   }
 
   train_args <- list(
@@ -152,7 +152,7 @@ lightgbm <- function(data,
   )
 
   # Store model under a specific name
-  bst$save_model(save_name)
+  bst$save_model(filename = save_name)
 
   return(bst)
 }


### PR DESCRIPTION
I've just opened #3390. I think it's a great thing for Hacktoberfest contributors to work on.

Today the R package has a lot of internal function calls that use positional arguments instead of keyword arguments. This can be dangerous and lead to silent mistakes if you mix up values parameters that can take similar input ranges, for example `nrounds` and `early_stopping_rounds`.

I'm opening this PR to fix the cases in `lightgbm.R` and to serve as an example for #3390 .