### PR TITLE
[R-package] remove unused variables in configure.ac

### DIFF
--- a/R-package/configure
+++ b/R-package/configure
@@ -1694,9 +1694,6 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
-CXX=`"${R_HOME}/bin/R" CMD config CXX11`
-CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
-CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -21,9 +21,6 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
-CXX=`"${R_HOME}/bin/R" CMD config CXX11`
-CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
-CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""


### PR DESCRIPTION
## Short summary

This removes some unused variables in `R-package/configure.ac`.

## Longer Summary

The CRAN build of the R package contains a file `configure`, which is a shell script that run whenever the package is installed. It looks around on the system to figure out things like "is OpenMP installed", then fills out variables in a templated Makefile (`R-package/src/Makevars.[w]in`), which is then used to compile the library.

`configure` is created from a file `R-package/configure.ac` using `autoconf`.

When `configure.ac` was originally added, I copied and pasted some code from other examples and ["Writing R Extensions"](https://cran.r-project.org/doc/manuals/r-release/R-exts.html). That included this snippet:

```shell
CC=`"${R_HOME}/bin/R" CMD config CC`
CXX=`"${R_HOME}/bin/R" CMD config CXX11`
CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
```

Now that I understand this better, I can see that `CXX`, `CFLAGS`, and `CPPFLAGS` are unused...they're not referenced in the `AC_SUBST()` calls used to replace template string in `src/Makevars.[w]in`.

## How I tested this

I ran the following to test the package, before and after this change:

```shell
sh build-cran-package.sh
R CMD INSTALL lightgbm*.tar.gz
```

The compiler and linker flags used in both cases were identical, and the library installed successfully, so I'm confident that these variables can be removed.