### PR TITLE
[R-package] remove Makefile hack in install.libs.R

### DIFF
--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -216,29 +216,6 @@ if (!makefiles_already_generated) {
   .run_shell_command("cmake", c(cmake_args, ".."))
 }
 
-# R CMD check complains about the .NOTPARALLEL directive created in the cmake
-# Makefile. We don't need it here anyway since targets are built serially, so trying
-# to remove it with this hack
-generated_makefile <- file.path(
-  build_dir
-  , "Makefile"
-)
-if (file.exists(generated_makefile)) {
-  makefile_txt <- readLines(
-    con = generated_makefile
-  )
-  makefile_txt <- gsub(
-    pattern = ".*NOTPARALLEL.*"
-    , replacement = ""
-    , x = makefile_txt
-  )
-  writeLines(
-    text = makefile_txt
-    , con = generated_makefile
-    , sep = "\n"
-  )
-}
-
 # build the library
 message("Building lib_lightgbm")
 .run_shell_command(build_cmd, build_args)


### PR DESCRIPTION
Way back in #2530 , we added some code to `R-package/src/install.libs.R` which removes `.NOTPARALLEL` directives from the makefiles generated by `CMake`. This was done to appease `R CMD CHECK` to get us closer to a CRAN-ready package.

Now that a CRAN-ready version of the R package exists and doesn't rely on CMake or `install.libs.R` at all, I think that that hack can be removed. We don't need to care that `R CMD CHECK` is complaining about this, and it might make installation with CMake faster: https://github.com/microsoft/LightGBM/pull/2530/files#r353195984.

We've already established that the CRAN package's main goal is portability / ease-of-installation and the CMake-created package's main goal is performance. I think this change is in line with that. I also think this is a good change because it reduces the complexity in `install.libs.R` (which is already quite complex) and reduces the difference between the R package and other LightGBM wrappers.

Let's see what our CI says :grinning: 