### PR TITLE
Added static cast from double to float

### DIFF
--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -340,7 +340,7 @@ class Dataset {
         if (has_raw_) {
           int feat_ind = numeric_feature_map_[feature_idx];
           if (feat_ind >= 0) {
-            raw_data_[feat_ind][row_idx] = feature_values[i];
+            raw_data_[feat_ind][row_idx] = static_cast<float>(feature_values[i]);
           }
         }
       }


### PR DESCRIPTION
Closes #3677 
Compile warnings have been fixed, `double` and `float` types where having issues when `double` values were assigned to a `float` type vector. In this case, the solution was just using a `static_cast<float>(doubleVal)` construction, which would lower the `double` value precission in order to fill the target `float` space.

There is to say that there could be a data loss during this process (not anything different than before), so it should be studied if `double` is the desired type for the `features_values` vector or it should be `float` type.

It would be desirable to use `.at()` instead of `[]` in order to throw exceptions when incorrect array positions are consulted.