### PR TITLE
Fix bug in ExtractFeaturesFromMemory when predidct_fun_ is used

### DIFF
--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -1205,7 +1205,7 @@ void DatasetLoader::ExtractFeaturesFromMemory(std::vector<std::string>* text_dat
       // set label
       dataset->metadata_.SetLabelAt(i, static_cast<label_t>(tmp_label));
       // free processed line:
-      text_data[i].clear();
+      ref_text_data[i].clear();
       // shrink_to_fit will be very slow in linux, and seems not free memory, disable for now
       // text_reader_->Lines()[i].shrink_to_fit();
       // push data


### PR DESCRIPTION
This is to fix #3657. In line 1208 of `dataset_loader.cpp`, it should use `ref_text_data` instead of `text_data`.