### PR TITLE
[ci] remove unused CI checks, other small simplifications

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -43,13 +43,13 @@ else  # Linux
         chmod +x cmake.sh
         ./cmake.sh --prefix=/usr/local --exclude-subdir
     fi
-    if [[ $TRAVIS == "true" ]] || [[ $GITHUB_ACTIONS == "true" ]]; then
+    if [[ $SETUP_CONDA != "false" ]]; then
         wget -q -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
     fi
 fi
 
 if [[ "${TASK:0:9}" != "r-package" ]]; then
-    if [[ $TRAVIS == "true" ]] || [[ $OS_NAME == "macos" ]]; then
+    if [[ $SETUP_CONDA != "false" ]]; then
         sh conda.sh -b -p $CONDA
     fi
     conda config --set always_yes yes --set changeps1 no

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -18,7 +18,7 @@ source activate $CONDA_ENV
 
 cd $BUILD_DIRECTORY
 
-if [[ $TRAVIS == "true" ]] && [[ $TASK == "check-docs" ]]; then
+if [[ $TASK == "check-docs" ]]; then
     cd $BUILD_DIRECTORY/docs
     conda install -q -y -n $CONDA_ENV -c conda-forge doxygen
     pip install --user -r requirements.txt rstcheck git+git://github.com/linkchecker/linkchecker.git@b9390c9ef63f7e1e210b48bc7fe97f76e8d39501
@@ -41,7 +41,7 @@ if [[ $TRAVIS == "true" ]] && [[ $TASK == "check-docs" ]]; then
     exit 0
 fi
 
-if [[ $TRAVIS == "true" ]] && [[ $TASK == "lint" ]]; then
+if [[ $TASK == "lint" ]]; then
     conda install -q -y -n $CONDA_ENV \
         pycodestyle \
         pydocstyle \

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -8,6 +8,7 @@ trigger:
 pr:
 - master
 variables:
+  AZURE: 'true'
   PYTHON_VERSION: 3.8
   CONDA_ENV: test-env
 resources:
@@ -20,6 +21,7 @@ jobs:
 ###########################################
   variables:
     COMPILER: gcc
+    SETUP_CONDA: 'false'
   pool:
     vmImage: 'ubuntu-latest'
   container: ubuntu1404
@@ -46,7 +48,6 @@ jobs:
   - script: |
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
       echo "##vso[task.setvariable variable=OS_NAME]linux"
-      echo "##vso[task.setvariable variable=AZURE]true"
       echo "##vso[task.setvariable variable=LGB_VER]$(head -n 1 VERSION.txt)"
       echo "##vso[task.prependpath]$CONDA/bin"
       AMDAPPSDK_PATH=$BUILD_SOURCESDIRECTORY/AMDAPPSDK
@@ -86,7 +87,6 @@ jobs:
   - script: |
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
       echo "##vso[task.setvariable variable=OS_NAME]macos"
-      echo "##vso[task.setvariable variable=AZURE]true"
       echo "##vso[task.setvariable variable=LGB_VER]$(head -n 1 VERSION.txt)"
       CONDA=$AGENT_HOMEDIRECTORY/miniconda
       echo "##vso[task.setvariable variable=CONDA]$CONDA"
@@ -122,7 +122,6 @@ jobs:
   steps:
   - powershell: |
       Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-      Write-Host "##vso[task.setvariable variable=AZURE]true"
     displayName: 'Set Variables'
   - task: Cache@2
     inputs:


### PR DESCRIPTION
This PR proposes a few of the small changes from #3672, which I think should be non-controversial. Hopefully this will make that PR's diff smaller and make it easier to review.

* removes `[[ $TRAVIS == "true" ]]` checks on `check-docs` and `lint` tasks
    - the fact that we happen to currently run those tasks on Travis doesn't need to be guarded in the code
* sets `AZURE=true` as a global variable in Azure DevOps config, reducing duplication
* changes the condition `if [[ $TRAVIS == "true" ]] || [[ $GITHUB_ACTIONS == "true" ]]` to simply `if [[ $SETUP_CONDA != "false" ]];`
     - this condition was capturing "Linux jobs on Azure run in a container that already has conda, and all other jobs need to set it up". I think it's more explicit and less error-prone to just have `setup.sh` install conda by default, and allow turning that off with a variable `SETUP_CONDA`