### PR TITLE
[ci] update SWIG installation on macOS

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -15,7 +15,7 @@ if [[ $OS_NAME == "macos" ]]; then
         brew install open-mpi
     fi
     if [[ $AZURE == "true" ]] && [[ $TASK == "sdist" ]]; then
-        brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f3544543a3115023fc7ca962c21d14b443f419d0/Formula/swig.rb  # swig 3.0.12
+        brew install swig@3
     fi
     wget -q -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
 else  # Linux

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - master
+    - brew_swig
   tags:
     include:
     - v*

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,6 +91,7 @@ jobs:
       CONDA=$AGENT_HOMEDIRECTORY/miniconda
       echo "##vso[task.setvariable variable=CONDA]$CONDA"
       echo "##vso[task.prependpath]$CONDA/bin"
+      echo "##vso[task.prependpath]/usr/local/opt/swig@3/bin"
       echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_8_X64"
     displayName: 'Set variables'
   - bash: $(Build.SourcesDirectory)/.ci/setup.sh

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - brew_swig
+    - master
   tags:
     include:
     - v*

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,7 +91,7 @@ jobs:
       CONDA=$AGENT_HOMEDIRECTORY/miniconda
       echo "##vso[task.setvariable variable=CONDA]$CONDA"
       echo "##vso[task.prependpath]$CONDA/bin"
-      echo "##vso[task.prependpath]/usr/local/opt/swig@3/bin"
+      echo "##vso[task.prependpath]$(brew --prefix swig@3)/bin"
       echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_8_X64"
     displayName: 'Set variables'
   - bash: $(Build.SourcesDirectory)/.ci/setup.sh


### PR DESCRIPTION
Howbrew has recently removed the possibility to install old versions of packages from GitHub commits.
```
Error: Calling Installation of swig from a GitHub commit URL is disabled! Use 'brew extract swig' to stable tap on GitHub instead.
```
Now one should maintain their own GitHub repo for that.
More reading:
https://github.com/Homebrew/brew/issues/8791
https://discourse.brew.sh/t/has-brew-install-force-formula-raw-path-been-taken-out/8793

But fortunately I've found `SWIG@3` official formulae. I remember I hadn't got a luck to find it when setup SWIG building pipeline.

@imatiach-msft Just wonder, can we eventually migrate to SWIG 4? How about backward compatibility in this case?