### PR TITLE
[R-package] [docs] fix broken plots in pkgdown site (fixes #3276)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -240,17 +240,18 @@ def generate_r_docs(app):
         The application object representing the Sphinx process.
     """
     commands = """
-    echo 'options(repos = "https://cran.rstudio.com")' > $HOME/.Rprofile
-    /home/docs/.conda/bin/conda create -q -y -n r_env \
-        r-base=3.5.1=h1e0a451_2 \
-        r-jsonlite=1.5=r351h96ca727_0 \
-        r-matrix=1.2_14=r351h96ca727_0 \
-        r-testthat=2.0.0=r351h29659fb_0 \
-        cmake=3.14.0=h52cb24c_0
-    /home/docs/.conda/bin/conda install -q -y -n r_env -c conda-forge \
-        r-data.table=1.12.8=r35hcdcec82_0 \
-        r-pkgdown=1.5.1=r35h6115d3f_0 \
-        r-roxygen2=7.1.0=r35h0357c0b_0
+    /home/docs/.conda/bin/conda create \
+        -q \
+        -y \
+        -c conda-forge \
+        -n r_env \
+            cmake=3.14.0=h52cb24c_0 \
+            r-base=4.0.3=hc603457_2 \
+            r-data.table=1.13.2=r40h0eb13af_0 \
+            r-jsonlite=1.7.1=r40hcdcec82_0 \
+            r-matrix=1.2_18=r40h7fa42b6_3 \
+            r-pkgdown=1.6.1=r40h6115d3f_0 \
+            r-roxygen2=7.1.1=r40h0357c0b_0
     source /home/docs/.conda/bin/activate r_env
     export TAR=/bin/tar
     cd {0}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -245,7 +245,7 @@ def generate_r_docs(app):
         -y \
         -c conda-forge \
         -n r_env \
-            cmake=3.14.0=h52cb24c_0 \
+            cmake=3.18.2=ha30ef3c_0 \
             r-base=4.0.3=hc603457_2 \
             r-data.table=1.13.2=r40h0eb13af_0 \
             r-jsonlite=1.7.1=r40hcdcec82_0 \


### PR DESCRIPTION
#3276 documents some issues rendering plots in examples for the R package's documentation site, at https://lightgbm.readthedocs.io/en/latest/R/reference/.

I think that this is caused by the use of an older R version. This PR proposes fixing that by upgrading to R 4.0.3. It seems that R 4.0.3 packages are now available from conda-forge (thanks to the hard work of @xhochy and other https://github.com/conda-forge/r-base-feedstock maintainers).

This PR also simplifies our setup on RTD in a few ways:

* removes unnecessary dependency `testthat`
* removes unnecessary setting of `repos` option
* builds the entire env in one step (instead of installing anaconda and conda-forge packages separately) 

### Notes for Reviewers

I tested locally with the following code, on an Ubuntu 18.04 laptop using `conda` 4.8.4:

```shell
conda create \
    -q \
    -y \
    -c conda-forge \
    -n r_env \
        cmake=3.14.0=h52cb24c_0 \
        r-base=4.0.3=hc603457_2 \
        r-data.table=1.13.2=r40h0eb13af_0 \
        r-jsonlite=1.7.1=r40hcdcec82_0 \
        r-matrix=1.2_18=r40h7fa42b6_3 \
        r-pkgdown=1.6.1=r40h6115d3f_0 \
        r-roxygen2=7.1.1=r40h0357c0b_0

export R_LIBS="$CONDA_PREFIX/lib/R/library"
Rscript build_r.R
cd R-package
Rscript -e "roxygen2::roxygenize(load = 'installed')"
Rscript -e "pkgdown::build_site( \
        lazy = FALSE \
        , install = FALSE \
        , devel = FALSE \
        , examples = TRUE \
        , run_dont_run = TRUE \
        , seed = 42L \
        , preview = FALSE \
        , new_process = TRUE \
    ) \
    "
```

At least locally, the plots look ok now

![image](https://user-images.githubusercontent.com/7608904/97756655-3ed7a280-1ac9-11eb-96e9-8becaeed0c3f.png)

![image](https://user-images.githubusercontent.com/7608904/97756677-48f9a100-1ac9-11eb-8b1c-90776d887d3e.png)