### PR TITLE
[dask] remove extra 'client' kwarg in DaskLGBMRegressor

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -710,7 +710,6 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         X: _DaskMatrixLike,
         y: _DaskCollection,
         sample_weight: Optional[_DaskCollection] = None,
-        client: Optional[Client] = None,
         **kwargs: Any
     ) -> "DaskLGBMRegressor":
         """Docstring is inherited from the lightgbm.LGBMRegressor.fit."""


### PR DESCRIPTION
Looks like I missed removing the `client` argument in `DaskLGBMRegressor` in #3883 , sorry!

I think in the future, we might be able to use `mypy` to catch API differences between the Dask package and its scikit-learn equivalents. For now, this PR removes that argument.