### PR TITLE
[docs] bump min sphinx_rtd_theme version

### DIFF
--- a/docs/requirements_base.txt
+++ b/docs/requirements_base.txt
@@ -1,2 +1,2 @@
 sphinx
-sphinx_rtd_theme >= 0.3
+sphinx_rtd_theme >= 0.5


### PR DESCRIPTION
Needed to fix (probably [this one](https://github.com/readthedocs/sphinx_rtd_theme/pull/941)?) the following problem with lists inside other elements where colon is missed in version < 0.5 and words are joined.

![image](https://user-images.githubusercontent.com/25141164/105257575-1d062d00-5b99-11eb-91ef-92a379002273.png)


Unfortunately, output from `breathe` still is not fixed. But there tooltip appeared on hover can help to split words.

![image](https://user-images.githubusercontent.com/25141164/105257856-b2092600-5b99-11eb-9325-066c1c3b42ea.png)

