### PR TITLE
bump minimal CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ elseif(USE_GPU OR APPLE)
 elseif(USE_CUDA)
   cmake_minimum_required(VERSION 3.16)
 else()
-  cmake_minimum_required(VERSION 2.8)
+  cmake_minimum_required(VERSION 3.0)
 endif()
 
 if(USE_CUDA)


### PR DESCRIPTION
According to the following discussion: https://github.com/microsoft/LightGBM/pull/3405#discussion_r502223468.

CMake < 3 is very-very old (in terms of their frequent releases). With 3.0 it will be possible to check API docs easier at least (docs for < 3 are hiddedn deep at their site and not structured). 