### PR TITLE
[ci] Use Ubuntu Focal image at Travis

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -16,7 +16,7 @@ cd $BUILD_DIRECTORY
 if [[ $TRAVIS == "true" ]] && [[ $TASK == "check-docs" ]]; then
     cd $BUILD_DIRECTORY/docs
     conda install -q -y -n $CONDA_ENV -c conda-forge doxygen
-    pip install --user -r requirements.txt rstcheck
+    pip install --user -r requirements.txt rstcheck git+git://github.com/linkchecker/linkchecker.git@b9390c9ef63f7e1e210b48bc7fe97f76e8d39501
     # check reStructuredText formatting
     cd $BUILD_DIRECTORY/python-package
     rstcheck --report warning `find . -type f -name "*.rst"` || exit -1
@@ -26,11 +26,7 @@ if [[ $TRAVIS == "true" ]] && [[ $TASK == "check-docs" ]]; then
     make html || exit -1
     find ./_build/html/ -type f -name '*.html' -exec \
     sed -i'.bak' -e 's;\(\.\/[^.]*\.\)rst\([^[:space:]]*\);\1html\2;g' {} \;  # emulate js function
-    if [[ $OS_NAME == "linux" ]]; then
-        sudo apt-get update
-        sudo apt-get install linkchecker
-        linkchecker --config=.linkcheckerrc ./_build/html/*.html || exit -1
-    fi
+    linkchecker --config=.linkcheckerrc ./_build/html/*.html || exit -1
     # check the consistency of parameters' descriptions and other stuff
     cp $BUILD_DIRECTORY/docs/Parameters.rst $BUILD_DIRECTORY/docs/Parameters-backup.rst
     cp $BUILD_DIRECTORY/src/io/config_auto.cpp $BUILD_DIRECTORY/src/io/config_auto-backup.cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ git:
 os:
   - linux
   - osx
-dist: bionic
+dist: focal
 osx_image: xcode12
 
 env:
@@ -24,7 +24,7 @@ env:
     - TASK=check-docs
     - TASK=mpi METHOD=source
     - TASK=mpi METHOD=pip PYTHON_VERSION=3.7
-    - TASK=gpu METHOD=source PYTHON_VERSION=3.5
+    - TASK=gpu METHOD=source PYTHON_VERSION=3.6
     - TASK=gpu METHOD=pip PYTHON_VERSION=3.6
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
         export COMPILER="gcc";
     else
         export OS_NAME="linux";
-        export COMPILER="clang";
+        export COMPILER="gcc";
     fi
   - export CONDA="$HOME/miniconda"
   - export PATH="$CONDA/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ git:
 os:
   - linux
   - osx
-dist: focal
+dist: bionic
 osx_image: xcode12
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - TASK=check-docs
     - TASK=mpi METHOD=source
     - TASK=mpi METHOD=pip PYTHON_VERSION=3.7
-    - TASK=gpu METHOD=source PYTHON_VERSION=3.6
+    - TASK=gpu METHOD=source PYTHON_VERSION=3.5
     - TASK=gpu METHOD=pip PYTHON_VERSION=3.6
 
 matrix:
@@ -47,7 +47,7 @@ before_install:
         export COMPILER="gcc";
     else
         export OS_NAME="linux";
-        export COMPILER="gcc";
+        export COMPILER="clang";
     fi
   - export CONDA="$HOME/miniconda"
   - export PATH="$CONDA/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ git:
 os:
   - linux
   - osx
-dist: bionic
+dist: focal
 osx_image: xcode12
 
 env:

--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -6,7 +6,6 @@ sslverify=0
 [filtering]
 ignore=
   pythonapi/lightgbm\..*\.html.*
-  http://sphinx-doc.org
 ignorewarnings=http-robots-denied,https-certificate-error
 checkextern=1
 


### PR DESCRIPTION
Refer to https://blog.travis-ci.com/2020-08-10-focal-build-environment.
Our policy is to test LightGBM against the most recent versions of OSes at Travis CI (in the opposite to Azure where we try to use the oldest images for producing public artifacts).