### PR TITLE
[python] add average precision into higher_better eval

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3292,7 +3292,7 @@ class Booster:
                 self.__name_inner_eval = \
                     [string_buffers[i].value.decode('utf-8') for i in range(self.__num_inner_eval)]
                 self.__higher_better_inner_eval = \
-                    [name.startswith(('auc', 'ndcg@', 'map@')) for name in self.__name_inner_eval]
+                    [name.startswith(('auc', 'ndcg@', 'map@', 'average_precision')) for name in self.__name_inner_eval]
 
     def attr(self, key):
         """Get attribute string from the Booster.


### PR DESCRIPTION
as mentioned in https://github.com/microsoft/LightGBM/issues/3648

the average precision metric is a higher and better metric as auc
and we need to add back the rule in __higher_better_inner_eval