### PR TITLE
[docs] fix R documentation builds (fixes #3655)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -248,8 +248,9 @@ def generate_r_docs(app):
     source /home/docs/.conda/bin/activate r_env
     export TAR=/bin/tar
     cd {0}
+    git submodule update --init --recursive
     export R_LIBS="$CONDA_PREFIX/lib/R/library"
-    Rscript build_r.R
+    Rscript build_r.R || exit 1
     cd {1}
     Rscript -e "roxygen2::roxygenize(load = 'installed')"
     Rscript -e "pkgdown::build_site( \


### PR DESCRIPTION
This PR attempts to fix the broken R documentation (see #3655). Building the docs requires installing the R package. Now that #3405 has been merged, LightGBM's submodules have to be initialized for the package to be built successfully, and I think they were not on readthedocs builds.

latest build: https://readthedocs.org/projects/lightgbm/builds/12567523/

```text
* checking for LF line-endings in source and make files and shell scripts
* checking for empty or unneeded directories
WARNING: directory ‘lightgbm/src/external_libs/fast_double_parser’ is empty
WARNING: directory ‘lightgbm/src/external_libs/fmt’ is empty
```

and then later

```text
* installing to library ‘/home/docs/.conda/envs/r_env/lib/R/library’
* installing *source* package ‘lightgbm’ ...
** using staged installation
** libs
installing via 'install.libs.R' to /home/docs/.conda/envs/r_env/lib/R/library/00LOCK-lightgbm/00new/lightgbm
Building lib_lightgbm
In file included from /tmp/Rtmp4mfEea/R.INSTALL30a33e035de/lightgbm/src/include/LightGBM/config.h:16,
                 from /tmp/Rtmp4mfEea/R.INSTALL30a33e035de/lightgbm/src/include/LightGBM/boosting.h:8,
                 from /tmp/Rtmp4mfEea/R.INSTALL30a33e035de/lightgbm/src/src/boosting/boosting.cpp:5:
/tmp/Rtmp4mfEea/R.INSTALL30a33e035de/lightgbm/src/include/LightGBM/utils/common.h:35:10: fatal error: ../../../external_libs/fmt/include/fmt/format.h: No such file or directory
   35 | #include "../../../external_libs/fmt/include/fmt/format.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Notes for Reviewers

@StrikerRUS could you please enable readthedocs builds for this branch?