### PR TITLE
[ci] run Azure linux tasks on self-hosted runner pool

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -22,8 +22,7 @@ jobs:
   variables:
     COMPILER: gcc
     SETUP_CONDA: 'false'
-  pool:
-    vmImage: 'ubuntu-latest'
+  pool: sh-ubuntu
   container: ubuntu1404
   strategy:
     matrix:


### PR DESCRIPTION
To help with #3519, @guolinke has created a pool of self-owned runners for CI jobs on Azure DevOps. https://github.com/microsoft/LightGBM/issues/3519#issuecomment-748589207

This PR proposes moving the linux jobs we currently run on Azure DevOps to that pool. This should have no effect on those jobs, since they are containerized and run in containers based on the image from https://github.com/guolinke/lightgbm-ci-docker.

Running on this pool should decrease our overall CI time. See some of the comments from https://github.com/microsoft/LightGBM/pull/3672#issuecomment-753727415. Azure allows us 10 concurrent builds across all operating systems for all jobs using microsoft-hosted runners. After this change, those 10 concurrent builds would only be used by Mac and Windows jobs.

## Notes from Reviewers

I think this PR needs approval from both @StrikerRUS and @guolinke . This will lead to 3 runs on the `sh-ubuntu` pool per commit pushed, and I want to be sure @guolinke is ok with whatever the cost implications of that is.