### PR TITLE
[docs] add doc on min_data_in_leaf approximation (fixes #3634)

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -282,7 +282,7 @@ Learning Control Parameters
 
    -  minimal number of data in one leaf. Can be used to deal with over-fitting
 
-   -  **Note**: this is an approximation based on the hessian, so occasionally you may observe splits which produce leaf nodes that have less than this many observations
+   -  **Note**: this is an approximation based on the Hessian, so occasionally you may observe splits which produce leaf nodes that have less than this many observations
 
 -  ``min_sum_hessian_in_leaf`` :raw-html:`<a id="min_sum_hessian_in_leaf" title="Permalink to this parameter" href="#min_sum_hessian_in_leaf">&#x1F517;&#xFE0E;</a>`, default = ``1e-3``, type = double, aliases: ``min_sum_hessian_per_leaf``, ``min_sum_hessian``, ``min_hessian``, ``min_child_weight``, constraints: ``min_sum_hessian_in_leaf >= 0.0``
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -282,6 +282,8 @@ Learning Control Parameters
 
    -  minimal number of data in one leaf. Can be used to deal with over-fitting
 
+   -  **Note**: this is an approximation based on the hessian, so occasionally you may observe splits which produce leaf nodes that have less than this many observations
+
 -  ``min_sum_hessian_in_leaf`` :raw-html:`<a id="min_sum_hessian_in_leaf" title="Permalink to this parameter" href="#min_sum_hessian_in_leaf">&#x1F517;&#xFE0E;</a>`, default = ``1e-3``, type = double, aliases: ``min_sum_hessian_per_leaf``, ``min_sum_hessian``, ``min_hessian``, ``min_child_weight``, constraints: ``min_sum_hessian_in_leaf >= 0.0``
 
    -  minimal sum hessian in one leaf. Like ``min_data_in_leaf``, it can be used to deal with over-fitting

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -273,7 +273,7 @@ struct Config {
   // alias = min_data_per_leaf, min_data, min_child_samples
   // check = >=0
   // desc = minimal number of data in one leaf. Can be used to deal with over-fitting
-  // desc = **Note**: this is an approximation based on the hessian, so occasionally you may observe splits which produce leaf nodes that have less than this many observations
+  // desc = **Note**: this is an approximation based on the Hessian, so occasionally you may observe splits which produce leaf nodes that have less than this many observations
   int min_data_in_leaf = 20;
 
   // alias = min_sum_hessian_per_leaf, min_sum_hessian, min_hessian, min_child_weight

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -273,6 +273,7 @@ struct Config {
   // alias = min_data_per_leaf, min_data, min_child_samples
   // check = >=0
   // desc = minimal number of data in one leaf. Can be used to deal with over-fitting
+  // desc = **Note**: this is an approximation based on the hessian, so occasionally you may observe splits which produce leaf nodes that have less than this many observations
   int min_data_in_leaf = 20;
 
   // alias = min_sum_hessian_per_leaf, min_sum_hessian, min_hessian, min_child_weight


### PR DESCRIPTION
This proposes a change to the `min_data_in_leaf` docs, explaining that splits can produced leaf nodes with smaller counts, per the discussion in #3634.