### PR TITLE
[dask] Support Dask dataframes with 'category' columns (fixes #3861)

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -350,13 +350,12 @@ def _predict_part(
     pred_contrib: bool,
     **kwargs: Any
 ) -> _DaskPart:
-    data = part.values if isinstance(part, pd_DataFrame) else part
 
-    if data.shape[0] == 0:
+    if part.shape[0] == 0:
         result = np.array([])
     elif pred_proba:
         result = model.predict_proba(
-            data,
+            part,
             raw_score=raw_score,
             pred_leaf=pred_leaf,
             pred_contrib=pred_contrib,
@@ -364,14 +363,15 @@ def _predict_part(
         )
     else:
         result = model.predict(
-            data,
+            part,
             raw_score=raw_score,
             pred_leaf=pred_leaf,
             pred_contrib=pred_contrib,
             **kwargs
         )
 
-    if isinstance(part, pd_DataFrame):
+    # dask.DataFrame.map_partitions() expects each call to return a pandas DataFrame or Series
+    if isinstance(part, pd_DataFrame)
         if pred_proba or pred_contrib:
             result = pd_DataFrame(result, index=part.index)
         else:

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -371,7 +371,7 @@ def _predict_part(
         )
 
     # dask.DataFrame.map_partitions() expects each call to return a pandas DataFrame or Series
-    if isinstance(part, pd_DataFrame)
+    if isinstance(part, pd_DataFrame):
         if pred_proba or pred_contrib:
             result = pd_DataFrame(result, index=part.index)
         else:

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -114,7 +114,7 @@ def _create_data(objective, n_samples=100, centers=2, output='array', chunk_size
     if objective == 'classification':
         X, y = make_blobs(n_samples=n_samples, centers=centers, random_state=42)
     elif objective == 'regression':
-        X, y = make_regression(n_samples=n_samples, random_state=42, n_informative=2)
+        X, y = make_regression(n_samples=n_samples, random_state=42)
     else:
         raise ValueError("Unknown objective '%s'" % objective)
     rnd = np.random.RandomState(42)
@@ -206,7 +206,7 @@ def test_classifier(output, centers, client, listen_port):
 
     params = {
         "n_estimators": 10,
-        "num_leaves": 10,
+        "num_leaves": 10
     }
     dask_classifier = lgb.DaskLGBMClassifier(
         client=client,
@@ -258,8 +258,7 @@ def test_classifier_pred_contrib(output, centers, client, listen_port):
 
     params = {
         "n_estimators": 10,
-        "num_leaves": 10,
-        "min_data_in_leaf": 1
+        "num_leaves": 10
     }
     dask_classifier = lgb.DaskLGBMClassifier(
         client=client,
@@ -341,12 +340,12 @@ def test_training_does_not_fail_on_port_conflicts(client):
 def test_regressor(output, client, listen_port):
     X, y, w, dX, dy, dw = _create_data(
         objective='regression',
-        output=output,
+        output=output
     )
 
     params = {
         "random_state": 42,
-        "num_leaves": 10,
+        "num_leaves": 10
     }
     dask_regressor = lgb.DaskLGBMRegressor(
         client=client,
@@ -375,7 +374,7 @@ def test_regressor(output, client, listen_port):
 
     # Predictions should be roughly the same
     assert_eq(y, p1, rtol=1., atol=100.)
-    assert_eq(y, p2, rtol=1., atol=100.)
+    assert_eq(y, p2, rtol=1., atol=50.)
     assert_eq(p1, p1_local)
 
     # be sure LightGBM actually used at least one categorical column
@@ -394,12 +393,12 @@ def test_regressor(output, client, listen_port):
 def test_regressor_pred_contrib(output, client, listen_port):
     X, y, w, dX, dy, dw = _create_data(
         objective='regression',
-        output=output,
+        output=output
     )
 
     params = {
-        "random_state": 42,
-        "num_leaves": 10,
+        "n_estimators": 10,
+        "num_leaves": 10
     }
     dask_regressor = lgb.DaskLGBMRegressor(
         client=client,
@@ -449,8 +448,7 @@ def test_regressor_quantile(output, client, listen_port, alpha):
         "alpha": alpha,
         "random_state": 42,
         "n_estimators": 10,
-        "num_leaves": 10,
-        "min_data_in_leaf": 1
+        "num_leaves": 10
     }
     dask_regressor = lgb.DaskLGBMRegressor(
         client=client,
@@ -483,8 +481,7 @@ def test_regressor_quantile(output, client, listen_port, alpha):
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)
 
 
-# @pytest.mark.parametrize('output', ['array', 'dataframe', 'dataframe-with-categorical'])
-@pytest.mark.parametrize('output', ['dataframe-with-categorical'])
+@pytest.mark.parametrize('output', ['array', 'dataframe', 'dataframe-with-categorical'])
 @pytest.mark.parametrize('group', [None, group_sizes])
 def test_ranker(output, client, listen_port, group):
 
@@ -516,8 +513,7 @@ def test_ranker(output, client, listen_port, group):
         "random_state": 42,
         "n_estimators": 50,
         "num_leaves": 20,
-        "min_child_samples": 1,
-        "min_data_in_leaf": 1
+        "min_child_samples": 1
     }
     dask_ranker = lgb.DaskLGBMRanker(
         client=client,
@@ -577,8 +573,7 @@ def test_training_works_if_client_not_provided_or_set_after_construction(task, l
         "time_out": 5,
         "local_listen_port": listen_port,
         "n_estimators": 1,
-        "num_leaves": 2,
-        "min_data_in_leaf": 1
+        "num_leaves": 2
     }
 
     # should be able to use the class without specifying a client

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -64,8 +64,11 @@ def _create_ranking_data(n_samples=100, output='array', chunk_size=50, **kwargs)
         # add target, weight, and group to DataFrame so that partitions abide by group boundaries.
         X_df = pd.DataFrame(X, columns=[f'feature_{i}' for i in range(X.shape[1])])
         if output == 'dataframe-with-categorical':
-            cat_series = pd.Series(np.random.choice(["a", "b", "y", "z"], n_samples), dtype="category")
-            X_df["cat_col"] = cat_series
+            cat_series = pd.Series(
+                np.random.choice(['a', 'b', 'y', 'z'], n_samples),
+                dtype='category'
+            )
+            X_df['cat_col'] = cat_series
             X = np.hstack((X, cat_series.cat.codes.values.reshape(-1, 1)))
         X = X_df.copy()
         X_df = X_df.assign(y=y, g=g, w=w)
@@ -122,8 +125,11 @@ def _create_data(objective, n_samples=100, centers=2, output='array', chunk_size
     elif output.startswith('dataframe'):
         X_df = pd.DataFrame(X, columns=['feature_%d' % i for i in range(X.shape[1])])
         if output == 'dataframe-with-categorical':
-            cat_series = pd.Series(np.random.choice(["a", "b", "y", "z"], n_samples), dtype="category")
-            X_df["cat_col"] = cat_series
+            cat_series = pd.Series(
+                np.random.choice(['a', 'b', 'y', 'z'], n_samples),
+                dtype='category'
+            )
+            X_df['cat_col'] = cat_series
             X = np.hstack((X, cat_series.cat.codes.values.reshape(-1, 1)))
         y_df = pd.Series(y, name='target')
         dX = dd.from_pandas(X_df, chunksize=chunk_size)

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -190,7 +190,7 @@ def test_classifier(output, centers, client, listen_port):
         centers=centers
     )
 
-    # be sure a categorical columne was added
+    # be sure a categorical column was added
     if output == 'dataframe-with-categorical':
         assert dX.dtypes['cat_col'].name == 'category'
 
@@ -315,7 +315,7 @@ def test_regressor(output, client, listen_port):
         output=output
     )
 
-    # be sure a categorical columne was added
+    # be sure a categorical column was added
     if output == 'dataframe-with-categorical':
         assert dX.dtypes['cat_col'].name == 'category'
 
@@ -439,7 +439,7 @@ def test_ranker(output, client, listen_port, group):
         group=group
     )
 
-    # be sure a categorical columne was added
+    # be sure a categorical column was added
     if output == 'dataframe-with-categorical':
         assert dX.dtypes['cat_col'].name == 'category'
 

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -372,10 +372,16 @@ def test_regressor(output, client, listen_port):
         assert_eq(s1, s2, atol=.01)
         assert_eq(s1, s1_local, atol=.003)
 
-    # Predictions should be roughly the same
-    assert_eq(y, p1, rtol=1., atol=100.)
-    assert_eq(y, p2, rtol=1., atol=50.)
+    # Predictions should be roughly the same.
     assert_eq(p1, p1_local)
+
+    # The checks below are skipped
+    # for the categorical data case because it's difficult to get
+    # a good fit from just categoricals for a regression problem
+    # with small data
+    if output != 'dataframe-with-categorical':
+        assert_eq(y, p1, rtol=1., atol=100.)
+        assert_eq(y, p2, rtol=1., atol=50.)
 
     # be sure LightGBM actually used at least one categorical column
     if output == 'dataframe-with-categorical':

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -65,7 +65,7 @@ def _create_ranking_data(n_samples=100, output='array', chunk_size=50, **kwargs)
         X_df = pd.DataFrame(X, columns=[f'feature_{i}' for i in range(X.shape[1])])
         if output == 'dataframe-with-categorical':
             cat_series = pd.Series(
-                np.random.choice(['a', 'b', 'y', 'z'], n_samples),
+                np.random.choice(['a', 'b', 'y', 'z'], X.shape[0]),
                 dtype='category'
             )
             X_df['cat_col'] = cat_series
@@ -126,7 +126,7 @@ def _create_data(objective, n_samples=100, centers=2, output='array', chunk_size
         X_df = pd.DataFrame(X, columns=['feature_%d' % i for i in range(X.shape[1])])
         if output == 'dataframe-with-categorical':
             cat_series = pd.Series(
-                np.random.choice(['a', 'b', 'y', 'z'], n_samples),
+                np.random.choice(['a', 'b', 'y', 'z'], X.shape[0]),
                 dtype='category'
             )
             X_df['cat_col'] = cat_series

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -69,7 +69,6 @@ def _create_ranking_data(n_samples=100, output='array', chunk_size=50, **kwargs)
                 dtype='category'
             )
             X_df['cat_col'] = cat_series
-            X = np.hstack((X, cat_series.cat.codes.values.reshape(-1, 1)))
         X = X_df.copy()
         X_df = X_df.assign(y=y, g=g, w=w)
 


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/LightGBM/issues/3861.

## Root Cause

Thanks to @jmoralez for figuring out that the root issue was `pandas` "category" columns for data frames! `lightgbm.dask._predict_part()` did some conversions thatt did not handle these columns correctly.

## Changes in this PR

1. Removes code in `_predict_part()` that converts a chunk of data to array before passing it through to `.predict()` on the underlying scikit-learn model.
    - LightGBM's scikit-learn estimators already support scoring directly on pandas data frames, so this was useless. And it was the root of the problem! Because when you use `.values` on a pandas "category" column, the results are strings. Passing a numpy array with string data into `.predict()` methods in LightGBM leads to errors.

2. Adds data frames with a "category" column to many of the Dask unit tests

## Reproducible example

I've added a reproducible example in https://github.com/microsoft/LightGBM/issues/3861#issuecomment-773011094. If you run the code on current `master`, it will fail with the error described in #3861. If you run that code on this branch, it will succeed 😀 .

## References

I found a few issues and PRs related to "category" columns in `pandas` being supported in the scikit-learn interface. Putting them here for anyone who finds this PR from search in the future.

* https://github.com/microsoft/LightGBM/pull/1979
* https://github.com/microsoft/LightGBM/pull/1766
* https://github.com/microsoft/LightGBM/pull/1764
* https://github.com/microsoft/LightGBM/blob/8ef874bd4804b54b48ef4d796c8110be671a6950/python-package/lightgbm/basic.py#L497-L500