### PR TITLE
openmp_wrapper.h stubs signature use __GOMP_NOTHROW

### DIFF
--- a/include/LightGBM/utils/openmp_wrapper.h
+++ b/include/LightGBM/utils/openmp_wrapper.h
@@ -4,6 +4,21 @@
  */
 #ifndef LIGHTGBM_OPENMP_WRAPPER_H_
 #define LIGHTGBM_OPENMP_WRAPPER_H_
+
+/*
+ * See https://github.com/dmlc/dmlc-core/blob/main/include/dmlc/omp.h#L14
+ */
+#if defined(__clang__)
+#undef __GOMP_NOTHROW
+#define __GOMP_NOTHROW
+#elif defined(__cplusplus)
+#undef __GOMP_NOTHROW
+#define __GOMP_NOTHROW throw()
+#else
+#undef __GOMP_NOTHROW
+#define __GOMP_NOTHROW __attribute__((__nothrow__))
+#endif
+
 #ifdef _OPENMP
 
 #include <LightGBM/utils/log.h>
@@ -76,11 +91,11 @@ class ThreadExceptionHelper {
   /** Fall here if no OPENMP support, so just
       simulate a single thread running.
       All #pragma omp should be ignored by the compiler **/
-  inline void omp_set_num_threads(int) {}
-  inline int omp_get_num_threads() {return 1;}
-  inline int omp_get_max_threads() {return 1;}
-  inline int omp_get_thread_num() {return 0;}
-  inline int OMP_NUM_THREADS() { return 1; }
+  inline void omp_set_num_threads(int) __GOMP_NOTHROW {}
+  inline int omp_get_num_threads() __GOMP_NOTHROW {return 1;}
+  inline int omp_get_max_threads() __GOMP_NOTHROW {return 1;}
+  inline int omp_get_thread_num() __GOMP_NOTHROW {return 0;}
+  inline int OMP_NUM_THREADS() __GOMP_NOTHROW { return 1; }
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/include/LightGBM/utils/openmp_wrapper.h
+++ b/include/LightGBM/utils/openmp_wrapper.h
@@ -5,20 +5,6 @@
 #ifndef LIGHTGBM_OPENMP_WRAPPER_H_
 #define LIGHTGBM_OPENMP_WRAPPER_H_
 
-/*
- * See https://github.com/dmlc/dmlc-core/blob/main/include/dmlc/omp.h#L14
- */
-#if defined(__clang__)
-#undef __GOMP_NOTHROW
-#define __GOMP_NOTHROW
-#elif defined(__cplusplus)
-#undef __GOMP_NOTHROW
-#define __GOMP_NOTHROW throw()
-#else
-#undef __GOMP_NOTHROW
-#define __GOMP_NOTHROW __attribute__((__nothrow__))
-#endif
-
 #ifdef _OPENMP
 
 #include <LightGBM/utils/log.h>
@@ -80,6 +66,22 @@ class ThreadExceptionHelper {
 #define OMP_THROW_EX() omp_except_helper.ReThrow()
 
 #else
+
+/*
+ * To be compatible with openmp, define a nothrow macro which is used by gcc
+ * openmp, but not by clang.
+ * See also https://github.com/dmlc/dmlc-core/blob/main/include/dmlc/omp.h#L14
+ */
+#if defined(__clang__)
+#undef __GOMP_NOTHROW
+#define __GOMP_NOTHROW
+#elif defined(__cplusplus)
+#undef __GOMP_NOTHROW
+#define __GOMP_NOTHROW throw()
+#else
+#undef __GOMP_NOTHROW
+#define __GOMP_NOTHROW __attribute__((__nothrow__))
+#endif
 
 #ifdef _MSC_VER
   #pragma warning(disable : 4068)  // disable unknown pragma warning

--- a/include/LightGBM/utils/openmp_wrapper.h
+++ b/include/LightGBM/utils/openmp_wrapper.h
@@ -70,7 +70,7 @@ class ThreadExceptionHelper {
 /*
  * To be compatible with openmp, define a nothrow macro which is used by gcc
  * openmp, but not by clang.
- * See also https://github.com/dmlc/dmlc-core/blob/main/include/dmlc/omp.h#L14
+ * See also https://github.com/dmlc/dmlc-core/blob/3106c1cbdcc9fc9ef3a2c1d2196a7a6f6616c13d/include/dmlc/omp.h#L14
  */
 #if defined(__clang__)
 #undef __GOMP_NOTHROW

--- a/include/LightGBM/utils/openmp_wrapper.h
+++ b/include/LightGBM/utils/openmp_wrapper.h
@@ -93,7 +93,7 @@ class ThreadExceptionHelper {
   /** Fall here if no OPENMP support, so just
       simulate a single thread running.
       All #pragma omp should be ignored by the compiler **/
-  inline void omp_set_num_threads(int) __GOMP_NOTHROW {}
+  inline void omp_set_num_threads(int) __GOMP_NOTHROW {}  // NOLINT (no cast done here)
   inline int omp_get_num_threads() __GOMP_NOTHROW {return 1;}
   inline int omp_get_max_threads() __GOMP_NOTHROW {return 1;}
   inline int omp_get_thread_num() __GOMP_NOTHROW {return 0;}


### PR DESCRIPTION
Fix #3915. OpenMP stubs do not use the noexcept attibute which is present in the gcc version of openmp, and which trigger compilation errors as seen below. dmlc-core uses the same technique and macro.

/usr/lib/gcc/x86_64-linux-gnu/9/include/omp.h:114:12: error: declaration of ‘int omp_get_thread_num() noexcept’ has a different exception specifier
  114 | extern int omp_get_thread_num (void) __GOMP_NOTHROW;
      |            ^~~~~~~~~~~~~~~~~~
...
xxx/include/LightGBM/utils/openmp_wrapper.h:81:14: note: from previous declaration ‘int omp_get_thread_num()’
   81 |   inline int omp_get_thread_num() {return 0;}
      |              ^~~~~~~~~~~~~~~~~~