### PR TITLE
[ci] add mypy to linting task

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -48,10 +48,11 @@ if [[ $TASK == "lint" ]]; then
         -c conda-forge \
             libxml2 \
             "r-lintr>=2.0"
-    pip install --user cpplint
+    pip install --user cpplint mypy
     echo "Linting Python code"
     pycodestyle --ignore=E501,W503 --exclude=./.nuget,./external_libs . || exit -1
     pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^external_libs|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1
+    mypy --ignore-missing-imports python-package/ || true
     echo "Linting R code"
     Rscript ${BUILD_DIRECTORY}/.ci/lint_r_code.R ${BUILD_DIRECTORY} || exit -1
     echo "Linting C++ code"


### PR DESCRIPTION
Based on https://github.com/microsoft/LightGBM/pull/3865#issuecomment-767897424, this PR proposes adding `mypy` to the `lint` task in CI.

Similar to the approach we took with `cpplint` (#1990), this PR will print logs from `mypy` but not actually enforce anything yet. I've opened https://github.com/microsoft/LightGBM/issues/3867 to document why `mypy` is valuable and explain how contributors can help with it.