### PR TITLE
[ci] Remove Python 2.7 CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
     - PYTHON_VERSION=3.8
   matrix:
     - TASK=regular PYTHON_VERSION=3.6
-    - TASK=sdist PYTHON_VERSION=2.7
     - TASK=bdist
     - TASK=if-else
     - TASK=lint

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -115,9 +115,6 @@ jobs:
       regular:
         TASK: regular
         PYTHON_VERSION: 3.6
-      sdist:
-        TASK: sdist
-        PYTHON_VERSION: 2.7
       bdist:
         TASK: bdist
   steps:


### PR DESCRIPTION
Now that v3.1.0 has been released (#3484) and marked as the final release that supports Python 2.7 (#3565), I'd like to propose removing the Python 2.7 CI jobs.

This would unblock the work to move `dask-lightgbm` into this project (https://github.com/microsoft/LightGBM/pull/3515#issuecomment-728232698) and could help us save some credits on Travis while we deal with the issues caused by Travis's new announcements around ending support for open source projects (#3519).

I know there are other code-level things we could do to simplify `lightgbm` now that Python 2.7 support is being dropped, but I think cutting out the CI jobs is valuable enough that it's worth doing as a simple, standalone pull request.