### PR TITLE
fix typos in log messages

### DIFF
--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -1232,7 +1232,7 @@ void Dataset::ConstructHistogramsInner(
   }
 }
 
-// explicitly initilize template methods, for cross module call
+// explicitly initialize template methods, for cross module call
 template void Dataset::ConstructHistogramsInner<true, true>(
     const std::vector<int8_t>& is_feature_used, const data_size_t* data_indices,
     data_size_t num_data, const score_t* gradients, const score_t* hessians,

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -67,7 +67,7 @@ void Network::Dispose() {
 
 void Network::Allreduce(char* input, comm_size_t input_size, int type_size, char* output, const ReduceFunction& reducer) {
   if (num_machines_ <= 1) {
-    Log::Fatal("Please initilize the network interface first");
+    Log::Fatal("Please initialize the network interface first");
   }
   comm_size_t count = input_size / type_size;
   // if small package or small count , do it by all gather.(reduce the communication times.)
@@ -94,7 +94,7 @@ void Network::Allreduce(char* input, comm_size_t input_size, int type_size, char
 
 void Network::AllreduceByAllGather(char* input, comm_size_t input_size, int type_size, char* output, const ReduceFunction& reducer) {
   if (num_machines_ <= 1) {
-    Log::Fatal("Please initilize the network interface first");
+    Log::Fatal("Please initialize the network interface first");
   }
   // assign blocks
   comm_size_t all_size = input_size * num_machines_;
@@ -120,7 +120,7 @@ void Network::AllreduceByAllGather(char* input, comm_size_t input_size, int type
 
 void Network::Allgather(char* input, comm_size_t send_size, char* output) {
   if (num_machines_ <= 1) {
-    Log::Fatal("Please initilize the network interface first");
+    Log::Fatal("Please initialize the network interface first");
     return;
   }
   // assign blocks
@@ -136,7 +136,7 @@ void Network::Allgather(char* input, comm_size_t send_size, char* output) {
 
 void Network::Allgather(char* input, const comm_size_t* block_start, const comm_size_t* block_len, char* output, comm_size_t all_size) {
   if (num_machines_ <= 1) {
-    Log::Fatal("Please initilize the network interface first");
+    Log::Fatal("Please initialize the network interface first");
   }
   if (allgather_ext_fun_ != nullptr) {
     return allgather_ext_fun_(input, block_len[rank_], block_start, block_len, num_machines_, output, all_size);
@@ -233,7 +233,7 @@ void Network::ReduceScatter(char* input, comm_size_t input_size, int type_size,
                             const comm_size_t* block_start, const comm_size_t* block_len, char* output,
                             comm_size_t output_size, const ReduceFunction& reducer) {
   if (num_machines_ <= 1) {
-    Log::Fatal("Please initilize the network interface first");
+    Log::Fatal("Please initialize the network interface first");
   }
   if (reduce_scatter_ext_fun_ != nullptr) {
     return reduce_scatter_ext_fun_(input, input_size, type_size, block_start, block_len, num_machines_, output, output_size, reducer);

--- a/src/treelearner/cuda_tree_learner.cpp
+++ b/src/treelearner/cuda_tree_learner.cpp
@@ -470,10 +470,10 @@ void CUDATreeLearner::InitGPU(int num_gpu) {
     Log::Fatal("bin size %d cannot run on GPU", max_num_bin_);
   }
   if (max_num_bin_ == 65) {
-    Log::Warning("Setting max_bin to 63 is sugguested for best performance");
+    Log::Warning("Setting max_bin to 63 is suggested for best performance");
   }
   if (max_num_bin_ == 17) {
-    Log::Warning("Setting max_bin to 15 is sugguested for best performance");
+    Log::Warning("Setting max_bin to 15 is suggested for best performance");
   }
 
   // get num_dense_feature_groups_

--- a/src/treelearner/gpu_tree_learner.cpp
+++ b/src/treelearner/gpu_tree_learner.cpp
@@ -720,10 +720,10 @@ void GPUTreeLearner::InitGPU(int platform_id, int device_id) {
     Log::Fatal("bin size %d cannot run on GPU", max_num_bin_);
   }
   if (max_num_bin_ == 65) {
-    Log::Warning("Setting max_bin to 63 is sugguested for best performance");
+    Log::Warning("Setting max_bin to 63 is suggested for best performance");
   }
   if (max_num_bin_ == 17) {
-    Log::Warning("Setting max_bin to 15 is sugguested for best performance");
+    Log::Warning("Setting max_bin to 15 is suggested for best performance");
   }
   ctx_ = boost::compute::context(dev_);
   queue_ = boost::compute::command_queue(ctx_, dev_);


### PR DESCRIPTION
I was reading through the code in `src/network` while reviewing #3823 , and found a typo in a log message. So I looked for others like this:

```shell
grep -E "Log\:\:" -r src/* | aspell list | sort -u
```

This PR fixes a few typos in log messages.