### PR TITLE
[dask] Add unit tests that signatures are the same between Dask and scikit-learn estimators 

### DIFF
--- a/LESSONS
+++ b/LESSONS
@@ -1,0 +1,3 @@
+1) It is meaningless to ask tbe qn: "What is the default value of a variable 
+	argument/keyword argument? " 
+2) Hacking mindset is crucial for success in open source

--- a/LESSONS
+++ b/LESSONS
@@ -1,3 +1,0 @@
-1) It is meaningless to ask tbe qn: "What is the default value of a variable 
-	argument/keyword argument? " 
-2) Hacking mindset is crucial for success in open source

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -837,7 +837,6 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
         (lgb.DaskLGBMRegressor.predict, lgb.LGBMRegressor.predict),
         (lgb.DaskLGBMRanker.fit, lgb.LGBMRanker.fit),
         (lgb.DaskLGBMRanker.predict, lgb.LGBMRanker.predict)
-
     ]
 )
 def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
@@ -846,9 +845,11 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     dask_params = inspect.signature(methods[0]).parameters
     sklearn_params = inspect.signature(methods[1]).parameters
     assert dask_spec.args == sklearn_spec.args[:len(dask_spec.args)]
-    assert dask_spec.defaults == sklearn_spec.defaults[:len(dask_spec.defaults)]
-    assert dask_spec.varargs == sklearn_spec.varargs[:len(dask_spec.varargs)]
-    assert dask_spec.varkw == sklearn_spec.varkw[:len(dask_spec.varkw)]
-    assert dask_spec.kwonlyargs == sklearn_spec.kwonlyargs[:len(dask_spec.kwonlyargs)]
-    assert dask_spec.kwonlydefaults == sklearn_spec.kwonlydefaults[:len(dask_spec.kwonlydefaults)]
-    assert all([dask_params[key].default == sklearn_params[key].default for key in dask_params]) is True
+    assert dask_spec.varargs == sklearn_spec.varargs
+    if sklearn_spec.varkw:
+        assert dask_spec.varkw == sklearn_spec.varkw[:len(dask_spec.varkw)]
+    assert dask_spec.kwonlyargs == sklearn_spec.kwonlyargs
+    assert dask_spec.kwonlydefaults == sklearn_spec.kwonlydefaults
+    for key in dask_params:
+        error_msg = f"param '{key}' has different default values in the methods"
+        assert dask_params[key].default == sklearn_params[key].default, error_msg

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -831,13 +831,13 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
 @pytest.mark.parametrize(
     "methods",
     [   
-        (lgb.DaskLGBMClassifier.fit, lgb.LGBMClassifier.fit)
-        (lgb.DaskLGBMClassifier.predict, lgb.LGBMClassifier.predict)
+        (lgb.DaskLGBMClassifier.fit, lgb.LGBMClassifier.fit),
+        (lgb.DaskLGBMClassifier.predict, lgb.LGBMClassifier.predict),
 
-        (lgb.DaskLGBMRegressor.fit, lgb.LGBMRegressor.fit)
-        (lgb.DaskLGBMRegressor.predict, lgb.LGBMRegressor.predict)
+        (lgb.DaskLGBMRegressor.fit, lgb.LGBMRegressor.fit),
+        (lgb.DaskLGBMRegressor.predict, lgb.LGBMRegressor.predict),
 
-        (lgb.DaskLGBMRanker.fit, lgb.LGBMRanker.fit)
+        (lgb.DaskLGBMRanker.fit, lgb.LGBMRanker.fit),
         (lgb.DaskLGBMRanker.predict, lgb.LGBMRanker.predict)
 
     ]

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -847,6 +847,6 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     sklearn_spec = inspect.getfullargspec(methods[1])
 
     # checks for a sublist in sklearn's kwargs which matches dask's
-    assert dark_spec.args is not None and sklearn_spec.args is not None
-    assert any(sklearn_spec.args[i: i + len(dask_spec.args)] == dask_spec.args for i in range(len(sklearn_spec.args) - len(dask_spec.args) + 1)) is True
-    assert any(sklearn_spec.defaults[i: i + len(dask_spec.defaults)] == dask_spec.defaults for i in range(len(sklearn_spec.defaults) - len(dask_spec.defaults) + 1)) is True
+    if dark_spec.args is not None and sklearn_spec.args is not None:
+        assert any(sklearn_spec.args[i: i + len(dask_spec.args)] == dask_spec.args for i in range(len(sklearn_spec.args) - len(dask_spec.args) + 1)) is True
+        assert any(sklearn_spec.defaults[i: i + len(dask_spec.defaults)] == dask_spec.defaults for i in range(len(sklearn_spec.defaults) - len(dask_spec.defaults) + 1)) is True

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -852,5 +852,5 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     assert dask_spec.kwonlyargs == sklearn_spec.kwonlyargs
     assert dask_spec.kwonlydefaults == sklearn_spec.kwonlydefaults
     for param in dask_spec.args:
-        error_msg = f"param '{key}' has different default values in the methods"
+        error_msg = f"param '{param}' has different default values in the methods"
         assert dask_params[param].default == sklearn_params[param].default, error_msg

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -833,7 +833,7 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
     [
         (lgb.DaskLGBMClassifier.fit, lgb.LGBMClassifier.fit),
         (lgb.DaskLGBMClassifier.predict, lgb.LGBMClassifier.predict),
-        (lgb.DaskLGBMClassifier.predict_proba, lgb.LGBMClassifier.predict_proba),    
+        (lgb.DaskLGBMClassifier.predict_proba, lgb.LGBMClassifier.predict_proba), 
         (lgb.DaskLGBMRegressor.fit, lgb.LGBMRegressor.fit),
         (lgb.DaskLGBMRegressor.predict, lgb.LGBMRegressor.predict),
         (lgb.DaskLGBMRanker.fit, lgb.LGBMRanker.fit),
@@ -854,5 +854,5 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     for key in dask_params:
         error_msg1 = f"param '{key}' has different default values in the methods"
         error_msg2 = f"param '{key}' in dask's method has no sklearn equivalent"
-        assert key in sklearn_params is True, error_msg2
+        assert key in sklearn_params == True, error_msg2
         assert dask_params[key].default == sklearn_params[key].default, error_msg1

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -847,6 +847,6 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     sklearn_spec = inspect.getfullargspec(methods[1])
 
     # checks for a sublist in sklearn's kwargs which matches dask's
-    if dark_spec.args is not None and sklearn_spec.args is not None:
+    if dask_spec.args is not None and sklearn_spec.args is not None:
         assert any(sklearn_spec.args[i: i + len(dask_spec.args)] == dask_spec.args for i in range(len(sklearn_spec.args) - len(dask_spec.args) + 1)) is True
         assert any(sklearn_spec.defaults[i: i + len(dask_spec.defaults)] == dask_spec.defaults for i in range(len(sklearn_spec.defaults) - len(dask_spec.defaults) + 1)) is True

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -849,4 +849,6 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     # checks for a sublist in sklearn's kwargs which matches dask's
     if dask_spec.args is not None and sklearn_spec.args is not None:
         assert any(sklearn_spec.args[i: i + len(dask_spec.args)] == dask_spec.args for i in range(len(sklearn_spec.args) - len(dask_spec.args) + 1)) is True
+    
+    if dask_spec.defaults is not None and sklearn_spec.defaults is not None:
         assert any(sklearn_spec.defaults[i: i + len(dask_spec.defaults)] == dask_spec.defaults for i in range(len(sklearn_spec.defaults) - len(dask_spec.defaults) + 1)) is True

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -854,4 +854,3 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
         if key in sklearn_params:
             error_msg = f"param '{key}' has different default values in the methods"
             assert dask_params[key].default == sklearn_params[key].default, error_msg
-

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -833,7 +833,7 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
     [
         (lgb.DaskLGBMClassifier.fit, lgb.LGBMClassifier.fit),
         (lgb.DaskLGBMClassifier.predict, lgb.LGBMClassifier.predict),
-        (lgb.DaskLGBMClassifier.predict_proba, lgb.LGBMClassifier.predict_proba), 
+        (lgb.DaskLGBMClassifier.predict_proba, lgb.LGBMClassifier.predict_proba),
         (lgb.DaskLGBMRegressor.fit, lgb.LGBMRegressor.fit),
         (lgb.DaskLGBMRegressor.predict, lgb.LGBMRegressor.predict),
         (lgb.DaskLGBMRanker.fit, lgb.LGBMRanker.fit),
@@ -854,5 +854,5 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     for key in dask_params:
         error_msg1 = f"param '{key}' has different default values in the methods"
         error_msg2 = f"param '{key}' in dask's method has no sklearn equivalent"
-        assert key in sklearn_params == True, error_msg2
+        assert key in sklearn_params is True, error_msg2
         assert dask_params[key].default == sklearn_params[key].default, error_msg1

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -833,7 +833,7 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
     [
         (lgb.DaskLGBMClassifier.fit, lgb.LGBMClassifier.fit),
         (lgb.DaskLGBMClassifier.predict, lgb.LGBMClassifier.predict),
-        (lgb.DaskLGBMClassifier.predict_proba, lgb.LGBMClassifier.predict_proba),        
+        (lgb.DaskLGBMClassifier.predict_proba, lgb.LGBMClassifier.predict_proba),    
         (lgb.DaskLGBMRegressor.fit, lgb.LGBMRegressor.fit),
         (lgb.DaskLGBMRegressor.predict, lgb.LGBMRegressor.predict),
         (lgb.DaskLGBMRanker.fit, lgb.LGBMRanker.fit),
@@ -851,6 +851,6 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
         assert dask_spec.varkw == sklearn_spec.varkw[:len(dask_spec.varkw)]
     assert dask_spec.kwonlyargs == sklearn_spec.kwonlyargs
     assert dask_spec.kwonlydefaults == sklearn_spec.kwonlydefaults
-    for key in dask_params:
-        error_msg = f"param '{key}' has different default values in the methods"
-        assert dask_params[key].default == sklearn_params[key].default, error_msg
+    for param_key in dask_params:
+        error_msg = f"param '{param_key}' has different default values in the methods"
+        assert dask_params[param_key].default == sklearn_params[param_key].default, error_msg

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -849,6 +849,6 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     # checks for a sublist in sklearn's kwargs which matches dask's
     if dask_spec.args is not None and sklearn_spec.args is not None:
         assert any(sklearn_spec.args[i: i + len(dask_spec.args)] == dask_spec.args for i in range(len(sklearn_spec.args) - len(dask_spec.args) + 1)) is True
-    
+
     if dask_spec.defaults is not None and sklearn_spec.defaults is not None:
         assert any(sklearn_spec.defaults[i: i + len(dask_spec.defaults)] == dask_spec.defaults for i in range(len(sklearn_spec.defaults) - len(dask_spec.defaults) + 1)) is True

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -851,6 +851,8 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
         assert dask_spec.varkw == sklearn_spec.varkw[:len(dask_spec.varkw)]
     assert dask_spec.kwonlyargs == sklearn_spec.kwonlyargs
     assert dask_spec.kwonlydefaults == sklearn_spec.kwonlydefaults
-    for param_key in dask_params:
-        error_msg = f"param '{param_key}' has different default values in the methods"
-        assert dask_params[param_key].default == sklearn_params[param_key].default, error_msg
+    for key in dask_params:
+        error_msg1 = f"param '{key}' has different default values in the methods"
+        error_msg2 = f"param '{key}' in dask's method has no sklearn equivalent"
+        assert key in sklearn_params is True, error_msg2
+        assert dask_params[key].default == sklearn_params[key].default, error_msg1

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -851,5 +851,7 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     assert dask_spec.kwonlyargs == sklearn_spec.kwonlyargs
     assert dask_spec.kwonlydefaults == sklearn_spec.kwonlydefaults
     for key in dask_params:
-        error_msg = f"param '{key}' has different default values in the methods"
-        assert dask_params[key].default == sklearn_params[key].default, error_msg
+        if key in sklearn_params:
+            error_msg = f"param '{key}' has different default values in the methods"
+            assert dask_params[key].default == sklearn_params[key].default, error_msg
+

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -851,8 +851,6 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
         assert dask_spec.varkw == sklearn_spec.varkw[:len(dask_spec.varkw)]
     assert dask_spec.kwonlyargs == sklearn_spec.kwonlyargs
     assert dask_spec.kwonlydefaults == sklearn_spec.kwonlydefaults
-    for key in dask_params:
-        error_msg1 = f"param '{key}' has different default values in the methods"
-        error_msg2 = f"param '{key}' in dask's method has no sklearn equivalent"
-        assert key in sklearn_params is True, error_msg2
-        assert dask_params[key].default == sklearn_params[key].default, error_msg1
+    for param in dask_spec.args:
+        error_msg = f"param '{key}' has different default values in the methods"
+        assert dask_params[param].default == sklearn_params[param].default, error_msg

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -833,10 +833,8 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
     [
         (lgb.DaskLGBMClassifier.fit, lgb.LGBMClassifier.fit),
         (lgb.DaskLGBMClassifier.predict, lgb.LGBMClassifier.predict),
-
         (lgb.DaskLGBMRegressor.fit, lgb.LGBMRegressor.fit),
         (lgb.DaskLGBMRegressor.predict, lgb.LGBMRegressor.predict),
-
         (lgb.DaskLGBMRanker.fit, lgb.LGBMRanker.fit),
         (lgb.DaskLGBMRanker.predict, lgb.LGBMRanker.predict)
 
@@ -845,10 +843,13 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
 def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     dask_spec = inspect.getfullargspec(methods[0])
     sklearn_spec = inspect.getfullargspec(methods[1])
-
-    # checks for a sublist in sklearn's kwargs which matches dask's
-    if dask_spec.args is not None and sklearn_spec.args is not None:
-        assert any(sklearn_spec.args[i: i + len(dask_spec.args)] == dask_spec.args for i in range(len(sklearn_spec.args) - len(dask_spec.args) + 1)) is True
-
-    if dask_spec.defaults is not None and sklearn_spec.defaults is not None:
-        assert any(sklearn_spec.defaults[i: i + len(dask_spec.defaults)] == dask_spec.defaults for i in range(len(sklearn_spec.defaults) - len(dask_spec.defaults) + 1)) is True
+    num_dask_args = len(dask_spec.args)
+    dask_params = inspect.signature(methods[0]).parameters
+    sklearn_params = inspect.signature(methods[1]).parameters
+    assert dask_spec.args == sklearn_spec.args[:num_dask_args]
+    assert dask_spec.defaults == sklearn_spec.defaults[:num_dask_args]
+    assert dask_spec.varargs == sklearn_spec.varargs[:num_dask_args]
+    assert dask_spec.varkw == sklearn_spec.varkw[:num_dask_args]
+    assert dask_spec.kwonlyargs == sklearn_spec.kwonlyargs[:num_dask_args]
+    assert dask_spec.kwonlydefaults == sklearn_spec.kwonlydefaults[:num_dask_args]
+    assert all([dask_params[key].default == sklearn_params[key].default for key in dask_params]) is True

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -826,3 +826,26 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
     assert dask_spec.defaults[:-1] == sklearn_spec.defaults
     assert dask_spec.args[-1] == 'client'
     assert dask_spec.defaults[-1] is None
+
+
+@pytest.mark.parametrize(
+    "methods",
+    [   
+        (lgb.DaskLGBMClassifier.fit, lgb.LGBMClassifier.fit)
+        (lgb.DaskLGBMClassifier.predict, lgb.LGBMClassifier.predict)
+
+        (lgb.DaskLGBMRegressor.fit, lgb.LGBMRegressor.fit)
+        (lgb.DaskLGBMRegressor.predict, lgb.LGBMRegressor.predict)
+
+        (lgb.DaskLGBMRanker.fit, lgb.LGBMRanker.fit)
+        (lgb.DaskLGBMRanker.predict, lgb.LGBMRanker.predict)
+
+    ]
+)
+def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
+    dask_spec = inspect.getfullargspec(methods[0])
+    sklearn_spec = inspect.getfullargspec(methods[1])
+
+    # checks for a sublist in sklearn's kwargs which matches dask's
+    assert any(sklearn_spec.args[i : i + len(dask_spec.args)] == dask_spec.args for i in range(len(sklearn_spec.args) - len(dask_spec.args) + 1)) is True
+    assert any(sklearn_spec.defaults[i : i + len(dask_spec.defaults)] == dask_spec.defaults for i in range(len(sklearn_spec.defaults) - len(dask_spec.defaults) + 1)) is True

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -830,7 +830,7 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
 
 @pytest.mark.parametrize(
     "methods",
-    [   
+    [
         (lgb.DaskLGBMClassifier.fit, lgb.LGBMClassifier.fit),
         (lgb.DaskLGBMClassifier.predict, lgb.LGBMClassifier.predict),
 
@@ -847,5 +847,6 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     sklearn_spec = inspect.getfullargspec(methods[1])
 
     # checks for a sublist in sklearn's kwargs which matches dask's
-    assert any(sklearn_spec.args[i : i + len(dask_spec.args)] == dask_spec.args for i in range(len(sklearn_spec.args) - len(dask_spec.args) + 1)) is True
-    assert any(sklearn_spec.defaults[i : i + len(dask_spec.defaults)] == dask_spec.defaults for i in range(len(sklearn_spec.defaults) - len(dask_spec.defaults) + 1)) is True
+    assert dark_spec.args is not None and sklearn_spec.args is not None
+    assert any(sklearn_spec.args[i: i + len(dask_spec.args)] == dask_spec.args for i in range(len(sklearn_spec.args) - len(dask_spec.args) + 1)) is True
+    assert any(sklearn_spec.defaults[i: i + len(dask_spec.defaults)] == dask_spec.defaults for i in range(len(sklearn_spec.defaults) - len(dask_spec.defaults) + 1)) is True

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -833,6 +833,7 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
     [
         (lgb.DaskLGBMClassifier.fit, lgb.LGBMClassifier.fit),
         (lgb.DaskLGBMClassifier.predict, lgb.LGBMClassifier.predict),
+        (lgb.DaskLGBMClassifier.predict_proba, lgb.LGBMClassifier.predict_proba),        
         (lgb.DaskLGBMRegressor.fit, lgb.LGBMRegressor.fit),
         (lgb.DaskLGBMRegressor.predict, lgb.LGBMRegressor.predict),
         (lgb.DaskLGBMRanker.fit, lgb.LGBMRanker.fit),
@@ -851,6 +852,5 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     assert dask_spec.kwonlyargs == sklearn_spec.kwonlyargs
     assert dask_spec.kwonlydefaults == sklearn_spec.kwonlydefaults
     for key in dask_params:
-        if key in sklearn_params:
-            error_msg = f"param '{key}' has different default values in the methods"
-            assert dask_params[key].default == sklearn_params[key].default, error_msg
+        error_msg = f"param '{key}' has different default values in the methods"
+        assert dask_params[key].default == sklearn_params[key].default, error_msg

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -843,13 +843,12 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
 def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     dask_spec = inspect.getfullargspec(methods[0])
     sklearn_spec = inspect.getfullargspec(methods[1])
-    num_dask_args = len(dask_spec.args)
     dask_params = inspect.signature(methods[0]).parameters
     sklearn_params = inspect.signature(methods[1]).parameters
-    assert dask_spec.args == sklearn_spec.args[:num_dask_args]
-    assert dask_spec.defaults == sklearn_spec.defaults[:num_dask_args]
-    assert dask_spec.varargs == sklearn_spec.varargs[:num_dask_args]
-    assert dask_spec.varkw == sklearn_spec.varkw[:num_dask_args]
-    assert dask_spec.kwonlyargs == sklearn_spec.kwonlyargs[:num_dask_args]
-    assert dask_spec.kwonlydefaults == sklearn_spec.kwonlydefaults[:num_dask_args]
+    assert dask_spec.args == sklearn_spec.args[:len(dask_spec.args)]
+    assert dask_spec.defaults == sklearn_spec.defaults[:len(dask_spec.defaults)]
+    assert dask_spec.varargs == sklearn_spec.varargs[:len(dask_spec.varargs)]
+    assert dask_spec.varkw == sklearn_spec.varkw[:len(dask_spec.varkw)]
+    assert dask_spec.kwonlyargs == sklearn_spec.kwonlyargs[:len(dask_spec.kwonlyargs)]
+    assert dask_spec.kwonlydefaults == sklearn_spec.kwonlydefaults[:len(dask_spec.kwonlydefaults)]
     assert all([dask_params[key].default == sklearn_params[key].default for key in dask_params]) is True


### PR DESCRIPTION
I tried to check for a sublist in sklearn's args which matches dask's (this ensures that order is checked), the same goes for the
default values. 

fixes #3907