### PR TITLE
remove unused code

### DIFF
--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -1173,8 +1173,6 @@ inline std::string ParseMetricAlias(const std::string& type) {
     return "kullback_leibler";
   } else if (type == std::string("mean_absolute_percentage_error") || type == std::string("mape")) {
     return "mape";
-  } else if (type == std::string("auc_mu")) {
-    return "auc_mu";
   } else if (type == std::string("none") || type == std::string("null") || type == std::string("custom") || type == std::string("na")) {
     return "custom";
   }


### PR DESCRIPTION
`ParseMetricAlias` and `ParseObjectiveAlias` functions should focus on enumerating aliases.
No need to overcomplicate the code. Cases for values that have no aliases are handled by the last unconditional `return` statement.
https://github.com/microsoft/LightGBM/blob/4885f063302ec5773376c90e56cb97f7a6d4b9a7/include/LightGBM/config.h#L1181