### PR TITLE
[ci] test 32-bit R in CI

### DIFF
--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -94,7 +94,7 @@ Download-File-With-Retries -url "https://github.com/microsoft/LightGBM/releases/
 
 # Install R
 Write-Output "Installing R"
-Start-Process -FilePath R-win.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH/R /COMPONENTS=main,x64" ; Check-Output $?
+Start-Process -FilePath R-win.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH/R /COMPONENTS=main,x64,i386" ; Check-Output $?
 Write-Output "Done installing R"
 
 Write-Output "Installing Rtools"

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -97,6 +97,12 @@ jobs:
           - os: windows-latest
             task: r-package
             compiler: MINGW
+            toolchain: MINGW
+            r_version: 3.6
+            build_type: cran
+          - os: windows-latest
+            task: r-package
+            compiler: MINGW
             toolchain: MSYS
             r_version: 4.0
             build_type: cran

--- a/R-package/tests/testthat/test_learning_to_rank.R
+++ b/R-package/tests/testthat/test_learning_to_rank.R
@@ -4,6 +4,7 @@ context("Learning to rank")
 TOLERANCE <- 1e-06
 
 ON_SOLARIS <- Sys.info()["sysname"] == "SunOS"
+ON_32_BIT_WINDOWS <- .Platform$OS.type == "windows" && .Machine$sizeof.pointer != 8L
 
 test_that("learning-to-rank with lgb.train() works as expected", {
     set.seed(708L)
@@ -48,14 +49,17 @@ test_that("learning-to-rank with lgb.train() works as expected", {
     }
     expect_identical(sapply(eval_results, function(x) {x$name}), eval_names)
     expect_equal(eval_results[[1L]][["value"]], 0.775)
-    if (!ON_SOLARIS) {
+    if (!(ON_SOLARIS || ON_32_BIT_WINDOWS)) {
         expect_true(abs(eval_results[[2L]][["value"]] - 0.745986) < TOLERANCE)
         expect_true(abs(eval_results[[3L]][["value"]] - 0.7351959) < TOLERANCE)
     }
 })
 
 test_that("learning-to-rank with lgb.cv() works as expected", {
-    testthat::skip_if(ON_SOLARIS, message = "Skipping on Solaris")
+    testthat::skip_if(
+        ON_SOLARIS || ON_32_BIT_WINDOWS
+        , message = "Skipping on Solaris and 32-bit Windows"
+    )
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")
     # just keep a few features,to generate an model with imperfect fit


### PR DESCRIPTION
Based on https://github.com/microsoft/LightGBM/issues/3585#issuecomment-731663718. We were recently surprised by some test failures on 32-bit Windows checks for CRAN.

I think this is because I thought we were running tests with a 32-bit version of R on Windows (#3311 ) but maybe we never actually were.

I think that the root cause is that the test setup for our R environment doesn't install i386 components for R-win.exe, as documented in https://cran.r-project.org/bin/windows/base/rw-FAQ.html#Can-I-customize-the-installation_003f.

As of this PR, 32-bit R will be installed in GitHub Actions jobs and the R package will be tested against both architectures (x86 and i386).

### Questions for Reviewers

In #3585 , we ran into issues only on CRAN's R 3.6 + Windows (32-bit) job. Today, the only tests of the CRAN package are on R 4.0. That's a gap between this project's CI and CRAN, which means we could run into this situation again in future CRAN submission. In this PR I'd like to also add an R 3.6 + Windows + `build_type: cran` job.

GitHub Actions gives you 20 concurrent job runs, and right now we have 17 jobs that run on every PR.

How do you feel about adding this additional job?

```yaml
          - os: windows-latest
            task: r-package
            compiler: MINGW
            toolchain: MINGW
            r_version: 3.6
            build_type: cran
```

~NOTE: this PR's tests won't pass until #3586 is merged. I wanted to keep them separate so this CI work doesn't slow down the process of releasing a fix for CRAN.~