### PR TITLE
[docs] add link to lightgbm4j to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Dask-LightGBM (distributed and parallel Python-package): https://github.com/dask
 
 Ruby gem: https://github.com/ankane/lightgbm
 
+LightGBM4j (Java high-level binding): https://github.com/metarank/lightgbm4j
+
 Support
 -------
 


### PR DESCRIPTION
LightGBM4j is a high-level Java wrapper for the LightGBM library. It can be nice to have it referenced from the main docs.