### PR TITLE
[python][tests] small Python tests cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,7 +423,7 @@ lightgbm.Rcheck/
 miktex*.zip
 *.def
 
-# Files created by R examples and tests
+# Files created by R and Python examples and tests
 **/lgb-Dataset.data
 **/lgb.Dataset.data
 **/model.txt

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -126,8 +126,8 @@ class TestBasic(unittest.TestCase):
         est_2 = lgb.train(params, train_data_2, num_boost_round=10)
         pred_2 = est_2.predict(X_train)
         np.testing.assert_allclose(pred_1, pred_2)
-        est_2.save_model('temp_model.txt')
-        est_3 = lgb.Booster(model_file='temp_model.txt')
+        est_2.save_model('model.txt')
+        est_3 = lgb.Booster(model_file='model.txt')
         pred_3 = est_3.predict(X_train)
         np.testing.assert_allclose(pred_2, pred_3)
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2612,7 +2612,8 @@ class TestEngine(unittest.TestCase):
 
     def test_reset_params_works_with_metric_num_class_and_boosting(self):
         X, y = load_breast_cancer(return_X_y=True)
-        params = {
+        dataset_params = {"max_bin": 150}
+        booster_params = {
             'objective': 'multiclass',
             'max_depth': 4,
             'bagging_fraction': 0.8,
@@ -2620,26 +2621,18 @@ class TestEngine(unittest.TestCase):
             'boosting': 'gbdt',
             'num_class': 5
         }
-        dtrain = lgb.Dataset(X, y, params={"max_bin": 150})
-
+        dtrain = lgb.Dataset(X, y, params=dataset_params)
         bst = lgb.Booster(
-            params=params,
+            params=booster_params,
             train_set=dtrain
         )
-        expected_params = {
-            'objective': 'multiclass',
-            'max_depth': 4,
-            'bagging_fraction': 0.8,
-            'metric': ['multi_logloss', 'multi_error'],
-            'boosting': 'gbdt',
-            'num_class': 5,
-            'max_bin': 150
-        }
-        assert bst.params == expected_params
 
-        params['bagging_fraction'] = 0.9
-        ret_bst = bst.reset_parameter(params)
+        expected_params = dict(dataset_params, **booster_params)
+        self.assertDictEqual(bst.params, expected_params)
 
-        expected_params['bagging_fraction'] = 0.9
-        assert bst.params == expected_params
-        assert ret_bst.params == expected_params
+        booster_params['bagging_fraction'] += 0.1
+        new_bst = bst.reset_parameter(booster_params)
+
+        expected_params = dict(dataset_params, **booster_params)
+        self.assertDictEqual(bst.params, expected_params)
+        self.assertDictEqual(new_bst.params, expected_params)


### PR DESCRIPTION
- Rename temp model file to not overcomplicate `.gitignore`.
- Reduce code duplication in params definition.
- Use asserts from `unittest` module for consistency with the rest codebase.