### PR TITLE
[R-package][tests] remove unused lines in tests for the speedup

### DIFF
--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -1735,7 +1735,6 @@ test_that("lgb.train() w/ linear learner fails already-constructed dataset with 
       data = dtrain
       , nrounds = 10L
       , params = modifyList(params, list(linear_tree = TRUE))
-      , valids = list("train" = dtrain)
     )
   }, regexp = "Cannot change linear_tree after constructed Dataset handle")
 })
@@ -1862,7 +1861,6 @@ test_that("lgb.train() works with linear learners and data where a feature has o
     data = dtrain
     , nrounds = 10L
     , params = modifyList(params, list(linear_tree = TRUE))
-    , valids = list("train" = dtrain)
   )
   expect_true(lgb.is.Booster(bst_linear))
 })

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -188,7 +188,6 @@ test_that("boosters with linear models at leaves can be written to text file and
         data = dtrain
         , nrounds = 10L
         , params = params
-        , valids = list("train" = dtrain)
     )
     expect_true(lgb.is.Booster(bst))
 
@@ -204,8 +203,8 @@ test_that("boosters with linear models at leaves can be written to text file and
     bst2 <- lgb.load(
         filename = model_file
     )
-    pred2 <- predict(bst2, X)
-    expect_identical(preds, pred2)
+    preds2 <- predict(bst2, X)
+    expect_identical(preds, preds2)
 })
 
 
@@ -792,7 +791,6 @@ test_that("boosters with linear models at leaves can be written to RDS and re-lo
         data = dtrain
         , nrounds = 10L
         , params = params
-        , valids = list("train" = dtrain)
     )
     expect_true(lgb.is.Booster(bst))
 
@@ -806,6 +804,6 @@ test_that("boosters with linear models at leaves can be written to RDS and re-lo
 
     # load the booster and make predictions...should be the same
     bst2 <- readRDS.lgb.Booster(file = model_file)
-    pred2 <- predict(bst2, X)
-    expect_identical(preds, pred2)
+    preds2 <- predict(bst2, X)
+    expect_identical(preds, preds2)
 })


### PR DESCRIPTION
Validation results are not asserts to anything in these tests. So I believe we can remove `valids` param for clearness and to not waste time computing validation scores.

Sorry, I should have mentioned this during review of #3699.