### PR TITLE
[SWIG] add size_t manipulation functions

### DIFF
--- a/swig/pointer_manipulation.i
+++ b/swig/pointer_manipulation.i
@@ -21,6 +21,7 @@
 %pointer_functions(float, floatp)
 %pointer_functions(int64_t, int64_tp)
 %pointer_functions(int32_t, int32_tp)
+%pointer_functions(size_t, size_tp)
 
 %pointer_cast(int64_t *, long *, int64_t_to_long_ptr)
 %pointer_cast(int64_t *, double *, int64_t_to_double_ptr)


### PR DESCRIPTION
I'm a maintainer of the [lightgbm4j](https://github.com/metarank/lightgbm4j) library, and would like to expose the `LGBM_DatasetGetFeatureNames` function in a more java-friendly way. 

The problem with the `LGBM_DatasetGetFeatureNames` function is that it requires a `size_t` [type param](https://lightgbm.readthedocs.io/en/latest/C-API.html#c.LGBM_DatasetGetFeatureNames), which is not possible to instantiate at all, as SWIG definition file only exposes int/long/double/float/int64_t/int32_t types.

This one-liner PR also exposes a `size_t` function family in SWIG wrapper, so `lightgbmlibJNI.java` will also include these new ones:

```
>   public final static native long new_size_tp();
>   public final static native long copy_size_tp(long jarg1);
>   public final static native void delete_size_tp(long jarg1);
>   public final static native void size_tp_assign(long jarg1, long jarg2);
>   public final static native long size_tp_value(long jarg1);
```