### PR TITLE
[dask] test training when a worker has no data

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -23,7 +23,7 @@ import numpy as np
 import pandas as pd
 from scipy.stats import spearmanr
 from dask.array.utils import assert_eq
-from dask.distributed import default_client, Client, futures_of, LocalCluster, wait
+from dask.distributed import default_client, Client, LocalCluster, wait
 from distributed.utils_test import client, cluster_fixture, gen_cluster, loop
 from scipy.sparse import csr_matrix
 from sklearn.datasets import make_blobs, make_regression

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -4,7 +4,7 @@
 import inspect
 import pickle
 import socket
-from itertools import groupby, product
+from itertools import groupby
 from os import getenv
 from sys import platform
 


### PR DESCRIPTION
This includes a test to check that the training process succeeds even when a worker has no data, e.g. verify that #3882 is solved. 

I wanted to persist the collections to a specific worker with something like:
```python
for worker in workers:
    dX, dy, dw = client.persist([dX, dy, dw], workers=worker)
```
However I got: `TypeError: unhashable type: 'Array'`.

So in the test I just create a collection with one chunk, persist it and check that it is only in one worker. Any feedback to make this test more robust is welcome.