### PR TITLE
[ci] add credentials to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -442,3 +442,10 @@ miktex*.zip
 
 # Files from local Dask work
 dask-worker-space/
+
+# credentials and key material
+*.env
+*.pem
+*.pub
+*.rdp
+*_rsa


### PR DESCRIPTION
While testing #3515 using some AWS services, I realized that some common types of files used to store credentials and sensitive key material are not currently ignored by this project's `.gitignore`.

This PR proposes adding them, to avoid accidentally checking in sensitive information.