### PR TITLE
[docs] [R-package] improve R-package docs on testing

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -207,7 +207,7 @@ Please visit [demo](https://github.com/microsoft/LightGBM/tree/master/R-package/
 Testing
 -------
 
-The R package's unit tests are run automatically on every commit, via integrations like [Travis CI](https://travis-ci.org/microsoft/LightGBM/) and [Azure DevOps](https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build). Adding new tests in `R-package/tests/testthat` is a valuable way to improve the reliability of the R package.
+The R package's unit tests are run automatically on every commit, via integrations like [GitHub Actions](https://github.com/microsoft/LightGBM/actions). Adding new tests in `R-package/tests/testthat` is a valuable way to improve the reliability of the R package.
 
 When adding tests, you may want to use test coverage to identify untested areas and to check if the tests you've added are covering all branches of the intended code.
 
@@ -215,13 +215,11 @@ The example below shows how to generate code coverage for the R package on a mac
 
 ```shell
 # Install
-export CXX=/usr/local/bin/g++-8
-export CC=/usr/local/bin/gcc-8
-Rscript build_r.R --skip-install
+sh build-cran-package.sh
 
 # Get coverage
 Rscript -e " \
-    coverage  <- covr::package_coverage('./lightgbm_r', quiet=FALSE);
+    coverage  <- covr::package_coverage('./lightgbm_r', type = 'tests', quiet = FALSE);
     print(coverage);
     covr::report(coverage, file = file.path(getwd(), 'coverage.html'), browse = TRUE);
     "


### PR DESCRIPTION
This PR proposes some small improvements to the R package README.

* note that R package tests are run on GitHub Actions (not Travis)
* change instructions for getting package coverage to use source builds of the CRAN package
    - for someone checking test coverage, I think using the more-likely-to-work installation method is a lot more important than using the cmake-based method that produces a more efficient lib_lightgbm
* change test coverage script to only care about tests (not examples or vignettes)