### PR TITLE
[ci] Move check-docs and lint jobs off Travis

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -48,7 +48,7 @@ else  # Linux
     fi
 fi
 
-if [[ "${TASK:0:9}" != "r-package" ]]; then
+if [[ "${TASK}" != "r-package" ]]; then
     if [[ $SETUP_CONDA != "false" ]]; then
         sh conda.sh -b -p $CONDA
     fi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -8,7 +8,7 @@ elif [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "clang" ]]; then
     export CC=clang
 fi
 
-if [[ "${TASK:0:9}" == "r-package" ]]; then
+if [[ "${TASK}" == "r-package" ]]; then
     bash ${BUILD_DIRECTORY}/.ci/test_r_package.sh || exit -1
     exit 0
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -105,24 +105,6 @@ if [[ $OS_NAME == "macos" ]]; then
 fi
 Rscript --vanilla -e "install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
 
-if [[ $TASK == "r-package-check-docs" ]]; then
-    Rscript build_r.R || exit -1
-    Rscript --vanilla -e "install.packages('roxygen2', repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
-    Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit -1
-    num_doc_files_changed=$(
-        git diff --name-only | grep --count -E "\.Rd|NAMESPACE"
-    )
-    if [[ ${num_doc_files_changed} -gt 0 ]]; then
-        echo "Some R documentation files have changed. Please re-generate them and commit those changes."
-        echo ""
-        echo "    Rscript build_r.R"
-        echo "    Rscript -e \"roxygen2::roxygenize('R-package/', load = 'installed')\""
-        echo ""
-        exit -1
-    fi
-    exit 0
-fi
-
 cd ${BUILD_DIRECTORY}
 
 PKG_TARBALL="lightgbm_*.tar.gz"

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -40,11 +40,6 @@ jobs:
             compiler: clang
             r_version: 4.0
             build_type: cmake
-          - os: ubuntu-latest
-            task: r-package-check-docs
-            compiler: gcc
-            r_version: 4.0
-            build_type: cmake
           - os: macOS-latest
             task: r-package
             compiler: gcc

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -1,4 +1,4 @@
-name: R GitHub Actions
+name: R-package
 
 on:
   push:

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -68,12 +68,6 @@ jobs:
           - os: windows-latest
             task: r-package
             compiler: MINGW
-            toolchain: MINGW
-            r_version: 3.6
-            build_type: cmake
-          - os: windows-latest
-            task: r-package
-            compiler: MINGW
             toolchain: MSYS
             r_version: 4.0
             build_type: cmake

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -63,17 +63,18 @@ jobs:
       - name: Test documentation
         shell: bash
         run: |
-          Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit -1
+          Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit 100
           num_doc_files_changed=$(
               git diff --name-only | grep --count -E "\.Rd|NAMESPACE"
           )
           if [[ ${num_doc_files_changed} -gt 0 ]]; then
               echo "Some R documentation files have changed. Please re-generate them and commit those changes."
               echo ""
-              echo "    Rscript build_r.R"
+              echo "    sh build-cran-package.sh"
+              echo "    R CMD INSTALL --with-keep.source lightgbm_*.tar.gz"
               echo "    Rscript -e \"roxygen2::roxygenize('R-package/', load = 'installed')\""
               echo ""
-              exit -1
+              exit 101
           fi
   all-successful:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -11,8 +11,10 @@ on:
     - master
 
 env:
+  COMPILER: 'gcc'
   CONDA_ENV: test-env
   GITHUB_ACTIONS: 'true'
+  OS_NAME: 'linux'
   PYTHON_VERSION: 3.8
 
 jobs:
@@ -36,8 +38,6 @@ jobs:
         shell: bash
         run: |
           export TASK="${{ matrix.task }}"
-          export OS_NAME="linux"
-          export COMPILER="gcc"
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           export CONDA=${HOME}/miniconda
           export PATH=${CONDA}/bin:$HOME/.local/bin:${PATH}

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -61,7 +61,7 @@ jobs:
           sh build-cran-package.sh || exit -1
           R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit -1
       - name: Test documentation
-        shell: bash --noprofile --norc -e {0}
+        shell: bash --noprofile --norc {0}
         run: |
           Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit 100
           num_doc_files_changed=$(

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           Rscript --vanilla -e "install.packages(c('R6', 'data.table', 'jsonlite', 'roxygen2', 'testthat'), repos = 'https://cran.r-project.org')"
           sh build-cran-package.sh || exit -1
-          R CMD INSTALL lightgbm_*.tar.gz || exit -1
+          R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit -1
       - name: Test documentation
         shell: bash
         run: |

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,5 +1,5 @@
-# contains tests that can run without compiling LightGBM, like
-# linters and documentation checks.
+# contains non-functional tests, like checks on docs
+# and code style
 name: Static Analysis
 
 on:
@@ -45,7 +45,7 @@ jobs:
           $GITHUB_WORKSPACE/.ci/test.sh || exit -1
   r-check-docs:
     name: r-package-check-docs
-    timeout-minutes: 120
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     container: rocker/verse
     steps:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,0 +1,52 @@
+# contains tests that can run without compiling LightGBM, like
+# linters and documentation checks.
+name: Static Analysis
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+env:
+  CONDA_ENV: test-env
+  GITHUB_ACTIONS: 'true'
+  PYTHON_VERSION: 3.8
+
+jobs:
+  test:
+    name: ${{ matrix.task }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: lint
+          - task: check-docs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 5
+          submodules: true
+      - name: Setup and run tests
+        shell: bash
+        run: |
+          export TASK="${{ matrix.task }}"
+          export OS_NAME="linux"
+          export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
+          export LGB_VER=$(head -n 1 VERSION.txt)
+          export CONDA=${HOME}/miniconda
+          export PATH=${CONDA}/bin:$HOME/.local/bin:${PATH}
+          $GITHUB_WORKSPACE/.ci/setup.sh
+          $GITHUB_WORKSPACE/.ci/test.sh
+  all-successful:
+    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+    - name: Note that all tests succeeded
+      run: echo "🎉"

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -57,11 +57,11 @@ jobs:
       - name: Install packages
         shell: bash
         run: |
-          Rscript --vanilla -e "install.packages(c('R6', 'data.table', 'jsonlite', 'roxygen2', 'testthat'), repos = 'https://cran.r-project.org')"
+          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'roxygen2', 'testthat'), repos = 'https://cran.r-project.org')"
           sh build-cran-package.sh || exit -1
           R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit -1
       - name: Test documentation
-        shell: bash
+        shell: bash --noprofile --norc -e {0}
         run: |
           Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit 100
           num_doc_files_changed=$(

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -43,10 +43,42 @@ jobs:
           export PATH=${CONDA}/bin:$HOME/.local/bin:${PATH}
           $GITHUB_WORKSPACE/.ci/setup.sh || exit -1
           $GITHUB_WORKSPACE/.ci/test.sh || exit -1
+  r-check-docs:
+    name: r-package-check-docs
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    container: rocker/verse
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 5
+          submodules: true
+      - name: Install packages
+        shell: bash
+        run: |
+          Rscript --vanilla -e "install.packages(c('R6', 'data.table', 'jsonlite', 'roxygen2', 'testthat'), repos = 'https://cran.r-project.org')"
+          sh build-cran-package.sh || exit -1
+          R CMD INSTALL lightgbm_*.tar.gz || exit -1
+      - name: Test documentation
+        shell: bash
+        run: |
+          Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit -1
+          num_doc_files_changed=$(
+              git diff --name-only | grep --count -E "\.Rd|NAMESPACE"
+          )
+          if [[ ${num_doc_files_changed} -gt 0 ]]; then
+              echo "Some R documentation files have changed. Please re-generate them and commit those changes."
+              echo ""
+              echo "    Rscript build_r.R"
+              echo "    Rscript -e \"roxygen2::roxygenize('R-package/', load = 'installed')\""
+              echo ""
+              exit -1
+          fi
   all-successful:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test, r-check-docs]
     steps:
     - name: Note that all tests succeeded
       run: echo "🎉"

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           export TASK="${{ matrix.task }}"
           export OS_NAME="linux"
-          COMPILER="gcc"
+          export COMPILER="gcc"
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           export CONDA=${HOME}/miniconda
           export PATH=${CONDA}/bin:$HOME/.local/bin:${PATH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ env:
     - TASK=sdist
     - TASK=bdist
     - TASK=if-else
-    - TASK=lint
-    - TASK=check-docs
     - TASK=mpi METHOD=source
     - TASK=mpi METHOD=pip PYTHON_VERSION=3.7
     - TASK=mpi METHOD=wheel PYTHON_VERSION=3.7
@@ -37,10 +35,6 @@ matrix:
       env: TASK=gpu METHOD=pip PYTHON_VERSION=3.6
     - os: osx
       env: TASK=gpu METHOD=wheel PYTHON_VERSION=3.7
-    - os: osx
-      env: TASK=lint
-    - os: osx
-      env: TASK=check-docs
 
 before_install:
   - test -n $CC  && unset CC

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -26,7 +26,6 @@ jobs:
     vmImage: 'ubuntu-latest'
   container: ubuntu1404
   strategy:
-    maxParallel: 6
     matrix:
       regular:
         TASK: regular
@@ -74,7 +73,6 @@ jobs:
   pool:
     vmImage: 'macOS-10.14'
   strategy:
-    maxParallel: 3
     matrix:
       regular:
         TASK: regular
@@ -110,7 +108,6 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   strategy:
-    maxParallel: 3
     matrix:
       regular:
         TASK: regular

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Light Gradient Boosting Machine
 ===============================
 
-[![R-package Build Status](https://github.com/microsoft/LightGBM/workflows/R-package/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
+[![R-package GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/R-package/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
 [![Static Analysis GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/Static%20Analysis/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
 [![Azure Pipelines Build Status](https://lightgbm-ci.visualstudio.com/lightgbm-ci/_apis/build/status/Microsoft.LightGBM?branchName=master)](https://lightgbm-ci.visualstudio.com/lightgbm-ci/_build/latest?definitionId=1)
 [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/1ys5ot401m0fep6l/branch/master?svg=true)](https://ci.appveyor.com/project/guolinke/lightgbm/branch/master)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Light Gradient Boosting Machine
 ===============================
 
-[![GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/R%20GitHub%20Actions/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
+[![R GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/R%20GitHub%20Actions/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
+[![Static Analysis GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/Static%20Analysis/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
 [![Azure Pipelines Build Status](https://lightgbm-ci.visualstudio.com/lightgbm-ci/_apis/build/status/Microsoft.LightGBM?branchName=master)](https://lightgbm-ci.visualstudio.com/lightgbm-ci/_build/latest?definitionId=1)
 [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/1ys5ot401m0fep6l/branch/master?svg=true)](https://ci.appveyor.com/project/guolinke/lightgbm/branch/master)
 [![Travis Build Status](https://travis-ci.org/microsoft/LightGBM.svg?branch=master)](https://travis-ci.org/microsoft/LightGBM)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Light Gradient Boosting Machine
 ===============================
 
-[![R GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/R%20GitHub%20Actions/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
+[![R-package Build Status](https://github.com/microsoft/LightGBM/workflows/R-package/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
 [![Static Analysis GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/Static%20Analysis/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
 [![Azure Pipelines Build Status](https://lightgbm-ci.visualstudio.com/lightgbm-ci/_apis/build/status/Microsoft.LightGBM?branchName=master)](https://lightgbm-ci.visualstudio.com/lightgbm-ci/_build/latest?definitionId=1)
 [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/1ys5ot401m0fep6l/branch/master?svg=true)](https://ci.appveyor.com/project/guolinke/lightgbm/branch/master)


### PR DESCRIPTION
Because of #3519 , we're in the process of removing all CI jobs that run on Travis and moving them to GitHub Actions.

This PR moves `check-docs` and `lint` to GitHub Actions. I wanted to do this one by itself to make #3672 smaller. These two jobs are also the easiest to move.

This PR proposes putting `check-docs` and `lint` into a separate GitHub Actions workflow called "Static Analysis". Today, GitHub Actions does not allow you to re-run individual failed jobs. So if one job fails for random or temporary reasons, you have to re-run all jobs in the workflow. Since the `check-docs` tasks fails somewhat regularly due to temporary network problems, I think it is a good idea to keep it + `lint` separate, so that the cost of re-running it is low.

Thanks for reviewing all of these @StrikerRUS . I know it's a lot of PRs but hopefully the end result will be that our CI is more stable.