### PR TITLE
[ci] fix CUDA CI builds

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Remove old folder with repository
         run: sudo rm -rf $GITHUB_WORKSPACE
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v1
         with:
           fetch-depth: 5
           submodules: true
@@ -52,6 +52,7 @@ jobs:
             OS_NAME=linux
             BUILD_DIRECTORY=$ROOT_DOCKER_FOLDER
             CONDA_ENV=test-env
+            PYTHON_VERSION=3.8
             EOF
             cat > docker-script.sh <<EOF
             export CONDA=\$HOME/miniconda


### PR DESCRIPTION
I was wrong in https://github.com/microsoft/LightGBM/pull/3524#pullrequestreview-522772442. I guess to use v2 we need update Actions runner first: https://github.com/actions/checkout/issues/348. @guolinke Could you help please? For now rollback to v1.
```
Run actions/checkout@v2.3.4
  with:
    fetch-depth: 5
    submodules: true
    repository: microsoft/LightGBM
    token: ***
    ssh-strict: true
    persist-credentials: true
    clean: true
    lfs: false
Error: No such file or directory
```