### PR TITLE
[ci] remove conda from R CI jobs

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -48,8 +48,10 @@ else  # Linux
     fi
 fi
 
-if [[ $TRAVIS == "true" ]] || [[ $GITHUB_ACTIONS == "true" ]] || [[ $OS_NAME == "macos" ]]; then
-    sh conda.sh -b -p $CONDA
+if [[ "${TASK:0:9}" != "r-package" ]]; then
+    if [[ $TRAVIS == "true" ]] || [[ $OS_NAME == "macos" ]]; then
+        sh conda.sh -b -p $CONDA
+    fi
+    conda config --set always_yes yes --set changeps1 no
+    conda update -q -y conda
 fi
-conda config --set always_yes yes --set changeps1 no
-conda update -q -y conda

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -8,6 +8,11 @@ elif [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "clang" ]]; then
     export CC=clang
 fi
 
+if [[ "${TASK:0:9}" == "r-package" ]]; then
+    bash ${BUILD_DIRECTORY}/.ci/test_r_package.sh || exit -1
+    exit 0
+fi
+
 conda create -q -y -n $CONDA_ENV python=$PYTHON_VERSION
 source activate $CONDA_ENV
 
@@ -62,11 +67,6 @@ if [[ $TASK == "if-else" ]]; then
     cd $BUILD_DIRECTORY/tests/cpp_test && ../../lightgbm config=train.conf convert_model_language=cpp convert_model=../../src/boosting/gbdt_prediction.cpp && ../../lightgbm config=predict.conf output_result=origin.pred || exit -1
     cd $BUILD_DIRECTORY/build && make lightgbm -j4 || exit -1
     cd $BUILD_DIRECTORY/tests/cpp_test && ../../lightgbm config=predict.conf output_result=ifelse.pred && python test.py || exit -1
-    exit 0
-fi
-
-if [[ "${TASK:0:9}" == "r-package" ]]; then
-    bash ${BUILD_DIRECTORY}/.ci/test_r_package.sh || exit -1
     exit 0
 fi
 

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -89,12 +89,6 @@ if [[ $OS_NAME == "macos" ]]; then
     fi
 fi
 
-conda install \
-    -y \
-    -q \
-    --no-deps \
-        pandoc
-
 # Manually install Depends and Imports libraries + 'testthat'
 # to avoid a CI-time dependency on devtools (for devtools::install_deps())
 packages="c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat')"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -120,7 +120,6 @@ if (($env:COMPILER -eq "MINGW") -or ($env:R_BUILD_TYPE -eq "cran")) {
     Write-Output "Done installing MiKTeX"
 
     Run-R-Code-Redirect-Stderr "result <- processx::run(command = 'initexmf', args = c('--set-config-value', '[MPM]AutoInstall=1'), echo = TRUE, windows_verbatim_args = TRUE, error_on_status = TRUE)" ; Check-Output $?
-    conda install -q -y --no-deps pandoc
 }
 
 Write-Output "Building R package"

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -143,7 +143,7 @@ jobs:
           $GITHUB_WORKSPACE/.ci/test.sh
       - name: Use conda on Windows
         if: startsWith(matrix.os, 'windows')
-        uses: conda-incubator/setup-miniconda@v1.7.0
+        uses: conda-incubator/setup-miniconda@v2.0.0
         with:
           auto-update-conda: true
       - name: Setup and run tests on Windows

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -120,6 +120,8 @@ jobs:
         with:
           fetch-depth: 5
           submodules: true
+      - name: Install pandoc
+        uses: r-lib/actions/setup-pandoc@v1
       - name: Setup and run tests on Linux and macOS
         if: matrix.os == 'macOS-latest' || matrix.os == 'ubuntu-latest'
         shell: bash
@@ -135,17 +137,10 @@ jobs:
               export R_LINUX_VERSION=3.6.3-1bionic
           fi
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
-          export CONDA="$HOME/miniconda"
-          export PATH="$CONDA/bin:${HOME}/.local/bin:$PATH"
           export R_VERSION="${{ matrix.r_version }}"
           export R_BUILD_TYPE="${{ matrix.build_type }}"
           $GITHUB_WORKSPACE/.ci/setup.sh
           $GITHUB_WORKSPACE/.ci/test.sh
-      - name: Use conda on Windows
-        if: startsWith(matrix.os, 'windows')
-        uses: conda-incubator/setup-miniconda@v2.0.0
-        with:
-          auto-update-conda: true
       - name: Setup and run tests on Windows
         if: startsWith(matrix.os, 'windows')
         shell: pwsh -command ". {0}"
@@ -157,7 +152,6 @@ jobs:
           $env:COMPILER = "${{ matrix.compiler }}"
           $env:GITHUB_ACTIONS = "true"
           $env:TASK = "${{ matrix.task }}"
-          conda init powershell
           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
   test-r-sanitizers:
     name: r-package (ubuntu-latest, R-devel, GCC ASAN/UBSAN)

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -145,7 +145,7 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         uses: conda-incubator/setup-miniconda@v1.7.0
         with:
-          auto-update-conda: false
+          auto-update-conda: true
       - name: Setup and run tests on Windows
         if: startsWith(matrix.os, 'windows')
         shell: pwsh -command ". {0}"


### PR DESCRIPTION
On https://github.com/microsoft/LightGBM/pull/3405#issuecomment-728353296, I see the Windows CI jobs on GitHub Actions failing with this output

```text
==> WARNING: A newer version of conda exists. <==
  current version: 4.8.3
  latest version: 4.9.2

Please update conda by running

    $ conda update -n base -c defaults conda

#
# To activate this environment, use
#
#     $ conda activate test
#
# To deactivate an active environment, use
#
#     $ conda deactivate
```

I'm worried that this is another case where programs writing to stderr in GitHub Actions Windows jobs causes those jobs to fail. I don't know if this recently started failing because of software updates in GitHub Actions images (https://github.com/actions/virtual-environments/commits/main) or something else.

This PR proposes just updating `conda` to the latest version every time, to hopefully avoid this warning.