### PR TITLE
[python] Drop Python 3.5 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,6 @@ install:
   - ps: >-
       switch ($env:PYTHON_VERSION) {
           "2.7" {$env:MINICONDA = "C:\Miniconda-x64"}
-          "3.5" {$env:MINICONDA = "C:\Miniconda35-x64"}
           "3.6" {$env:MINICONDA = "C:\Miniconda36-x64"}
           "3.7" {$env:MINICONDA = "C:\Miniconda37-x64"}
           default {$env:MINICONDA = "C:\Miniconda37-x64"}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,5 +165,5 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-    - name: note that all tests succeeded
+    - name: Note that all tests succeeded
       run: echo "🎉"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,13 @@ env:
     - TASK=check-docs
     - TASK=mpi METHOD=source
     - TASK=mpi METHOD=pip PYTHON_VERSION=3.7
-    - TASK=gpu METHOD=source PYTHON_VERSION=3.5
+    - TASK=gpu METHOD=source
     - TASK=gpu METHOD=pip PYTHON_VERSION=3.6
 
 matrix:
   exclude:
     - os: osx
-      env: TASK=gpu METHOD=source PYTHON_VERSION=3.5
+      env: TASK=gpu METHOD=source
     - os: osx
       env: TASK=gpu METHOD=pip PYTHON_VERSION=3.6
     - os: osx

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -30,7 +30,6 @@ jobs:
         TASK: regular
       sdist:
         TASK: sdist
-        PYTHON_VERSION: 3.5
       bdist:
         TASK: bdist
         PYTHON_VERSION: 3.7
@@ -81,7 +80,6 @@ jobs:
         PYTHON_VERSION: 3.7
       sdist:
         TASK: sdist
-        PYTHON_VERSION: 3.5
       bdist:
         TASK: bdist
   steps:

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -302,7 +302,6 @@ if __name__ == "__main__":
                        'Programming Language :: Python :: 2',
                        'Programming Language :: Python :: 2.7',
                        'Programming Language :: Python :: 3',
-                       'Programming Language :: Python :: 3.5',
                        'Programming Language :: Python :: 3.6',
                        'Programming Language :: Python :: 3.7',
                        'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
Python 3.5 is reaching its End of Life today and no need to support it anymore.
https://devguide.python.org/#branchstatus