### PR TITLE
[docs] update documentation with AUC-mu, average precision

### DIFF
--- a/docs/Features.rst
+++ b/docs/Features.rst
@@ -205,9 +205,9 @@ LightGBM supports the following metrics:
 
 -  Multi-class error rate
 
--  AUC-mu **(--- new in v3.0.0 ---)**
+-  AUC-mu ``(new in v3.0.0)``
 
--  Average precision **(new in v3.1.0)**
+-  Average precision ``(new in v3.1.0)``
 
 -  Fair
 

--- a/docs/Features.rst
+++ b/docs/Features.rst
@@ -205,6 +205,10 @@ LightGBM supports the following metrics:
 
 -  Multi-class error rate
 
+-  AUC-mu **(--- new in v3.0.0 ---)**
+
+-  Average precision **(new in v3.1.0)**
+
 -  Fair
 
 -  Huber


### PR DESCRIPTION
I was reading https://lightgbm.readthedocs.io/en/latest/Features.html today and realized that a list of metrics is maintained there. That list is missing some of the newer things that @btrotta has added (average precision, AUC-mu). This PR proposes adding them.

I'm also proposing something I think we should do more of...adding a label like `new in v3.0.0`. Since we only host one version of the documentation, based on `master`, I think these types of annotations are useful. This is a practice I really appreciate in the `scikit-learn` docs, for example.

For example, https://scikit-learn.org/stable/modules/generated/sklearn.compose.ColumnTransformer.html#sklearn-compose-columntransformer

![image](https://user-images.githubusercontent.com/7608904/101186576-e2f8c000-3618-11eb-9094-cf30fc435225.png)
