### PR TITLE
[ci] Make valgrind check stricter

### DIFF
--- a/.ci/test_r_package_valgrind.sh
+++ b/.ci/test_r_package_valgrind.sh
@@ -64,3 +64,21 @@ if [[ ${bytes_possibly_lost} -gt 352 ]]; then
     echo "valgrind found ${bytes_possibly_lost} bytes possibly lost"
     exit -1
 fi
+
+invalid_reads=$(
+  cat ${VALGRIND_LOGS_FILE} \
+    | grep --count -i "Invalid read"
+)
+if [[ ${invalid_reads} -gt 0 ]]; then
+    echo "valgrind found invalid reads: ${invalid_reads}"
+    exit -1
+fi
+
+invalid_writes=$(
+  cat ${VALGRIND_LOGS_FILE} \
+    | grep --count -i "Invalid write"
+)
+if [[ ${invalid_writes} -gt 0 ]]; then
+    echo "valgrind found invalid writes: ${invalid_writes}"
+    exit -1
+fi


### PR DESCRIPTION
An issue caught by `valgrind` was recently introduced onto `master` because the `valgrind` CI job didn't catch it: #3525 .

This PR fixes that so similar problems are caught in the future. Specifically, it will now fail builds where valgrind produces "invalid read" (like https://github.com/microsoft/LightGBM/issues/3525) or "invalid write" (like https://www.stats.ox.ac.uk/pub/bdr/memtests/valgrind/lightgbm/tests/testthat.Rout) errors.