### PR TITLE
[docs] simplify bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -7,7 +7,7 @@ about: Something isn't working as expected? Here is the right place to report.
 <!-- A clear description of the bug -->
 
 ## Reproducible example
-<!-- Minimal code that exhibits this behavior.-->
+<!-- Minimal code that exhibits this behavior -->
 
 ## Environment info
 

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -3,65 +3,24 @@ name: Bug Report 🐞
 about: Something isn't working as expected? Here is the right place to report.
 ---
 
-<!--
-Please search your question on previous issues, Stack Overflow (https://stackoverflow.com/questions/tagged/lightgbm) or other search engines before you open a new one.
+## Description
+<!-- A clear description of the bug -->
 
-Also, for bugs and unexpected issues, please check the latest master branch first.
--->
-
-## How you are using LightGBM?
-
-<!-- 
-Choose one of the following components
-
-* R package
-* Python package
-* C++ library
-* Command Line Interface (CLI)
-* Java via SWIG
-* Other (please specify)
--->
-LightGBM component: 
+## Reproducible example
+<!-- Minimal code that exhibits this behavior.-->
 
 ## Environment info
 
-<!-- Fill out each of the below. If something is not applicable, put 'N/A' or leave it blank -->
-
-Operating System:
-
-CPU/GPU model:
-
-C++ compiler version:
-
-CMake version:
-
-Java version:
-
-Python version:
-
-R version:
-
-Other:
-
-<!-- Please check the latest master branch first -->
 LightGBM version or commit hash:
 
-## Error message and / or logs
+Command(s) you used to install LightGBM
 
-<!-- Paste error log below (please avoid screenshots, use raw text) -->
+```shell
+
+```
+
+<!-- Put any additional environment information here -->
 
 
-## Reproducible example(s)
-
-<!--
-Paste examples code below (please avoid screenshots, use raw text).
-
-If possible, try to provide a minimum working example that does not
-require access to proprietary data: https://stackoverflow.com/help/minimal-reproducible-example.
--->
-
-## Steps to reproduce
-
-1.
-2.
-3.
+## Additional Comments
+<!-- What else should we know? -->


### PR DESCRIPTION
I've observed that people reporting bugs in this project very very rarely use the issue template. I think that we're asking for too much information, and that people just get overwhelmed and ignore it entirely.

I've noticed that other projects like https://github.com/PrefectHQ/prefect/issues and https://github.com/dask/distributed/issues get a much higher % of issues following their template, and I think this is because their templates are so much simpler.

This PR proposes simplifying the issue template for bug reports greatly, to hopefully get higher-quality reports.

![image](https://user-images.githubusercontent.com/7608904/107155123-5500c480-693c-11eb-9b7a-498dc7da5e2b.png)

