### PR TITLE
Add support for cuda version less then 10.0

### DIFF
--- a/include/LightGBM/cuda/vector_cudahost.h
+++ b/include/LightGBM/cuda/vector_cudahost.h
@@ -65,9 +65,15 @@ struct CHAllocator {
       if (LGBM_config_::current_device == lgbm_device_cuda) {
         cudaPointerAttributes attributes;
         cudaPointerGetAttributes(&attributes, p);
-        if ((attributes.type == cudaMemoryTypeHost) && (attributes.devicePointer != NULL)) {
-          cudaFreeHost(p);
-        }
+        #if CUDA_VERSION >= 10000
+          if ((attributes.type == cudaMemoryTypeHost) && (attributes.devicePointer != NULL)) {
+            cudaFreeHost(p);
+          }
+        #else
+          if ((attributes.memoryType == cudaMemoryTypeHost) && (attributes.devicePointer != NULL)) {
+            cudaFreeHost(p);
+          }
+        #endif
       } else {
         _mm_free(p);
       }


### PR DESCRIPTION
For `cudaPointerAttributes`, the attribute name has been updated from `memoryType` to `type` since 10.0, add support for compiling version less then 10.0 .
https://docs.nvidia.com/cuda/archive/9.2/cuda-runtime-api/structcudaPointerAttributes.html#structcudaPointerAttributes
https://docs.nvidia.com/cuda/archive/10.0/cuda-runtime-api/structcudaPointerAttributes.html#structcudaPointerAttributes
