### PR TITLE
[docs] fix current RTD failures

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -1243,7 +1243,7 @@ For wrapper libraries like in Python and R, this information can also be provide
 
 ::
 
-   [27, 18, 67, ...]
+    [27, 18, 67, ...]
 
 For example, if you have a 112-document dataset with ``group = [27, 18, 67]``, that means that you have 3 groups, where the first 27 records are in the first group, records 28-45 are in the second group, and records 46-112 are in the third group.
 

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -944,7 +944,8 @@ class Dataset:
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
+            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Init score for Dataset.
         silent : bool, optional (default=False)
@@ -1362,7 +1363,8 @@ class Dataset:
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
+            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Init score for Dataset.
         silent : bool, optional (default=False)
@@ -1724,7 +1726,8 @@ class Dataset:
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
+            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
 
         Returns
         -------
@@ -1842,7 +1845,8 @@ class Dataset:
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
+            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
         """
         if self.group is None:
             self.group = self.get_field('group')

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2244,7 +2244,9 @@ class Booster:
             - ``split_feature`` : string, name of the feature used for splitting. ``None`` for leaf nodes.
             - ``split_gain`` : float64, gain from adding this split to the tree. ``NaN`` for leaf nodes.
             - ``threshold`` : float64, value of the feature used to decide which side of the split a record will go down. ``NaN`` for leaf nodes.
-            - ``decision_type`` : string, logical operator describing how to compare a value to ``threshold``. For example, ``split_feature = "Column_10", threshold = 15, decision_type = "<="`` means that records where ``Column_10 <= 15`` follow the left side of the split, otherwise follows the right side of the split. ``None`` for leaf nodes.
+            - ``decision_type`` : string, logical operator describing how to compare a value to ``threshold``.
+              For example, ``split_feature = "Column_10", threshold = 15, decision_type = "<="`` means that
+              records where ``Column_10 <= 15`` follow the left side of the split, otherwise follows the right side of the split. ``None`` for leaf nodes.
             - ``missing_direction`` : string, split direction that missing values should go to. ``None`` for leaf nodes.
             - ``missing_type`` : string, describes what types of values are treated as missing.
             - ``value`` : float64, predicted value for this leaf node, multiplied by the learning rate.

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -945,7 +945,7 @@ class Dataset:
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
             For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
-            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
+            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the third group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Init score for Dataset.
         silent : bool, optional (default=False)
@@ -1364,7 +1364,7 @@ class Dataset:
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
             For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
-            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
+            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the third group, etc.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Init score for Dataset.
         silent : bool, optional (default=False)
@@ -1727,7 +1727,7 @@ class Dataset:
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
             For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
-            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
+            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the third group, etc.
 
         Returns
         -------
@@ -1846,7 +1846,7 @@ class Dataset:
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
             For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
-            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
+            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the third group, etc.
         """
         if self.group is None:
             self.group = self.get_field('group')

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -125,7 +125,8 @@ def train(params, train_set, num_boost_round=100,
     keep_training_booster : bool, optional (default=False)
         Whether the returned Booster will be used to keep training.
         If False, the returned value will be converted into _InnerPredictor before returning.
-        When your model is very large and cause the memory error, you can try to set this param to ``True`` to avoid the model conversion performed during the internal call of ``model_to_string``.
+        When your model is very large and cause the memory error,
+        you can try to set this param to ``True`` to avoid the model conversion performed during the internal call of ``model_to_string``.
         You can still use _InnerPredictor as ``init_model`` for future continue training.
     callbacks : list of callables or None, optional (default=None)
         List of callback functions that are applied at each iteration.

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -39,7 +39,8 @@ class _ObjectiveFunctionWrapper:
                     Group/query data.
                     Only used in the learning-to-rank task.
                     sum(group) = n_samples.
-                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
+                    where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
                 grad : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                     The value of the first order derivative (gradient) for each sample point.
                 hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
@@ -128,7 +129,8 @@ class _EvalFunctionWrapper:
                     Group/query data.
                     Only used in the learning-to-rank task.
                     sum(group) = n_samples.
-                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+                    For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
+                    where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
                 eval_name : string
                     The name of evaluation function (without whitespaces).
                 eval_result : float
@@ -275,7 +277,8 @@ class LGBMModel(_LGBMModelBase):
                 Group/query data.
                 Only used in the learning-to-rank task.
                 sum(group) = n_samples.
-                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
+                where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
             grad : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                 The value of the first order derivative (gradient) for each sample point.
             hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
@@ -396,7 +399,8 @@ class LGBMModel(_LGBMModelBase):
             Group/query data.
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
-            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
+            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
         eval_set : list or None, optional (default=None)
             A list of (X, y) tuple pairs to use as validation sets.
         eval_names : list of strings or None, optional (default=None)
@@ -475,7 +479,8 @@ class LGBMModel(_LGBMModelBase):
                 Group/query data.
                 Only used in the learning-to-rank task.
                 sum(group) = n_samples.
-                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups, where the first 10 records are in the first group, records 11-30 are in the second group, etc.
+                For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
+                where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
             eval_name : string
                 The name of evaluation function (without whitespaces).
             eval_result : float

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -40,7 +40,7 @@ class _ObjectiveFunctionWrapper:
                     Only used in the learning-to-rank task.
                     sum(group) = n_samples.
                     For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
-                    where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
+                    where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the third group, etc.
                 grad : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                     The value of the first order derivative (gradient) for each sample point.
                 hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
@@ -130,7 +130,7 @@ class _EvalFunctionWrapper:
                     Only used in the learning-to-rank task.
                     sum(group) = n_samples.
                     For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
-                    where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
+                    where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the third group, etc.
                 eval_name : string
                     The name of evaluation function (without whitespaces).
                 eval_result : float
@@ -278,7 +278,7 @@ class LGBMModel(_LGBMModelBase):
                 Only used in the learning-to-rank task.
                 sum(group) = n_samples.
                 For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
-                where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
+                where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the third group, etc.
             grad : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
                 The value of the first order derivative (gradient) for each sample point.
             hess : array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task)
@@ -400,7 +400,7 @@ class LGBMModel(_LGBMModelBase):
             Only used in the learning-to-rank task.
             sum(group) = n_samples.
             For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
-            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
+            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the third group, etc.
         eval_set : list or None, optional (default=None)
             A list of (X, y) tuple pairs to use as validation sets.
         eval_names : list of strings or None, optional (default=None)
@@ -480,7 +480,7 @@ class LGBMModel(_LGBMModelBase):
                 Only used in the learning-to-rank task.
                 sum(group) = n_samples.
                 For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
-                where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the second group, etc.
+                where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the third group, etc.
             eval_name : string
                 The name of evaluation function (without whitespaces).
             eval_result : float


### PR DESCRIPTION
After merging #3772 RTD builds started to fail with very strange error during creating PDF.
```
[143
! pdfTeX error (ext4): \pdfendlink ended up in different nesting level than \pd
fstartlink.
\AtBegShi@Output ...ipout \box \AtBeginShipoutBox 
                                                  \fi \fi 
l.13061 \item[{Return type}]
                             \leavevmode
!  ==> Fatal error occurred, no output PDF file produced!
```


![image](https://user-images.githubusercontent.com/25141164/104977833-8fe49c00-5a11-11eb-8911-f48535a50124.png)


I guess we hit the following issue: https://tex.stackexchange.com/a/424262.
I guess that the change of docstrings caused that some reference has been broken up by new page break position.

By trial and errors I found that either significant reduction of new `group` param description can change page breaks and solve th issue or some small addition to the current description. So I added `..., records 31-70 are in the third group ...`.


Also, I broke extremely huge docstring lines so that there is no terrible horizontal scrolling bar at GitHub for corresponding files.