### PR TITLE
[ci] run artifacts packaging job on Ubuntu

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -105,7 +105,7 @@ jobs:
 - job: Windows
 ###########################################
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'vs2017-win2016'
   strategy:
     matrix:
       regular:
@@ -143,7 +143,7 @@ jobs:
   - Windows
   condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'ubuntu-latest'
   steps:
   # Download all agent packages from all previous phases
   - task: DownloadBuildArtifacts@0
@@ -152,7 +152,7 @@ jobs:
       artifactName: PackageAssets
       downloadPath: $(Build.SourcesDirectory)/binaries
   - script: |
-      python %BUILD_SOURCESDIRECTORY%/.nuget/create_nuget.py %BUILD_SOURCESDIRECTORY%/binaries/PackageAssets
+      python "$(Build.SourcesDirectory)/.nuget/create_nuget.py" "$(Build.SourcesDirectory)/binaries/PackageAssets"
     displayName: 'Create NuGet configuration files'
   - task: NuGetCommand@2
     inputs:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -105,7 +105,7 @@ jobs:
 - job: Windows
 ###########################################
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'ubuntu-latest'
   strategy:
     matrix:
       regular:


### PR DESCRIPTION
I noticed that the availability of Ubuntu machines is greater than Windows ones in general (jobs start faster). Also, Windows machines cost more (see screenshot below, it is for GitHub Actions but they utilize Azure). I think it makes sense to run packaging job on the most cheap and available VM type.

![image](https://user-images.githubusercontent.com/25141164/104454817-7679c500-55b7-11eb-9839-6792a52190d5.png)
