### PR TITLE
[dask] factor dask-ml out of tests (fixes #3796)

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -87,7 +87,7 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV dask dask-ml distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+conda install -q -y -n $CONDA_ENV dask distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
 
 # graphviz must come from conda-forge to avoid this on some linux distros:
 # https://github.com/conda-forge/graphviz-feedstock/issues/18

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -124,8 +124,8 @@ def _create_data(objective, n_samples=100, centers=2, output='array', chunk_size
 
 
 def _r2_score(dy_true, dy_pred):
-    numerator = ((dy_true - dy_pred) ** 2).sum(axis=0, dtype="f8")
-    denominator = ((dy_true - dy_pred.mean(axis=0)) ** 2).sum(axis=0, dtype="f8")
+    numerator = ((dy_true - dy_pred) ** 2).sum(axis=0, dtype=np.float64)
+    denominator = ((dy_true - dy_pred.mean(axis=0)) ** 2).sum(axis=0, dtype=np.float64)
     return (1 - numerator / denominator).compute()
 
 


### PR DESCRIPTION
This PR fixes #3796.

We currently install `dask-ml` in CI, but only for the use of two small metrics functions in tests. To reduce CI times and other issues that dependencies can introduce (e.g. incompatibilities that lead to failed or slower conda environment solves, breaking API changes), this proposes removing `dask-ml` and just using our own small implementations of the two metrics needed by tests.

This PR uses @ffineis 's simple R^2 originally proposed in https://github.com/microsoft/LightGBM/pull/3708/commits/b39a1617af2eff0b618f4aa93a2d45ac7f2db963#diff-25c5c42e96fce8e0eb89cc7c991691d224c8b238cd91d2f795efe9fe7151750c.