### PR TITLE
fix constant hessian for huber objective 

### DIFF
--- a/src/objective/regression_objective.hpp
+++ b/src/objective/regression_objective.hpp
@@ -338,10 +338,6 @@ class RegressionHuberLoss: public RegressionL2loss {
     return "huber";
   }
 
-  bool IsConstantHessian() const override {
-    return false;
-  }
-
  private:
   /*! \brief delta for Huber loss */
   double alpha_;


### PR DESCRIPTION
huber loss should use the same `IsConstantHessian` as its parent class, not need to override.