### PR TITLE
[ci] move Python Mac jobs from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -1,0 +1,73 @@
+name: Python-package
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+env:
+  CONDA_ENV: test-env
+  COMPILER: gcc
+  GITHUB_ACTIONS: 'true'
+  OS_NAME: 'macOS-latest'
+
+jobs:
+  test:
+    name: ${{ matrix.task }} (${{ matrix.os }}, ${{ matrix.compiler }}, Python ${{ matrix.python_version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      os: macOS-latest
+      fail-fast: false
+      matrix:
+        include:
+          - task: regular
+            python_version: 3.7
+          - task: sdist
+            python_version: 3.8
+          - task: bdist
+            python_version: 3.8
+          - task: if-else
+            python_version: 3.8
+          - task: mpi
+            method: source
+            python_version: 3.8
+          - task: mpi
+            method: pip
+            python_version: 3.7
+          - task: mpi
+            method: wheel
+            python_version: 3.7
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 5
+          submodules: true
+      - name: Setup and run tests
+        shell: bash
+        run: |
+          export TASK="${{ matrix.task }}"
+          export METHOD="${{ matrix.method }}"
+          export COMPILER="${{ matrix.compiler }}"
+          export PYTHON_VERSION="${{ matrix.python_version }}"
+          export AMDAPPSDK_PATH=$HOME/AMDAPPSDK
+          export LD_LIBRARY_PATH="$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH"
+          export LD_LIBRARY_PATH="/usr/local/clang/lib:$LD_LIBRARY_PATH"  # fix error "libomp.so: cannot open shared object file: No such file or directory" on Linux with Clang
+          export OPENCL_VENDOR_PATH=$AMDAPPSDK_PATH/etc/OpenCL/vendors
+          export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
+          export LGB_VER=$(head -n 1 VERSION.txt)
+          export CONDA=${HOME}/miniconda
+          export PATH=${CONDA}/bin:${PATH}
+          $GITHUB_WORKSPACE/.ci/setup.sh || exit -1
+          $GITHUB_WORKSPACE/.ci/test.sh || exit -1
+  all-successful:
+    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+    - name: Note that all tests succeeded
+      run: echo "🎉"

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -9,8 +9,8 @@ on:
     - master
 
 env:
-  CONDA_ENV: test-env
   COMPILER: gcc
+  CONDA_ENV: test-env
   GITHUB_ACTIONS: 'true'
   OS_NAME: 'macOS-latest'
 

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -59,10 +59,10 @@ jobs:
           export COMPILER="${{ matrix.compiler }}"
           export PYTHON_VERSION="${{ matrix.python_version }}"
           if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
-              export COMPILER="clang"
+              export COMPILER="gcc"
               export OS_NAME="macos"
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-              export COMPILER="gcc"
+              export COMPILER="clang"
               export OS_NAME="linux"
           fi
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -16,11 +16,10 @@ env:
 
 jobs:
   test:
-    name: ${{ matrix.task }} (${{ matrix.os }}, ${{ matrix.compiler }}, Python ${{ matrix.python_version }})
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }}, ${{ matrix.compiler }}, Python ${{ matrix.python_version }}
+    runs-on: macOS-latest
     timeout-minutes: 60
     strategy:
-      os: macOS-latest
       fail-fast: false
       matrix:
         include:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -59,10 +59,10 @@ jobs:
           export COMPILER="${{ matrix.compiler }}"
           export PYTHON_VERSION="${{ matrix.python_version }}"
           if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
-              export COMPILER="gcc"
+              export COMPILER="clang"
               export OS_NAME="macos"
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-              export COMPILER="clang"
+              export COMPILER="gcc"
               export OS_NAME="linux"
           fi
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -12,11 +12,11 @@ env:
   COMPILER: gcc
   CONDA_ENV: test-env
   GITHUB_ACTIONS: 'true'
-  OS_NAME: 'macOS-latest'
+  OS_NAME: 'macos'
 
 jobs:
   test:
-    name: macOS-latest, gcc, Python ${{ matrix.python_version }}
+    name: ${{ matrix.task }} (macOS-latest, gcc, Python ${{ matrix.python_version }})
     runs-on: macOS-latest
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   test:
-    name: ${{ matrix.task }} (${{ matrix.os }}, ${{ matrix.compiler }}, Python ${{ matrix.python_version }})
+    name: ${{ matrix.task }} ${{ matrix.method }} (${{ matrix.os }}, ${{ matrix.compiler }}, Python ${{ matrix.python_version }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -23,7 +23,7 @@ jobs:
         include:
           - os: macOS-latest
             task: regular
-            python_version: 3.7
+            python_version: 3.6
             compiler: gcc
           - os: macOS-latest
             task: sdist
@@ -45,7 +45,7 @@ jobs:
           - os: macOS-latest
             task: mpi
             method: pip
-            python_version: 3.7
+            python_version: 3.6
             compiler: gcc
           - os: macOS-latest
             task: mpi
@@ -70,10 +70,6 @@ jobs:
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
               export OS_NAME="linux"
           fi
-          export AMDAPPSDK_PATH=$HOME/AMDAPPSDK
-          export LD_LIBRARY_PATH="$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH"
-          export LD_LIBRARY_PATH="/usr/local/clang/lib:$LD_LIBRARY_PATH"  # fix error "libomp.so: cannot open shared object file: No such file or directory" on Linux with Clang
-          export OPENCL_VENDOR_PATH=$AMDAPPSDK_PATH/etc/OpenCL/vendors
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           export LGB_VER=$(head -n 1 VERSION.txt)
           export CONDA=${HOME}/miniconda

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   test:
-    name: ${{ matrix.os }}, ${{ matrix.compiler }}, Python ${{ matrix.python_version }}
+    name: macOS-latest, gcc, Python ${{ matrix.python_version }}
     runs-on: macOS-latest
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   test:
-    name: ${{ matrix.task }} ${{ matrix.method }} (${{ matrix.os }}, ${{ matrix.compiler }}, Python ${{ matrix.python_version }})
+    name: ${{ matrix.task }} ${{ matrix.method }} (${{ matrix.os }}, Python ${{ matrix.python_version }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -9,37 +9,49 @@ on:
     - master
 
 env:
-  COMPILER: gcc
   CONDA_ENV: test-env
   GITHUB_ACTIONS: 'true'
-  OS_NAME: 'macos'
 
 jobs:
   test:
-    name: ${{ matrix.task }} (macOS-latest, gcc, Python ${{ matrix.python_version }})
-    runs-on: macOS-latest
+    name: ${{ matrix.task }} (${{ matrix.os }}, ${{ matrix.compiler }}, Python ${{ matrix.python_version }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         include:
-          - task: regular
+          - os: macOS-latest
+            task: regular
             python_version: 3.7
-          - task: sdist
+            compiler: gcc
+          - os: macOS-latest
+            task: sdist
             python_version: 3.8
-          - task: bdist
+            compiler: gcc
+          - os: macOS-latest
+            task: bdist
             python_version: 3.8
-          - task: if-else
+            compiler: gcc
+          - os: macOS-latest
+            task: if-else
             python_version: 3.8
-          - task: mpi
+            compiler: gcc
+          - os: macOS-latest
+            task: mpi
             method: source
             python_version: 3.8
-          - task: mpi
+            compiler: gcc
+          - os: macOS-latest
+            task: mpi
             method: pip
             python_version: 3.7
-          - task: mpi
+            compiler: gcc
+          - os: macOS-latest
+            task: mpi
             method: wheel
             python_version: 3.7
+            compiler: gcc
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
@@ -53,6 +65,11 @@ jobs:
           export METHOD="${{ matrix.method }}"
           export COMPILER="${{ matrix.compiler }}"
           export PYTHON_VERSION="${{ matrix.python_version }}"
+          if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
+              export OS_NAME="macos"
+          elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+              export OS_NAME="linux"
+          fi
           export AMDAPPSDK_PATH=$HOME/AMDAPPSDK
           export LD_LIBRARY_PATH="$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH"
           export LD_LIBRARY_PATH="/usr/local/clang/lib:$LD_LIBRARY_PATH"  # fix error "libomp.so: cannot open shared object file: No such file or directory" on Linux with Clang

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -24,34 +24,27 @@ jobs:
           - os: macOS-latest
             task: regular
             python_version: 3.6
-            compiler: gcc
           - os: macOS-latest
             task: sdist
             python_version: 3.8
-            compiler: gcc
           - os: macOS-latest
             task: bdist
             python_version: 3.8
-            compiler: gcc
           - os: macOS-latest
             task: if-else
             python_version: 3.8
-            compiler: gcc
           - os: macOS-latest
             task: mpi
             method: source
             python_version: 3.8
-            compiler: gcc
           - os: macOS-latest
             task: mpi
             method: pip
             python_version: 3.6
-            compiler: gcc
           - os: macOS-latest
             task: mpi
             method: wheel
             python_version: 3.7
-            compiler: gcc
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
@@ -66,8 +59,10 @@ jobs:
           export COMPILER="${{ matrix.compiler }}"
           export PYTHON_VERSION="${{ matrix.python_version }}"
           if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
+              export COMPILER="gcc"
               export OS_NAME="macos"
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+              export COMPILER="clang"
               export OS_NAME="linux"
           fi
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -56,7 +56,6 @@ jobs:
         run: |
           export TASK="${{ matrix.task }}"
           export METHOD="${{ matrix.method }}"
-          export COMPILER="${{ matrix.compiler }}"
           export PYTHON_VERSION="${{ matrix.python_version }}"
           if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
               export COMPILER="gcc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ git:
 
 os:
   - linux
-  - osx
 dist: focal
-osx_image: xcode12.2
 
 env:
   global:  # default values
+    - COMPILER=clang
     - PYTHON_VERSION=3.8
+    - OS_NAME=linux
   matrix:
     - TASK=regular PYTHON_VERSION=3.6
     - TASK=sdist
@@ -27,26 +27,10 @@ env:
     - TASK=gpu METHOD=pip PYTHON_VERSION=3.6
     - TASK=gpu METHOD=wheel PYTHON_VERSION=3.7
 
-matrix:
-  exclude:
-    - os: osx
-      env: TASK=gpu METHOD=source
-    - os: osx
-      env: TASK=gpu METHOD=pip PYTHON_VERSION=3.6
-    - os: osx
-      env: TASK=gpu METHOD=wheel PYTHON_VERSION=3.7
-
 before_install:
   - test -n $CC  && unset CC
   - test -n $CXX && unset CXX
   - export BUILD_DIRECTORY="$TRAVIS_BUILD_DIR"
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-        export OS_NAME="macos";
-        export COMPILER="gcc";
-    else
-        export OS_NAME="linux";
-        export COMPILER="clang";
-    fi
   - export CONDA="$HOME/miniconda"
   - export PATH="$CONDA/bin:$PATH"
   - export CONDA_ENV="test-env"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Light Gradient Boosting Machine
 ===============================
 
+[![Python-package GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/Python-package/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
 [![R-package GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/R-package/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
 [![Static Analysis GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/Static%20Analysis/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
 [![Azure Pipelines Build Status](https://lightgbm-ci.visualstudio.com/lightgbm-ci/_apis/build/status/Microsoft.LightGBM?branchName=master)](https://lightgbm-ci.visualstudio.com/lightgbm-ci/_build/latest?definitionId=1)


### PR DESCRIPTION
This is another step towards removing Travis from this project, in response to recent policy changes there (#3519).

This was originally proposed in #3672. On that PR, there is still a bit of work to be done for Linux jobs (https://github.com/microsoft/LightGBM/pull/3672#issuecomment-757387694), so this pulls out just the Mac changes so that we can reduce our reliance on Travis and start using GitHub Actions. The sooner this is done, the sooner we'll start learning about things that can be changed / fixed on GitHub Actions.