### PR TITLE
[dask] fix Dask import order

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -12,6 +12,8 @@ from urllib.parse import urlparse
 
 import numpy as np
 import pandas as pd
+import scipy.sparse as ss
+
 from dask import array as da
 from dask import dataframe as dd
 from dask import delayed
@@ -19,8 +21,6 @@ from dask.distributed import Client, default_client, get_worker, wait
 
 from .basic import _LIB, _safe_call
 from .sklearn import LGBMClassifier, LGBMRegressor
-
-import scipy.sparse as ss
 
 logger = logging.getLogger(__name__)
 

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -109,7 +109,7 @@ def test_training_does_not_fail_on_port_conflicts(client):
             n_estimators=5,
             num_leaves=5
         )
-        for i in range(5):
+        for _ in range(5):
             dask_classifier.fit(
                 X=dX,
                 y=dy,
@@ -204,7 +204,7 @@ def test_regressor_quantile(output, client, listen_port, alpha):
 
 
 def test_regressor_local_predict(client, listen_port):
-    X, y, w, dX, dy, dw = _create_data('regression', output='array')
+    X, y, _, dX, dy, dw = _create_data('regression', output='array')
 
     dask_regressor = dlgbm.DaskLGBMRegressor(
         local_listen_port=listen_port,


### PR DESCRIPTION
This PR has two small cleanup actions for the Dask module.

1. moves `scipy` import above relative imports like `from .basic`, matching the ordering we use in other modules
2. replaces unused variables in tests with `_`

I found both of these small things with `pylint`.