### PR TITLE
Improve GPU build instructions

### DIFF
--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -566,9 +566,12 @@ Following procedure is for the **MSVC** (Microsoft Visual C++) build.
      cd LightGBM
      mkdir build
      cd build
-     cmake -A x64 -DUSE_GPU=1 -DBOOST_ROOT=C:/local/boost_1_63_0 -DBOOST_LIBRARYDIR=C:/local/boost_1_63_0/lib64-msvc-14.0 ..
+     cmake -G"Visual Studio 16 2019" -A x64 -DUSE_GPU=1 -DBOOST_ROOT=C:/local/boost_1_63_0 -DBOOST_LIBRARYDIR=C:/local/boost_1_63_0/lib64-msvc-14.2 ..
+     # for VS14: cmake -G"Visual Studio 14 2015 Win64" ...
+     # for VS15: cmake .. -G"Visual Studio 15 2017" -A x64 ...
+     # for VS16: cmake .. -G"Visual Studio 16 2019" -A x64 ...
      # if you have installed NVIDIA CUDA to a customized location, you should specify paths to OpenCL headers and library like the following:
-     # cmake -A x64 -DUSE_GPU=1 -DBOOST_ROOT=C:/local/boost_1_63_0 -DBOOST_LIBRARYDIR=C:/local/boost_1_63_0/lib64-msvc-14.0 -DOpenCL_LIBRARY="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.0/lib/x64/OpenCL.lib" -DOpenCL_INCLUDE_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.0/include" ..
+     # cmake -G"Visual Studio 16 2019" -A x64 -DUSE_GPU=1 -DBOOST_ROOT=C:/local/boost_1_63_0 -DBOOST_LIBRARYDIR=C:/local/boost_1_63_0/lib64-msvc-14.2 -DOpenCL_LIBRARY="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.0/lib/x64/OpenCL.lib" -DOpenCL_INCLUDE_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.0/include" ..
      cmake --build . --target ALL_BUILD --config Release
 
    **Note**: ``C:/local/boost_1_63_0`` and ``C:/local/boost_1_63_0/lib64-msvc-14.0`` are locations of your **Boost** binaries (assuming you've downloaded 1.63.0 version for Visual Studio 2015).


### PR DESCRIPTION
Until I added the -G flag I kept getting errors like

```
CMake Error at CMakeLists.txt:30 (PROJECT):
  Generator

    NMake Makefiles

  does not support platform specification, but platform

    x64

  was specified.
```

The solution came form the [xgboost gpu build instructions](https://xgboost.readthedocs.io/en/latest/build.html)