### PR TITLE
[ci] revert forcing CMake to try compile static library for R-package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,16 +20,9 @@ elseif(USE_GPU OR APPLE)
   cmake_minimum_required(VERSION 3.2)
 elseif(USE_CUDA)
   cmake_minimum_required(VERSION 3.16)
-elseif(__BUILD_FOR_R)
-  cmake_minimum_required(VERSION 3.6)
 else()
   cmake_minimum_required(VERSION 3.0)
 endif()
-
-if(__BUILD_FOR_R)
-  # Should be always before PROJECT command
-  set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
-endif(__BUILD_FOR_R)
 
 if(USE_CUDA)
   PROJECT(lightgbm LANGUAGES C CXX CUDA)


### PR DESCRIPTION
Partly reverts #3541.
That PR was an attempt to fix CMake + R 3.6 frequent random failures happen due to CMake cannot see standard libraries, tools, etc.
Unfortunately, that attempt didn't solve the issue.

I believe we should revert it to not hide real problems behind not executing linking step.