### PR TITLE
Use ctypes to pass parameters (fixes #3398)

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2976,9 +2976,9 @@ class Booster(object):
         ptr_string_buffers = (ctypes.c_char_p * num_feature)(*map(ctypes.addressof, string_buffers))
         _safe_call(_LIB.LGBM_BoosterGetFeatureNames(
             self.handle,
-            num_feature,
+            ctypes.c_int(num_feature),
             ctypes.byref(tmp_out_len),
-            reserved_string_buffer_size,
+            ctypes.c_size_t(reserved_string_buffer_size),
             ctypes.byref(required_string_buffer_size),
             ptr_string_buffers))
         if num_feature != tmp_out_len.value:
@@ -3175,9 +3175,9 @@ class Booster(object):
                 ptr_string_buffers = (ctypes.c_char_p * self.__num_inner_eval)(*map(ctypes.addressof, string_buffers))
                 _safe_call(_LIB.LGBM_BoosterGetEvalNames(
                     self.handle,
-                    self.__num_inner_eval,
+                    ctypes.c_int(self.__num_inner_eval),
                     ctypes.byref(tmp_out_len),
-                    reserved_string_buffer_size,
+                    ctypes.c_size_t(reserved_string_buffer_size),
                     ctypes.byref(required_string_buffer_size),
                     ptr_string_buffers))
                 if self.__num_inner_eval != tmp_out_len.value:


### PR DESCRIPTION
I was able to reproduce the bug from #3398 consistently on my machine with the script below (Windows, Visual Studio, Python 2.7). It always crashes on `seed=105`.

I think the cause is that `LGBM_DatasetGetFeatureNames` is expecting a `size_t` input for `buffer_len` but we pass a Python integer. Apparently this can cause unpredictable behavior depending on the compiler, see https://stackoverflow.com/questions/51903911/calling-c-functions-via-python-ctypes-why-does-passing-uints-to-a-function-expe

```
import lightgbm as lgb
from sklearn.datasets import load_breast_cancer
from sklearn.model_selection import train_test_split

X_train, X_test, y_train, y_test = train_test_split(*load_breast_cancer(return_X_y=True),
                                                                        test_size=0.1, random_state=1)
train_data = lgb.Dataset(X_train, y_train)

for seed in range(0, 200):
    print(seed)
    params = {
        "objective": "binary",
        "verbose": -1,
        "num_leaves": 3,
        "seed": seed
    }

    gbm1 = lgb.LGBMClassifier(n_estimators=3, num_leaves=3, silent=True)
    gbm1.fit(X_train, y_train)
    print(gbm1.booster_.feature_name()[27])
```