### PR TITLE
[R-package] fix learning-to-rank tests on Solaris

### DIFF
--- a/R-package/tests/testthat/test_learning_to_rank.R
+++ b/R-package/tests/testthat/test_learning_to_rank.R
@@ -3,7 +3,7 @@ context("Learning to rank")
 # numerical tolerance to use when checking metric values
 TOLERANCE <- 1e-06
 
-ON_SOLARIS <- Sys.info()['sysname'] == "SunOS"
+ON_SOLARIS <- Sys.info()["sysname"] == "SunOS"
 
 test_that("learning-to-rank with lgb.train() works as expected", {
     set.seed(708L)

--- a/R-package/tests/testthat/test_learning_to_rank.R
+++ b/R-package/tests/testthat/test_learning_to_rank.R
@@ -3,6 +3,8 @@ context("Learning to rank")
 # numerical tolerance to use when checking metric values
 TOLERANCE <- 1e-06
 
+ON_SOLARIS <- Sys.info()['sysname'] == "SunOS"
+
 test_that("learning-to-rank with lgb.train() works as expected", {
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
@@ -46,11 +48,14 @@ test_that("learning-to-rank with lgb.train() works as expected", {
     }
     expect_identical(sapply(eval_results, function(x) {x$name}), eval_names)
     expect_equal(eval_results[[1L]][["value"]], 0.775)
-    expect_true(abs(eval_results[[2L]][["value"]] - 0.745986) < TOLERANCE)
-    expect_true(abs(eval_results[[3L]][["value"]] - 0.7351959) < TOLERANCE)
+    if (!ON_SOLARIS) {
+        expect_true(abs(eval_results[[2L]][["value"]] - 0.745986) < TOLERANCE)
+        expect_true(abs(eval_results[[3L]][["value"]] - 0.7351959) < TOLERANCE)
+    }
 })
 
 test_that("learning-to-rank with lgb.cv() works as expected", {
+    testthat::skip_if(ON_SOLARIS, message = "Skipping on Solaris")
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     # just keep a few features,to generate an model with imperfect fit


### PR DESCRIPTION
This is a (hopefully temporary) workaround for #3513, as suggested in https://github.com/microsoft/LightGBM/issues/3513#issuecomment-720132153. See that issue for details.

I think this is necessary for the `3.1.0` release (#3484 ), because without it the R package might fail CRAN's checks on Solaris.

I have tested on R Hub and confirmed this allows the R package to pass `R CMD check` on Solaris:

```shell
sh build-cran-package.sh
```

```r
result <- rhub::check(
    path = "lightgbm_3.0.0.99.tar.gz"
    , email = "jaylamb20@gmail.com"
    , check_args = c(
        "--as-cran"
    )
    , platform = c(
        "solaris-x86-patched"
        , "solaris-x86-patched-ods"
    )
    , env_vars = c(
        "R_COMPILE_AND_INSTALL_PACKAGES" = "always"
        , "_R_CHECK_FORCE_SUGGESTS_" = "true"
        , "_R_CHECK_CRAN_INCOMING_USE_ASPELL_" = "true"
    )
)
```