### PR TITLE
[dask] reduce test times

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -98,7 +98,8 @@ def test_training_does_not_fail_on_port_conflicts(client):
 
         dask_classifier = dlgbm.DaskLGBMClassifier(
             time_out=5,
-            local_listen_port=12400
+            local_listen_port=12400,
+            n_estimators=5
         )
         for i in range(5):
             dask_classifier.fit(
@@ -115,12 +116,16 @@ def test_training_does_not_fail_on_port_conflicts(client):
 def test_classifier_proba(output, centers, client, listen_port):
     X, y, w, dX, dy, dw = _create_data('classification', output=output, centers=centers)
 
-    dask_classifier = dlgbm.DaskLGBMClassifier(time_out=5, local_listen_port=listen_port)
+    dask_classifier = dlgbm.DaskLGBMClassifier(
+        time_out=5,
+        local_listen_port=listen_port,
+        n_estimators=10
+    )
     dask_classifier = dask_classifier.fit(dX, dy, sample_weight=dw, client=client)
     p1 = dask_classifier.predict_proba(dX)
     p1 = p1.compute()
 
-    local_classifier = lightgbm.LGBMClassifier()
+    local_classifier = lightgbm.LGBMClassifier(n_estimators=10)
     local_classifier.fit(X, y, sample_weight=w)
     p2 = local_classifier.predict_proba(X)
 
@@ -130,11 +135,15 @@ def test_classifier_proba(output, centers, client, listen_port):
 def test_classifier_local_predict(client, listen_port):
     X, y, w, dX, dy, dw = _create_data('classification', output='array')
 
-    dask_classifier = dlgbm.DaskLGBMClassifier(time_out=5, local_listen_port=listen_port)
+    dask_classifier = dlgbm.DaskLGBMClassifier(
+        time_out=5,
+        local_listen_port=listen_port,
+        n_estimators=10
+    )
     dask_classifier = dask_classifier.fit(dX, dy, sample_weight=dw, client=client)
     p1 = dask_classifier.to_local().predict(dX)
 
-    local_classifier = lightgbm.LGBMClassifier()
+    local_classifier = lightgbm.LGBMClassifier(n_estimators=10)
     local_classifier.fit(X, y, sample_weight=w)
     p2 = local_classifier.predict(X)
 
@@ -173,12 +182,23 @@ def test_regressor(output, client, listen_port):
 def test_regressor_quantile(output, client, listen_port, alpha):
     X, y, w, dX, dy, dw = _create_data('regression', output=output)
 
-    dask_regressor = dlgbm.DaskLGBMRegressor(local_listen_port=listen_port, seed=42, objective='quantile', alpha=alpha)
+    dask_regressor = dlgbm.DaskLGBMRegressor(
+        local_listen_port=listen_port,
+        seed=42,
+        objective='quantile',
+        alpha=alpha,
+        n_estimators=10
+    )
     dask_regressor = dask_regressor.fit(dX, dy, client=client, sample_weight=dw)
     p1 = dask_regressor.predict(dX).compute()
     q1 = np.count_nonzero(y < p1) / y.shape[0]
 
-    local_regressor = lightgbm.LGBMRegressor(seed=42, objective='quantile', alpha=alpha)
+    local_regressor = lightgbm.LGBMRegressor(
+        seed=42,
+        objective='quantile',
+        alpha=alpha,
+        n_estimatores=10
+    )
     local_regressor.fit(X, y, sample_weight=w)
     p2 = local_regressor.predict(X)
     q2 = np.count_nonzero(y < p2) / y.shape[0]
@@ -191,7 +211,11 @@ def test_regressor_quantile(output, client, listen_port, alpha):
 def test_regressor_local_predict(client, listen_port):
     X, y, w, dX, dy, dw = _create_data('regression', output='array')
 
-    dask_regressor = dlgbm.DaskLGBMRegressor(local_listen_port=listen_port, seed=42)
+    dask_regressor = dlgbm.DaskLGBMRegressor(
+        local_listen_port=listen_port,
+        seed=42,
+        n_estimators=10
+    )
     dask_regressor = dask_regressor.fit(dX, dy, sample_weight=dw, client=client)
     p1 = dask_regressor.predict(dX)
     p2 = dask_regressor.to_local().predict(X)


### PR DESCRIPTION
This PR proposes a refactoring of `tests/python_package_test/test_dask.py`, to reduce the runtime of the Dask tests.

* makes models smaller by setting `n_estimators=10` and `num_leaves=10` (the defaults are `n_estimators=100` and `num_leaves=31`)
* adds the `predict_proba()` tests for `DaskLGBMClassifier` into the existing `test_classifier` test. I don't think effectively testing `predict()` and `predict_proba()` requires separate training runs

### Impact of this change

I tried running `pytest tests/python_package_test/test_dask.py` 5 times on `master` and 5 times on this branch (on my laptop). I found that the changes in this PR reduce the runtime of the Dask tests by around  35 seconds.

I think this speedup will have a meaningful impact on development speed for the Dask module.

```text
before (avg = 137s):

============================ 29 passed, 2 warnings in 150.19s (0:02:30) =============================
============================= 29 passed, 1 warning in 140.21s (0:02:20) =============================
============================ 29 passed, 2 warnings in 132.08s (0:02:12) =============================
============================ 29 passed, 2 warnings in 132.68s (0:02:12) =============================
============================ 29 passed, 2 warnings in 133.04s (0:02:13) =============================

after combining plus less iterations (avg = 102s):

============================= 23 passed, 1 warning in 101.96s (0:01:41) =============================
============================= 23 passed, 1 warning in 103.60s (0:01:43) =============================
============================= 23 passed, 1 warning in 101.74s (0:01:41) =============================
============================= 23 passed, 1 warning in 101.34s (0:01:41) =============================
============================= 23 passed, 1 warning in 102.70s (0:01:42) =============================
```

### Notes for Reviewers

1. I intentionally did not change `n_estimators` in the `test_regression` test. That test requires a lot of iterations from distributed and local training to look similar, and I found that they produced very different results for small values of `n_estimators`.
2. If this PR is accepted, I'll add a review comment with similar suggestions on #3708 
