### PR TITLE
[ci][R-package] remove CI workaround with manual withr installation

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -97,11 +97,6 @@ if [[ $OS_NAME == "macos" ]]; then
     fi
 fi
 
-# hack to fix https://github.com/microsoft/LightGBM/pull/3876#issuecomment-769187766
-if [[ $OS_NAME == "macos" ]]; then
-    Rscript --vanilla -e "install.packages('withr', repos = '${CRAN_MIRROR}', type = 'source', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))"
-fi
-
 # Manually install Depends and Imports libraries + 'testthat'
 # to avoid a CI-time dependency on devtools (for devtools::install_deps())
 packages="c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat')"

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -3,7 +3,7 @@ name: R-package
 on:
   push:
     branches:
-    - r_ci
+    - master
   pull_request:
     branches:
     - master

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -3,7 +3,7 @@ name: R-package
 on:
   push:
     branches:
-    - master
+    - r_ci
   pull_request:
     branches:
     - master


### PR DESCRIPTION
Partly reverts #3876.

https://github.com/microsoft/LightGBM/pull/3876#issuecomment-769202545

macOS binaries for `withr` have been uploaded to CRAN.

https://cran.r-project.org/web/packages/withr/index.html

![image](https://user-images.githubusercontent.com/25141164/106208224-19dff200-61d4-11eb-9c03-f347e6887c05.png)
