### PR TITLE
[dask] warn if attempting to use tree_learner other than data parallel

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -244,6 +244,7 @@ def _train(client, data, label, params, model_factory, sample_weight=None, group
     for tree_learner_param in _ConfigAliases.get('tree_learner'):
         tree_learner = params.get(tree_learner_param)
         if tree_learner is not None:
+            params['tree_learner'] = tree_learner
             break
 
     allowed_tree_learners = {
@@ -263,7 +264,7 @@ def _train(client, data, label, params, model_factory, sample_weight=None, group
 
     if params['tree_learner'] not in {'data', 'data_parallel'}:
         _log_warning(
-            'Support for tree_learner %s in lightgbm.dask is currently untested, and should be considered experimental' % params['tree_learner']
+            'Support for tree_learner %s in lightgbm.dask is experimental and may break in a future release. Use "data" for a stable, well-tested interface.' % params['tree_learner']
         )
 
     local_listen_port = 12400

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -261,6 +261,11 @@ def _train(client, data, label, params, model_factory, sample_weight=None, group
         _log_warning('Parameter tree_learner set to %s, which is not allowed. Using "data" as default' % tree_learner)
         params['tree_learner'] = 'data'
 
+    if params['tree_learner'] not in {'data', 'data_parallel'}:
+        _log_warning(
+            'Support for tree_learner %s in lightgbm.dask is currently untested, and should be considered experimental' % params['tree_learner']
+        )
+
     local_listen_port = 12400
     for port_param in _ConfigAliases.get('local_listen_port'):
         val = params.get(port_param)


### PR DESCRIPTION
Based on https://github.com/microsoft/LightGBM/issues/3834#issuecomment-766351436.

Today, LightGBM's distributed learning supports three methods (feature parallel, data parallel, and voting parallel) --> https://lightgbm.readthedocs.io/en/latest/Features.html#optimization-in-parallel-learning

The Dask interface in `lightgbm.dask` is currently only tested with data parallel, where each chunk of the dataset is a row-wise chunk (all features, subset of rows).

The other methods MIGHT work with `lightgbm.dask`, but significant testing and documentation is needed. Supporting those methods might include adding extra validation to the Dask package as well.

## Changes in this PR

The other parallel learning methods are optimizations, and I don't think the work to support them (#3834) needs to make it into the next LightGBM release (3.2.0). So that testing and documentation won't happen in the next few weeks.

This PR proposes adding a warning if you use one of these methods, to tell users that support for methods other than "data" is experimental and might break.

@StrikerRUS I know you recommended an error in https://github.com/microsoft/LightGBM/issues/3834#issuecomment-766351436, but in my opinion it would be better to make this only a warning so that expert users (who know how to do the Dask partitioning for the different methods) are still able to experiment with the other methods.