### PR TITLE
Minor C API cleanup in predictor & SingleRowPredictor 

### DIFF
--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -251,7 +251,7 @@ class Predictor {
 
  private:
   void CopyToPredictBuffer(double* pred_buf, const std::vector<std::pair<int, double>>& features) {
-    for (const auto &feature: features) {
+    for (const auto &feature : features) {
       if (feature.first < num_feature_) {
         pred_buf[feature.first] = feature.second;
       }

--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -251,10 +251,9 @@ class Predictor {
 
  private:
   void CopyToPredictBuffer(double* pred_buf, const std::vector<std::pair<int, double>>& features) {
-    int loop_size = static_cast<int>(features.size());
-    for (int i = 0; i < loop_size; ++i) {
-      if (features[i].first < num_feature_) {
-        pred_buf[features[i].first] = features[i].second;
+    for (const auto &feature: features) {
+      if (feature.first < num_feature_) {
+        pred_buf[feature.first] = feature.second;
       }
     }
   }
@@ -263,10 +262,9 @@ class Predictor {
     if (features.size() > static_cast<size_t>(buf_size / 2)) {
       std::memset(pred_buf, 0, sizeof(double)*(buf_size));
     } else {
-      int loop_size = static_cast<int>(features.size());
-      for (int i = 0; i < loop_size; ++i) {
-        if (features[i].first < num_feature_) {
-          pred_buf[features[i].first] = 0.0f;
+      for (const auto &feature: features) {
+        if (feature.first < num_feature_) {
+          pred_buf[feature.first] = 0.0f;
         }
       }
     }
@@ -274,10 +272,9 @@ class Predictor {
 
   std::unordered_map<int, double> CopyToPredictMap(const std::vector<std::pair<int, double>>& features) {
     std::unordered_map<int, double> buf;
-    int loop_size = static_cast<int>(features.size());
-    for (int i = 0; i < loop_size; ++i) {
-      if (features[i].first < num_feature_) {
-        buf[features[i].first] = features[i].second;
+    for (const auto &feature: features) {
+      if (feature.first < num_feature_) {
+        buf[feature.first] = feature.second;
       }
     }
     return buf;

--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -272,7 +272,7 @@ class Predictor {
 
   std::unordered_map<int, double> CopyToPredictMap(const std::vector<std::pair<int, double>>& features) {
     std::unordered_map<int, double> buf;
-    for (const auto &feature: features) {
+    for (const auto &feature : features) {
       if (feature.first < num_feature_) {
         buf[feature.first] = feature.second;
       }

--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -262,7 +262,7 @@ class Predictor {
     if (features.size() > static_cast<size_t>(buf_size / 2)) {
       std::memset(pred_buf, 0, sizeof(double)*(buf_size));
     } else {
-      for (const auto &feature: features) {
+      for (const auto &feature : features) {
         if (feature.first < num_feature_) {
           pred_buf[feature.first] = 0.0f;
         }

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -72,8 +72,6 @@ class SingleRowPredictor {
       is_raw_score = true;
     } else if (predict_type == C_API_PREDICT_CONTRIB) {
       predict_contrib = true;
-    } else {
-      is_raw_score = false;
     }
     early_stop_ = config.pred_early_stop;
     early_stop_freq_ = config.pred_early_stop_freq;


### PR DESCRIPTION
- Switch to for-based range loops in predictor.hpp (same performance, slightly more readable)
- Eliminate repeated and redundant variable update in SingleRowPredictor