### PR TITLE
[ci] simplify R CI scripts

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -108,7 +108,7 @@ if [[ $TASK == "r-package-check-docs" ]]; then
     Rscript --vanilla -e "install.packages('roxygen2', repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
     Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit -1
     num_doc_files_changed=$(
-        git diff --name-only | grep -E "\.Rd|NAMESPACE" | wc -l
+        git diff --name-only | grep --count -E "\.Rd|NAMESPACE"
     )
     if [[ ${num_doc_files_changed} -gt 0 ]]; then
         echo "Some R documentation files have changed. Please re-generate them and commit those changes."
@@ -208,8 +208,7 @@ fi
 if [[ $OS_NAME == "macos" ]] && [[ $R_BUILD_TYPE == "cran" ]]; then
     omp_working=$(
         cat $BUILD_LOG_FILE \
-        | grep -E "checking whether OpenMP will work .*yes" \
-        | wc -l
+        | grep --count -E "checking whether OpenMP will work .*yes"
     )
     if [[ $omp_working -ne 1 ]]; then
         echo "OpenMP was not found, and should be when testing the CRAN package on macOS"
@@ -222,8 +221,7 @@ fi
 if [[ $R_BUILD_TYPE == "cran" ]]; then
     pragma_warning_present=$(
         cat $BUILD_LOG_FILE \
-        | grep -E "warning: unknown pragma ignored" \
-        | wc -l
+        | grep --count -E "warning: unknown pragma ignored"
     )
     if [[ $pragma_warning_present -ne 0 ]]; then
         echo "Unknown pragma warning is present, pragmas should have been removed before build"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -70,13 +70,12 @@ tzutil /s "GMT Standard Time"
 [Void][System.IO.Directory]::CreateDirectory($env:R_LIB_PATH)
 
 if ($env:R_BUILD_TYPE -eq "cmake") {
+  $install_libs = "$env:BUILD_SOURCESDIRECTORY/R-package/src/install.libs.R"
   if ($env:TOOLCHAIN -eq "MINGW") {
     Write-Output "Telling R to use MinGW"
-    $install_libs = "$env:BUILD_SOURCESDIRECTORY/R-package/src/install.libs.R"
     ((Get-Content -Path $install_libs -Raw) -Replace 'use_mingw <- FALSE','use_mingw <- TRUE') | Set-Content -Path $install_libs
   } elseif ($env:TOOLCHAIN -eq "MSYS") {
     Write-Output "Telling R to use MSYS"
-    $install_libs = "$env:BUILD_SOURCESDIRECTORY/R-package/src/install.libs.R"
     ((Get-Content -Path $install_libs -Raw) -Replace 'use_msys2 <- FALSE','use_msys2 <- TRUE') | Set-Content -Path $install_libs
   } elseif ($env:TOOLCHAIN -eq "MSVC") {
     # no customization for MSVC

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -187,7 +187,7 @@ jobs:
           cd R-package/tests
           Rscriptdevel testthat.R 2>&1 > ubsan-tests.log
           cat ubsan-tests.log
-          exit $(cat ubsan-tests.log | grep "runtime error" | wc -l)
+          exit $(cat ubsan-tests.log | grep --count "runtime error")
   all-successful:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
     runs-on: ubuntu-latest


### PR DESCRIPTION
I've been learning about [`shellcheck`](https://github.com/koalaman/shellcheck), a linter for shell scripts.

This PR has a small simplification to `test_r_package.sh` that it suggested: replacing `grep "something | wc -l` with `grep --count "something"`. This might make that script a tiny tiny bit faster, but more importantly makes it a little easier to understand.

This PR also simplifies away a duplicated line in `test_r_package_windows.ps1` that I noticed while working on #3523 