### PR TITLE
fix test_monotone_constraints often fails on MPI builds

### DIFF
--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -944,14 +944,14 @@ class FeatureHistogram {
         is_splittable_ = true;
         // better split point
         if (current_gain > best_gain) {
-        if (USE_MC) {
-          best_right_constraints = constraints->RightToBasicConstraint();
-          best_left_constraints = constraints->LeftToBasicConstraint();
-          if (best_right_constraints.min > best_right_constraints.max ||
-              best_left_constraints.min > best_left_constraints.max) {
-            continue;
+          if (USE_MC) {
+            best_right_constraints = constraints->RightToBasicConstraint();
+            best_left_constraints = constraints->LeftToBasicConstraint();
+            if (best_right_constraints.min > best_right_constraints.max ||
+                best_left_constraints.min > best_left_constraints.max) {
+              continue;
+            }
           }
-        }
           best_left_count = left_count;
           best_sum_left_gradient = sum_left_gradient;
           best_sum_left_hessian = sum_left_hessian;

--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -944,16 +944,20 @@ class FeatureHistogram {
         is_splittable_ = true;
         // better split point
         if (current_gain > best_gain) {
+        if (USE_MC) {
+          best_right_constraints = constraints->RightToBasicConstraint();
+          best_left_constraints = constraints->LeftToBasicConstraint();
+          if (best_right_constraints.min > best_right_constraints.max ||
+              best_left_constraints.min > best_left_constraints.max) {
+            continue;
+          }
+        }
           best_left_count = left_count;
           best_sum_left_gradient = sum_left_gradient;
           best_sum_left_hessian = sum_left_hessian;
           // left is <= threshold, right is > threshold.  so this is t-1
           best_threshold = static_cast<uint32_t>(t - 1 + offset);
           best_gain = current_gain;
-          if (USE_MC) {
-            best_right_constraints = constraints->RightToBasicConstraint();
-            best_left_constraints = constraints->LeftToBasicConstraint();
-          }
         }
       }
     } else {
@@ -1033,15 +1037,19 @@ class FeatureHistogram {
         is_splittable_ = true;
         // better split point
         if (current_gain > best_gain) {
+          if (USE_MC) {
+            best_right_constraints = constraints->RightToBasicConstraint();
+            best_left_constraints = constraints->LeftToBasicConstraint();
+            if (best_right_constraints.min > best_right_constraints.max ||
+                best_left_constraints.min > best_left_constraints.max) {
+              continue;
+            }
+          }
           best_left_count = left_count;
           best_sum_left_gradient = sum_left_gradient;
           best_sum_left_hessian = sum_left_hessian;
           best_threshold = static_cast<uint32_t>(t + offset);
           best_gain = current_gain;
-          if (USE_MC) {
-            best_right_constraints = constraints->RightToBasicConstraint();
-            best_left_constraints = constraints->LeftToBasicConstraint();
-          }
         }
       }
     }


### PR DESCRIPTION
This is a PR to fix issue #3621. The thing was I didn't take into account the case where different constraints on different thresholds would prevent a split from happening. So, very rarely, a bad split happened which made the test fail. In theory this could have broken the monotone constraints required by the end user, but it happens so rarely that I don't think the end users have really been impacted (if it happens on a single tree in a forest of 100 trees, it most likely won't show). In this PR I make sure that constraints are admissible for any split, and I think that should remove the bug @StrikerRUS reported. Let me know what you think.

As an example, the following piece of code was producing the error mentioned in #3621, but runs smoothly now.
```
import lightgbm as lgb
import numpy as np

def generate_trainset_for_monotone_constraints_tests(x3_to_category=True):
    number_of_dpoints = 3000
    x1_positively_correlated_with_y = np.random.random(size=number_of_dpoints)
    x2_negatively_correlated_with_y = np.random.random(size=number_of_dpoints)
    x3_negatively_correlated_with_y = np.random.random(size=number_of_dpoints)
    x = np.column_stack(
        (x1_positively_correlated_with_y,
         x2_negatively_correlated_with_y,
         categorize(x3_negatively_correlated_with_y) if x3_to_category else x3_negatively_correlated_with_y))

    zs = np.random.normal(loc=0.0, scale=0.01, size=number_of_dpoints)
    scales = 10. * (np.random.random(6) + 0.5)
    y = (scales[0] * x1_positively_correlated_with_y
         + np.sin(scales[1] * np.pi * x1_positively_correlated_with_y)
         - scales[2] * x2_negatively_correlated_with_y
         - np.cos(scales[3] * np.pi * x2_negatively_correlated_with_y)
         - scales[4] * x3_negatively_correlated_with_y
         - np.cos(scales[5] * np.pi * x3_negatively_correlated_with_y)
         + zs)
    categorical_features = []
    if x3_to_category:
        categorical_features = [2]
    trainset = lgb.Dataset(x, label=y, categorical_feature=categorical_features, free_raw_data=False)
    return trainset

test_with_categorical_variable = False
monotone_constraints_method = "advanced"

i = 1487
np.random.seed(i)
trainset = generate_trainset_for_monotone_constraints_tests(test_with_categorical_variable)
params = {
    'min_data': 20,
    'num_leaves': 19,
    "max_depth": 10,
    'monotone_constraints': [1, -1, 0],
    "monotone_constraints_method": monotone_constraints_method,
    "use_missing": False,
    "verbose": -999,
    "min_data_in_leaf": 1
}
constrained_model = lgb.train(params, trainset, num_boost_round=1)