### PR TITLE
ignore files from local Dask work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -439,3 +439,6 @@ miktex*.zip
 # GraphViz artifacts
 *.gv
 *.gv.*
+
+# Files from local Dask work
+dask-worker-space/


### PR DESCRIPTION
When you work locally with `dask`, by default it will create a directory for itself called `dask-worker-space/`. You can see this by running a small example like this

```python
from dask.distributed import Client
client = Client()
```

We'll start doing more local development with Dask in this project soon, based on #3515, so I think this directory `dask-worker-space/` should be added to `.gitignore`.