### PR TITLE
[R-package] fix partial matching of keyword arguments in lgb.cv() (fixes #3629)

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -190,16 +190,8 @@ if [[ $check_succeeded == "no" ]]; then
     exit -1
 fi
 
-if grep -q -R "NOTE" "$LOG_FILE_NAME"; then
-    echo "NOTEs have been found by R CMD check!"
-    exit -1
-fi
-if grep -q -R "WARNING" "$LOG_FILE_NAME"; then
-    echo "WARNINGS have been found by R CMD check!"
-    exit -1
-fi
-if grep -q -R "ERROR" "$LOG_FILE_NAME"; then
-    echo "ERRORs have been found by R CMD check!"
+if grep -q -E "NOTE|WARNING|ERROR" "$LOG_FILE_NAME"; then
+    echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
     exit -1
 fi
 

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -190,19 +190,16 @@ if [[ $check_succeeded == "no" ]]; then
     exit -1
 fi
 
+if grep -q -R "NOTE" "$LOG_FILE_NAME"; then
+    echo "NOTEs have been found by R CMD check!"
+    exit -1
+fi
 if grep -q -R "WARNING" "$LOG_FILE_NAME"; then
     echo "WARNINGS have been found by R CMD check!"
     exit -1
 fi
-
-ALLOWED_CHECK_NOTES=0
-NUM_CHECK_NOTES=$(
-    cat ${LOG_FILE_NAME} \
-        | grep -e '^Status: .* NOTE.*' \
-        | sed 's/[^0-9]*//g'
-)
-if [[ ${NUM_CHECK_NOTES} -gt ${ALLOWED_CHECK_NOTES} ]]; then
-    echo "Found ${NUM_CHECK_NOTES} NOTEs from R CMD check. Only ${ALLOWED_CHECK_NOTES} are allowed"
+if grep -q -R "ERROR" "$LOG_FILE_NAME"; then
+    echo "ERRORs have been found by R CMD check!"
     exit -1
 fi
 

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -11,6 +11,15 @@ export PATH="$R_LIB_PATH/R/bin:$PATH"
 # https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
 export _R_CHECK_SYSTEM_CLOCK_=0
 
+# ignore R CMD CHECK NOTE checking how long it has
+# been since the last submission
+export _R_CHECK_CRAN_INCOMING_REMOTE_=0
+
+# CRAN ignores the "installed size is too large" NOTE,
+# so our CI can too. Setting to a large value here just
+# to catch extreme problems
+export _R_CHECK_PKG_SIZES_THRESHOLD_=60
+
 # Get details needed for installing R components
 R_MAJOR_VERSION=( ${R_VERSION//./ } )
 if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
@@ -186,7 +195,7 @@ if grep -q -R "WARNING" "$LOG_FILE_NAME"; then
     exit -1
 fi
 
-ALLOWED_CHECK_NOTES=2
+ALLOWED_CHECK_NOTES=0
 NUM_CHECK_NOTES=$(
     cat ${LOG_FILE_NAME} \
         | grep -e '^Status: .* NOTE.*' \

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -165,16 +165,8 @@ if ($env:COMPILER -ne "MSVC") {
   Check-Output $check_succeeded
 
   Write-Output "Looking for issues with R CMD check results"
-  if (Get-Content "$LOG_FILE_NAME" | Select-String -Pattern "NOTE" -CaseSensitive -Quiet) {
-      echo "NOTEs have been found by R CMD check!"
-      Check-Output $False
-  }
-  if (Get-Content "$LOG_FILE_NAME" | Select-String -Pattern "ERROR" -CaseSensitive -Quiet) {
-      echo "ERRORs have been found by R CMD check!"
-      Check-Output $False
-  }
-  if (Get-Content "$LOG_FILE_NAME" | Select-String -Pattern "WARNING" -CaseSensitive -Quiet) {
-      echo "WARNINGS have been found by R CMD check!"
+  if (Get-Content "$LOG_FILE_NAME" | Select-String -Pattern "NOTE|WARNING|ERROR" -CaseSensitive -Quiet) {
+      echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
       Check-Output $False
   }
 

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -62,6 +62,15 @@ $env:CTAN_PACKAGE_ARCHIVE = "$env:CTAN_MIRROR/tm/packages/"
 # https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
 $env:_R_CHECK_SYSTEM_CLOCK_ = 0
 
+# ignore R CMD CHECK NOTE checking how long it has
+# been since the last submission
+$env:_R_CHECK_CRAN_INCOMING_REMOTE_ = 0
+
+# CRAN ignores the "installed size is too large" NOTE,
+# so our CI can too. Setting to a large value here just
+# to catch extreme problems
+$env:_R_CHECK_PKG_SIZES_THRESHOLD_ = 60
+
 if (($env:COMPILER -eq "MINGW") -and ($env:R_BUILD_TYPE -eq "cmake")) {
   $env:CXX = "$env:RTOOLS_MINGW_BIN/g++.exe"
   $env:CC = "$env:RTOOLS_MINGW_BIN/gcc.exe"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -165,6 +165,10 @@ if ($env:COMPILER -ne "MSVC") {
   Check-Output $check_succeeded
 
   Write-Output "Looking for issues with R CMD check results"
+  if (Get-Content "$LOG_FILE_NAME" | Select-String -Pattern "NOTE" -CaseSensitive -Quiet) {
+      echo "NOTEs have been found by R CMD check!"
+      Check-Output $False
+  }
   if (Get-Content "$LOG_FILE_NAME" | Select-String -Pattern "ERROR" -CaseSensitive -Quiet) {
       echo "ERRORs have been found by R CMD check!"
       Check-Output $False
@@ -174,14 +178,6 @@ if ($env:COMPILER -ne "MSVC") {
       Check-Output $False
   }
 
-  $note_str = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern '.*Status.* NOTE' | Out-String ; Check-Output $?
-  $relevant_line = $note_str -match '(\d+) NOTE'
-  $NUM_CHECK_NOTES = $matches[1]
-  $ALLOWED_CHECK_NOTES = 0
-  if ([int]$NUM_CHECK_NOTES -gt $ALLOWED_CHECK_NOTES) {
-      Write-Output "Found ${NUM_CHECK_NOTES} NOTEs from R CMD check. Only ${ALLOWED_CHECK_NOTES} are allowed"
-      Check-Output $False
-  }
 } else {
   $env:TMPDIR = $env:USERPROFILE  # to avoid warnings about incremental builds inside a temp directory
   $INSTALL_LOG_FILE_NAME = "$env:BUILD_SOURCESDIRECTORY\00install_out.txt"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -177,7 +177,7 @@ if ($env:COMPILER -ne "MSVC") {
   $note_str = Get-Content -Path "${LOG_FILE_NAME}" | Select-String -Pattern '.*Status.* NOTE' | Out-String ; Check-Output $?
   $relevant_line = $note_str -match '(\d+) NOTE'
   $NUM_CHECK_NOTES = $matches[1]
-  $ALLOWED_CHECK_NOTES = 2
+  $ALLOWED_CHECK_NOTES = 0
   if ([int]$NUM_CHECK_NOTES -gt $ALLOWED_CHECK_NOTES) {
       Write-Output "Found ${NUM_CHECK_NOTES} NOTEs from R CMD check. Only ${ALLOWED_CHECK_NOTES} are allowed"
       Check-Output $False

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -317,8 +317,8 @@ lgb.cv <- function(params = list()
       # set up training set
       indexDT <- data.table::data.table(
         indices = train_indices
-        , weight = getinfo(data = data, name = "weight")[train_indices]
-        , init_score = getinfo(data = data, name = "init_score")[train_indices]
+        , weight = getinfo(dataset = data, name = "weight")[train_indices]
+        , init_score = getinfo(dataset = data, name = "init_score")[train_indices]
       )
       data.table::setorderv(x = indexDT, cols = "indices", order = 1L)
       dtrain <- slice(data, indexDT$indices)


### PR DESCRIPTION
This PR fixes #3629 , and fixes the R package CI to be sure that similar issues don't arise in the future.

Also fixes #3616

For CI, I'm proposing that instead of having a limit on the NUMBER of R CMD CHECK NOTES, we just ignore very specific NOTEs that we know are not problematic for CRAN. I think that will be less susceptible to issues like #3629 and give us more confidence that CI is catching problems that would be caught by CRAN.

This is blocking release 3.1.1 (#3611)