### PR TITLE
[docs] added daal4py to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Treelite (model compiler for efficient deployment): https://github.com/dmlc/tree
 
 cuML Forest Inference Library (GPU-accelerated inference): https://github.com/rapidsai/cuml
 
+daal4py (Intel CPU-accelerated inference): https://github.com/IntelPython/daal4py
+
 m2cgen (model appliers for various languages): https://github.com/BayesWitnesses/m2cgen
 
 leaves (Go model applier): https://github.com/dmitryikh/leaves


### PR DESCRIPTION
Found it from here: https://medium.com/intel-analytics-software/improving-the-performance-of-xgboost-and-lightgbm-inference-3b542c03447e.