### PR TITLE
[docs] expand documentation on 'group' for ranking task

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -1002,7 +1002,7 @@ slice.lgb.Dataset <- function(dataset, idxset, ...) {
 #'         group rows together as ordered results from the same set of candidate results to be ranked.
 #'         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10)},
 #'         that means that you have 5 groups, where the first 10 records are in the first group,
-#'         records 11-30 are the second group, etc.}
+#'         records 11-30 are in the second group, etc.}
 #'     \item \code{init_score}: initial score is the base prediction lightgbm will boost from.
 #' }
 #'
@@ -1058,7 +1058,7 @@ getinfo.lgb.Dataset <- function(dataset, name, ...) {
 #'         group rows together as ordered results from the same set of candidate results to be ranked.
 #'         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10)},
 #'         that means that you have 5 groups, where the first 10 records are in the first group,
-#'         records 11-30 are the second group, etc.}
+#'         records 11-30 are in the second group, etc.}
 #' }
 #'
 #' @examples

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -998,7 +998,11 @@ slice.lgb.Dataset <- function(dataset, idxset, ...) {
 #' \itemize{
 #'     \item \code{label}: label lightgbm learn from ;
 #'     \item \code{weight}: to do a weight rescale ;
-#'     \item \code{group}: group size ;
+#'     \item{\code{group}: used for learning-to-rank tasks. An integer vector describing how to
+#'         group rows together as ordered results from the same set of candidate results to be ranked.
+#'         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10)},
+#'         that means that you have 5 groups, where the first 10 records are in the first group,
+#'         records 11-30 are the second group, etc.}
 #'     \item \code{init_score}: initial score is the base prediction lightgbm will boost from.
 #' }
 #'
@@ -1052,8 +1056,9 @@ getinfo.lgb.Dataset <- function(dataset, name, ...) {
 #'     \item{\code{init_score}: initial score is the base prediction lightgbm will boost from}
 #'     \item{\code{group}: used for learning-to-rank tasks. An integer vector describing how to
 #'         group rows together as ordered results from the same set of candidate results to be ranked.
-#'         For example, if you have a 1000-row dataset that contains 250 4-document query results,
-#'         set this to \code{rep(4L, 250L)}}
+#'         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10)},
+#'         that means that you have 5 groups, where the first 10 records are in the first group,
+#'         records 11-30 are the second group, etc.}
 #' }
 #'
 #' @examples

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -1001,7 +1001,7 @@ slice.lgb.Dataset <- function(dataset, idxset, ...) {
 #'     \item{\code{group}: used for learning-to-rank tasks. An integer vector describing how to
 #'         group rows together as ordered results from the same set of candidate results to be ranked.
 #'         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10, 10)},
-#'         that means that you have 5 groups, where the first 10 records are in the first group,
+#'         that means that you have 6 groups, where the first 10 records are in the first group,
 #'         records 11-30 are in the second group, etc.}
 #'     \item \code{init_score}: initial score is the base prediction lightgbm will boost from.
 #' }
@@ -1056,8 +1056,8 @@ getinfo.lgb.Dataset <- function(dataset, name, ...) {
 #'     \item{\code{init_score}: initial score is the base prediction lightgbm will boost from}
 #'     \item{\code{group}: used for learning-to-rank tasks. An integer vector describing how to
 #'         group rows together as ordered results from the same set of candidate results to be ranked.
-#'         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10)},
-#'         that means that you have 5 groups, where the first 10 records are in the first group,
+#'         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10, 10)},
+#'         that means that you have 6 groups, where the first 10 records are in the first group,
 #'         records 11-30 are in the second group, etc.}
 #' }
 #'

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -1000,7 +1000,7 @@ slice.lgb.Dataset <- function(dataset, idxset, ...) {
 #'     \item \code{weight}: to do a weight rescale ;
 #'     \item{\code{group}: used for learning-to-rank tasks. An integer vector describing how to
 #'         group rows together as ordered results from the same set of candidate results to be ranked.
-#'         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10)},
+#'         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10, 10)},
 #'         that means that you have 5 groups, where the first 10 records are in the first group,
 #'         records 11-30 are in the second group, etc.}
 #'     \item \code{init_score}: initial score is the base prediction lightgbm will boost from.

--- a/R-package/man/getinfo.Rd
+++ b/R-package/man/getinfo.Rd
@@ -34,7 +34,7 @@ The \code{name} field can be one of the following:
         group rows together as ordered results from the same set of candidate results to be ranked.
         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10)},
         that means that you have 5 groups, where the first 10 records are in the first group,
-        records 11-30 are the second group, etc.}
+        records 11-30 are in the second group, etc.}
     \item \code{init_score}: initial score is the base prediction lightgbm will boost from.
 }
 }

--- a/R-package/man/getinfo.Rd
+++ b/R-package/man/getinfo.Rd
@@ -33,7 +33,7 @@ The \code{name} field can be one of the following:
     \item{\code{group}: used for learning-to-rank tasks. An integer vector describing how to
         group rows together as ordered results from the same set of candidate results to be ranked.
         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10, 10)},
-        that means that you have 5 groups, where the first 10 records are in the first group,
+        that means that you have 6 groups, where the first 10 records are in the first group,
         records 11-30 are in the second group, etc.}
     \item \code{init_score}: initial score is the base prediction lightgbm will boost from.
 }

--- a/R-package/man/getinfo.Rd
+++ b/R-package/man/getinfo.Rd
@@ -30,7 +30,11 @@ The \code{name} field can be one of the following:
 \itemize{
     \item \code{label}: label lightgbm learn from ;
     \item \code{weight}: to do a weight rescale ;
-    \item \code{group}: group size ;
+    \item{\code{group}: used for learning-to-rank tasks. An integer vector describing how to
+        group rows together as ordered results from the same set of candidate results to be ranked.
+        For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10)},
+        that means that you have 5 groups, where the first 10 records are in the first group,
+        records 11-30 are the second group, etc.}
     \item \code{init_score}: initial score is the base prediction lightgbm will boost from.
 }
 }

--- a/R-package/man/getinfo.Rd
+++ b/R-package/man/getinfo.Rd
@@ -32,7 +32,7 @@ The \code{name} field can be one of the following:
     \item \code{weight}: to do a weight rescale ;
     \item{\code{group}: used for learning-to-rank tasks. An integer vector describing how to
         group rows together as ordered results from the same set of candidate results to be ranked.
-        For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10)},
+        For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10, 10)},
         that means that you have 5 groups, where the first 10 records are in the first group,
         records 11-30 are in the second group, etc.}
     \item \code{init_score}: initial score is the base prediction lightgbm will boost from.

--- a/R-package/man/setinfo.Rd
+++ b/R-package/man/setinfo.Rd
@@ -37,7 +37,7 @@ The \code{name} field can be one of the following:
         group rows together as ordered results from the same set of candidate results to be ranked.
         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10)},
         that means that you have 5 groups, where the first 10 records are in the first group,
-        records 11-30 are the second group, etc.}
+        records 11-30 are in the second group, etc.}
 }
 }
 \examples{

--- a/R-package/man/setinfo.Rd
+++ b/R-package/man/setinfo.Rd
@@ -36,7 +36,7 @@ The \code{name} field can be one of the following:
     \item{\code{group}: used for learning-to-rank tasks. An integer vector describing how to
         group rows together as ordered results from the same set of candidate results to be ranked.
         For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10, 10)},
-        that means that you have 5 groups, where the first 10 records are in the first group,
+        that means that you have 6 groups, where the first 10 records are in the first group,
         records 11-30 are in the second group, etc.}
 }
 }

--- a/R-package/man/setinfo.Rd
+++ b/R-package/man/setinfo.Rd
@@ -35,7 +35,7 @@ The \code{name} field can be one of the following:
     \item{\code{init_score}: initial score is the base prediction lightgbm will boost from}
     \item{\code{group}: used for learning-to-rank tasks. An integer vector describing how to
         group rows together as ordered results from the same set of candidate results to be ranked.
-        For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10)},
+        For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10, 10)},
         that means that you have 5 groups, where the first 10 records are in the first group,
         records 11-30 are in the second group, etc.}
 }

--- a/R-package/man/setinfo.Rd
+++ b/R-package/man/setinfo.Rd
@@ -35,8 +35,9 @@ The \code{name} field can be one of the following:
     \item{\code{init_score}: initial score is the base prediction lightgbm will boost from}
     \item{\code{group}: used for learning-to-rank tasks. An integer vector describing how to
         group rows together as ordered results from the same set of candidate results to be ranked.
-        For example, if you have a 1000-row dataset that contains 250 4-document query results,
-        set this to \code{rep(4L, 250L)}}
+        For example, if you have a 100-document dataset with \code{group = c(10, 20, 40, 10, 10)},
+        that means that you have 5 groups, where the first 10 records are in the first group,
+        records 11-30 are the second group, etc.}
 }
 }
 \examples{

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -1234,7 +1234,7 @@ Query Data
 
 For learning to rank, it needs query information for training data.
 
-LightGBM's CLI uses an additional file to store query data, like the following:
+LightGBM uses an additional file to store query data, like the following:
 
 ::
 
@@ -1243,7 +1243,7 @@ LightGBM's CLI uses an additional file to store query data, like the following:
     67
     ...
 
-For wrapper libraries like in Python and R, this information is provided as an array-like via the Dataset parameter ``group``.
+For wrapper libraries like in Python and R, this information can also be provided as an array-like via the Dataset parameter ``group``.
 
 ::
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -762,11 +762,9 @@ Dataset Parameters
 
    -  **Note**: works only in case of loading data directly from file
 
-   -  **Note**: data should be grouped by query\_id
+   -  **Note**: data should be grouped by query\_id, for more information, see `Query Data <#query-data>`__
 
    -  **Note**: index starts from ``0`` and it doesn't count the label column when passing type is ``int``, e.g. when label is column\_0 and query\_id is column\_1, the correct parameter is ``query=0``
-
-   -  for more information, see `Query Data <#query-data>`__
 
 -  ``ignore_column`` :raw-html:`<a id="ignore_column" title="Permalink to this parameter" href="#ignore_column">&#x1F517;&#xFE0E;</a>`, default = ``""``, type = multi-int or string, aliases: ``ignore_feature``, ``blacklist``
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -766,6 +766,8 @@ Dataset Parameters
 
    -  **Note**: index starts from ``0`` and it doesn't count the label column when passing type is ``int``, e.g. when label is column\_0 and query\_id is column\_1, the correct parameter is ``query=0``
 
+   -  for more information, see `Query Data <#query-data>`__
+
 -  ``ignore_column`` :raw-html:`<a id="ignore_column" title="Permalink to this parameter" href="#ignore_column">&#x1F517;&#xFE0E;</a>`, default = ``""``, type = multi-int or string, aliases: ``ignore_feature``, ``blacklist``
 
    -  used to specify some ignoring columns in training
@@ -1231,7 +1233,8 @@ Query Data
 ~~~~~~~~~~
 
 For learning to rank, it needs query information for training data.
-LightGBM uses an additional file to store query data, like the following:
+
+LightGBM's CLI uses an additional file to store query data, like the following:
 
 ::
 
@@ -1240,7 +1243,13 @@ LightGBM uses an additional file to store query data, like the following:
     67
     ...
 
-It means first ``27`` lines samples belong to one query and next ``18`` lines belong to another, and so on.
+For wrapper libraries like in Python and R, this information is provided as an array-like via the Dataset parameter ``group``.
+
+::
+
+   [27, 18, 67, ...]
+
+For example, if you have a 112-document dataset with ``group = [27, 18, 67]``, that means that you have 3 groups, where the first 27 records are in the first group, records 28-45 are in the second group, and records 46-112 are in the third group.
 
 **Note**: data should be ordered by the query.
 

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -671,9 +671,8 @@ struct Config {
   // desc = use number for index, e.g. ``query=0`` means column\_0 is the query id
   // desc = add a prefix ``name:`` for column name, e.g. ``query=name:query_id``
   // desc = **Note**: works only in case of loading data directly from file
-  // desc = **Note**: data should be grouped by query\_id
+  // desc = **Note**: data should be grouped by query\_id, for more information, see `Query Data <#query-data>`__
   // desc = **Note**: index starts from ``0`` and it doesn't count the label column when passing type is ``int``, e.g. when label is column\_0 and query\_id is column\_1, the correct parameter is ``query=0``
-  // desc = for more information, see `Query Data <#query-data>`__
   std::string group_column = "";
 
   // type = multi-int or string

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -673,6 +673,7 @@ struct Config {
   // desc = **Note**: works only in case of loading data directly from file
   // desc = **Note**: data should be grouped by query\_id
   // desc = **Note**: index starts from ``0`` and it doesn't count the label column when passing type is ``int``, e.g. when label is column\_0 and query\_id is column\_1, the correct parameter is ``query=0``
+  // desc = for more information, see `Query Data <#query-data>`__
   std::string group_column = "";
 
   // type = multi-int or string

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -941,7 +941,10 @@ class Dataset:
         weight : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Weight for each instance.
         group : list, numpy 1-D array, pandas Series or None, optional (default=None)
-            Group/query size for Dataset.
+            Group/query data, only used for ranking task.
+            Only used in the learning-to-rank task.
+            sum(group) = n_samples.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Init score for Dataset.
         silent : bool, optional (default=False)
@@ -1357,6 +1360,10 @@ class Dataset:
             Weight for each instance.
         group : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Group/query size for Dataset.
+            Only used in the learning-to-rank task.
+            Group/query data, only used for ranking task.
+            sum(group) = n_samples.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Init score for Dataset.
         silent : bool, optional (default=False)
@@ -1715,7 +1722,10 @@ class Dataset:
         Parameters
         ----------
         group : list, numpy 1-D array, pandas Series or None
-            Group size of each group.
+            Group/query data, only used for ranking task.
+            Only used in the learning-to-rank task.
+            sum(group) = n_samples.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
 
         Returns
         -------
@@ -1830,7 +1840,10 @@ class Dataset:
         Returns
         -------
         group : numpy array or None
-            Group size of each group.
+            Group/query data, only used for ranking task.
+            Only used in the learning-to-rank task.
+            sum(group) = n_samples.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
         """
         if self.group is None:
             self.group = self.get_field('group')

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -944,7 +944,7 @@ class Dataset:
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Init score for Dataset.
         silent : bool, optional (default=False)
@@ -1362,7 +1362,7 @@ class Dataset:
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Init score for Dataset.
         silent : bool, optional (default=False)
@@ -1724,7 +1724,7 @@ class Dataset:
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
 
         Returns
         -------
@@ -1842,7 +1842,7 @@ class Dataset:
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         """
         if self.group is None:
             self.group = self.get_field('group')

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -941,7 +941,7 @@ class Dataset:
         weight : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Weight for each instance.
         group : list, numpy 1-D array, pandas Series or None, optional (default=None)
-            Group/query data, only used for ranking task.
+            Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
             For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
@@ -1359,9 +1359,8 @@ class Dataset:
         weight : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Weight for each instance.
         group : list, numpy 1-D array, pandas Series or None, optional (default=None)
-            Group/query size for Dataset.
+            Group/query data.
             Only used in the learning-to-rank task.
-            Group/query data, only used for ranking task.
             sum(group) = n_samples.
             For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
@@ -1722,7 +1721,7 @@ class Dataset:
         Parameters
         ----------
         group : list, numpy 1-D array, pandas Series or None
-            Group/query data, only used for ranking task.
+            Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
             For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
@@ -1840,7 +1839,7 @@ class Dataset:
         Returns
         -------
         group : numpy array or None
-            Group/query data, only used for ranking task.
+            Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
             For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -944,7 +944,7 @@ class Dataset:
             Group/query data, only used for ranking task.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Init score for Dataset.
         silent : bool, optional (default=False)
@@ -1363,7 +1363,7 @@ class Dataset:
             Only used in the learning-to-rank task.
             Group/query data, only used for ranking task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Init score for Dataset.
         silent : bool, optional (default=False)
@@ -1725,7 +1725,7 @@ class Dataset:
             Group/query data, only used for ranking task.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
 
         Returns
         -------
@@ -1843,7 +1843,7 @@ class Dataset:
             Group/query data, only used for ranking task.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         """
         if self.group is None:
             self.group = self.get_field('group')

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -944,7 +944,7 @@ class Dataset:
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Init score for Dataset.
         silent : bool, optional (default=False)
@@ -1362,7 +1362,7 @@ class Dataset:
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Init score for Dataset.
         silent : bool, optional (default=False)
@@ -1724,7 +1724,7 @@ class Dataset:
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
 
         Returns
         -------
@@ -1842,7 +1842,7 @@ class Dataset:
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         """
         if self.group is None:
             self.group = self.get_field('group')

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -39,7 +39,7 @@ class _ObjectiveFunctionWrapper:
                     Group/query data, only used for ranking task.
                     Only used in the learning-to-rank task.
                     sum(group) = n_samples.
-                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
+                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
                 grad : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                     The value of the first order derivative (gradient) for each sample point.
                 hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
@@ -128,7 +128,7 @@ class _EvalFunctionWrapper:
                     Group/query data, only used for ranking task.
                     Only used in the learning-to-rank task.
                     sum(group) = n_samples.
-                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
+                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
                 eval_name : string
                     The name of evaluation function (without whitespaces).
                 eval_result : float
@@ -275,7 +275,7 @@ class LGBMModel(_LGBMModelBase):
                 Group/query data, only used for ranking task.
                 Only used in the learning-to-rank task.
                 sum(group) = n_samples.
-                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
+                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
             grad : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                 The value of the first order derivative (gradient) for each sample point.
             hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
@@ -396,7 +396,7 @@ class LGBMModel(_LGBMModelBase):
             Group/query data, only used for ranking task.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         eval_set : list or None, optional (default=None)
             A list of (X, y) tuple pairs to use as validation sets.
         eval_names : list of strings or None, optional (default=None)
@@ -475,7 +475,7 @@ class LGBMModel(_LGBMModelBase):
                 Group/query data, only used for ranking task.
                 Only used in the learning-to-rank task.
                 sum(group) = n_samples.
-                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
+                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
             eval_name : string
                 The name of evaluation function (without whitespaces).
             eval_result : float

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -39,7 +39,7 @@ class _ObjectiveFunctionWrapper:
                     Group/query data.
                     Only used in the learning-to-rank task.
                     sum(group) = n_samples.
-                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
                 grad : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                     The value of the first order derivative (gradient) for each sample point.
                 hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
@@ -128,7 +128,7 @@ class _EvalFunctionWrapper:
                     Group/query data.
                     Only used in the learning-to-rank task.
                     sum(group) = n_samples.
-                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
                 eval_name : string
                     The name of evaluation function (without whitespaces).
                 eval_result : float
@@ -275,7 +275,7 @@ class LGBMModel(_LGBMModelBase):
                 Group/query data.
                 Only used in the learning-to-rank task.
                 sum(group) = n_samples.
-                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
             grad : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                 The value of the first order derivative (gradient) for each sample point.
             hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
@@ -396,7 +396,7 @@ class LGBMModel(_LGBMModelBase):
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         eval_set : list or None, optional (default=None)
             A list of (X, y) tuple pairs to use as validation sets.
         eval_names : list of strings or None, optional (default=None)
@@ -475,7 +475,7 @@ class LGBMModel(_LGBMModelBase):
                 Group/query data.
                 Only used in the learning-to-rank task.
                 sum(group) = n_samples.
-                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
             eval_name : string
                 The name of evaluation function (without whitespaces).
             eval_result : float

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -36,7 +36,7 @@ class _ObjectiveFunctionWrapper:
                 y_pred : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                     The predicted values.
                 group : array-like
-                    Group/query data, only used for ranking task.
+                    Group/query data.
                     Only used in the learning-to-rank task.
                     sum(group) = n_samples.
                     For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
@@ -125,7 +125,7 @@ class _EvalFunctionWrapper:
                 weight : array-like of shape = [n_samples]
                     The weight of samples.
                 group : array-like
-                    Group/query data, only used for ranking task.
+                    Group/query data.
                     Only used in the learning-to-rank task.
                     sum(group) = n_samples.
                     For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
@@ -272,7 +272,7 @@ class LGBMModel(_LGBMModelBase):
             y_pred : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                 The predicted values.
             group : array-like
-                Group/query data, only used for ranking task.
+                Group/query data.
                 Only used in the learning-to-rank task.
                 sum(group) = n_samples.
                 For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
@@ -393,7 +393,7 @@ class LGBMModel(_LGBMModelBase):
         init_score : array-like of shape = [n_samples] or None, optional (default=None)
             Init score of training data.
         group : array-like or None, optional (default=None)
-            Group/query data, only used for ranking task.
+            Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
             For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
@@ -472,7 +472,7 @@ class LGBMModel(_LGBMModelBase):
             weight : array-like of shape = [n_samples]
                 The weight of samples.
             group : array-like
-                Group/query data, only used for ranking task.
+                Group/query data.
                 Only used in the learning-to-rank task.
                 sum(group) = n_samples.
                 For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -36,7 +36,10 @@ class _ObjectiveFunctionWrapper:
                 y_pred : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                     The predicted values.
                 group : array-like
-                    Group/query data, used for ranking task.
+                    Group/query data, only used for ranking task.
+                    Only used in the learning-to-rank task.
+                    sum(group) = n_samples.
+                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
                 grad : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                     The value of the first order derivative (gradient) for each sample point.
                 hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
@@ -122,7 +125,10 @@ class _EvalFunctionWrapper:
                 weight : array-like of shape = [n_samples]
                     The weight of samples.
                 group : array-like
-                    Group/query data, used for ranking task.
+                    Group/query data, only used for ranking task.
+                    Only used in the learning-to-rank task.
+                    sum(group) = n_samples.
+                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
                 eval_name : string
                     The name of evaluation function (without whitespaces).
                 eval_result : float
@@ -266,7 +272,10 @@ class LGBMModel(_LGBMModelBase):
             y_pred : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                 The predicted values.
             group : array-like
-                Group/query data, used for ranking task.
+                Group/query data, only used for ranking task.
+                Only used in the learning-to-rank task.
+                sum(group) = n_samples.
+                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
             grad : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                 The value of the first order derivative (gradient) for each sample point.
             hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
@@ -384,7 +393,10 @@ class LGBMModel(_LGBMModelBase):
         init_score : array-like of shape = [n_samples] or None, optional (default=None)
             Init score of training data.
         group : array-like or None, optional (default=None)
-            Group data of training data.
+            Group/query data, only used for ranking task.
+            Only used in the learning-to-rank task.
+            sum(group) = n_samples.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
         eval_set : list or None, optional (default=None)
             A list of (X, y) tuple pairs to use as validation sets.
         eval_names : list of strings or None, optional (default=None)
@@ -460,7 +472,10 @@ class LGBMModel(_LGBMModelBase):
             weight : array-like of shape = [n_samples]
                 The weight of samples.
             group : array-like
-                Group/query data, used for ranking task.
+                Group/query data, only used for ranking task.
+                Only used in the learning-to-rank task.
+                sum(group) = n_samples.
+                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are the second group, etc.
             eval_name : string
                 The name of evaluation function (without whitespaces).
             eval_result : float

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -39,7 +39,7 @@ class _ObjectiveFunctionWrapper:
                     Group/query data.
                     Only used in the learning-to-rank task.
                     sum(group) = n_samples.
-                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
                 grad : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                     The value of the first order derivative (gradient) for each sample point.
                 hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
@@ -128,7 +128,7 @@ class _EvalFunctionWrapper:
                     Group/query data.
                     Only used in the learning-to-rank task.
                     sum(group) = n_samples.
-                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
                 eval_name : string
                     The name of evaluation function (without whitespaces).
                 eval_result : float
@@ -275,7 +275,7 @@ class LGBMModel(_LGBMModelBase):
                 Group/query data.
                 Only used in the learning-to-rank task.
                 sum(group) = n_samples.
-                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
             grad : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                 The value of the first order derivative (gradient) for each sample point.
             hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
@@ -396,7 +396,7 @@ class LGBMModel(_LGBMModelBase):
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
         eval_set : list or None, optional (default=None)
             A list of (X, y) tuple pairs to use as validation sets.
         eval_names : list of strings or None, optional (default=None)
@@ -475,7 +475,7 @@ class LGBMModel(_LGBMModelBase):
                 Group/query data.
                 Only used in the learning-to-rank task.
                 sum(group) = n_samples.
-                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 5 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
             eval_name : string
                 The name of evaluation function (without whitespaces).
             eval_result : float


### PR DESCRIPTION
Based on the discussion in https://github.com/microsoft/LightGBM/pull/3708#discussion_r558570787, this PR proposes adding more details to the explanation of `group` in the Python and R packages.

I think that the current description doesn't give enough details for someone unfamiliar with LightGBM to get started. I know that I personally really struggled to understand what "group" should look like the first time I did learning-to-rank with LightGBM.