### PR TITLE
[R-package] Suppresses unknown pragma warnings during CRAN build

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -226,7 +226,7 @@ if [[ $R_BUILD_TYPE == "cran" ]]; then
         | wc -l
     )
     if [[ $pragma_warning_present -ne 0 ]]; then
-        echo "Unknown pragma warning is present, pragmas should have been remove before build"
+        echo "Unknown pragma warning is present, pragmas should have been removed before build"
         exit -1
     fi
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -219,7 +219,7 @@ fi
 
 # this check makes sure that no "warning: unknown pragma ignored" logs
 # reach the user leading them to believe that something went wrong
-if [[ $OS_NAME == "macos" || $OS_NAME == "linux" ]] && [[ $R_BUILD_TYPE == "cran" ]]; then
+if [[ $R_BUILD_TYPE == "cran" ]]; then
     pragma_warning_present=$(
         cat $BUILD_LOG_FILE \
         | grep -E "warning: unknown pragma ignored" \

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -216,3 +216,17 @@ if [[ $OS_NAME == "macos" ]] && [[ $R_BUILD_TYPE == "cran" ]]; then
         exit -1
     fi
 fi
+
+# this check makes sure that no "warning: unknown pragma ignored" logs
+# reach the user leading them to believe that something went wrong
+if [[ $OS_NAME == "macos" || $OS_NAME == "linux" ]] && [[ $R_BUILD_TYPE == "cran" ]]; then
+    pragma_warning_present=$(
+        cat $BUILD_LOG_FILE \
+        | grep -E "warning: unknown pragma ignored" \
+        | wc -l
+    )
+    if [[ $pragma_warning_present -ne 0 ]]; then
+        echo "Unknown pragma warning is present, pragmas should have been remove before build"
+        exit -1
+    fi
+fi

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -55,7 +55,7 @@ cd ${TEMP_R_DIR}
     # not allow you to use compiler flag '-Wno-unknown-pragmas' or
     # pragmas that suppress warnings.
     echo "Removing unknown pragmas in headers"
-    for file in $(find . -regex ".*\.\(h\|cpp\|hpp\)$"); do
+    for file in $(find . -regex '.*\.\(h\|cpp\|hpp\)$'); do
       sed \
         -i.bak \
         -e 's/^.*#pragma region.*$//' \
@@ -63,7 +63,7 @@ cd ${TEMP_R_DIR}
         -e 's/^.*#pragma warning.*$//' \
         "${file}"
     done
-    find . -regex ".*\.\(h\|cpp\|hpp\)\.bak$" -exec rm {} \;
+    find . -regex '.*\.\(h\|cpp\|hpp\)\.bak$' -exec rm {} \;
 
     # When building an R package with 'configure', it seems
     # you're guaranteed to get a shared library called

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -50,19 +50,20 @@ cd ${TEMP_R_DIR}
     sed -i.bak -e "s/~~VERSION~~/${LGB_VERSION}/" DESCRIPTION
     sed -i.bak -e "s/~~DATE~~/${CURRENT_DATE}/" DESCRIPTION
 
-    # Remove 'region' and 'endregion' pragmas. This won't change
-    # the correctness of the code. CRAN does not allow you
-    # to use compiler flag '-Wno-unknown-pragmas' or
+    # Remove 'region', 'endregion', and 'warning' pragmas.
+    # This won't change the correctness of the code. CRAN does
+    # not allow you to use compiler flag '-Wno-unknown-pragmas' or
     # pragmas that suppress warnings.
     echo "Removing unknown pragmas in headers"
-    for file in src/include/LightGBM/*.h; do
+    for file in $(find . -name *.h); do
       sed \
         -i.bak \
         -e 's/^.*#pragma region.*$//' \
         -e 's/^.*#pragma endregion.*$//' \
+        -e 's/^.*#pragma warning.*$//' \
         "${file}"
     done
-    rm src/include/LightGBM/*.h.bak
+    find . -name *.h.bak -exec rm {} \;
 
     # When building an R package with 'configure', it seems
     # you're guaranteed to get a shared library called

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -55,7 +55,7 @@ cd ${TEMP_R_DIR}
     # not allow you to use compiler flag '-Wno-unknown-pragmas' or
     # pragmas that suppress warnings.
     echo "Removing unknown pragmas in headers"
-    for file in $(find . -name *.h); do
+    for file in $(find . -regex ".*\.\(h\|cpp\|hpp\)$"); do
       sed \
         -i.bak \
         -e 's/^.*#pragma region.*$//' \
@@ -63,7 +63,7 @@ cd ${TEMP_R_DIR}
         -e 's/^.*#pragma warning.*$//' \
         "${file}"
     done
-    find . -name *.h.bak -exec rm {} \;
+    find . -regex ".*\.\(h\|cpp\|hpp\)\.bak$" -exec rm {} \;
 
     # When building an R package with 'configure', it seems
     # you're guaranteed to get a shared library called

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -55,7 +55,7 @@ cd ${TEMP_R_DIR}
     # not allow you to use compiler flag '-Wno-unknown-pragmas' or
     # pragmas that suppress warnings.
     echo "Removing unknown pragmas in headers"
-    for file in $(find . -regex '.*\.\(h\|cpp\|hpp\)$'); do
+    for file in $(find . -name '*.h' -o -name '*.hpp' -o -name '*.cpp'); do
       sed \
         -i.bak \
         -e 's/^.*#pragma region.*$//' \
@@ -63,7 +63,7 @@ cd ${TEMP_R_DIR}
         -e 's/^.*#pragma warning.*$//' \
         "${file}"
     done
-    find . -regex '.*\.\(h\|cpp\|hpp\)\.bak$' -exec rm {} \;
+    find . -name '*.h.bak' -o -name '*.hpp.bak' -o -name '*.cpp.bak' -exec rm {} \;
 
     # When building an R package with 'configure', it seems
     # you're guaranteed to get a shared library called


### PR DESCRIPTION
This PR addresses pragma warnings that gcc was outputting since CRAN builds cannot suppress them. See issue #3433 for more information and recreation steps.

Major changes:
1. `build-cran-package.sh` was modified to remove `#pragma warning`s from all `h`, `hpp`, and `cpp` files in the temporary build folder (`lightgbm_r`).
2. An additional check was added to the end of the CI script `test_r_package.sh` that ensures no unknown pragma warnings were omitted during the build or else it will exit.

Closes #3433 