### PR TITLE
[docs][ci] drop special dependency requirements for RTD site

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ formats:
 python:
   version: 3
   install:
-    - requirements: docs/requirements_rtd.txt
+    - requirements: docs/requirements.txt
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -1,2 +1,0 @@
--r requirements.txt
-sphinx >= 3.2.2


### PR DESCRIPTION
Refer to https://github.com/microsoft/LightGBM/pull/3554#issue-518762299.

Finally pip is smart enough to resolve dependency conflicts without our help. Now it forces updating `Sphinx` due to new `breathe` version.
https://github.com/michaeljones/breathe/blob/a8be7365bc3e6f4380053291b1e66e3a788e342a/setup.py#L17

Live demo: https://lightgbm.readthedocs.io/en/test_docs/

![image](https://user-images.githubusercontent.com/25141164/106387453-e0350400-63ea-11eb-8331-73ebc5a565fc.png)
