### PR TITLE
[ci] improve and run CUDA jobs for every commit and PR

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -77,6 +77,7 @@ else  # Linux
         echo libamdocl64.so > $OPENCL_VENDOR_PATH/amdocl64.icd
     fi
     if [[ $TASK == "cuda" ]]; then
+        echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
         apt-get update
         apt-get install --no-install-recommends -y \
             cmake \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -22,7 +22,7 @@ else  # Linux
     if [[ $IN_UBUNTU_LATEST_CONTAINER == "true" ]]; then
         # fixes error "unable to initialize frontend: Dialog"
         # https://github.com/moby/moby/issues/27988#issuecomment-462809153
-        echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+        echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -78,10 +78,10 @@ else  # Linux
     fi
     if [[ $TASK == "cuda" ]]; then
         apt-get update
-        apt-get install --no-install-recommends -y curl wget
-        curl -sL https://cmake.org/files/v3.18/cmake-3.18.1-Linux-x86_64.sh -o cmake.sh
-        chmod +x cmake.sh
-        ./cmake.sh --prefix=/usr/local --exclude-subdir
+        apt-get install --no-install-recommends -y \
+            cmake \
+            curl \
+            wget
     fi
     if [[ $SETUP_CONDA != "false" ]]; then
         wget -q -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -22,7 +22,7 @@ else  # Linux
     if [[ $IN_UBUNTU_LATEST_CONTAINER == "true" ]]; then
         # fixes error "unable to initialize frontend: Dialog"
         # https://github.com/moby/moby/issues/27988#issuecomment-462809153
-        echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+        echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
 
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
@@ -77,7 +77,7 @@ else  # Linux
         echo libamdocl64.so > $OPENCL_VENDOR_PATH/amdocl64.icd
     fi
     if [[ $TASK == "cuda" ]]; then
-        echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+        echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
         apt-get update
         apt-get install --no-install-recommends -y \
             cmake \

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -52,10 +52,8 @@ jobs:
                 docker-ce \
                 docker-ce-cli \
                 nvidia-docker2
-            sudo chmod 666 /var/run/docker.sock
+            sudo chmod a+rw /var/run/docker.sock
             sudo systemctl restart docker
-      - name: Remove old folder with repository
-        run: sudo rm -rf $GITHUB_WORKSPACE
       - name: Checkout repository
         uses: actions/checkout@v1
         with:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Remove old folder with repository
         run: sudo rm -rf $GITHUB_WORKSPACE
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v1
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -54,7 +54,7 @@ jobs:
                 nvidia-docker2
             sudo chmod a+rw /var/run/docker.sock
             sudo systemctl restart docker
-      - name: Remove old folder with repository	
+      - name: Remove old folder with repository
         run: sudo rm -rf $GITHUB_WORKSPACE
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -1,8 +1,12 @@
-name: CUDA GitHub Actions
+name: CUDA Version
 
 on:
-  pull_request_review_comment:
-    types: [created]
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   test:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -3,7 +3,7 @@ name: CUDA Version
 on:
   push:
     branches:
-    - master
+    - cuda_ci
   pull_request:
     branches:
     - master

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -3,7 +3,7 @@ name: CUDA Version
 on:
   push:
     branches:
-    - cuda_ci
+    - master
   pull_request:
     branches:
     - master
@@ -54,6 +54,8 @@ jobs:
                 nvidia-docker2
             sudo chmod a+rw /var/run/docker.sock
             sudo systemctl restart docker
+      - name: Remove old folder with repository	
+        run: sudo rm -rf $GITHUB_WORKSPACE
       - name: Checkout repository
         uses: actions/checkout@v1
         with:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -54,8 +54,6 @@ jobs:
                 nvidia-docker2
             sudo chmod a+rw /var/run/docker.sock
             sudo systemctl restart docker
-      - name: Remove old folder with repository	
-        run: sudo rm -rf $GITHUB_WORKSPACE
       - name: Checkout repository
         uses: actions/checkout@v1
         with:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -52,6 +52,7 @@ jobs:
                 docker-ce \
                 docker-ce-cli \
                 nvidia-docker2
+            sudo chmod 666 /var/run/docker.sock
             sudo systemctl restart docker
       - name: Remove old folder with repository
         run: sudo rm -rf $GITHUB_WORKSPACE

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -54,6 +54,8 @@ jobs:
                 nvidia-docker2
             sudo chmod a+rw /var/run/docker.sock
             sudo systemctl restart docker
+      - name: Remove old folder with repository	
+        run: sudo rm -rf $GITHUB_WORKSPACE
       - name: Checkout repository
         uses: actions/checkout@v1
         with:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -8,14 +8,28 @@ on:
     branches:
     - master
 
+env:
+  github_actions: 'true'
+  os_name: linux
+  compiler: gcc
+  task: cuda
+  conda_env: test-env
+
 jobs:
   test:
-    name: CUDA
+    name: ${{ env.task }} ${{ matrix.method }} (${{ env.os_name }}, Python ${{ matrix.python_version }})
     runs-on: [self-hosted, linux]
-    if: github.event.comment.body == '/gha run cuda-builds' && contains('OWNER,MEMBER,COLLABORATOR', github.event.comment.author_association)
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      matrix:
+        include:
+          - method: source
+            python_version: 3.6
+          - method: pip
+            python_version: 3.7
+          - method: wheel
+            python_version: 3.8
     steps:
       - name: Setup or update software on host machine
         run: |
@@ -42,22 +56,23 @@ jobs:
       - name: Remove old folder with repository
         run: sudo rm -rf $GITHUB_WORKSPACE
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 5
           submodules: true
-      - name: Test CUDA
+      - name: Setup and run tests
         run: |
             export ROOT_DOCKER_FOLDER=/LightGBM
             cat > docker.env <<EOF
-            TASK=cuda
-            METHOD=source
-            COMPILER=gcc
-            GITHUB_ACTIONS=true
-            OS_NAME=linux
+            GITHUB_ACTIONS=${{ env.github_actions }}
+            OS_NAME=${{ env.os_name }}
+            COMPILER=${{ env.compiler }}
+            TASK=${{ env.task }}
+            METHOD=${{ matrix.method }}
+            CONDA_ENV=${{ env.conda_env }}
+            PYTHON_VERSION=${{ matrix.python_version }}
             BUILD_DIRECTORY=$ROOT_DOCKER_FOLDER
-            CONDA_ENV=test-env
-            PYTHON_VERSION=3.8
+            LGB_VER=$(head -n 1 VERSION.txt)
             EOF
             cat > docker-script.sh <<EOF
             export CONDA=\$HOME/miniconda
@@ -66,4 +81,11 @@ jobs:
             $ROOT_DOCKER_FOLDER/.ci/setup.sh || exit -1
             $ROOT_DOCKER_FOLDER/.ci/test.sh || exit -1
             EOF
-            sudo docker run --env-file docker.env -v "$GITHUB_WORKSPACE":"$ROOT_DOCKER_FOLDER" --rm --gpus all nvidia/cuda:11.0-devel-ubuntu20.04 /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
+            sudo docker run --env-file docker.env -v "$GITHUB_WORKSPACE":"$ROOT_DOCKER_FOLDER" --rm --gpus all nvidia/cuda:11.2.0-devel /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
+  all-successful:
+    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+    - name: Note that all tests succeeded
+      run: echo "🎉"

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -81,7 +81,7 @@ jobs:
             $ROOT_DOCKER_FOLDER/.ci/setup.sh || exit -1
             $ROOT_DOCKER_FOLDER/.ci/test.sh || exit -1
             EOF
-            sudo docker run --env-file docker.env -v "$GITHUB_WORKSPACE":"$ROOT_DOCKER_FOLDER" --rm --gpus all nvidia/cuda:11.2.0-devel /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
+            docker run --env-file docker.env -v "$GITHUB_WORKSPACE":"$ROOT_DOCKER_FOLDER" --rm --gpus all nvidia/cuda:11.2.0-devel /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
   all-successful:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
     runs-on: ubuntu-latest

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   test:
-    name: ${{ env.task }} ${{ matrix.method }} (${{ env.os_name }}, Python ${{ matrix.python_version }})
+    name: cuda ${{ matrix.method }} (linux, Python ${{ matrix.python_version }})
     runs-on: [self-hosted, linux]
     timeout-minutes: 60
     strategy:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Light Gradient Boosting Machine
 
 [![Python-package GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/Python-package/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
 [![R-package GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/R-package/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
+[![CUDA Version GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/CUDA%20Version/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
 [![Static Analysis GitHub Actions Build Status](https://github.com/microsoft/LightGBM/workflows/Static%20Analysis/badge.svg?branch=master)](https://github.com/microsoft/LightGBM/actions)
 [![Azure Pipelines Build Status](https://lightgbm-ci.visualstudio.com/lightgbm-ci/_apis/build/status/Microsoft.LightGBM?branchName=master)](https://lightgbm-ci.visualstudio.com/lightgbm-ci/_build/latest?definitionId=1)
 [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/1ys5ot401m0fep6l/branch/master?svg=true)](https://ci.appveyor.com/project/guolinke/lightgbm/branch/master)


### PR DESCRIPTION
Due to 
> It seems currently both azure pipeline and github actions cannot support the power-off/turn-on machines.
Even with the VM scale set in azure pipeline, it needs at least one machine stand by.
I know there are some external solutions, but they seems to require my Azure (Microsoft) account permission, which seems to violate our policy.
    https://github.com/microsoft/LightGBM/pull/3424#issuecomment-701723558

machine with NVIDIA GPU is always turned on and I don't see any reasons to not run CUDA jobs on it for every PR in this case. Running CUDA jobs on a regular basis will make us sure that no one new PR breaks CUDA source code.

CUDA jobs cannot be run in parallel but the duration of all 3 jobs I set in this PR are about 20 min. Is it OK?