### PR TITLE
[ci] upgrade GitHub Actions third-party actions to newest versions

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Remove old folder with repository
         run: sudo rm -rf $GITHUB_WORKSPACE
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/r_artifacts.yml
+++ b/.github/workflows/r_artifacts.yml
@@ -13,7 +13,7 @@ jobs:
     container: rocker/r-base
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -165,6 +165,11 @@ jobs:
     runs-on: ubuntu-latest
     container: rhub/rocker-gcc-san
     steps:
+      - name: Install Git before checkout
+        shell: bash
+        run: |
+          apt-get update
+          apt-get install -y git
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
         with:
@@ -173,8 +178,6 @@ jobs:
       - name: Install packages
         shell: bash
         run: |
-          apt-get update
-          apt-get install -y git
           Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'testthat'), repos = 'https://cran.r-project.org')"
           sh build-cran-package.sh
           Rdevel CMD INSTALL lightgbm_*.tar.gz || exit -1

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -173,6 +173,8 @@ jobs:
       - name: Install packages
         shell: bash
         run: |
+          apt-get update
+          apt-get install -y git
           Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'testthat'), repos = 'https://cran.r-project.org')"
           sh build-cran-package.sh
           Rdevel CMD INSTALL lightgbm_*.tar.gz || exit -1

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -116,7 +116,7 @@ jobs:
         shell: pwsh
         run: git config --global core.autocrlf false
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 5
           submodules: true
@@ -143,7 +143,7 @@ jobs:
           $GITHUB_WORKSPACE/.ci/test.sh
       - name: Use conda on Windows
         if: startsWith(matrix.os, 'windows')
-        uses: goanpeca/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v1.7.0
         with:
           auto-update-conda: false
       - name: Setup and run tests on Windows
@@ -166,7 +166,7 @@ jobs:
     container: rhub/rocker-gcc-san
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -169,7 +169,7 @@ jobs:
         shell: bash
         run: |
           apt-get update
-          apt-get install -y git
+          apt-get install --no-install-recommends -y git
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -13,7 +13,7 @@ jobs:
     container: wch1/r-debug
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 5
           submodules: true


### PR DESCRIPTION
I've been noticing a bunch of these warnings in GitHub Actions jobs:

> The `add-path` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

> The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

For example, you can see these annotations on https://github.com/microsoft/LightGBM/actions/runs/343069981.

To be sure that these changes from GitHub don't disrupt our CI, this PR updates the GitHub Actions workflows in this project to use the newest versions of third-party actions. You can see, specifically, that updates to deal with this deprecation were made in the most recent release of `actions/checkout`: https://github.com/actions/checkout/releases/tag/v2.3.4

It also fixes a mistake I made setting them up....we should be using https://github.com/conda-incubator/setup-miniconda, not this fork of it: https://github.com/goanpeca/setup-miniconda.