### PR TITLE
[ci] remove unnecessary environment variables in R-package CI

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -137,10 +137,8 @@ jobs:
           export GITHUB_ACTIONS="true"
           if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
               export OS_NAME="macos"
-              export R_MAC_VERSION=3.6.3
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
               export OS_NAME="linux"
-              export R_LINUX_VERSION=3.6.3-1bionic
           fi
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           export R_VERSION="${{ matrix.r_version }}"


### PR DESCRIPTION
I realized tonight that we're setting environment variables `R_*_VERSION` unnecessarily in the GitHub Actions config for the R-package tests. It's set directly in https://github.com/microsoft/LightGBM/blob/6be3e57d21446022d33266605375660a9b35d9af/.ci/test_r_package.sh#L16-L24,  and I think that's a better place because we should try to keep the CI config files as simple as possible, in case they ever need to move to different CI providers.

This PR removes those unnecessary statements.