### PR TITLE
[R-package] use keyword arguments for internal functions in utils.R

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -1,9 +1,9 @@
 lgb.is.Booster <- function(x) {
-  lgb.check.r6.class(x, "lgb.Booster")
+  lgb.check.r6.class(object = x, name = "lgb.Booster")
 }
 
 lgb.is.Dataset <- function(x) {
-  lgb.check.r6.class(x, "lgb.Dataset")
+  lgb.check.r6.class(object = x, name = "lgb.Dataset")
 }
 
 lgb.null.handle <- function() {
@@ -53,7 +53,7 @@ lgb.last_error <- function() {
     )
   }
 
-  stop("api error: ", lgb.encode.char(err_msg, act_len))
+  stop("api error: ", lgb.encode.char(arr = err_msg, len = act_len))
 }
 
 lgb.call <- function(fun_name, ret, ...) {
@@ -104,7 +104,7 @@ lgb.call.return.str <- function(fun_name, ...) {
     buf <- lgb.call(fun_name, ret = buf, ..., buf_len, act_len)
   }
 
-  return(lgb.encode.char(buf, act_len))
+  return(lgb.encode.char(arr = buf, len = act_len))
 
 }
 
@@ -163,10 +163,10 @@ lgb.params2str <- function(params, ...) {
 
   # Check ret length
   if (length(ret) == 0L) {
-    return(lgb.c_str(""))
+    return(lgb.c_str(x = ""))
   }
 
-  return(lgb.c_str(paste0(ret, collapse = " ")))
+  return(lgb.c_str(x = paste0(ret, collapse = " ")))
 
 }
 


### PR DESCRIPTION
This PR contributes to issue #3390 for the utils.R file. I added keyword arguments for the following functions `lgb.check.r6.class`, `lgb.encode.char`, and `lgb.c_str` and did not add keyword arguments for functions in R's standard library. I also checked that building the package and `R CMD INSTALL` works successfully.

Let me know if I did anything wrong with the PR. Thanks!