### PR TITLE
[ci] ignore R CMD CHECK warnings on new R version

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -18,8 +18,8 @@ if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
     export R_LINUX_VERSION="3.6.3-1bionic"
     export R_APT_REPO="bionic-cran35/"
 elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
-    export R_MAC_VERSION=4.0.2
-    export R_LINUX_VERSION="4.0.2-1.1804.0"
+    export R_MAC_VERSION=4.0.3
+    export R_LINUX_VERSION="4.0.3-1.1804.0"
     export R_APT_REPO="bionic-cran40/"
 else
     echo "Unrecognized R version: ${R_VERSION}"
@@ -187,13 +187,7 @@ if [[ $check_succeeded == "no" ]]; then
     exit -1
 fi
 
-num_warnings=$(
-    cat ${LOG_FILE_NAME} \
-    | grep -q -R "WARNING" \
-    | grep -v "was built under R version" \
-    | wc -l
-)
-if [[ ${num_warnings} -gt 0 ]]; then
+if grep -q -R "WARNING" "$LOG_FILE_NAME"; then
     echo "WARNINGS have been found by R CMD check!"
     exit -1
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -187,7 +187,13 @@ if [[ $check_succeeded == "no" ]]; then
     exit -1
 fi
 
-if grep -q -R "WARNING" "$LOG_FILE_NAME"; then
+num_warnings=$(
+    cat ${LOG_FILE_NAME} \
+    | grep -q -R "WARNING" \
+    | grep -v "was built under R version" \
+    | wc -l
+)
+if [[ ${num_warnings} -gt 0 ]]; then
     echo "WARNINGS have been found by R CMD check!"
     exit -1
 fi

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -43,7 +43,7 @@ if ($env:R_MAJOR_VERSION -eq "3") {
   $RTOOLS_INSTALL_PATH = "C:\rtools40"
   $env:RTOOLS_MINGW_BIN = "$RTOOLS_INSTALL_PATH/mingw64/bin"
   $env:RTOOLS_EXE_FILE = "rtools40-x86_64.exe"
-  $env:R_WINDOWS_VERSION = "4.0.2"
+  $env:R_WINDOWS_VERSION = "4.0.3"
 } else {
   Write-Output "[ERROR] Unrecognized R version: $env:R_VERSION"
   Check-Output $false
@@ -164,7 +164,7 @@ if ($env:COMPILER -ne "MSVC") {
       echo "ERRORs have been found by R CMD check!"
       Check-Output $False
   }
-  if (Get-Content "$LOG_FILE_NAME" | Select-String -Pattern "WARNING" -CaseSensitive -Quiet | Select-String -Pattern "was built under R version" -NotMatch -CaseSensitive -Quiet) {
+  if (Get-Content "$LOG_FILE_NAME" | Select-String -Pattern "WARNING" -CaseSensitive -Quiet) {
       echo "WARNINGS have been found by R CMD check!"
       Check-Output $False
   }

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -164,7 +164,7 @@ if ($env:COMPILER -ne "MSVC") {
       echo "ERRORs have been found by R CMD check!"
       Check-Output $False
   }
-  if (Get-Content "$LOG_FILE_NAME" | Select-String -Pattern "WARNING" -CaseSensitive -Quiet) {
+  if (Get-Content "$LOG_FILE_NAME" | Select-String -Pattern "WARNING" -CaseSensitive -Quiet | Select-String -Pattern "was built under R version" -NotMatch -CaseSensitive -Quiet) {
       echo "WARNINGS have been found by R CMD check!"
       Check-Output $False
   }

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -163,8 +163,7 @@ jobs:
     name: r-package (ubuntu-latest, R-devel, GCC ASAN/UBSAN)
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    container:
-      image: rhub/rocker-gcc-san
+    container: rhub/rocker-gcc-san
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1


### PR DESCRIPTION
In CI for the R package,  we check for `R CMD CHECK` warnings by looking for the string "warning" in its logs. That test is currently breaking builds (https://github.com/microsoft/LightGBM/runs/1268855023)  for a  warning that  can safely be ignored:

> Warning: package 'R6' was built under R version 4.0.3

This PR proposes ignoring those warnings. It also slightly simplifies the config for the UBSAN tests added in #3439  (based on https://github.com/microsoft/LightGBM/pull/3443#discussion_r506961056)