### PR TITLE
Fix bug in corner case with histogram bin mismatch

### DIFF
--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -542,18 +542,11 @@ MultiValBin* Dataset::GetMultiBinFromAllFeatures(const std::vector<uint32_t>& of
     }
   }
   sum_dense_ratio /= ncol;
-  const int offset = (1.0f - sum_dense_ratio) >=
-    MultiValBin::multi_val_bin_sparse_threshold ? 1 : 0;
-  int num_total_bin = offset;
   for (int gid = 0; gid < num_groups_; ++gid) {
     if (feature_groups_[gid]->is_multi_val_) {
       for (int fid = 0; fid < feature_groups_[gid]->num_feature_; ++fid) {
         const auto& bin_mapper = feature_groups_[gid]->bin_mappers_[fid];
         most_freq_bins.push_back(bin_mapper->GetMostFreqBin());
-        num_total_bin += bin_mapper->num_bin();
-        if (most_freq_bins.back() == 0) {
-          num_total_bin -= offset;
-        }
 #pragma omp parallel for schedule(static, 1)
         for (int tid = 0; tid < num_threads; ++tid) {
           iters[tid].emplace_back(
@@ -562,7 +555,6 @@ MultiValBin* Dataset::GetMultiBinFromAllFeatures(const std::vector<uint32_t>& of
       }
     } else {
       most_freq_bins.push_back(0);
-      num_total_bin += feature_groups_[gid]->bin_offsets_.back() - offset;
       for (int tid = 0; tid < num_threads; ++tid) {
         iters[tid].emplace_back(feature_groups_[gid]->FeatureGroupIterator());
       }
@@ -572,7 +564,7 @@ MultiValBin* Dataset::GetMultiBinFromAllFeatures(const std::vector<uint32_t>& of
   Log::Debug("Dataset::GetMultiBinFromAllFeatures: sparse rate %f",
              1.0 - sum_dense_ratio);
   ret.reset(MultiValBin::CreateMultiValBin(
-      num_data_, num_total_bin, static_cast<int>(most_freq_bins.size()),
+      num_data_, offsets.back(), static_cast<int>(most_freq_bins.size()),
       1.0 - sum_dense_ratio, offsets));
   PushDataToMultiValBin(num_data_, most_freq_bins, offsets, &iters, ret.get());
   ret->FinishLoad();

--- a/src/io/train_share_states.cpp
+++ b/src/io/train_share_states.cpp
@@ -176,6 +176,9 @@ void MultiValBinWrapper::CopyMultiValBinSubset(
       if (feature_groups[i]->is_multi_val_) {
         for (int j = 0; j < feature_groups[i]->num_feature_; ++j) {
           const auto& bin_mapper = feature_groups[i]->bin_mappers_[j];
+          if (i == 0 && j == 0 && bin_mapper->GetMostFreqBin() > 0) {
+            num_total_bin = 1;
+          }
           int cur_num_bin = bin_mapper->num_bin();
           if (bin_mapper->GetMostFreqBin() == 0) {
             cur_num_bin -= offset;


### PR DESCRIPTION
This is to fix corner case bug due to histogram bin mismatch, which is introduced by a previous PR #3522. An error can occur when all the following conditions are satisfied
1. Row-wise histogram construction is used or feature subsampling is used.
2. The first feature group is a multi-value feature group.
3. The first group needs an extra padding bin.
