### PR TITLE
[docs] Remove Gitter and Slack (fixes #3689)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Light Gradient Boosting Machine
 [![Python Versions](https://img.shields.io/pypi/pyversions/lightgbm.svg?logo=python&logoColor=white)](https://pypi.org/project/lightgbm)
 [![PyPI Version](https://img.shields.io/pypi/v/lightgbm.svg?logo=pypi&logoColor=white)](https://pypi.org/project/lightgbm)
 [![CRAN Version](https://www.r-pkg.org/badges/version/lightgbm)](https://cran.r-project.org/package=lightgbm)
-[![Join Gitter at https://gitter.im/Microsoft/LightGBM](https://badges.gitter.im/Microsoft/LightGBM.svg)](https://gitter.im/Microsoft/LightGBM?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Slack](https://lightgbm-slack-autojoin.herokuapp.com/badge.svg)](https://lightgbm-slack-autojoin.herokuapp.com)
 
 LightGBM is a gradient boosting framework that uses tree based learning algorithms. It is designed to be distributed and efficient with the following advantages:
 
@@ -104,9 +102,6 @@ Support
 -------
 
 - Ask a question [on Stack Overflow with the `lightgbm` tag](https://stackoverflow.com/questions/ask?tags=lightgbm), we monitor this for new questions.
-- Discuss on the [LightGBM Gitter](https://gitter.im/Microsoft/LightGBM).
-- Discuss on the [LightGBM Slack team](https://lightgbm.slack.com).
-  - Use [this invite link](https://lightgbm-slack-autojoin.herokuapp.com/) to join the team.
 - Open **bug reports** and **feature requests** (not questions) on [GitHub issues](https://github.com/microsoft/LightGBM/issues).
 
 How to Contribute


### PR DESCRIPTION
This PR closes #3689. It removes references to Gitter and Slack.

I hope this will strengthen the LightGBM community by consolidating the conversation. As of this PR, the official advice in the README will be that general questions about LightGBM should go to the `lightgbm` tag on Stack Overflow, and bugs + feature requests should go on the GitHub Issues page here.