### PR TITLE
TST make sklearn integration test compatible with 0.24

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -315,8 +315,16 @@ class LGBMModel(_LGBMModelBase):
         self.set_params(**kwargs)
 
     def _more_tags(self):
-        return {'allow_nan': True,
-                'X_types': ['2darray', 'sparse', '1dlabels']}
+        return {
+            'allow_nan': True,
+            'X_types': ['2darray', 'sparse', '1dlabels'],
+            '_xfail_checks': {
+                'check_no_attributes_set_in_init':
+                'scikit-learn incorrectly asserts that  private attributes '
+                'cannot be set in __init__: '
+                '(see https://github.com/microsoft/LightGBM/issues/2628)'
+            }
+        }
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -320,10 +320,9 @@ class LGBMModel(_LGBMModelBase):
             'X_types': ['2darray', 'sparse', '1dlabels'],
             '_xfail_checks': {
                 'check_no_attributes_set_in_init':
-                'xxx'
-                # 'scikit-learn incorrectly asserts that  private attributes '
-                # 'cannot be set in __init__: '
-                # '(see https://github.com/microsoft/LightGBM/issues/2628)'
+                'scikit-learn incorrectly asserts that  private attributes '
+                'cannot be set in __init__: '
+                '(see https://github.com/microsoft/LightGBM/issues/2628)'
             }
         }
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -320,9 +320,10 @@ class LGBMModel(_LGBMModelBase):
             'X_types': ['2darray', 'sparse', '1dlabels'],
             '_xfail_checks': {
                 'check_no_attributes_set_in_init':
-                'scikit-learn incorrectly asserts that  private attributes '
-                'cannot be set in __init__: '
-                '(see https://github.com/microsoft/LightGBM/issues/2628)'
+                'xxx'
+                # 'scikit-learn incorrectly asserts that  private attributes '
+                # 'cannot be set in __init__: '
+                # '(see https://github.com/microsoft/LightGBM/issues/2628)'
             }
         }
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -320,7 +320,7 @@ class LGBMModel(_LGBMModelBase):
             'X_types': ['2darray', 'sparse', '1dlabels'],
             '_xfail_checks': {
                 'check_no_attributes_set_in_init':
-                'scikit-learn incorrectly asserts that  private attributes '
+                'scikit-learn incorrectly asserts that private attributes '
                 'cannot be set in __init__: '
                 '(see https://github.com/microsoft/LightGBM/issues/2628)'
             }

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -4,20 +4,17 @@ import joblib
 import math
 import os
 import unittest
-import warnings
 
 import lightgbm as lgb
 import numpy as np
 from sklearn import __version__ as sk_version
 from sklearn.base import clone
 from sklearn.datasets import load_svmlight_file, make_multilabel_classification
-from sklearn.exceptions import SkipTestWarning
 from sklearn.metrics import log_loss, mean_squared_error
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV, train_test_split
 from sklearn.multioutput import (MultiOutputClassifier, ClassifierChain, MultiOutputRegressor,
                                  RegressorChain)
 from sklearn.utils.estimator_checks import (
-     SkipTest,
     check_parameters_default_constructible,
     check_estimator,
 )

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -15,8 +15,8 @@ from sklearn.model_selection import GridSearchCV, RandomizedSearchCV, train_test
 from sklearn.multioutput import (MultiOutputClassifier, ClassifierChain, MultiOutputRegressor,
                                  RegressorChain)
 from sklearn.utils.estimator_checks import (
-    check_parameters_default_constructible,
     check_estimator,
+    check_parameters_default_constructible,
 )
 from sklearn.utils.validation import check_is_fitted
 

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -455,7 +455,6 @@ class TestSklearn(unittest.TestCase):
     # sklearn <0.19 cannot accept instance, but many tests could be passed only with min_data=1 and min_data_in_bin=1
     @unittest.skipIf(sk_version < '0.19.0', 'scikit-learn version is less than 0.19')
     def test_sklearn_integration(self):
-        # we cannot use `check_estimator` directly since there is no skip test mechanism
         for name, estimator in ((lgb.sklearn.LGBMClassifier.__name__, lgb.sklearn.LGBMClassifier),
                                 (lgb.sklearn.LGBMRegressor.__name__, lgb.sklearn.LGBMRegressor)):
             # we cannot leave default params (see https://github.com/microsoft/LightGBM/issues/833)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -25,6 +25,8 @@ except ImportError:
     # setuptools not installed
     parse_version = LooseVersion  # type: ignore
 
+from .utils import load_boston, load_breast_cancer, load_digits, load_iris, load_linnerud
+
 sk_version = parse_version(sk_version)
 if sk_version < parse_version("0.23"):
     import warnings
@@ -32,8 +34,6 @@ if sk_version < parse_version("0.23"):
     from sklearn.utils.estimator_checks import _yield_all_checks, SkipTest
 else:
     from sklearn.utils.estimator_checks import parametrize_with_checks
-
-from .utils import load_boston, load_breast_cancer, load_digits, load_iris, load_linnerud
 
 
 decreasing_generator = itertools.count(0, -1)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1143,6 +1143,13 @@ def test_sklearn_integration(estimator, check, request):
     check(estimator)
 
 
+@pytest.mark.skipif(
+    (sk_version < "0.23.0") or (sk_version >= "0.24.0"),
+    reason=(
+        "Default constructible check is included in the common check from "
+        "sklearn 0.24"
+    )
+)
 @pytest.mark.parametrize("estimator", list(_tested_estimators()))
 def test_parameters_default_constructible(estimator):
     name, Estimator = estimator.__class__.__name__, estimator.__class__

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -8,22 +8,16 @@ import unittest
 import lightgbm as lgb
 import numpy as np
 import pytest
+from pkg_resources import parse_version
 from sklearn import __version__ as sk_version
 from sklearn.base import clone
 from sklearn.datasets import load_svmlight_file, make_multilabel_classification
+from sklearn.utils.estimator_checks import check_parameters_default_constructible
 from sklearn.metrics import log_loss, mean_squared_error
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV, train_test_split
 from sklearn.multioutput import (MultiOutputClassifier, ClassifierChain, MultiOutputRegressor,
                                  RegressorChain)
 from sklearn.utils.validation import check_is_fitted
-
-from sklearn.utils.estimator_checks import check_parameters_default_constructible
-
-try:
-    from pkg_resources import parse_version  # type: ignore
-except ImportError:
-    # setuptools not installed
-    parse_version = LooseVersion  # type: ignore
 
 from .utils import load_boston, load_breast_cancer, load_digits, load_iris, load_linnerud
 
@@ -34,7 +28,6 @@ if sk_version < parse_version("0.23"):
     from sklearn.utils.estimator_checks import _yield_all_checks, SkipTest
 else:
     from sklearn.utils.estimator_checks import parametrize_with_checks
-
 
 decreasing_generator = itertools.count(0, -1)
 
@@ -1177,7 +1170,7 @@ else:
 
 
 @pytest.mark.skipif(
-    not (sk_version < parse_version("0.24")),
+    sk_version >= parse_version("0.24"),
     reason="Default constructible check included in common check from 0.24"
 )
 @pytest.mark.parametrize("estimator", list(_tested_estimators()))


### PR DESCRIPTION
Modify the integration test for scikit-learn. Some deprecations have been raised in 0.23 and the upcoming release of 0.24 will break this test.