### PR TITLE
[docs] fix MLflow spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Ruby gem: https://github.com/ankane/lightgbm
 
 LightGBM4j (Java high-level binding): https://github.com/metarank/lightgbm4j
 
-ML Flow (experiment tracking, model monitoring framework): https://github.com/mlflow/mlflow
+MLflow (experiment tracking, model monitoring framework): https://github.com/mlflow/mlflow
 
 `{treesnip}` (R `{parsnip}`-compliant interface): https://github.com/curso-r/treesnip
 


### PR DESCRIPTION
In the official docs name of this package is written as `MLflow` (without a whitespace). I think it is like someone call `LightGBM` as `Light GBM`. And it improves searchability.