### PR TITLE
Fix #3557 and potential issue with dense multi-val feature groups.

### DIFF
--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -543,7 +543,7 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
     dataset->feature_groups_.emplace_back(std::unique_ptr<FeatureGroup>(
       new FeatureGroup(buffer.data(),
                        *num_global_data,
-                       *used_data_indices)));
+                       *used_data_indices, i)));
   }
   dataset->feature_groups_.shrink_to_fit();
   dataset->is_finish_load_ = true;


### PR DESCRIPTION
This PR is to fix:

1. Issue #3557 . The issue is due to that `used_feature_map_` is not correctly extended before being used in `Dataset::AddFeaturesFrom`. And the `real_feature_idx_` of the new dataset after adding features is not set correctly. The `bin_offsets_` is not extended in `FeatureGroup::AddFeaturesFrom`.

2. Potential problem with dense multi-val feature groups, when all the following conditions are satisfied:
    - The first feature group is a dense multi-val feature group.
    - The first feature of the dense multi-val feature group has non-zero `most_freq_bin_`
    - In col-wise histogram construction case.

    In this case, the `bin_offsets_` and `num_total_bin_` are not set correctly in `FeatureGroup` constructors (including `AddFeaturesFrom` method). And there will be a `CHECK` failure raised in line 275 of `train_share_states.cpp`, and the histogram will not be constructed correctly. Though this can not happen very often.