### PR TITLE
[R-package] add new copyright holder in DESCRIPTION

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
     person("Damien", "Soukhavong", email = "damien.soukhavong@skema.edu", role = c("aut")),
     person("Yachen", "Yan", role = c("ctb")),
     person("James", "Lamb", email="jaylamb20@gmail.com", role = c("aut")),
-    person("IBM Corporation", role = c("IBM Corporation"))
+    person("IBM Corporation", role = c("ctb"))
     )
 Description: Tree based algorithms can be improved by introducing boosting frameworks. 'LightGBM' is one such framework, and this package offers an R interface to work with it.
     It is designed to be distributed and efficient with the following advantages:

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -7,7 +7,8 @@ Authors@R: c(
     person("Guolin", "Ke", email = "guolin.ke@microsoft.com", role = c("aut", "cre")),
     person("Damien", "Soukhavong", email = "damien.soukhavong@skema.edu", role = c("aut")),
     person("Yachen", "Yan", role = c("ctb")),
-    person("James", "Lamb", email="jaylamb20@gmail.com", role = c("aut"))
+    person("James", "Lamb", email="jaylamb20@gmail.com", role = c("aut")),
+    person("IBM Corporation", role = c("IBM Corporation"))
     )
 Description: Tree based algorithms can be improved by introducing boosting frameworks. 'LightGBM' is one such framework, and this package offers an R interface to work with it.
     It is designed to be distributed and efficient with the following advantages:


### PR DESCRIPTION
In #3338 ,  we learned from CRAN that all copyright holders of any part of the source code need to be listed in the R package's `DESCRIPTION` file.

Since #3160 added some code with an IBM copyright on it, IBM needs to be added to `DESCRIPTION`. https://github.com/microsoft/LightGBM/pull/3338#discussion_r493584038