### PR TITLE
[docs] fix RTD builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -239,7 +239,7 @@ def generate_r_docs(app):
         -c conda-forge \
         -n r_env \
             cmake=3.18.2=ha30ef3c_0 \
-            r-base=4.0.3=hc603457_2 \
+            r-base=4.0.3=ha43b4e8_3 \
             r-data.table=1.13.2=r40h0eb13af_0 \
             r-jsonlite=1.7.1=r40hcdcec82_0 \
             r-matrix=1.2_18=r40h7fa42b6_3 \


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25141164/101907191-42cc0980-3bcb-11eb-96ba-882d2802af46.png)


```
Collecting package metadata: ...working... done
Solving environment: ...working... failed


PackagesNotFoundError: The following packages are not available from current channels:

  - r-base==4.0.3=hc603457_2

Current channels:

  - https://conda.anaconda.org/conda-forge/linux-64
  - https://conda.anaconda.org/conda-forge/noarch
  - https://repo.anaconda.com/pkgs/main/linux-64
  - https://repo.anaconda.com/pkgs/main/noarch
  - https://repo.anaconda.com/pkgs/free/linux-64
  - https://repo.anaconda.com/pkgs/free/noarch
  - https://repo.anaconda.com/pkgs/r/linux-64
  - https://repo.anaconda.com/pkgs/r/noarch

To search for alternate channels that may provide the conda package you're
looking for, navigate to

    https://anaconda.org

and use the search bar at the top of the page.


Could not find conda environment: r_env
You can list all discoverable environments with `conda info --envs`.
```