### PR TITLE
Fix #2898: Clearer warning message for user (2^max_depth > num_leaves).

### DIFF
--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -317,7 +317,7 @@ void Config::CheckParamConflict() {
     double full_num_leaves = std::pow(2, max_depth);
     if (full_num_leaves > num_leaves
         && num_leaves == kDefaultNumLeaves) {
-      Log::Warning("Accuracy may be bad since you didn't set num_leaves OR 2^max_depth > num_leaves."
+      Log::Warning("Accuracy may be bad since you didn't explicitly set num_leaves OR 2^max_depth > num_leaves."
                    " (num_leaves=%d).",
                    num_leaves);
     }

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -317,7 +317,9 @@ void Config::CheckParamConflict() {
     double full_num_leaves = std::pow(2, max_depth);
     if (full_num_leaves > num_leaves
         && num_leaves == kDefaultNumLeaves) {
-      Log::Warning("Accuracy may be bad since you didn't set num_leaves and 2^max_depth > num_leaves");
+      Log::Warning("Accuracy may be bad since you didn't set num_leaves OR 2^max_depth > num_leaves."
+                   " (num_leaves=%d).", 
+                   num_leaves);
     }
 
     if (full_num_leaves < num_leaves) {

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -318,7 +318,7 @@ void Config::CheckParamConflict() {
     if (full_num_leaves > num_leaves
         && num_leaves == kDefaultNumLeaves) {
       Log::Warning("Accuracy may be bad since you didn't set num_leaves OR 2^max_depth > num_leaves."
-                   " (num_leaves=%d).", 
+                   " (num_leaves=%d).",
                    num_leaves);
     }
 


### PR DESCRIPTION
Fix https://github.com/microsoft/LightGBM/issues/2898

Clearer warning message for user when `2^max_depth > num_leaves` happens.