### PR TITLE
[dask] Add support for 'pred_leaf' in Dask estimators (fixes #3792)

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -372,7 +372,7 @@ def _predict_part(
         )
 
     if isinstance(part, pd_DataFrame):
-        if pred_proba or pred_contrib:
+        if pred_proba or pred_contrib or pred_leaf:
             result = pd_DataFrame(result, index=part.index)
         else:
             result = pd_Series(result, index=part.index, name='predictions')

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -710,7 +710,6 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         X: _DaskMatrixLike,
         y: _DaskCollection,
         sample_weight: Optional[_DaskCollection] = None,
-        client: Optional[Client] = None,
         **kwargs: Any
     ) -> "DaskLGBMRegressor":
         """Docstring is inherited from the lightgbm.LGBMRegressor.fit."""


### PR DESCRIPTION
This PR adds support in the Dask module for getting indices of the leaf nodes in each tree that each observation in a dataset falls into, via `.predict(X, pred_leaf=True)`. It fixes #3792.

This brings the Dask module a step closer to feature parity with the estimators available from `lightgbm.sklearn`.

## Notes for Reviewers

These tests also led to the discovery of this bug: https://github.com/microsoft/LightGBM/issues/3918
