### PR TITLE
[docs] simplify RTD config and use latest Sphinx

### DIFF
--- a/docs/requirements_base.txt
+++ b/docs/requirements_base.txt
@@ -1,3 +1,3 @@
-sphinx < 3.2
+sphinx
 sphinx_rtd_theme >= 0.3
 mock; python_version < '3'

--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -1,5 +1,2 @@
-sphinx >= 3.0.2,<3.2
-sphinx_rtd_theme >= 0.5
-readthedocs-sphinx-ext > 2.1
-mock; python_version < '3'
-breathe
+-r requirements.txt
+sphinx >= 3.2.2


### PR DESCRIPTION
Build successful: https://readthedocs.org/projects/lightgbm/builds/12308946/.

I hope in the future we will be able to drop `requirements_rtd.txt` completely, but now `pip` still fails to resolve conflicts with preinstalled old (`1.8.5`) Sphinx and latest Breathe.