### PR TITLE
[ci] removed unused environment variable CONDA_ENV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,6 @@ jobs:
               export R_LINUX_VERSION=3.6.3-1bionic
           fi
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
-          export CONDA_ENV="test-env"
           export CONDA="$HOME/miniconda"
           export PATH="$CONDA/bin:${HOME}/.local/bin:$PATH"
           export R_VERSION="${{ matrix.r_version }}"


### PR DESCRIPTION
I realized today that the environment variable `CONDA_ENV` is not used by any of the R CI jobs. So it can safely be removed from the GitHub Actions config for this jobs.