### PR TITLE
[docs][R-package] change obsolete wordings in R README

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -211,7 +211,7 @@ The R package's unit tests are run automatically on every commit, via integratio
 
 When adding tests, you may want to use test coverage to identify untested areas and to check if the tests you've added are covering all branches of the intended code.
 
-The example below shows how to generate code coverage for the R package on a macOS or Linux setup, using `gcc-8` to compile `LightGBM`. To adjust for your environment, swap out the 'Install' step with [the relevant code from the instructions above](#install).
+The example below shows how to generate code coverage for the R package on a macOS or Linux setup. To adjust for your environment, refer to [the customization step described above](#custom-installation-linux-mac).
 
 ```shell
 # Install


### PR DESCRIPTION
Sorry, noticed this inconsistency only after merging #3724.
Previous link led to the customization of installation with CMake.