### PR TITLE
[ci] improve optional checks

### DIFF
--- a/.github/workflows/triggering_comments.yml
+++ b/.github/workflows/triggering_comments.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   triggering-tests:
-    if: github.event.issue.pull_request && contains('OWNER,MEMBER,COLLABORATOR', github.event.comment.author_association)
+    if: github.event.issue.pull_request && contains('OWNER,MEMBER,COLLABORATOR', github.event.comment.author_association) && startsWith(github.event.comment.body, '/gha run')
     runs-on: ubuntu-latest
     env:
       SECRETS_WORKFLOW: ${{ secrets.WORKFLOW }}


### PR DESCRIPTION
Do not waste time (~20s) to clone the repo.

Skip everything for comments not starting with `/gha run`

![image](https://user-images.githubusercontent.com/25141164/105613908-a35b8280-5dd6-11eb-8574-abca22b1c907.png)
