### PR TITLE
[ci] ignore CUDA-related strings in Python logger test

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -3,7 +3,7 @@ name: CUDA Version
 on:
   push:
     branches:
-    - master
+    - fix_cuda_tests
   pull_request:
     branches:
     - master

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -3,7 +3,7 @@ name: CUDA Version
 on:
   push:
     branches:
-    - fix_cuda_tests
+    - master
   pull_request:
     branches:
     - master

--- a/src/treelearner/cuda_tree_learner.cpp
+++ b/src/treelearner/cuda_tree_learner.cpp
@@ -265,7 +265,7 @@ void CUDATreeLearner::CountDenseFeatureGroups() {
     }
   }
   if (!num_dense_feature_groups_) {
-    Log::Warning("GPU acceleration is disabled because no non-trival dense features can be found");
+    Log::Warning("GPU acceleration is disabled because no non-trivial dense features can be found");
   }
 }
 

--- a/tests/python_package_test/test_utilities.py
+++ b/tests/python_package_test/test_utilities.py
@@ -81,7 +81,9 @@ WARNING | More than one metric available, picking one to plot.
         "INFO | [LightGBM] [Info] Using GPU Device:",
         "INFO | [LightGBM] [Info] Compiling OpenCL Kernel with 16 bins...",
         "INFO | [LightGBM] [Info] GPU programs have been built",
-        "INFO | [LightGBM] [Warning] GPU acceleration is disabled because no non-trivial dense features can be found"
+        "INFO | [LightGBM] [Warning] GPU acceleration is disabled because no non-trivial dense features can be found",
+        "INFO | [LightGBM] [Warning] Using sparse features with CUDA is currently not supported.",
+        "INFO | [LightGBM] [Warning] CUDA currently requires double precision calculations."
     ]
     with open(log_filename, "rt", encoding="utf-8") as f:
         actual_log = f.read().strip()

--- a/tests/python_package_test/test_utilities.py
+++ b/tests/python_package_test/test_utilities.py
@@ -83,7 +83,8 @@ WARNING | More than one metric available, picking one to plot.
         "INFO | [LightGBM] [Info] GPU programs have been built",
         "INFO | [LightGBM] [Warning] GPU acceleration is disabled because no non-trivial dense features can be found",
         "INFO | [LightGBM] [Warning] Using sparse features with CUDA is currently not supported.",
-        "INFO | [LightGBM] [Warning] CUDA currently requires double precision calculations."
+        "INFO | [LightGBM] [Warning] CUDA currently requires double precision calculations.",
+        "INFO | [LightGBM] [Info] LightGBM using CUDA trainer with DP float!!"
     ]
     with open(log_filename, "rt", encoding="utf-8") as f:
         actual_log = f.read().strip()


### PR DESCRIPTION
Fix current CUDA workflow failures in `master` due to merge conflict.