### PR TITLE
Fix thread-safety in C API's PredictSingleRow

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -391,7 +391,7 @@ class Booster {
       Log::Fatal("The number of features in data (%d) is not the same as it was in training data (%d).\n"\
                  "You can set ``predict_disable_shape_check=true`` to discard this error, but please be aware what you are doing.", ncol, boosting_->MaxFeatureIdx() + 1);
     }
-    SHARED_LOCK(mutex_)
+    UNIQUE_LOCK(mutex_)
     const auto& single_row_predictor = single_row_predictor_[predict_type];
     auto one_row = get_row_fun(0);
     auto pred_wrt_ptr = out_result;


### PR DESCRIPTION
The single row predictor methods in the C APi are not thread safe as reported in https://github.com/microsoft/LightGBM/issues/3751 and https://github.com/microsoft/LightGBM/issues/3675. This fixes both reports. Thank you https://github.com/tarunreddy1018 for the detailed reports!



By using a unique lock instead of the shared lock the timings are very similar, but predictions are correct.

Remarks for future work:

- Even so, by designing a small C++ benchmark with a very simple LGBM model, more threads on a simple model are slower than the single-thread case. This is probably due to very small work units, the lock contention overhead increases.
- We should in the future benchmark with more complex models to see if supporting
threading on these calls is worth it in performance gains.
- If not, then we could choose to not to provide thread-safety and remove the locks altogether for maximal throughput (though people that didn't read the documentation carefully might be surprised that such methods were not thread-safe).
  - We should in that case use non-shared resources so there is no synchronization required and multiple calls can be issued in parallel with no lock contention.

See https://github.com/microsoft/LightGBM/issues/3751 for timings of the small benchmark and the benchmark gist https://gist.github.com/AlbertoEAF/5972db15a27c294bab65b97e1bc4c315