### PR TITLE
[R-package] fix MM_PREFETCH and MM_MALLOC checks in configure.ac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,6 +402,7 @@ python-package/lightgbm/VERSION.txt
 
 # R build artefacts
 **/autom4te.cache/
+conftest*
 R-package/config.status
 R-package/docs
 R-package/src/CMakeLists.txt

--- a/R-package/configure
+++ b/R-package/configure
@@ -1694,6 +1694,7 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
+CXX=`"${R_HOME}/bin/R" CMD config CXX11`
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""
@@ -1705,6 +1706,12 @@ LGB_CPPFLAGS=""
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether MM_PREFETCH works" >&5
 $as_echo_n "checking whether MM_PREFETCH works... " >&6; }
 ac_mmprefetch=no
+ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -1715,11 +1722,9 @@ int
 main ()
 {
 
-                int main() {
-                    int a = 0;
-                    _mm_prefetch(&a, _MM_HINT_NTA);
-                    return 0;
-                }
+                int a = 0;
+                _mm_prefetch(&a, _MM_HINT_NTA);
+                return 0;
 
 
   ;
@@ -1728,7 +1733,7 @@ main ()
 
 
 _ACEOF
-${CC} -o conftest conftest.c 2>/dev/null && ./conftest && ac_mmprefetch=yes
+${CXX} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mmprefetch=yes
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${ac_mmprefetch}" >&5
 $as_echo "${ac_mmprefetch}" >&6; }
 if test "${ac_mmprefetch}" = yes; then
@@ -1742,6 +1747,12 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether MM_MALLOC works" >&5
 $as_echo_n "checking whether MM_MALLOC works... " >&6; }
 ac_mm_malloc=no
+ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -1752,11 +1763,9 @@ int
 main ()
 {
 
-                int main() {
-                    char *a = (char*)_mm_malloc(8, 16);
-                    _mm_free(a);
-                    return 0;
-                }
+                char *a = (char*)_mm_malloc(8, 16);
+                _mm_free(a);
+                return 0;
 
 
   ;
@@ -1765,7 +1774,7 @@ main ()
 
 
 _ACEOF
-${CC} -o conftest conftest.c 2>/dev/null && ./conftest && ac_mm_malloc=yes
+${CXX} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mm_malloc=yes
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${ac_mm_malloc}" >&5
 $as_echo "${ac_mm_malloc}" >&6; }
 if test "${ac_mm_malloc}" = yes; then
@@ -1790,6 +1799,12 @@ then
     ac_pkg_openmp=no
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenMP will work in a package" >&5
 $as_echo_n "checking whether OpenMP will work in a package... " >&6; }
+    ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -21,6 +21,7 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
+CXX=`"${R_HOME}/bin/R" CMD config CXX11`
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""
@@ -31,6 +32,7 @@ LGB_CPPFLAGS=""
 
 AC_MSG_CHECKING([whether MM_PREFETCH works])
 ac_mmprefetch=no
+AC_LANG(C++)
 AC_LANG_CONFTEST(
     [
         AC_LANG_PROGRAM(
@@ -38,16 +40,14 @@ AC_LANG_CONFTEST(
                 #include <xmmintrin.h>
             ]],
             [[
-                int main() {
-                    int a = 0;
-                    _mm_prefetch(&a, _MM_HINT_NTA);
-                    return 0;
-                }
+                int a = 0;
+                _mm_prefetch(&a, _MM_HINT_NTA);
+                return 0;
             ]]
         )
     ]
 )
-${CC} -o conftest conftest.c 2>/dev/null && ./conftest && ac_mmprefetch=yes
+${CXX} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mmprefetch=yes
 AC_MSG_RESULT([${ac_mmprefetch}])
 if test "${ac_mmprefetch}" = yes; then
     LGB_CPPFLAGS+=" -DMM_PREFETCH=1"
@@ -59,6 +59,7 @@ fi
 
 AC_MSG_CHECKING([whether MM_MALLOC works])
 ac_mm_malloc=no
+AC_LANG(C++)
 AC_LANG_CONFTEST(
     [
         AC_LANG_PROGRAM(
@@ -66,16 +67,14 @@ AC_LANG_CONFTEST(
                 #include <mm_malloc.h>
             ]],
             [[
-                int main() {
-                    char *a = (char*)_mm_malloc(8, 16);
-                    _mm_free(a);
-                    return 0;
-                }
+                char *a = (char*)_mm_malloc(8, 16);
+                _mm_free(a);
+                return 0;
             ]]
         )
     ]
 )
-${CC} -o conftest conftest.c 2>/dev/null && ./conftest && ac_mm_malloc=yes
+${CXX} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mm_malloc=yes
 AC_MSG_RESULT([${ac_mm_malloc}])
 if test "${ac_mm_malloc}" = yes; then
     LGB_CPPFLAGS+=" -DMM_MALLOC=1"
@@ -98,6 +97,7 @@ then
     OPENMP_LIB='-lomp'
     ac_pkg_openmp=no
     AC_MSG_CHECKING([whether OpenMP will work in a package])
+    AC_LANG(C)
     AC_LANG_CONFTEST(
         [
             AC_LANG_PROGRAM(


### PR DESCRIPTION
This PR fixes two bugs in the CRAN package

* uses a C++ compiler, not a C compiler, for `MM_PREFETCH` and `MM_MALLOC` checks
* removes extra `int main(...)` scaffolding in `MM_PREFETCH` and `MM_MALLOC` checks, which was causing them to fail

## More explanation

Look at the diff for `R-package/configure` and [the autoconf documentation on AC_LANG_CONFTEST](https://www.gnu.org/software/autoconf/manual/autoconf-2.61/html_node/Generating-Sources.html)...autoconf adds that scaffolding for you! So this check was ~always failing for the CRAN package on Mac and Linux~ failing for the CRAN on Mac, because the conftest code has an extra `int main(...)`!!

~NOTE: Once CI runs, I'm going to update this and a table here comparing the `MM_MALLOC` and `MM_PREFETCH` check results for CRAN vs. CMake builds...I think they'll match now.~

### Comparison of R 4.0 builds

✅ below means

```text
checking whether <thing> works... yes
```

❌ means

```text
checking whether <thing> works...no
```

Latest commit on `master`: https://github.com/microsoft/LightGBM/actions/runs/338789296

|           | CRAN | CMake (gcc) | CMake (clang) |
|------|-------|---------------|----------------|
| Mac   |  MM_PREFETCH ❌  <br>MM_PREFETCH ❌  | MM_PREFETCH ✅ <br>MM_PREFETCH ✅  | MM_PREFETCH ✅ <br>MM_PREFETCH ✅ |
| Linux | MM_PREFETCH ✅ <br>MM_PREFETCH ✅  | MM_PREFETCH ✅ <br>MM_PREFETCH ✅  | MM_PREFETCH ✅ <br>MM_PREFETCH ✅ |

this PR: https://github.com/microsoft/LightGBM/actions/runs/338808198

|           | CRAN | CMake (gcc) | CMake (clang) |
|------|-------|---------------|----------------|
| Mac   | MM_PREFETCH ✅ <br>MM_PREFETCH ✅  | MM_PREFETCH ✅ <br>MM_PREFETCH ✅  | MM_PREFETCH ✅ <br>MM_PREFETCH ✅ |
| Linux | MM_PREFETCH ✅ <br>MM_PREFETCH ✅  | MM_PREFETCH ✅ <br>MM_PREFETCH ✅  | MM_PREFETCH ✅ <br>MM_PREFETCH ✅ |

### Notes for Reviewers

@StrikerRUS I am really glad you asked me about the compiler used in `R-package/configure.ac` in https://github.com/microsoft/LightGBM/pull/3509#pullrequestreview-521099919. I think I misunderstood your question the first time I read it, but that misunderstanding led me to an investigation that resulted in fixing a bug 😀 

@guolinke I think we should try to get this into 3.1.0 (#3484) 