### PR TITLE
[ci] remove maxParallel limits on Azure DevOps

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -26,7 +26,6 @@ jobs:
     vmImage: 'ubuntu-latest'
   container: ubuntu1404
   strategy:
-    maxParallel: 6
     matrix:
       regular:
         TASK: regular
@@ -74,7 +73,6 @@ jobs:
   pool:
     vmImage: 'macOS-10.14'
   strategy:
-    maxParallel: 3
     matrix:
       regular:
         TASK: regular
@@ -110,7 +108,6 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   strategy:
-    maxParallel: 3
     matrix:
       regular:
         TASK: regular


### PR DESCRIPTION
Trying to take the non-controversial changes off of #3672 to make that PR smaller, and to get some changes onto `master` without needing to wait on that PR.

This PR is based on https://github.com/microsoft/LightGBM/pull/3672#issuecomment-751888860

> Could you please remove all occurrences of the maxParallel param to give Azure full control under the jobs' queue?

Per https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#job, `maxParallel` in an Azure DevOps pipeline config controls the maximum number of jobs to try to run simultaneously. This limit might be useful if you have some autoscaling set up or if you had some reason to want to slow down, but for our purposes it would be better to just let the default limits work and try to max out the utilization of the Microsoft-hosted runners.

This change shouldn't change anything about our current CI, since we already set `maxParallel` exactly equal to the number of matrix jobs. But it means that in the future when we add / remove Azure jobs, this will be one less thing that has to be changed.