### PR TITLE
[python] remove unnecessary files to reduce sdist size

### DIFF
--- a/python-package/MANIFEST.in
+++ b/python-package/MANIFEST.in
@@ -4,9 +4,13 @@ include *.rst *.txt
 recursive-include lightgbm *.py *.txt *.so
 recursive-include compile *.txt *.so
 recursive-include compile/Release *.dll
-recursive-include compile/compute *
+recursive-include compile/compute/ *.txt
+recursive-include compile/compute/cmake *
+recursive-include compile/compute/include *
+recursive-include compile/compute/meta *
 recursive-include compile/include *
 recursive-include compile/src *
 recursive-include compile/windows LightGBM.sln LightGBM.vcxproj
 recursive-include compile/windows/x64/DLL *.dll
 global-exclude *.py[co]
+exclude compile/compute/.git


### PR DESCRIPTION
## Short Description

This PR removes unnecessary files from the tarball created by `python setup.py sdist`,  to make that source distribution smaller.

## Long Description

This week I've been revisiting a conference talk I gave in April, where I showed how to deploy a LightGBM model on [AWS Lambda](https://aws.amazon.com/lambda/), using a Python Lambda.

To make external dependencies like `lightgbm`  available to a Python Lambda, you have to create something called a ["Lambda Layer"](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html), which is basically like a volume with files on it that get mounted into the filesystem used by your code. The sum of all "layers" that you add cannot exceed 250 MB uncompressed. This made it hard to set up, for example, a Lambda that used `lightgbm`, `pandas`,  and `scikit-learn`. I had to do some surgery on the packages' source distributions to get under the limit: https://github.com/jameslamb/talks/blob/main/cloud-intro/scripts/create-layers.sh

To help people using Lambdas or any other settings that are very sensitive to code footprint, this PR proposes some changes to remove unnecessary files from the source distribution of the Python package.

If you look in the `sdist` logs, there are a bunch of files from the `compute` submodule that don't need to be included in `lightgbm`,  like that submodule's tests and documentation.

```shell
cd python-package
python setup.py sdist
```

This pull request proposes changes to exclude them. I tested on my Mac and found the following changes in the package size.

|                                       | `master` | this PR     |
|:----------------------:|:----------:|:---------:|
| sdist (compressed)      |     740K    |       576K |
| sdist (uncompressed)  |     6.1M     |        4.3M|
| wheel (compressed)     |     1.0M    |         1.0M |
| wheel (uncompressed) |      3.6M   |        3.6M |

It makes sense that the wheel didn't change sizes, since we don't include `compute` in it.

<details><summary>script I used to check sizes (click me)</summary>

```shell
#!/bin/bash

pushd $(pwd)/python-package

    # clean up files from previous builds
    rm -rf build_cpp
    rm -rf build
    rm -rf compile
    rm -rf dist
    rm -rf lightgbm.egg-info
    rm ~/lgb-tmp.log

    echo ""
    echo "building source distribution"
    echo ""
    rm -rf dist/
    python setup.py sdist >> ~/lgb-tmp.log
    pushd dist/
        echo ""
        echo "sdist compressed size"
        echo ""
        du -a -h .
        tar -xf lightgbm*.tar.gz
        rm lightgbm*.tar.gz
        ls .
        echo ""
        echo "sdist uncompressed size"
        echo ""
        du -sh .
    popd

    echo ""
    echo "building wheel"
    echo ""
    rm -rf build_cpp
    rm -rf build
    rm -rf compile
    rm -rf lightgbm.egg-info
    rm -rf dist/
    python setup.py bdist_wheel --plat-name=macosx --universal >> ~/lgb-tmp.log
    pushd dist/
        echo ""
        echo "wheel compressed size"
        echo ""
        du -a -h .
        tar -xf lightgbm*.whl
        rm *.whl
        echo ""
        echo "wheel uncompressed size"
        echo ""
        du -sh .
    popd

popd
```

</details>

### Notes for Reviewers

If you agree with the spirit of this PR, we should also be careful to exclude unnecessary files from the sub-modules introduced in #3405 , but that PR already has a lot of comments so I'd rather do that as a follow-up after #3405 is merged.

For reference, the `compute` submodule comes from https://github.com/boostorg/compute.