### PR TITLE
[ci][docs] set limit for max requests per second to one host in linkchecker

### DIFF
--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -1,5 +1,5 @@
 [checking]
-maxrequestspersecond=3
+maxrequestspersecond=1
 recursionlevel=1
 anchors=1
 sslverify=0

--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -1,4 +1,5 @@
 [checking]
+maxrequestspersecond=3
 recursionlevel=1
 anchors=1
 sslverify=0


### PR DESCRIPTION
Try to workaround `Valid: 429 too many requests` to GitHub.
This is the most frequent error I see.

https://github.com/linkchecker/linkchecker/issues/193
https://github.com/linkchecker/linkchecker/blob/7db035d1bc124d531370ac25179af3e7a08a40ff/config/linkcheckerrc#L170-L171