### PR TITLE
[dask] rename _LGBMModel to _DaskLGBMModel

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -377,7 +377,7 @@ def _predict(model, data, raw_score=False, pred_proba=False, pred_leaf=False, pr
         raise TypeError('Data must be either Dask array or dataframe. Got %s.' % str(type(data)))
 
 
-class _LGBMModel:
+class _DaskLGBMModel:
     def __init__(self):
         if not all((DASK_INSTALLED, PANDAS_INSTALLED, SKLEARN_INSTALLED)):
             raise LightGBMError('dask, pandas and scikit-learn are required for lightgbm.dask')
@@ -419,7 +419,7 @@ class _LGBMModel:
             setattr(dest, name, attributes[name])
 
 
-class DaskLGBMClassifier(LGBMClassifier, _LGBMModel):
+class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
     """Distributed version of lightgbm.LGBMClassifier."""
 
     def fit(self, X, y=None, sample_weight=None, client=None, **kwargs):
@@ -467,7 +467,7 @@ class DaskLGBMClassifier(LGBMClassifier, _LGBMModel):
         return self._to_local(LGBMClassifier)
 
 
-class DaskLGBMRegressor(LGBMRegressor, _LGBMModel):
+class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
     """Docstring is inherited from the lightgbm.LGBMRegressor."""
 
     def fit(self, X, y=None, sample_weight=None, client=None, **kwargs):
@@ -503,7 +503,7 @@ class DaskLGBMRegressor(LGBMRegressor, _LGBMModel):
         return self._to_local(LGBMRegressor)
 
 
-class DaskLGBMRanker(LGBMRanker, _LGBMModel):
+class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
     """Docstring is inherited from the lightgbm.LGBMRanker."""
 
     def fit(self, X, y=None, sample_weight=None, init_score=None, group=None, client=None, **kwargs):


### PR DESCRIPTION
I started working on type hints for the Dask module (#3756 ), and to do that effectively I needed to import `lightgbm.sklearn.LGBMModel`.

This PR proposes changing `_LGBMModel` to `_DaskLGBMModel`, so that when that type hints PR happens, we don't have two classes being referenced in the dask module whose names are only different by one character. I felt this change was valuable anyway for consistency, and would be quick and non-controversial to review, so broke it into a separate PR.