### PR TITLE
[docs] add link to ML Flow and treesnip in LightGBM docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Ruby gem: https://github.com/ankane/lightgbm
 
 LightGBM4j (Java high-level binding): https://github.com/metarank/lightgbm4j
 
-ML Flow (experiment tracking, model monitoring framework): https://mlflow.org/docs/latest/models.html#lightgbm-lightgbm
+ML Flow (experiment tracking, model monitoring framework): https://github.com/mlflow/mlflow
 
 Support
 -------

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Ruby gem: https://github.com/ankane/lightgbm
 
 LightGBM4j (Java high-level binding): https://github.com/metarank/lightgbm4j
 
+ML Flow (experiment tracking, model monitoring framework): https://mlflow.org/docs/latest/models.html#lightgbm-lightgbm
+
 Support
 -------
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ LightGBM4j (Java high-level binding): https://github.com/metarank/lightgbm4j
 
 ML Flow (experiment tracking, model monitoring framework): https://github.com/mlflow/mlflow
 
+`{treesnip}` (R `{parsnip}`-compliant interface): https://github.com/curso-r/treesnip
+
 Support
 -------
 


### PR DESCRIPTION
This PR adds a link to the LightGBM integration with [ML Flow](https://mlflow.org/docs/latest/index.html). If you're curious, you can see more details on the individual methods at https://mlflow.org/docs/latest/python_api/mlflow.lightgbm.html#module-mlflow.lightgbm.