### PR TITLE
[dask] add tests on warnings, fix incorrect variable in log

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -222,7 +222,7 @@ def _train(client, data, label, params, model_factory, sample_weight=None, group
         'voting_parallel'
     }
     if params["tree_learner"] not in allowed_tree_learners:
-        _log_warning('Parameter tree_learner set to %s, which is not allowed. Using "data" as default' % tree_learner)
+        _log_warning('Parameter tree_learner set to %s, which is not allowed. Using "data" as default' % params['tree_learner'])
         params['tree_learner'] = 'data'
 
     if params['tree_learner'] not in {'data', 'data_parallel'}:

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -446,7 +446,7 @@ def test_warns_and_continues_on_unrecognized_tree_learner(client):
     assert dask_regressor.fitted_
 
 
-def test_warns_but_makes_no_changes_for_feature_or_voting_parallel(client):
+def test_warns_but_makes_no_changes_for_feature_or_voting_tree_learner(client):
     X = da.random.random((1e3, 10))
     y = da.random.random((1e3, 1))
     for tree_learner in ['feature_parallel', 'voting']:


### PR DESCRIPTION
While working on #3756 , I've been running `mypy python-package/`. This caught a bug in my refactoring from recent PRs (not sure which one).

> python-package/lightgbm/dask.py:251: error: Name 'tree_learner' is not defined

This PR fixes that, and adds unit tests to cover the behavior under the two warnings in `lightgbm.dask._train()`.