### PR TITLE
[docs] fix min CMake version in docs for macOS

### DIFF
--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -290,7 +290,7 @@ Apple Clang
 
 Only **Apple Clang** version 8.1 or higher is supported.
 
-1. Install `CMake`_ (3.12 or higher):
+1. Install `CMake`_ (3.16 or higher):
 
    .. code::
 


### PR DESCRIPTION
No exceptions for threadless version.

https://github.com/microsoft/LightGBM/blob/d107872a5342442420edaa1d1849901f865f2331/CMakeLists.txt#L47-L51