### PR TITLE
[ci] [python] reduce unnecessary data loading in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -318,6 +318,8 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
+prof/
+*.prof
 coverage.xml
 *,cover
 .hypothesis/

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -14,6 +14,7 @@ try:
     from functools import lru_cache
 except ImportError:
     warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
+
     def lru_cache(user_function, maxsize=None):
         @wraps(user_function)
         def wrapper(*args, **kwargs):

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -10,19 +10,7 @@ from scipy import sparse
 from sklearn.datasets import load_breast_cancer, dump_svmlight_file, load_svmlight_file
 from sklearn.model_selection import train_test_split
 
-try:
-    from functools import lru_cache
-except ImportError:
-    warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
-
-    def lru_cache(user_function, maxsize=None):
-        @wraps(user_function)
-        def wrapper(*args, **kwargs):
-            arg_key = tuple(args, [item for item in kwargs.items()])
-            if arg_key not in cache:
-                cache[arg_key] = user_function(*args)
-            return cache[arg_key]
-        return wrapper
+from .utils import lru_cache
 
 
 @lru_cache(maxsize=None)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import unittest
 
-from functools import lru_cache
+from functools import cache
 
 import lightgbm as lgb
 import numpy as np
@@ -13,7 +13,7 @@ from sklearn.datasets import load_breast_cancer, dump_svmlight_file, load_svmlig
 from sklearn.model_selection import train_test_split
 
 
-@lru_cache
+@cache
 def _load_breast_cancer(**kwargs):
     return load_breast_cancer(**kwargs)
 

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -3,14 +3,25 @@ import os
 import tempfile
 import unittest
 
-from functools import lru_cache
-
 import lightgbm as lgb
 import numpy as np
 
 from scipy import sparse
 from sklearn.datasets import load_breast_cancer, dump_svmlight_file, load_svmlight_file
 from sklearn.model_selection import train_test_split
+
+try:
+    from functools import lru_cache
+except ImportError:
+    warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
+    def lru_cache(user_function, maxsize=None):
+        @wraps(user_function)
+        def wrapper(*args, **kwargs):
+            arg_key = tuple(args, [item for item in kwargs.items()])
+            if arg_key not in cache:
+                cache[arg_key] = user_function(*args)
+            return cache[arg_key]
+        return wrapper
 
 
 @lru_cache(maxsize=None)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -7,21 +7,16 @@ import lightgbm as lgb
 import numpy as np
 
 from scipy import sparse
-from sklearn.datasets import load_breast_cancer, dump_svmlight_file, load_svmlight_file
+from sklearn.datasets import dump_svmlight_file, load_svmlight_file
 from sklearn.model_selection import train_test_split
 
-from .utils import lru_cache
-
-
-@lru_cache(maxsize=None)
-def _load_breast_cancer(**kwargs):
-    return load_breast_cancer(**kwargs)
+from .utils import load_breast_cancer, lru_cache
 
 
 class TestBasic(unittest.TestCase):
 
     def test(self):
-        X_train, X_test, y_train, y_test = train_test_split(*_load_breast_cancer(return_X_y=True),
+        X_train, X_test, y_train, y_test = train_test_split(*load_breast_cancer(return_X_y=True),
                                                             test_size=0.1, random_state=2)
         train_data = lgb.Dataset(X_train, label=y_train)
         valid_data = train_data.create_valid(X_test, label=y_test)
@@ -93,7 +88,7 @@ class TestBasic(unittest.TestCase):
         os.remove(tname)
 
     def test_chunked_dataset(self):
-        X_train, X_test, y_train, y_test = train_test_split(*_load_breast_cancer(return_X_y=True), test_size=0.1, random_state=2)
+        X_train, X_test, y_train, y_test = train_test_split(*load_breast_cancer(return_X_y=True), test_size=0.1, random_state=2)
 
         chunk_size = X_train.shape[0] // 10 + 1
         X_train = [X_train[i * chunk_size:(i + 1) * chunk_size, :] for i in range(X_train.shape[0] // chunk_size + 1)]
@@ -316,7 +311,7 @@ class TestBasic(unittest.TestCase):
             self.assertAlmostEqual(data.label[1], data.weight[1])
             self.assertListEqual(data.feature_name, data.get_feature_name())
 
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
         sequence = np.ones(y.shape[0])
         sequence[0] = np.nan
         sequence[1] = np.inf

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -10,7 +10,7 @@ from scipy import sparse
 from sklearn.datasets import dump_svmlight_file, load_svmlight_file
 from sklearn.model_selection import train_test_split
 
-from .utils import load_breast_cancer, lru_cache
+from .utils import load_breast_cancer
 
 
 class TestBasic(unittest.TestCase):

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import unittest
 
-from functools import cache
+from functools import lru_cache
 
 import lightgbm as lgb
 import numpy as np
@@ -13,7 +13,7 @@ from sklearn.datasets import load_breast_cancer, dump_svmlight_file, load_svmlig
 from sklearn.model_selection import train_test_split
 
 
-@cache
+@lru_cache(maxsize=None)
 def _load_breast_cancer(**kwargs):
     return load_breast_cancer(**kwargs)
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -7,8 +7,6 @@ import psutil
 import random
 import unittest
 
-from functools import lru_cache
-
 import lightgbm as lgb
 import numpy as np
 from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_csc
@@ -21,6 +19,19 @@ try:
     import cPickle as pickle
 except ImportError:
     import pickle
+
+try:
+    from functools import lru_cache
+except ImportError:
+    warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
+    def lru_cache(user_function, maxsize=None):
+        @wraps(user_function)
+        def wrapper(*args, **kwargs):
+            arg_key = tuple(args, [item for item in kwargs.items()])
+            if arg_key not in cache:
+                cache[arg_key] = user_function(*args)
+            return cache[arg_key]
+        return wrapper
 
 
 decreasing_generator = itertools.count(0, -1)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     import pickle
 
-from .utils import load_boston, load_breast_cancer, load_digits, load_iris, lru_cache
+from .utils import load_boston, load_breast_cancer, load_digits, load_iris
 
 
 decreasing_generator = itertools.count(0, -1)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -7,7 +7,7 @@ import psutil
 import random
 import unittest
 
-from functools import cache
+from functools import lru_cache
 
 import lightgbm as lgb
 import numpy as np
@@ -53,19 +53,19 @@ def categorize(continuous_x):
     return np.digitize(continuous_x, bins=np.arange(0, 1, 0.01))
 
 
-@cache
+@lru_cache(maxsize=None)
 def _load_boston(**kwargs):
     return load_boston(**kwargs)
 
-@cache
+@lru_cache(maxsize=None)
 def _load_breast_cancer(**kwargs):
     return load_breast_cancer(**kwargs)
 
-@cache
+@lru_cache(maxsize=None)
 def _load_digits(**kwargs):
     return load_digits(**kwargs)
 
-@cache
+@lru_cache(maxsize=None)
 def _load_iris(**kwargs):
     return load_iris(**kwargs)
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -20,19 +20,7 @@ try:
 except ImportError:
     import pickle
 
-try:
-    from functools import lru_cache
-except ImportError:
-    warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
-
-    def lru_cache(user_function, maxsize=None):
-        @wraps(user_function)
-        def wrapper(*args, **kwargs):
-            arg_key = tuple(args, [item for item in kwargs.items()])
-            if arg_key not in cache:
-                cache[arg_key] = user_function(*args)
-            return cache[arg_key]
-        return wrapper
+from .utils import lru_cache
 
 
 decreasing_generator = itertools.count(0, -1)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -7,7 +7,7 @@ import psutil
 import random
 import unittest
 
-from functools import lru_cache
+from functools import cache
 
 import lightgbm as lgb
 import numpy as np
@@ -53,19 +53,19 @@ def categorize(continuous_x):
     return np.digitize(continuous_x, bins=np.arange(0, 1, 0.01))
 
 
-@lru_cache
+@cache
 def _load_boston(**kwargs):
     return load_boston(**kwargs)
 
-@lru_cache
+@cache
 def _load_breast_cancer(**kwargs):
     return load_breast_cancer(**kwargs)
 
-@lru_cache
+@cache
 def _load_digits(**kwargs):
     return load_digits(**kwargs)
 
-@lru_cache
+@cache
 def _load_iris(**kwargs):
     return load_iris(**kwargs)
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -24,6 +24,7 @@ try:
     from functools import lru_cache
 except ImportError:
     warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
+
     def lru_cache(user_function, maxsize=None):
         @wraps(user_function)
         def wrapper(*args, **kwargs):
@@ -68,13 +69,16 @@ def categorize(continuous_x):
 def _load_boston(**kwargs):
     return load_boston(**kwargs)
 
+
 @lru_cache(maxsize=None)
 def _load_breast_cancer(**kwargs):
     return load_breast_cancer(**kwargs)
 
+
 @lru_cache(maxsize=None)
 def _load_digits(**kwargs):
     return load_digits(**kwargs)
+
 
 @lru_cache(maxsize=None)
 def _load_iris(**kwargs):

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -10,8 +10,7 @@ import unittest
 import lightgbm as lgb
 import numpy as np
 from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_csc
-from sklearn.datasets import (load_boston, load_breast_cancer, load_digits,
-                              load_iris, load_svmlight_file, make_multilabel_classification)
+from sklearn.datasets import load_svmlight_file, make_multilabel_classification
 from sklearn.metrics import log_loss, mean_absolute_error, mean_squared_error, roc_auc_score, average_precision_score
 from sklearn.model_selection import train_test_split, TimeSeriesSplit, GroupKFold
 
@@ -20,7 +19,7 @@ try:
 except ImportError:
     import pickle
 
-from .utils import lru_cache
+from .utils import load_boston, load_breast_cancer, load_digits, load_iris, lru_cache
 
 
 decreasing_generator = itertools.count(0, -1)
@@ -53,29 +52,9 @@ def categorize(continuous_x):
     return np.digitize(continuous_x, bins=np.arange(0, 1, 0.01))
 
 
-@lru_cache(maxsize=None)
-def _load_boston(**kwargs):
-    return load_boston(**kwargs)
-
-
-@lru_cache(maxsize=None)
-def _load_breast_cancer(**kwargs):
-    return load_breast_cancer(**kwargs)
-
-
-@lru_cache(maxsize=None)
-def _load_digits(**kwargs):
-    return load_digits(**kwargs)
-
-
-@lru_cache(maxsize=None)
-def _load_iris(**kwargs):
-    return load_iris(**kwargs)
-
-
 class TestEngine(unittest.TestCase):
     def test_binary(self):
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'binary',
@@ -97,7 +76,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['binary_logloss'][-1], ret, places=5)
 
     def test_rf(self):
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'boosting_type': 'rf',
@@ -122,7 +101,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['binary_logloss'][-1], ret, places=5)
 
     def test_regression(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'metric': 'l2',
@@ -399,7 +378,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['auc'][-1], ret, places=5)
 
     def test_multiclass(self):
-        X, y = _load_digits(n_class=10, return_X_y=True)
+        X, y = load_digits(n_class=10, return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'multiclass',
@@ -420,7 +399,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['multi_logloss'][-1], ret, places=5)
 
     def test_multiclass_rf(self):
-        X, y = _load_digits(n_class=10, return_X_y=True)
+        X, y = load_digits(n_class=10, return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'boosting_type': 'rf',
@@ -448,7 +427,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['multi_logloss'][-1], ret, places=5)
 
     def test_multiclass_prediction_early_stopping(self):
-        X, y = _load_digits(n_class=10, return_X_y=True)
+        X, y = load_digits(n_class=10, return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'multiclass',
@@ -474,7 +453,7 @@ class TestEngine(unittest.TestCase):
         self.assertLess(ret, 0.2)
 
     def test_multi_class_error(self):
-        X, y = _load_digits(n_class=10, return_X_y=True)
+        X, y = load_digits(n_class=10, return_X_y=True)
         params = {'objective': 'multiclass', 'num_classes': 10, 'metric': 'multi_error',
                   'num_leaves': 4, 'verbose': -1}
         lgb_data = lgb.Dataset(X, label=y)
@@ -519,7 +498,7 @@ class TestEngine(unittest.TestCase):
 
     def test_auc_mu(self):
         # should give same result as binary auc for 2 classes
-        X, y = _load_digits(n_class=10, return_X_y=True)
+        X, y = load_digits(n_class=10, return_X_y=True)
         y_new = np.zeros((len(y)))
         y_new[y != 0] = 1
         lgb_X = lgb.Dataset(X, label=y_new)
@@ -597,7 +576,7 @@ class TestEngine(unittest.TestCase):
         self.assertNotEqual(results_weight['training']['auc_mu'][-1], results_no_weight['training']['auc_mu'][-1])
 
     def test_early_stopping(self):
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
         params = {
             'objective': 'binary',
             'metric': 'binary_logloss',
@@ -629,7 +608,7 @@ class TestEngine(unittest.TestCase):
         self.assertIn('binary_logloss', gbm.best_score[valid_set_name])
 
     def test_continue_train(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'regression',
@@ -657,7 +636,7 @@ class TestEngine(unittest.TestCase):
         os.remove(model_name)
 
     def test_continue_train_reused_dataset(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         params = {
             'objective': 'regression',
             'verbose': -1
@@ -670,7 +649,7 @@ class TestEngine(unittest.TestCase):
         self.assertEqual(gbm.current_iteration(), 20)
 
     def test_continue_train_dart(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'boosting_type': 'dart',
@@ -693,7 +672,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['l1'][-1], ret, places=5)
 
     def test_continue_train_multiclass(self):
-        X, y = _load_iris(return_X_y=True)
+        X, y = load_iris(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'multiclass',
@@ -716,7 +695,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['multi_logloss'][-1], ret, places=5)
 
     def test_cv(self):
-        X_train, y_train = _load_boston(return_X_y=True)
+        X_train, y_train = load_boston(return_X_y=True)
         params = {'verbose': -1}
         lgb_train = lgb.Dataset(X_train, y_train)
         # shuffle = False, override metric in params
@@ -775,7 +754,7 @@ class TestEngine(unittest.TestCase):
         np.testing.assert_allclose(cv_res_lambda['ndcg@3-mean'], cv_res_lambda_obj['ndcg@3-mean'])
 
     def test_cvbooster(self):
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'binary',
@@ -819,7 +798,7 @@ class TestEngine(unittest.TestCase):
         self.assertLess(ret, 0.15)
 
     def test_feature_name(self):
-        X_train, y_train = _load_boston(return_X_y=True)
+        X_train, y_train = load_boston(return_X_y=True)
         params = {'verbose': -1}
         lgb_train = lgb.Dataset(X_train, y_train)
         feature_names = ['f_' + str(i) for i in range(X_train.shape[-1])]
@@ -847,7 +826,7 @@ class TestEngine(unittest.TestCase):
 
     def test_save_load_copy_pickle(self):
         def train_and_predict(init_model=None, return_model=False):
-            X, y = _load_boston(return_X_y=True)
+            X, y = load_boston(return_X_y=True)
             X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
             params = {
                 'objective': 'regression',
@@ -1011,7 +990,7 @@ class TestEngine(unittest.TestCase):
         self.assertEqual(len(evals_result['valid_1']['rmse']), 20)
 
     def test_contribs(self):
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'binary',
@@ -1394,7 +1373,7 @@ class TestEngine(unittest.TestCase):
         np.random.seed()  # reset seed
 
     def test_refit(self):
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'binary',
@@ -1410,7 +1389,7 @@ class TestEngine(unittest.TestCase):
         self.assertGreater(err_pred, new_err_pred)
 
     def test_mape_rf(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         params = {
             'boosting_type': 'rf',
             'objective': 'mape',
@@ -1427,7 +1406,7 @@ class TestEngine(unittest.TestCase):
         self.assertGreater(pred_mean, 20)
 
     def test_mape_dart(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         params = {
             'boosting_type': 'dart',
             'objective': 'mape',
@@ -1506,7 +1485,7 @@ class TestEngine(unittest.TestCase):
             params['num_class'] = 4
             return dtrain, dtest, params
 
-        X, y = _load_iris(return_X_y=True)
+        X, y = load_iris(return_X_y=True)
         dataset = lgb.Dataset(X, y, free_raw_data=False)
         params = {'objective': 'multiclass', 'num_class': 3, 'verbose': -1}
         results = lgb.cv(params, dataset, num_boost_round=10, fpreproc=preprocess_data)
@@ -1514,7 +1493,7 @@ class TestEngine(unittest.TestCase):
         self.assertEqual(len(results['multi_logloss-mean']), 10)
 
     def test_metrics(self):
-        X, y = _load_digits(n_class=2, return_X_y=True)
+        X, y = load_digits(n_class=2, return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         lgb_train = lgb.Dataset(X_train, y_train, silent=True)
         lgb_valid = lgb.Dataset(X_test, y_test, reference=lgb_train, silent=True)
@@ -1820,7 +1799,7 @@ class TestEngine(unittest.TestCase):
         self.assertEqual(len(evals_result), 1)
         self.assertIn('error', evals_result['valid_0'])
 
-        X, y = _load_digits(n_class=3, return_X_y=True)
+        X, y = load_digits(n_class=3, return_X_y=True)
         lgb_train = lgb.Dataset(X, y, silent=True)
 
         obj_multi_aliases = ['multiclass', 'softmax', 'multiclassova', 'multiclass_ova', 'ova', 'ovr']
@@ -1888,7 +1867,7 @@ class TestEngine(unittest.TestCase):
                           params_class_3_verbose, metrics='binary_error', fobj=dummy_obj)
 
     def test_multiple_feval_train(self):
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
 
         params = {'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
 
@@ -1911,7 +1890,7 @@ class TestEngine(unittest.TestCase):
         self.assertIn('decreasing_metric', evals_result['valid_0'])
 
     def test_multiple_feval_cv(self):
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
 
         params = {'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
 
@@ -1934,7 +1913,7 @@ class TestEngine(unittest.TestCase):
 
     @unittest.skipIf(psutil.virtual_memory().available / 1024 / 1024 / 1024 < 3, 'not enough RAM')
     def test_model_size(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         data = lgb.Dataset(X, y)
         bst = lgb.train({'verbose': -1}, data, num_boost_round=2)
         y_pred = bst.predict(X)
@@ -1960,7 +1939,7 @@ class TestEngine(unittest.TestCase):
             self.skipTest('not enough RAM')
 
     def test_get_split_value_histogram(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         lgb_train = lgb.Dataset(X, y, categorical_feature=[2])
         gbm = lgb.train({'verbose': -1}, lgb_train, num_boost_round=20)
         # test XGBoost-style return value
@@ -2070,7 +2049,7 @@ class TestEngine(unittest.TestCase):
                          eval_train_metric=eval_train_metric)
             self.assertEqual(assumed_iteration, len(ret[list(ret.keys())[0]]))
 
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
         X_test1, X_test2, y_test1, y_test2 = train_test_split(X_test, y_test, test_size=0.5, random_state=73)
         lgb_train = lgb.Dataset(X_train, y_train)
@@ -2148,7 +2127,7 @@ class TestEngine(unittest.TestCase):
                                                                            decreasing_metric(preds, train_data)])
 
     def test_node_level_subcol(self):
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'binary',
@@ -2329,7 +2308,7 @@ class TestEngine(unittest.TestCase):
 
     def test_extra_trees(self):
         # check extra trees increases regularization
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         lgb_x = lgb.Dataset(X, label=y)
         params = {'objective': 'regression',
                   'num_leaves': 32,
@@ -2347,7 +2326,7 @@ class TestEngine(unittest.TestCase):
 
     def test_path_smoothing(self):
         # check path smoothing increases regularization
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         lgb_x = lgb.Dataset(X, label=y)
         params = {'objective': 'regression',
                   'num_leaves': 32,
@@ -2369,7 +2348,7 @@ class TestEngine(unittest.TestCase):
             cols = ['Column_' + str(i) for i in range(X.shape[1])]
             return [impcts_dict.get(col, 0.) for col in cols]
 
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
         data = lgb.Dataset(X, label=y)
         num_trees = 10
         bst = lgb.train({"objective": "binary", "verbose": -1}, data, num_trees)
@@ -2414,7 +2393,7 @@ class TestEngine(unittest.TestCase):
             self.assertIsNone(tree_df.loc[0, col])
 
     def test_interaction_constraints(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         num_features = X.shape[1]
         train_data = lgb.Dataset(X, label=y)
         # check that constraint containing all features is equivalent to no constraint
@@ -2491,7 +2470,7 @@ class TestEngine(unittest.TestCase):
             np.testing.assert_allclose(pred4, pred6)
 
         # test for regression
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         params = {
             'objective': 'regression',
             'verbose': -1,
@@ -2504,7 +2483,7 @@ class TestEngine(unittest.TestCase):
         inner_test(X, y, params, early_stopping_rounds=None)
 
         # test for multi-class
-        X, y = _load_iris(return_X_y=True)
+        X, y = load_iris(return_X_y=True)
         params = {
             'objective': 'multiclass',
             'metric': 'multi_logloss',
@@ -2518,7 +2497,7 @@ class TestEngine(unittest.TestCase):
         inner_test(X, y, params, early_stopping_rounds=None)
 
         # test for binary
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
         params = {
             'objective': 'binary',
             'metric': 'binary_logloss',
@@ -2546,6 +2525,7 @@ class TestEngine(unittest.TestCase):
         sklearn_ap = average_precision_score(y, pred)
         self.assertAlmostEqual(ap, sklearn_ap)
         # test that average precision is 1 where model predicts perfectly
+        y = y.copy()
         y[:] = 1
         lgb_X = lgb.Dataset(X, label=y)
         lgb.train(params, lgb_X, num_boost_round=1, valid_sets=[lgb_X], evals_result=res)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -7,6 +7,8 @@ import psutil
 import random
 import unittest
 
+from functools import lru_cache
+
 import lightgbm as lgb
 import numpy as np
 from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_csc
@@ -51,9 +53,26 @@ def categorize(continuous_x):
     return np.digitize(continuous_x, bins=np.arange(0, 1, 0.01))
 
 
+@lru_cache
+def _load_boston(**kwargs):
+    return load_boston(**kwargs)
+
+@lru_cache
+def _load_breast_cancer(**kwargs):
+    return load_breast_cancer(**kwargs)
+
+@lru_cache
+def _load_digits(**kwargs):
+    return load_digits(**kwargs)
+
+@lru_cache
+def _load_iris(**kwargs):
+    return load_iris(**kwargs)
+
+
 class TestEngine(unittest.TestCase):
     def test_binary(self):
-        X, y = load_breast_cancer(return_X_y=True)
+        X, y = _load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'binary',
@@ -75,7 +94,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['binary_logloss'][-1], ret, places=5)
 
     def test_rf(self):
-        X, y = load_breast_cancer(return_X_y=True)
+        X, y = _load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'boosting_type': 'rf',
@@ -100,7 +119,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['binary_logloss'][-1], ret, places=5)
 
     def test_regression(self):
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'metric': 'l2',
@@ -377,7 +396,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['auc'][-1], ret, places=5)
 
     def test_multiclass(self):
-        X, y = load_digits(n_class=10, return_X_y=True)
+        X, y = _load_digits(n_class=10, return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'multiclass',
@@ -398,7 +417,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['multi_logloss'][-1], ret, places=5)
 
     def test_multiclass_rf(self):
-        X, y = load_digits(n_class=10, return_X_y=True)
+        X, y = _load_digits(n_class=10, return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'boosting_type': 'rf',
@@ -426,7 +445,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['multi_logloss'][-1], ret, places=5)
 
     def test_multiclass_prediction_early_stopping(self):
-        X, y = load_digits(n_class=10, return_X_y=True)
+        X, y = _load_digits(n_class=10, return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'multiclass',
@@ -452,7 +471,7 @@ class TestEngine(unittest.TestCase):
         self.assertLess(ret, 0.2)
 
     def test_multi_class_error(self):
-        X, y = load_digits(n_class=10, return_X_y=True)
+        X, y = _load_digits(n_class=10, return_X_y=True)
         params = {'objective': 'multiclass', 'num_classes': 10, 'metric': 'multi_error',
                   'num_leaves': 4, 'verbose': -1}
         lgb_data = lgb.Dataset(X, label=y)
@@ -497,7 +516,7 @@ class TestEngine(unittest.TestCase):
 
     def test_auc_mu(self):
         # should give same result as binary auc for 2 classes
-        X, y = load_digits(n_class=10, return_X_y=True)
+        X, y = _load_digits(n_class=10, return_X_y=True)
         y_new = np.zeros((len(y)))
         y_new[y != 0] = 1
         lgb_X = lgb.Dataset(X, label=y_new)
@@ -575,7 +594,7 @@ class TestEngine(unittest.TestCase):
         self.assertNotEqual(results_weight['training']['auc_mu'][-1], results_no_weight['training']['auc_mu'][-1])
 
     def test_early_stopping(self):
-        X, y = load_breast_cancer(return_X_y=True)
+        X, y = _load_breast_cancer(return_X_y=True)
         params = {
             'objective': 'binary',
             'metric': 'binary_logloss',
@@ -607,7 +626,7 @@ class TestEngine(unittest.TestCase):
         self.assertIn('binary_logloss', gbm.best_score[valid_set_name])
 
     def test_continue_train(self):
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'regression',
@@ -635,7 +654,7 @@ class TestEngine(unittest.TestCase):
         os.remove(model_name)
 
     def test_continue_train_reused_dataset(self):
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         params = {
             'objective': 'regression',
             'verbose': -1
@@ -648,7 +667,7 @@ class TestEngine(unittest.TestCase):
         self.assertEqual(gbm.current_iteration(), 20)
 
     def test_continue_train_dart(self):
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'boosting_type': 'dart',
@@ -671,7 +690,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['l1'][-1], ret, places=5)
 
     def test_continue_train_multiclass(self):
-        X, y = load_iris(return_X_y=True)
+        X, y = _load_iris(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'multiclass',
@@ -694,7 +713,7 @@ class TestEngine(unittest.TestCase):
         self.assertAlmostEqual(evals_result['valid_0']['multi_logloss'][-1], ret, places=5)
 
     def test_cv(self):
-        X_train, y_train = load_boston(return_X_y=True)
+        X_train, y_train = _load_boston(return_X_y=True)
         params = {'verbose': -1}
         lgb_train = lgb.Dataset(X_train, y_train)
         # shuffle = False, override metric in params
@@ -753,7 +772,7 @@ class TestEngine(unittest.TestCase):
         np.testing.assert_allclose(cv_res_lambda['ndcg@3-mean'], cv_res_lambda_obj['ndcg@3-mean'])
 
     def test_cvbooster(self):
-        X, y = load_breast_cancer(return_X_y=True)
+        X, y = _load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'binary',
@@ -797,7 +816,7 @@ class TestEngine(unittest.TestCase):
         self.assertLess(ret, 0.15)
 
     def test_feature_name(self):
-        X_train, y_train = load_boston(return_X_y=True)
+        X_train, y_train = _load_boston(return_X_y=True)
         params = {'verbose': -1}
         lgb_train = lgb.Dataset(X_train, y_train)
         feature_names = ['f_' + str(i) for i in range(X_train.shape[-1])]
@@ -825,7 +844,7 @@ class TestEngine(unittest.TestCase):
 
     def test_save_load_copy_pickle(self):
         def train_and_predict(init_model=None, return_model=False):
-            X, y = load_boston(return_X_y=True)
+            X, y = _load_boston(return_X_y=True)
             X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
             params = {
                 'objective': 'regression',
@@ -989,7 +1008,7 @@ class TestEngine(unittest.TestCase):
         self.assertEqual(len(evals_result['valid_1']['rmse']), 20)
 
     def test_contribs(self):
-        X, y = load_breast_cancer(return_X_y=True)
+        X, y = _load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'binary',
@@ -1372,7 +1391,7 @@ class TestEngine(unittest.TestCase):
         np.random.seed()  # reset seed
 
     def test_refit(self):
-        X, y = load_breast_cancer(return_X_y=True)
+        X, y = _load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'binary',
@@ -1388,7 +1407,7 @@ class TestEngine(unittest.TestCase):
         self.assertGreater(err_pred, new_err_pred)
 
     def test_mape_rf(self):
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         params = {
             'boosting_type': 'rf',
             'objective': 'mape',
@@ -1405,7 +1424,7 @@ class TestEngine(unittest.TestCase):
         self.assertGreater(pred_mean, 20)
 
     def test_mape_dart(self):
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         params = {
             'boosting_type': 'dart',
             'objective': 'mape',
@@ -1484,7 +1503,7 @@ class TestEngine(unittest.TestCase):
             params['num_class'] = 4
             return dtrain, dtest, params
 
-        X, y = load_iris(return_X_y=True)
+        X, y = _load_iris(return_X_y=True)
         dataset = lgb.Dataset(X, y, free_raw_data=False)
         params = {'objective': 'multiclass', 'num_class': 3, 'verbose': -1}
         results = lgb.cv(params, dataset, num_boost_round=10, fpreproc=preprocess_data)
@@ -1492,7 +1511,7 @@ class TestEngine(unittest.TestCase):
         self.assertEqual(len(results['multi_logloss-mean']), 10)
 
     def test_metrics(self):
-        X, y = load_digits(n_class=2, return_X_y=True)
+        X, y = _load_digits(n_class=2, return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         lgb_train = lgb.Dataset(X_train, y_train, silent=True)
         lgb_valid = lgb.Dataset(X_test, y_test, reference=lgb_train, silent=True)
@@ -1798,7 +1817,7 @@ class TestEngine(unittest.TestCase):
         self.assertEqual(len(evals_result), 1)
         self.assertIn('error', evals_result['valid_0'])
 
-        X, y = load_digits(n_class=3, return_X_y=True)
+        X, y = _load_digits(n_class=3, return_X_y=True)
         lgb_train = lgb.Dataset(X, y, silent=True)
 
         obj_multi_aliases = ['multiclass', 'softmax', 'multiclassova', 'multiclass_ova', 'ova', 'ovr']
@@ -1866,7 +1885,7 @@ class TestEngine(unittest.TestCase):
                           params_class_3_verbose, metrics='binary_error', fobj=dummy_obj)
 
     def test_multiple_feval_train(self):
-        X, y = load_breast_cancer(return_X_y=True)
+        X, y = _load_breast_cancer(return_X_y=True)
 
         params = {'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
 
@@ -1889,7 +1908,7 @@ class TestEngine(unittest.TestCase):
         self.assertIn('decreasing_metric', evals_result['valid_0'])
 
     def test_multiple_feval_cv(self):
-        X, y = load_breast_cancer(return_X_y=True)
+        X, y = _load_breast_cancer(return_X_y=True)
 
         params = {'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
 
@@ -1912,7 +1931,7 @@ class TestEngine(unittest.TestCase):
 
     @unittest.skipIf(psutil.virtual_memory().available / 1024 / 1024 / 1024 < 3, 'not enough RAM')
     def test_model_size(self):
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         data = lgb.Dataset(X, y)
         bst = lgb.train({'verbose': -1}, data, num_boost_round=2)
         y_pred = bst.predict(X)
@@ -1938,7 +1957,7 @@ class TestEngine(unittest.TestCase):
             self.skipTest('not enough RAM')
 
     def test_get_split_value_histogram(self):
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         lgb_train = lgb.Dataset(X, y, categorical_feature=[2])
         gbm = lgb.train({'verbose': -1}, lgb_train, num_boost_round=20)
         # test XGBoost-style return value
@@ -2048,7 +2067,7 @@ class TestEngine(unittest.TestCase):
                          eval_train_metric=eval_train_metric)
             self.assertEqual(assumed_iteration, len(ret[list(ret.keys())[0]]))
 
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
         X_test1, X_test2, y_test1, y_test2 = train_test_split(X_test, y_test, test_size=0.5, random_state=73)
         lgb_train = lgb.Dataset(X_train, y_train)
@@ -2126,7 +2145,7 @@ class TestEngine(unittest.TestCase):
                                                                            decreasing_metric(preds, train_data)])
 
     def test_node_level_subcol(self):
-        X, y = load_breast_cancer(return_X_y=True)
+        X, y = _load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         params = {
             'objective': 'binary',
@@ -2307,7 +2326,7 @@ class TestEngine(unittest.TestCase):
 
     def test_extra_trees(self):
         # check extra trees increases regularization
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         lgb_x = lgb.Dataset(X, label=y)
         params = {'objective': 'regression',
                   'num_leaves': 32,
@@ -2325,7 +2344,7 @@ class TestEngine(unittest.TestCase):
 
     def test_path_smoothing(self):
         # check path smoothing increases regularization
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         lgb_x = lgb.Dataset(X, label=y)
         params = {'objective': 'regression',
                   'num_leaves': 32,
@@ -2347,7 +2366,7 @@ class TestEngine(unittest.TestCase):
             cols = ['Column_' + str(i) for i in range(X.shape[1])]
             return [impcts_dict.get(col, 0.) for col in cols]
 
-        X, y = load_breast_cancer(return_X_y=True)
+        X, y = _load_breast_cancer(return_X_y=True)
         data = lgb.Dataset(X, label=y)
         num_trees = 10
         bst = lgb.train({"objective": "binary", "verbose": -1}, data, num_trees)
@@ -2392,7 +2411,7 @@ class TestEngine(unittest.TestCase):
             self.assertIsNone(tree_df.loc[0, col])
 
     def test_interaction_constraints(self):
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         num_features = X.shape[1]
         train_data = lgb.Dataset(X, label=y)
         # check that constraint containing all features is equivalent to no constraint
@@ -2469,7 +2488,7 @@ class TestEngine(unittest.TestCase):
             np.testing.assert_allclose(pred4, pred6)
 
         # test for regression
-        X, y = load_boston(return_X_y=True)
+        X, y = _load_boston(return_X_y=True)
         params = {
             'objective': 'regression',
             'verbose': -1,
@@ -2482,7 +2501,7 @@ class TestEngine(unittest.TestCase):
         inner_test(X, y, params, early_stopping_rounds=None)
 
         # test for multi-class
-        X, y = load_iris(return_X_y=True)
+        X, y = _load_iris(return_X_y=True)
         params = {
             'objective': 'multiclass',
             'metric': 'multi_logloss',
@@ -2496,7 +2515,7 @@ class TestEngine(unittest.TestCase):
         inner_test(X, y, params, early_stopping_rounds=None)
 
         # test for binary
-        X, y = load_breast_cancer(return_X_y=True)
+        X, y = _load_breast_cancer(return_X_y=True)
         params = {
             'objective': 'binary',
             'metric': 'binary_logloss',

--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -3,7 +3,6 @@ import unittest
 
 import lightgbm as lgb
 from lightgbm.compat import MATPLOTLIB_INSTALLED, GRAPHVIZ_INSTALLED
-from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
 
 if MATPLOTLIB_INSTALLED:
@@ -11,6 +10,8 @@ if MATPLOTLIB_INSTALLED:
     matplotlib.use('Agg')
 if GRAPHVIZ_INSTALLED:
     import graphviz
+
+from .utils import load_breast_cancer
 
 
 class TestBasic(unittest.TestCase):

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -6,7 +6,7 @@ import os
 import unittest
 import warnings
 
-from functools import lru_cache
+from functools import cache
 
 import lightgbm as lgb
 import numpy as np
@@ -76,23 +76,23 @@ def multi_logloss(y_true, y_pred):
     return np.mean([-math.log(y_pred[i][y]) for i, y in enumerate(y_true)])
 
 
-@lru_cache
+@cache
 def _load_boston(**kwargs):
     return load_boston(**kwargs)
 
-@lru_cache
+@cache
 def _load_breast_cancer(**kwargs):
     return load_breast_cancer(**kwargs)
 
-@lru_cache
+@cache
 def _load_digits(**kwargs):
     return load_digits(**kwargs)
 
-@lru_cache
+@cache
 def _load_iris(**kwargs):
     return load_iris(**kwargs)
 
-@lru_cache
+@cache
 def _load_linnerud(**kwargs):
     return load_linnerud(**kwargs)
 

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -6,7 +6,7 @@ import os
 import unittest
 import warnings
 
-from functools import cache
+from functools import lru_cache
 
 import lightgbm as lgb
 import numpy as np
@@ -76,23 +76,23 @@ def multi_logloss(y_true, y_pred):
     return np.mean([-math.log(y_pred[i][y]) for i, y in enumerate(y_true)])
 
 
-@cache
+@lru_cache(maxsize=None)
 def _load_boston(**kwargs):
     return load_boston(**kwargs)
 
-@cache
+@lru_cache(maxsize=None)
 def _load_breast_cancer(**kwargs):
     return load_breast_cancer(**kwargs)
 
-@cache
+@lru_cache(maxsize=None)
 def _load_digits(**kwargs):
     return load_digits(**kwargs)
 
-@cache
+@lru_cache(maxsize=None)
 def _load_iris(**kwargs):
     return load_iris(**kwargs)
 
-@cache
+@lru_cache(maxsize=None)
 def _load_linnerud(**kwargs):
     return load_linnerud(**kwargs)
 

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -10,9 +10,7 @@ import lightgbm as lgb
 import numpy as np
 from sklearn import __version__ as sk_version
 from sklearn.base import clone
-from sklearn.datasets import (load_boston, load_breast_cancer, load_digits,
-                              load_iris, load_linnerud, load_svmlight_file,
-                              make_multilabel_classification)
+from sklearn.datasets import load_svmlight_file, make_multilabel_classification
 from sklearn.exceptions import SkipTestWarning
 from sklearn.metrics import log_loss, mean_squared_error
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV, train_test_split
@@ -22,7 +20,7 @@ from sklearn.utils.estimator_checks import (_yield_all_checks, SkipTest,
                                             check_parameters_default_constructible)
 from sklearn.utils.validation import check_is_fitted
 
-from .utils import lru_cache
+from .utils import load_boston, load_breast_cancer, load_digits, load_iris, load_linnerud, lru_cache
 
 
 decreasing_generator = itertools.count(0, -1)
@@ -76,35 +74,10 @@ def multi_logloss(y_true, y_pred):
     return np.mean([-math.log(y_pred[i][y]) for i, y in enumerate(y_true)])
 
 
-@lru_cache(maxsize=None)
-def _load_boston(**kwargs):
-    return load_boston(**kwargs)
-
-
-@lru_cache(maxsize=None)
-def _load_breast_cancer(**kwargs):
-    return load_breast_cancer(**kwargs)
-
-
-@lru_cache(maxsize=None)
-def _load_digits(**kwargs):
-    return load_digits(**kwargs)
-
-
-@lru_cache(maxsize=None)
-def _load_iris(**kwargs):
-    return load_iris(**kwargs)
-
-
-@lru_cache(maxsize=None)
-def _load_linnerud(**kwargs):
-    return load_linnerud(**kwargs)
-
-
 class TestSklearn(unittest.TestCase):
 
     def test_binary(self):
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         gbm = lgb.LGBMClassifier(n_estimators=50, silent=True)
         gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], early_stopping_rounds=5, verbose=False)
@@ -113,7 +86,7 @@ class TestSklearn(unittest.TestCase):
         self.assertAlmostEqual(ret, gbm.evals_result_['valid_0']['binary_logloss'][gbm.best_iteration_ - 1], places=5)
 
     def test_regression(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         gbm = lgb.LGBMRegressor(n_estimators=50, silent=True)
         gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], early_stopping_rounds=5, verbose=False)
@@ -122,7 +95,7 @@ class TestSklearn(unittest.TestCase):
         self.assertAlmostEqual(ret, gbm.evals_result_['valid_0']['l2'][gbm.best_iteration_ - 1], places=5)
 
     def test_multiclass(self):
-        X, y = _load_digits(n_class=10, return_X_y=True)
+        X, y = load_digits(n_class=10, return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         gbm = lgb.LGBMClassifier(n_estimators=50, silent=True)
         gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], early_stopping_rounds=5, verbose=False)
@@ -165,7 +138,7 @@ class TestSklearn(unittest.TestCase):
         self.assertGreater(gbm.best_score_['valid_0']['ndcg@3'], 0.6253)
 
     def test_regression_with_custom_objective(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         gbm = lgb.LGBMRegressor(n_estimators=50, silent=True, objective=objective_ls)
         gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], early_stopping_rounds=5, verbose=False)
@@ -174,7 +147,7 @@ class TestSklearn(unittest.TestCase):
         self.assertAlmostEqual(ret, gbm.evals_result_['valid_0']['l2'][gbm.best_iteration_ - 1], places=5)
 
     def test_binary_classification_with_custom_objective(self):
-        X, y = _load_digits(n_class=2, return_X_y=True)
+        X, y = load_digits(n_class=2, return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         gbm = lgb.LGBMClassifier(n_estimators=50, silent=True, objective=logregobj)
         gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], early_stopping_rounds=5, verbose=False)
@@ -186,7 +159,7 @@ class TestSklearn(unittest.TestCase):
         self.assertLess(ret, 0.05)
 
     def test_dart(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         gbm = lgb.LGBMRegressor(boosting_type='dart', n_estimators=50)
         gbm.fit(X_train, y_train)
@@ -199,7 +172,7 @@ class TestSklearn(unittest.TestCase):
     def test_stacking_classifier(self):
         from sklearn.ensemble import StackingClassifier
 
-        X, y = _load_iris(return_X_y=True)
+        X, y = load_iris(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
         classifiers = [('gbm1', lgb.LGBMClassifier(n_estimators=3)),
                        ('gbm2', lgb.LGBMClassifier(n_estimators=3))]
@@ -226,7 +199,7 @@ class TestSklearn(unittest.TestCase):
     def test_stacking_regressor(self):
         from sklearn.ensemble import StackingRegressor
 
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
         regressors = [('gbm1', lgb.LGBMRegressor(n_estimators=3)),
                       ('gbm2', lgb.LGBMRegressor(n_estimators=3))]
@@ -245,7 +218,7 @@ class TestSklearn(unittest.TestCase):
         self.assertEqual(len(reg.final_estimator_.feature_importances_), 15)
 
     def test_grid_search(self):
-        X, y = _load_iris(return_X_y=True)
+        X, y = load_iris(return_X_y=True)
         y = y.astype(str)  # utilize label encoder at it's max power
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1,
                                                             random_state=42)
@@ -275,7 +248,7 @@ class TestSklearn(unittest.TestCase):
         self.assertLessEqual(score, 1.)
 
     def test_random_search(self):
-        X, y = _load_iris(return_X_y=True)
+        X, y = load_iris(return_X_y=True)
         y = y.astype(str)  # utilize label encoder at it's max power
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1,
                                                             random_state=42)
@@ -329,7 +302,7 @@ class TestSklearn(unittest.TestCase):
     # sklearn < 0.23 does not have as_frame parameter
     @unittest.skipIf(sk_version < '0.23.0', 'scikit-learn version is less than 0.23')
     def test_multioutput_regressor(self):
-        bunch = _load_linnerud(as_frame=True)  # returns a Bunch instance
+        bunch = load_linnerud(as_frame=True)  # returns a Bunch instance
         X, y = bunch['data'], bunch['target']
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1,
                                                             random_state=42)
@@ -368,7 +341,7 @@ class TestSklearn(unittest.TestCase):
     # sklearn < 0.23 does not have as_frame parameter
     @unittest.skipIf(sk_version < '0.23.0', 'scikit-learn version is less than 0.23')
     def test_regressor_chain(self):
-        bunch = _load_linnerud(as_frame=True)  # returns a Bunch instance
+        bunch = load_linnerud(as_frame=True)  # returns a Bunch instance
         X, y = bunch['data'], bunch['target']
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         order = [2, 0, 1]
@@ -385,7 +358,7 @@ class TestSklearn(unittest.TestCase):
             self.assertIsInstance(regressor.booster_, lgb.Booster)
 
     def test_clone_and_property(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         gbm = lgb.LGBMRegressor(n_estimators=10, silent=True)
         gbm.fit(X, y, verbose=False)
 
@@ -393,7 +366,7 @@ class TestSklearn(unittest.TestCase):
         self.assertIsInstance(gbm.booster_, lgb.Booster)
         self.assertIsInstance(gbm.feature_importances_, np.ndarray)
 
-        X, y = _load_digits(n_class=2, return_X_y=True)
+        X, y = load_digits(n_class=2, return_X_y=True)
         clf = lgb.LGBMClassifier(n_estimators=10, silent=True)
         clf.fit(X, y, verbose=False)
         self.assertListEqual(sorted(clf.classes_), [0, 1])
@@ -402,7 +375,7 @@ class TestSklearn(unittest.TestCase):
         self.assertIsInstance(clf.feature_importances_, np.ndarray)
 
     def test_joblib(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         gbm = lgb.LGBMRegressor(n_estimators=10, objective=custom_asymmetric_obj,
                                 silent=True, importance_type='split')
@@ -427,7 +400,7 @@ class TestSklearn(unittest.TestCase):
         np.testing.assert_allclose(pred_origin, pred_pickle)
 
     def test_random_state_object(self):
-        X, y = _load_iris(return_X_y=True)
+        X, y = load_iris(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         state1 = np.random.RandomState(123)
         state2 = np.random.RandomState(123)
@@ -460,14 +433,14 @@ class TestSklearn(unittest.TestCase):
                           df1, df3)
 
     def test_feature_importances_single_leaf(self):
-        data = _load_iris(return_X_y=False)
+        data = load_iris(return_X_y=False)
         clf = lgb.LGBMClassifier(n_estimators=10)
         clf.fit(data.data, data.target)
         importances = clf.feature_importances_
         self.assertEqual(len(importances), 4)
 
     def test_feature_importances_type(self):
-        data = _load_iris(return_X_y=False)
+        data = load_iris(return_X_y=False)
         clf = lgb.LGBMClassifier(n_estimators=10)
         clf.fit(data.data, data.target)
         clf.set_params(importance_type='split')
@@ -591,7 +564,7 @@ class TestSklearn(unittest.TestCase):
 
     def test_predict(self):
         # With default params
-        iris = _load_iris(return_X_y=False)
+        iris = load_iris(return_X_y=False)
         X_train, X_test, y_train, y_test = train_test_split(iris.data, iris.target,
                                                             test_size=0.2, random_state=42)
 
@@ -671,7 +644,7 @@ class TestSklearn(unittest.TestCase):
                           res_engine, res_sklearn_params)
 
     def test_evaluate_train_set(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         gbm = lgb.LGBMRegressor(n_estimators=10, silent=True)
         gbm.fit(X_train, y_train, eval_set=[(X_train, y_train), (X_test, y_test)], verbose=False)
@@ -684,7 +657,7 @@ class TestSklearn(unittest.TestCase):
         self.assertIn('l2', gbm.evals_result_['valid_1'])
 
     def test_metrics(self):
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         params = {'n_estimators': 2, 'verbose': -1}
         params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
 
@@ -724,7 +697,7 @@ class TestSklearn(unittest.TestCase):
         self.assertIn('mape', gbm.evals_result_['training'])
 
         # non-default metric with multiple metrics in eval_metric for LGBMClassifier
-        X_classification, y_classification = _load_breast_cancer(return_X_y=True)
+        X_classification, y_classification = load_breast_cancer(return_X_y=True)
         params_classification = {'n_estimators': 2, 'verbose': -1,
                                  'objective': 'binary', 'metric': 'binary_logloss'}
         params_fit_classification = {'X': X_classification, 'y': y_classification,
@@ -907,7 +880,7 @@ class TestSklearn(unittest.TestCase):
         self.assertIn('mape', gbm.evals_result_['training'])
         self.assertIn('error', gbm.evals_result_['training'])
 
-        X, y = _load_digits(n_class=3, return_X_y=True)
+        X, y = load_digits(n_class=3, return_X_y=True)
         params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
 
         # default metric and invalid binary metric is replaced with multiclass alternative
@@ -934,7 +907,7 @@ class TestSklearn(unittest.TestCase):
         self.assertIn('multi_logloss', gbm.evals_result_['training'])
         self.assertIn('multi_error', gbm.evals_result_['training'])
 
-        X, y = _load_digits(n_class=2, return_X_y=True)
+        X, y = load_digits(n_class=2, return_X_y=True)
         params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
 
         # default metric and invalid multiclass metric is replaced with binary alternative
@@ -951,7 +924,7 @@ class TestSklearn(unittest.TestCase):
 
     def test_multiple_eval_metrics(self):
 
-        X, y = _load_breast_cancer(return_X_y=True)
+        X, y = load_breast_cancer(return_X_y=True)
 
         params = {'n_estimators': 2, 'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
         params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
@@ -1030,7 +1003,7 @@ class TestSklearn(unittest.TestCase):
                     self.assertEqual(assumed_iteration if eval_set_name != 'training' else gbm.n_estimators,
                                      gbm.best_iteration_)
 
-        X, y = _load_boston(return_X_y=True)
+        X, y = load_boston(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
         X_test1, X_test2, y_test1, y_test2 = train_test_split(X_test, y_test, test_size=0.5, random_state=72)
         params = {'n_estimators': 30,
@@ -1111,7 +1084,7 @@ class TestSklearn(unittest.TestCase):
         fit_and_check(['valid_0', 'valid_1'], ['l1', 'l2'], iter_min_l2, True)
 
     def test_class_weight(self):
-        X, y = _load_digits(n_class=10, return_X_y=True)
+        X, y = load_digits(n_class=10, return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
         y_train_str = y_train.astype('str')
         y_test_str = y_test.astype('str')
@@ -1145,7 +1118,7 @@ class TestSklearn(unittest.TestCase):
                                            gbm_str.evals_result_[eval_set][metric])
 
     def test_continue_training_with_model(self):
-        X, y = _load_digits(n_class=3, return_X_y=True)
+        X, y = load_digits(n_class=3, return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
         init_gbm = lgb.LGBMClassifier(n_estimators=5).fit(X_train, y_train, eval_set=(X_test, y_test),
                                                           verbose=False)
@@ -1160,7 +1133,7 @@ class TestSklearn(unittest.TestCase):
     # sklearn < 0.22 requires passing "attributes" argument
     @unittest.skipIf(sk_version < '0.22.0', 'scikit-learn version is less than 0.22')
     def test_check_is_fitted(self):
-        X, y = _load_digits(n_class=2, return_X_y=True)
+        X, y = load_digits(n_class=2, return_X_y=True)
         est = lgb.LGBMModel(n_estimators=5, objective="binary")
         clf = lgb.LGBMClassifier(n_estimators=5)
         reg = lgb.LGBMRegressor(n_estimators=5)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -6,8 +6,6 @@ import os
 import unittest
 import warnings
 
-from functools import lru_cache
-
 import lightgbm as lgb
 import numpy as np
 from sklearn import __version__ as sk_version
@@ -23,6 +21,19 @@ from sklearn.multioutput import (MultiOutputClassifier, ClassifierChain, MultiOu
 from sklearn.utils.estimator_checks import (_yield_all_checks, SkipTest,
                                             check_parameters_default_constructible)
 from sklearn.utils.validation import check_is_fitted
+
+try:
+    from functools import lru_cache
+except ImportError:
+    warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
+    def lru_cache(user_function, maxsize=None):
+        @wraps(user_function)
+        def wrapper(*args, **kwargs):
+            arg_key = tuple(args, [item for item in kwargs.items()])
+            if arg_key not in cache:
+                cache[arg_key] = user_function(*args)
+            return cache[arg_key]
+        return wrapper
 
 
 decreasing_generator = itertools.count(0, -1)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -22,19 +22,7 @@ from sklearn.utils.estimator_checks import (_yield_all_checks, SkipTest,
                                             check_parameters_default_constructible)
 from sklearn.utils.validation import check_is_fitted
 
-try:
-    from functools import lru_cache
-except ImportError:
-    warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
-
-    def lru_cache(user_function, maxsize=None):
-        @wraps(user_function)
-        def wrapper(*args, **kwargs):
-            arg_key = tuple(args, [item for item in kwargs.items()])
-            if arg_key not in cache:
-                cache[arg_key] = user_function(*args)
-            return cache[arg_key]
-        return wrapper
+from .utils import lru_cache
 
 
 decreasing_generator = itertools.count(0, -1)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -26,6 +26,7 @@ try:
     from functools import lru_cache
 except ImportError:
     warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
+
     def lru_cache(user_function, maxsize=None):
         @wraps(user_function)
         def wrapper(*args, **kwargs):
@@ -91,17 +92,21 @@ def multi_logloss(y_true, y_pred):
 def _load_boston(**kwargs):
     return load_boston(**kwargs)
 
+
 @lru_cache(maxsize=None)
 def _load_breast_cancer(**kwargs):
     return load_breast_cancer(**kwargs)
+
 
 @lru_cache(maxsize=None)
 def _load_digits(**kwargs):
     return load_digits(**kwargs)
 
+
 @lru_cache(maxsize=None)
 def _load_iris(**kwargs):
     return load_iris(**kwargs)
+
 
 @lru_cache(maxsize=None)
 def _load_linnerud(**kwargs):

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -20,7 +20,7 @@ from sklearn.utils.estimator_checks import (_yield_all_checks, SkipTest,
                                             check_parameters_default_constructible)
 from sklearn.utils.validation import check_is_fitted
 
-from .utils import load_boston, load_breast_cancer, load_digits, load_iris, load_linnerud, lru_cache
+from .utils import load_boston, load_breast_cancer, load_digits, load_iris, load_linnerud
 
 
 decreasing_generator = itertools.count(0, -1)

--- a/tests/python_package_test/utils.py
+++ b/tests/python_package_test/utils.py
@@ -1,8 +1,8 @@
-
 try:
     from functools import lru_cache
 except ImportError:
     import warnings
+    from functools import wraps
     warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
 
     def lru_cache(user_function, maxsize=None):

--- a/tests/python_package_test/utils.py
+++ b/tests/python_package_test/utils.py
@@ -11,7 +11,7 @@ except ImportError:
             def wrapper(*args, **kwargs):
                 arg_key = (args, tuple([item for item in kwargs.items()]))
                 if arg_key not in cache:
-                    cache[arg_key] = user_function(*args)
+                    cache[arg_key] = user_function(*args, **kwargs)
                 return cache[arg_key]
             return wrapper
         return _lru_wrapper

--- a/tests/python_package_test/utils.py
+++ b/tests/python_package_test/utils.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+import sklearn.datasets
+
 try:
     from functools import lru_cache
 except ImportError:
@@ -16,3 +18,28 @@ except ImportError:
                 return cache[arg_key]
             return wrapper
         return _lru_wrapper
+
+
+@lru_cache(maxsize=None)
+def load_boston(**kwargs):
+    return sklearn.datasets.load_boston(**kwargs)
+
+
+@lru_cache(maxsize=None)
+def load_breast_cancer(**kwargs):
+    return sklearn.datasets.load_breast_cancer(**kwargs)
+
+
+@lru_cache(maxsize=None)
+def load_digits(**kwargs):
+    return sklearn.datasets.load_digits(**kwargs)
+
+
+@lru_cache(maxsize=None)
+def load_iris(**kwargs):
+    return sklearn.datasets.load_iris(**kwargs)
+
+
+@lru_cache(maxsize=None)
+def load_linnerud(**kwargs):
+    return sklearn.datasets.load_linnerud(**kwargs)

--- a/tests/python_package_test/utils.py
+++ b/tests/python_package_test/utils.py
@@ -2,6 +2,7 @@
 try:
     from functools import lru_cache
 except ImportError:
+    import warnings
     warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
 
     def lru_cache(user_function, maxsize=None):

--- a/tests/python_package_test/utils.py
+++ b/tests/python_package_test/utils.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 try:
     from functools import lru_cache
 except ImportError:
@@ -9,7 +10,7 @@ except ImportError:
 
         def _lru_wrapper(user_function):
             def wrapper(*args, **kwargs):
-                arg_key = (args, tuple([item for item in kwargs.items()]))
+                arg_key = (args, tuple(kwargs.items()))
                 if arg_key not in cache:
                     cache[arg_key] = user_function(*args, **kwargs)
                 return cache[arg_key]

--- a/tests/python_package_test/utils.py
+++ b/tests/python_package_test/utils.py
@@ -2,14 +2,16 @@ try:
     from functools import lru_cache
 except ImportError:
     import warnings
-    from functools import wraps
     warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
 
-    def lru_cache(user_function, maxsize=None):
-        @wraps(user_function)
-        def wrapper(*args, **kwargs):
-            arg_key = tuple(args, [item for item in kwargs.items()])
-            if arg_key not in cache:
-                cache[arg_key] = user_function(*args)
-            return cache[arg_key]
-        return wrapper
+    def lru_cache(maxsize=None):
+        cache = {}
+
+        def _lru_wrapper(user_function):
+            def wrapper(*args, **kwargs):
+                arg_key = (args, tuple([item for item in kwargs.items()]))
+                if arg_key not in cache:
+                    cache[arg_key] = user_function(*args)
+                return cache[arg_key]
+            return wrapper
+        return _lru_wrapper

--- a/tests/python_package_test/utils.py
+++ b/tests/python_package_test/utils.py
@@ -1,0 +1,14 @@
+
+try:
+    from functools import lru_cache
+except ImportError:
+    warnings.warn("Could not import functools.lru_cache", RuntimeWarning)
+
+    def lru_cache(user_function, maxsize=None):
+        @wraps(user_function)
+        def wrapper(*args, **kwargs):
+            arg_key = tuple(args, [item for item in kwargs.items()])
+            if arg_key not in cache:
+                cache[arg_key] = user_function(*args)
+            return cache[arg_key]
+        return wrapper


### PR DESCRIPTION
I spent some time this weekend learning [`snakeviz`](https://jiffyclub.github.io/snakeviz/), a Python profiler. I tried running it over the Python package tests here, and I think I found an opportunity to cut the test run time.


I realized we're spending time loading and reloading the same datasets.  This PR proposes reducing those calls by caching the results of `sklearn.datasets.load_*` calls. The datasets are really small so I don't think holding them all in memory will cause an issue.

**UPDATE:** Ok from some experiments, the speedup from this seems really small on my laptop. But might be larger in CI environments, where we know that disk I/O is a lot slower (https://github.com/microsoft/LightGBM/pull/2965#issuecomment-624421092).

## Results

These results were obtained on my laptop.  The blockquote results come from one run of each test. Then I ran them all again 10 times to get a better estimate of the mean time.

### `test_basic.py`

**before (mean = 1.33s)**

> 58216 function calls (57604 primitive calls) in 0.462 seconds
    ==== 10 passed, 3 warnings in 2.18s ====

* trials (seconds):  [1.37, 1.40, 1.34, 1.37, 1.31, 1.30, 1.31, 1.31, 1.31, 1.31]

**after (mean = 1.36s)**

> 53470 function calls (52858 primitive calls) in 0.396 seconds
    ==== 10 passed, 3 warnings in 1.36s ====

* trials (seconds):  [1.39, 1.39, 1.40, 1.36, 1.35, 1.41, 1.40, 1.29, 1.31, 1.35]

### `test_engine.py`

**before (mean = 12.78s)**

> 2749043 function calls (2651956 primitive calls) in 9.456 seconds
    ==== 63 passed, 2 skipped, 20 warnings in 13.69s ====

* trials (seconds): [14.16, 13.13, 12.85, 12.66, 12.34, 12.60, 13.17, 12.98, 12.40, 11.50]

**after (mean = 11.84s)**

> 2749043 function calls (2651956 primitive calls) in 9.456 seconds
    ==== 63 passed, 2 skipped, 20 warnings in 11.29s ====

* trials (seconds): [12.18, 10.71, 11.09, 10.88, 10.77, 12.64, 12.47, 14.90, 11.62, 11.14]

### `test_sklearn.py`

**before(mean = 9.68s)**

> 4292703 function calls (4172793 primitive calls) in 8.044 seconds
    ==== 34 passed, 15 warnings in 11.07s ====

* trials (seconds): [10.17, 9.52, 9.34, 9.58, 9.22, 9.34, 9.75, 10.21, 9.67, 9.99]

**after (mean = 9.50s)**

> 2945200 function calls (2843392 primitive calls) in 8.867 seconds
    ==== 34 passed, 15 warnings in 9.26s ====

* trials (seconds): [9.67, 8.64, 9.32, 8.71, 8.73, 9.29, 8.97, 12.73, 9.48, 9.44]

## How to reproduce these tests

```shell
# install lightgbm
pushd python-package
python setup.py install
popd

# install dependencies
pip install snakeviz pytest-profiling

# profile tests
pytest --profile tests/python_package_test/test_basic.py
pytest --profile tests/python_package_test/test_engine.py
pytest --profile tests/python_package_test/test_sklearn.py

# (optional) visualize profiling data
snakeviz prof/combined.prof
```