### PR TITLE
[ci][docs] replace file extensions in docs during Sphinx build

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -29,8 +29,6 @@ if [[ $TASK == "check-docs" ]]; then
     rstcheck --report warning --ignore-directives=autoclass,autofunction,doxygenfile `find . -type f -name "*.rst"` || exit -1
     # build docs and check them for broken links
     make html || exit -1
-    find ./_build/html/ -type f -name '*.html' -exec \
-    sed -i'.bak' -e 's;\(\.\/[^.]*\.\)rst\([^[:space:]]*\);\1html\2;g' {} \;  # emulate js function
     linkchecker --config=.linkcheckerrc ./_build/html/*.html || exit -1
     # check the consistency of parameters' descriptions and other stuff
     cp $BUILD_DIRECTORY/docs/Parameters.rst $BUILD_DIRECTORY/docs/Parameters-backup.rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-if: branch = sphinx
+if: branch = master
 
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-if: branch = master
+if: branch = sphinx
 
 language: cpp
 

--- a/docs/_static/js/script.js
+++ b/docs/_static/js/script.js
@@ -1,7 +1,4 @@
 $(function() {
-    /* Replace '.rst' with '.html' in all internal links like './[Something].rst[#anchor]' */
-    $('a[href^="./"][href*=".rst"]').attr('href', (i, val) => { return val.replace('.rst', '.html'); });
-
     /* Use wider container for the page content */
     $('.wy-nav-content').each(function() { this.style.setProperty('max-width', 'none', 'important'); });
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,12 +45,13 @@ for mod_name in MOCK_MODULES:
 
 
 class InternalRefTransform(Transform):
-    """Replaces '.rst' with '.html' in all internal links
-    like './[Something].rst[#anchor]'."""
+    """Replaces '.rst' with '.html' in all internal links like './[Something].rst[#anchor]'."""
 
     default_priority = 210
+    """Numerical priority of this transform, 0 through 999."""
 
     def apply(self, **kwargs):
+    """Apply the transform to the document tree."""
         for section in self.document.traverse(reference):
             if section.get("refuri") is not None:
                 section["refuri"] = INTERNAL_REF_REGEX.sub(r"\g<url>.html\g<anchor>", section["refuri"])

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ class InternalRefTransform(Transform):
     def apply(self, **kwargs):
         for section in self.document.traverse(reference):
             if section.get("refuri") is not None:
-                section["refuri"] = INTERNAL_REF_REGEX.sub("\g<url>.html\g<anchor>", section["refuri"])
+                section["refuri"] = INTERNAL_REF_REGEX.sub(r"\g<url>.html\g<anchor>", section["refuri"])
 
 
 class IgnoredDirective(Directive):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ class InternalRefTransform(Transform):
     """Numerical priority of this transform, 0 through 999."""
 
     def apply(self, **kwargs):
-    """Apply the transform to the document tree."""
+        """Apply the transform to the document tree."""
         for section in self.document.traverse(reference):
             if section.get("refuri") is not None:
                 section["refuri"] = INTERNAL_REF_REGEX.sub(r"\g<url>.html\g<anchor>", section["refuri"])


### PR DESCRIPTION
@jameslamb I remember you proposed this change some time ago. But I was against because was not bought of idea to rewrite all docs source files during the build process. Now I know that we can do it via internal Sphinx process which doesn't require rewriting files on a disk. Also, this approach safer than rewriting files because we are sure our regex is applied **only** to links in docs (`self.document.traverse(reference)`) not to the whole document.


Live demo: https://lightgbm.readthedocs.io/en/sphinx/