### PR TITLE
[dask] fix Dask docstrings and mimic sklearn wrapper importing way

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - master
+    - dask_docs
   tags:
     include:
     - v*

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - dask_docs
+    - master
   tags:
     include:
     - v*

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -13,7 +13,7 @@ from tempfile import NamedTemporaryFile
 import numpy as np
 import scipy.sparse
 
-from .compat import PANDAS_INSTALLED, DataFrame, Series, is_dtype_sparse, DataTable
+from .compat import PANDAS_INSTALLED, DataFrame, Series, concat, is_dtype_sparse, DataTable
 from .libpath import find_lib_path
 
 
@@ -2040,7 +2040,6 @@ class Dataset:
                 if not PANDAS_INSTALLED:
                     raise LightGBMError("Cannot add features to DataFrame type of raw data "
                                         "without pandas installed")
-                from pandas import concat
                 if isinstance(other.data, np.ndarray):
                     self.data = concat((self.data, DataFrame(other.data)),
                                        axis=1, ignore_index=True)

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -3,7 +3,7 @@
 
 """pandas"""
 try:
-    from pandas import Series, DataFrame
+    from pandas import Series, DataFrame, concat
     from pandas.api.types import is_sparse as is_dtype_sparse
     PANDAS_INSTALLED = True
 except ImportError:
@@ -19,6 +19,7 @@ except ImportError:
 
         pass
 
+    concat = None
     is_dtype_sparse = None
 
 """matplotlib"""
@@ -108,9 +109,25 @@ except ImportError:
 
 """dask"""
 try:
-    from dask import array
-    from dask import dataframe
-    from dask.distributed import Client
+    from dask import delayed
+    from dask.array import Array
+    from dask.dataframe import _Frame
+    from dask.distributed import Client, default_client, get_worker, wait
     DASK_INSTALLED = True
 except ImportError:
     DASK_INSTALLED = False
+    delayed = None
+    Client = object
+    default_client = None
+    get_worker = None
+    wait = None
+
+    class Array:
+        """Dummy class for Array."""
+
+        pass
+
+    class _Frame:
+        """Dummy class for _Frame."""
+
+        pass

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -110,8 +110,8 @@ except ImportError:
 """dask"""
 try:
     from dask import delayed
-    from dask.array import Array
-    from dask.dataframe import _Frame
+    from dask.array import Array as dask_Array
+    from dask.dataframe import _Frame as dask_Frame
     from dask.distributed import Client, default_client, get_worker, wait
     DASK_INSTALLED = True
 except ImportError:
@@ -122,12 +122,12 @@ except ImportError:
     get_worker = None
     wait = None
 
-    class Array:
-        """Dummy class for Array."""
+    class dask_Array:
+        """Dummy class for dask.array.Array."""
 
         pass
 
-    class _Frame:
-        """Dummy class for _Frame."""
+    class dask_Frame:
+        """Dummy class for ddask.dataframe._Frame."""
 
         pass

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -366,6 +366,8 @@ def _predict(model, data, raw_score=False, pred_proba=False, pred_leaf=False, pr
     X_SHAP_values : dask array of shape = [n_samples, n_features + 1] or shape = [n_samples, (n_features + 1) * n_classes] or list with n_classes length of such objects
         If ``pred_contrib=True``, the feature contributions for each sample.
     """
+    if not all((DASK_INSTALLED, PANDAS_INSTALLED, SKLEARN_INSTALLED)):
+        raise LightGBMError('dask, pandas and scikit-learn are required for lightgbm.dask')
     if isinstance(data, _Frame):
         return data.map_partitions(
             _predict_part,

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -368,7 +368,7 @@ def _predict(model, data, raw_score=False, pred_proba=False, pred_leaf=False, pr
     """
     if not all((DASK_INSTALLED, PANDAS_INSTALLED, SKLEARN_INSTALLED)):
         raise LightGBMError('dask, pandas and scikit-learn are required for lightgbm.dask')
-    if isinstance(data, _Frame):
+    if isinstance(data, dask_Frame):
         return data.map_partitions(
             _predict_part,
             model=model,
@@ -378,7 +378,7 @@ def _predict(model, data, raw_score=False, pred_proba=False, pred_leaf=False, pr
             pred_contrib=pred_contrib,
             **kwargs
         ).values
-    elif isinstance(data, Array):
+    elif isinstance(data, dask_Array):
         if pred_proba:
             kwargs['chunks'] = (data.chunks[0], (model.n_classes_,))
         else:

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -18,7 +18,7 @@ import scipy.sparse as ss
 from .basic import _choose_param_value, _ConfigAliases, _LIB, _log_warning, _safe_call, LightGBMError
 from .compat import (PANDAS_INSTALLED, DataFrame, Series, concat,
                      SKLEARN_INSTALLED,
-                     DASK_INSTALLED, _Frame, Array, delayed, Client, default_client, get_worker, wait)
+                     DASK_INSTALLED, dask_Frame, dask_Array, delayed, Client, default_client, get_worker, wait)
 from .sklearn import LGBMClassifier, LGBMRegressor, LGBMRanker
 
 

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -492,6 +492,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
 
 class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
     """Distributed version of lightgbm.LGBMRegressor."""
+
     def fit(self, X, y, sample_weight=None, client=None, **kwargs):
         """Docstring is inherited from the lightgbm.LGBMRegressor.fit."""
         return self._fit(
@@ -533,6 +534,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
 
 class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
     """Distributed version of lightgbm.LGBMRanker."""
+
     def fit(self, X, y, sample_weight=None, init_score=None, group=None, client=None, **kwargs):
         """Docstring is inherited from the lightgbm.LGBMRanker.fit."""
         if init_score is not None:


### PR DESCRIPTION
Will be reworked after discussion in #3808.
But for now this PR makes docstrings consistent with actual method signatures and reliable for early-adopters of lightgbm.dask.
Live demo: https://lightgbm.readthedocs.io/en/dask_docs/Python-API.html#dask-api.

With fixed importing way via `compat.py` module users are able to actually import classes, read their docstrings but in case of missing Dask dependencies informative error will be raised:

![image](https://user-images.githubusercontent.com/25141164/105776872-6f20c700-5f7a-11eb-9765-f4eec8bbe525.png)
