### PR TITLE
Check max_bin, etc. match config when using binary

### DIFF
--- a/include/LightGBM/dataset_loader.h
+++ b/include/LightGBM/dataset_loader.h
@@ -44,7 +44,7 @@ class DatasetLoader {
 
   void SetHeader(const char* filename);
 
-  void CheckDataset(const Dataset* dataset);
+  void CheckDataset(const Dataset* dataset, bool is_load_from_binary);
 
   std::vector<std::string> LoadTextDataToMemory(const char* filename, const Metadata& metadata, int rank, int num_machines, int* num_global_data, std::vector<data_size_t>* used_data_indices);
 

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -754,6 +754,14 @@ void DatasetLoader::CheckDataset(const Dataset* dataset, bool is_load_from_binar
     if (dataset->zero_as_missing_ != config_.zero_as_missing) {
       Log::Fatal("Dataset zero_as_missing %d != config %d", dataset->zero_as_missing_, config_.zero_as_missing);
     }
+    if (dataset->bin_construct_sample_cnt_ != config_.bin_construct_sample_cnt) {
+      Log::Fatal("Dataset bin_construct_sample_cnt %d != config %d", dataset->bin_construct_sample_cnt_, config_.bin_construct_sample_cnt);
+    }
+    if ((dataset->max_bin_by_feature_.size() != config_.max_bin_by_feature.size()) ||
+        !std::equal(dataset->max_bin_by_feature_.begin(), dataset->max_bin_by_feature_.end(),
+            config_.max_bin_by_feature.begin())) {
+      Log::Fatal("Dataset max_bin_by_feature does not match with config");
+    }
 
     int label_idx = -1;
     if (Common::AtoiAndCheck(config_.label_column.c_str(), &label_idx)) {


### PR DESCRIPTION
To avoid binary file with non-matching parameters from being used.