### PR TITLE
[R-package] add 'cleanup' script to handle left-behind Makevars

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -29,6 +29,8 @@ fi
 # installing precompiled R for Ubuntu
 # https://cran.r-project.org/bin/linux/ubuntu/#installation
 # adding steps from https://stackoverflow.com/a/56378217/3986677 to get latest version
+#
+# `devscripts` is required for 'checkbashisms' (https://github.com/r-lib/actions/issues/111)
 if [[ $OS_NAME == "linux" ]]; then
     sudo apt-key adv \
         --keyserver keyserver.ubuntu.com \
@@ -39,6 +41,7 @@ if [[ $OS_NAME == "linux" ]]; then
     sudo apt-get install \
         --no-install-recommends \
         -y --allow-downgrades \
+            devscripts \
             r-base-dev=${R_LINUX_VERSION} \
             texinfo \
             texlive-latex-recommended \
@@ -47,13 +50,12 @@ if [[ $OS_NAME == "linux" ]]; then
             qpdf \
             || exit -1
 
-    # https://github.com/r-lib/actions/issues/111
+    
     if [[ $R_BUILD_TYPE == "cran" ]]; then
         sudo apt-get install \
             --no-install-recommends \
             -y \
                 autoconf=$(cat R-package/AUTOCONF_UBUNTU_VERSION) \
-                devscripts \
                 || exit -1
     fi
 fi
@@ -61,11 +63,11 @@ fi
 # Installing R precompiled for Mac OS 10.11 or higher
 if [[ $OS_NAME == "macos" ]]; then
     if [[ $R_BUILD_TYPE == "cran" ]]; then
-        brew install \
-            automake \
-            checkbashisms
+        brew install automake
     fi
-    brew install qpdf
+    brew install \
+        checkbashisms \
+        qpdf
     brew cask install basictex
     export PATH="/Library/TeX/texbin:$PATH"
     sudo tlmgr --verify-repo=none update --self

--- a/R-package/cleanup
+++ b/R-package/cleanup
@@ -1,0 +1,2 @@
+#!/bin/sh
+rm -f src/Makevars


### PR DESCRIPTION
While working on https://github.com/microsoft/LightGBM/pull/3405#issuecomment-703203133, I ran into this NOTE from `R CMD check`:

```text
* checking compilation flags in Makevars ... NOTE
Package has both ‘src/Makevars.in’ and ‘src/Makevars’.
Installation with --no-configure' is unlikely to work.  If you intended
‘src/Makevars’ to be used on Windows, rename it to ‘src/Makevars.win’
otherwise remove it.  If ‘configure’ created ‘src/Makevars’, you need a
‘cleanup’ script.
```

I don't completely understand the conditions when this might happen, but I know how to prevent it! 

From ["Writing R Extensions"](https://cran.r-project.org/doc/manuals/R-exts.html#Configure-and-cleanup):

> Under a Unix-alike only, an executable (Bourne shell) script cleanup is executed as the last thing by `R CMD INSTALL` if option `--clean` was given, and by `R CMD build` when preparing the package for building from its source.

and

> If the configure script creates files, e.g. src/Makevars, you do need a cleanup script to remove them. 

This PR proposes adding a small `cleanup` to `{lightgbm}` to prevent this issue in the future. This is exactly the approach other packages on CRAN have taken:

* [`{arrow}`](https://github.com/cran/arrow/blob/master/cleanup)
* [`{data.table}`](https://github.com/cran/data.table/blob/master/cleanup)
* [`{xgboost}`](https://github.com/cran/xgboost/blob/master/cleanup)
