### PR TITLE
[ci] Rename linkchecker job

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 5
           submodules: false
-      - name: Check that all tests succeeded
+      - name: Setup and run tests
         run: |
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           export CONDA=${HOME}/miniconda


### PR DESCRIPTION
Just noticed this. I think our ordinary name for a such jobs better reflects what's happening inside.

Wording `Note(Check) that all tests succeeded` we are using for special `all-successful` jobs:
https://github.com/microsoft/LightGBM/blob/c324e891be58789f0423cd5c986e7396a524b3ce/.github/workflows/python_package.yml#L73-L79