### PR TITLE
[R-package] [ci] add correct path for mingw32-make in CI

### DIFF
--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -51,7 +51,7 @@ if ($env:R_MAJOR_VERSION -eq "3") {
 
 $env:R_LIB_PATH = "$env:BUILD_SOURCESDIRECTORY/RLibrary" -replace '[\\]', '/'
 $env:R_LIBS = "$env:R_LIB_PATH"
-$env:PATH = "$RTOOLS_INSTALL_PATH/bin;" + "$RTOOLS_INSTALL_PATH/usr/bin;" + "$env:R_LIB_PATH/R/bin/x64;" + "$env:R_LIB_PATH/miktex/texmfs/install/miktex/bin/x64;" + $env:PATH
+$env:PATH = "$RTOOLS_INSTALL_PATH/bin;" + "$RTOOLS_INSTALL_PATH/usr/bin;" + "$env:RTOOLS_MINGW_BIN;" + "$env:R_LIB_PATH/R/bin/x64;" + "$env:R_LIB_PATH/miktex/texmfs/install/miktex/bin/x64;" + $env:PATH
 $env:CRAN_MIRROR = "https://cloud.r-project.org/"
 $env:CTAN_MIRROR = "https://ctan.math.illinois.edu/systems/win32/miktex"
 $env:CTAN_PACKAGE_ARCHIVE = "$env:CTAN_MIRROR/tm/packages/"


### PR DESCRIPTION
In #3469, I've been trying to figure out why this CI job on GitHub Actions often fails:

```text
- os: windows-latest
  task: r-package
  compiler: MINGW
  toolchain: MINGW
  r_version: 3.6
  build_type: cmake
```

I don't think I've solved it yet, but I did find one problem we definitely need to fix. `Rtools35` stores `mingw32-make.exe` at `C:\Rtools\mingw_64\bin\mingw32-make.exe`, but that path isn't currently on `PATH` in our CI. I think it was just lost accidentally in some refactoring.

This PR doesn't fix #3469 but based on my testing, it does seem to make that issue happen less often. So maybe it will  at least make the contributor experience better.