### PR TITLE
[dask] [python] Store co-local data parts as dicts instead of lists

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -203,13 +203,13 @@ def _train(client, data, label, params, model_factory, sample_weight=None, group
 
     if sample_weight is not None:
         weight_parts = _split_to_parts(data=sample_weight, is_matrix=False)
-        for i, d in enumerate(parts):
-            parts[i] = {**d, 'weight': weight_parts[i]}
+        for i in range(len(parts)):
+            parts[i]['weight'] = weight_parts[i]
 
     if group is not None:
         group_parts = _split_to_parts(data=group, is_matrix=False)
-        for i, d in enumerate(parts):
-            parts[i] = {**d, 'group': group_parts[i]}
+        for i in range(len(parts)):
+            parts[i]['group'] = group_parts[i]
 
     # Start computation in the background
     parts = list(map(delayed, parts))

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -136,25 +136,24 @@ def _train_part(params, model_factory, list_of_parts, worker_address_to_port, re
     is_ranker = issubclass(model_factory, LGBMRanker)
 
     # Concatenate many parts into one
-    parts = tuple(zip(*list_of_parts))
-    data = _concat(parts[0])
-    label = _concat(parts[1])
+    data = _concat([x['data'] for x in list_of_parts])
+    label = _concat([x['label'] for x in list_of_parts])
+
+    if 'weight' in list_of_parts[0]:
+        weight = _concat([x['weight'] for x in list_of_parts])
+    else:
+        weight = None
+
+    if 'group' in list_of_parts[0]:
+        group = _concat([x['group'] for x in list_of_parts])
+    else:
+        group = None
 
     try:
         model = model_factory(**params)
-
         if is_ranker:
-            group = _concat(parts[-1])
-            if len(parts) == 4:
-                weight = _concat(parts[2])
-            else:
-                weight = None
             model.fit(data, y=label, sample_weight=weight, group=group, **kwargs)
         else:
-            if len(parts) == 3:
-                weight = _concat(parts[2])
-            else:
-                weight = None
             model.fit(data, y=label, sample_weight=weight, **kwargs)
 
     finally:
@@ -197,29 +196,20 @@ def _train(client, data, label, params, model_factory, sample_weight=None, group
     """
     params = deepcopy(params)
 
-    # Split arrays/dataframes into parts. Arrange parts into tuples to enforce co-locality
+    # Split arrays/dataframes into parts. Arrange parts into dicts to enforce co-locality
     data_parts = _split_to_parts(data=data, is_matrix=True)
     label_parts = _split_to_parts(data=label, is_matrix=False)
+    parts = [{'data': x, 'label': y} for (x, y) in zip(data_parts, label_parts)]
 
     if sample_weight is not None:
         weight_parts = _split_to_parts(data=sample_weight, is_matrix=False)
-    else:
-        weight_parts = None
+        for i, d in enumerate(parts):
+            parts[i] = {**d, 'weight': weight_parts[i]}
 
     if group is not None:
         group_parts = _split_to_parts(data=group, is_matrix=False)
-    else:
-        group_parts = None
-
-    # choose between four options of (sample_weight, group) being (un)specified
-    if weight_parts is None and group_parts is None:
-        parts = zip(data_parts, label_parts)
-    elif weight_parts is not None and group_parts is None:
-        parts = zip(data_parts, label_parts, weight_parts)
-    elif weight_parts is None and group_parts is not None:
-        parts = zip(data_parts, label_parts, group_parts)
-    else:
-        parts = zip(data_parts, label_parts, weight_parts, group_parts)
+        for i, d in enumerate(parts):
+            parts[i] = {**d, 'group': group_parts[i]}
 
     # Start computation in the background
     parts = list(map(delayed, parts))


### PR DESCRIPTION
Addresses #3795. The `_train` function in `dask.py` places delayed "parts," i.e. `data`, `label`, `sample_weight`, and `group` data into lists (which get distributed to workers) to enforce co-locality of data.  Each worker is distributed a `list_of_parts`, a list of lists. Once the worker receives its lists of parts, it infers the `data`, `label`, and then optionally `sample_weight` and `group` from each `list_of_parts` by assuming that `data` is in position 0, `label` is in position 1, and if the model is *not* a DaskLGBMRanker, the second position is reserved for `sample_weight`.

This is an issue of readability + scalability - implying the presence of `sample_weight` and `group` based on the length of each sublist of `list_of_parts` in conjunction with the estimator type is... hard to understand and doesn't lend itself well to storing additional `parts` like `eval_sets`. Instead, let's just store individual sets of parts as dicts instead of lists. Now each worker will receive its portion of the overall dataset as a list of dicts instead of a list of lists.