### PR TITLE
[ci] fix deprecated 'brew cask install' call

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -59,7 +59,6 @@ if [[ $OS_NAME == "linux" ]]; then
             qpdf \
             || exit -1
 
-    
     if [[ $R_BUILD_TYPE == "cran" ]]; then
         sudo apt-get install \
             --no-install-recommends \
@@ -77,7 +76,7 @@ if [[ $OS_NAME == "macos" ]]; then
     brew install \
         checkbashisms \
         qpdf
-    brew cask install basictex
+    brew install --cask basictex
     export PATH="/Library/TeX/texbin:$PATH"
     sudo tlmgr --verify-repo=none update --self
     sudo tlmgr --verify-repo=none install inconsolata helvetic


### PR DESCRIPTION
Noticed this warning in R CI jobs on Mac (for example https://github.com/microsoft/LightGBM/runs/1620012053).

> Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.

This PR changes the one use of `brew cask install` to `brew install --cask` so that warning does not become an error whenever `brew cask install` is formally removed. It also removes some leftover horizontal whitespace in CI scripts.