### PR TITLE
[dask] Address flaky test_ranker tests

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -512,7 +512,7 @@ def test_ranker(output, client, listen_port, group):
     # have high rank correlation with scores from serial ranker.
     dcor = spearmanr(rnkvec_dask, y).correlation
     assert dcor > 0.6
-    assert spearmanr(rnkvec_dask, rnkvec_local).correlation > 0.9
+    assert spearmanr(rnkvec_dask, rnkvec_local).correlation > 0.75
 
     client.close()
 


### PR DESCRIPTION
Addresses issue #3817. Correlation between dask's ranker scores and locally-trained ranker scores is stochastic, despite our best efforts to make deterministic `_make_ranking` data and using `seed=42` throughout DaskLGBM* tests.

I ran the test 100 times and this is the observed distribution:
![spearmanr_dist](https://user-images.githubusercontent.com/11701129/105534118-a3626200-5cb2-11eb-9fd4-947dbd116568.png)

@StrikerRUS observed a run achieving only 0.86 correlation.
So lowering the threshold to a more conservative 0.75.

This is a stopgap - ideally there is a way to distribute data deterministically to dask workers in tests.