### PR TITLE
[python] fix regex in MANIFEST file

### DIFF
--- a/python-package/MANIFEST.in
+++ b/python-package/MANIFEST.in
@@ -4,7 +4,7 @@ include *.rst *.txt
 recursive-include lightgbm *.py *.txt *.so
 recursive-include compile *.txt *.so
 recursive-include compile/Release *.dll
-recursive-include compile/compute/ *.txt
+recursive-include compile/compute *.txt
 recursive-include compile/compute/cmake *
 recursive-include compile/compute/include *
 recursive-include compile/compute/meta *


### PR DESCRIPTION
Fix warning on Windows:
```
warning: manifest_maker: MANIFEST.in, line 7: path 'compile/compute/' cannot end with '/'
```

https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=8065&view=logs&j=e0c3ed1e-0c79-508f-2647-33e12d6ed3d4&t=d764710f-c78e-54fd-dda4-11d6a80fefc7&l=439