### PR TITLE
[ci] Fix missing git install in R artifact job (fixes #3567)

### DIFF
--- a/.github/workflows/r_artifacts.yml
+++ b/.github/workflows/r_artifacts.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     container: rocker/r-base
     steps:
+      - name: Install Git before checkout
+        shell: bash
+        run: |
+          apt-get update
+          apt-get install --no-install-recommends -y git
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
This PR fixes #3567 . When third-party actions were updated in #3524 I think it broke the job that is used to create a source distribution of the CRAN package.