### PR TITLE
[ci] Slightly optimize optional workflows checks

### DIFF
--- a/.ci/get_workflow_status.py
+++ b/.ci/get_workflow_status.py
@@ -1,5 +1,11 @@
 # coding: utf-8
-"""Get the most recent status of workflow for the current PR."""
+"""Get the most recent status of workflow for the current PR.
+
+[usage]
+    python get_workflow_status.py TRIGGER_PHRASE
+
+TRIGGER_PHRASE: Code phrase that triggers workflow.
+"""
 import json
 from os import environ
 from sys import argv, exit
@@ -10,13 +16,13 @@ except ImportError:
     import urllib2 as request
 
 
-def get_runs(workflow_name):
+def get_runs(trigger_phrase):
     """Get all triggering workflow comments in the current PR.
 
     Parameters
     ----------
-    workflow_name : string
-        Name of the workflow.
+    trigger_phrase : string
+        Code phrase that triggers workflow.
 
     Returns
     -------
@@ -34,8 +40,7 @@ def get_runs(workflow_name):
         url.close()
         pr_runs = [i for i in data
                    if i['author_association'].lower() in {'owner', 'member', 'collaborator'}
-                   and i['body'].startswith('/gha run')
-                   and 'Workflow **{}** has been triggered!'.format(workflow_name) in i['body']]
+                   and i['body'].startswith('/gha run {}'.format(trigger_phrase))]
     return pr_runs[::-1]
 
 
@@ -72,9 +77,9 @@ def get_status(runs):
 
 
 if __name__ == "__main__":
-    workflow_name = argv[1]
+    trigger_phrase = argv[1]
     while True:
-        status = get_status(get_runs(workflow_name))
+        status = get_status(get_runs(trigger_phrase))
         if status != 'in-progress':
             break
         sleep(60)

--- a/.github/workflows/optional_checks.yml
+++ b/.github/workflows/optional_checks.yml
@@ -17,9 +17,11 @@ jobs:
           submodules: false
       - name: Check that all tests succeeded
         run: |
-            workflows=("R valgrind tests")
+            workflows=("R valgrind tests;r-valgrind")
             for i in "${workflows[@]}"; do
-                python "$GITHUB_WORKSPACE/.ci/get_workflow_status.py" "$i" \
-                || { echo "The last reported status from workflow \"$i\" is failure. Commit fixes and rerun the workflow."; \
+                workflow_name=${i%;*}
+                trigger_phrase=${i#*;}
+                python "$GITHUB_WORKSPACE/.ci/get_workflow_status.py" "$trigger_phrase" \
+                || { echo "The last reported status from workflow \"$workflow_name\" is failure. Commit fixes and rerun the workflow."; \
                 exit -1; }
             done


### PR DESCRIPTION
By passing code phase instead of workflow name to `get_workflow_status.py` we can filter triggering comments by this phrase. It allows to workaround time delta described in first bad scenario in https://github.com/microsoft/LightGBM/pull/3740#issue-551423557. In other words, even for big queue for optional workflows in case commit was made nearly in the same time as triggering comment, required `Optional checks` workflow will wait for the latest reported status of just triggered optional workflow.