### PR TITLE
[dask] test that Dask automatically treats 'category' columns as categorical features

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -210,11 +210,6 @@ def test_classifier(output, centers, client, listen_port):
         "num_leaves": 10
     }
 
-    if output == 'dataframe-with-categorical':
-        params["categorical_feature"] = [
-            i for i, col in enumerate(dX.columns) if col.startswith('cat_')
-        ]
-
     dask_classifier = lgb.DaskLGBMClassifier(
         client=client,
         time_out=5,
@@ -282,11 +277,6 @@ def test_classifier_pred_contrib(output, centers, client, listen_port):
         "n_estimators": 10,
         "num_leaves": 10
     }
-
-    if output == 'dataframe-with-categorical':
-        params["categorical_feature"] = [
-            i for i, col in enumerate(dX.columns) if col.startswith('cat_')
-        ]
 
     dask_classifier = lgb.DaskLGBMClassifier(
         client=client,
@@ -379,11 +369,6 @@ def test_regressor(output, client, listen_port):
         "num_leaves": 10
     }
 
-    if output == 'dataframe-with-categorical':
-        params["categorical_feature"] = [
-            i for i, col in enumerate(dX.columns) if col.startswith('cat_')
-        ]
-
     dask_regressor = lgb.DaskLGBMRegressor(
         client=client,
         time_out=5,
@@ -460,11 +445,6 @@ def test_regressor_pred_contrib(output, client, listen_port):
         "num_leaves": 10
     }
 
-    if output == 'dataframe-with-categorical':
-        params["categorical_feature"] = [
-            i for i, col in enumerate(dX.columns) if col.startswith('cat_')
-        ]
-
     dask_regressor = lgb.DaskLGBMRegressor(
         client=client,
         time_out=5,
@@ -518,11 +498,6 @@ def test_regressor_quantile(output, client, listen_port, alpha):
         "n_estimators": 10,
         "num_leaves": 10
     }
-
-    if output == 'dataframe-with-categorical':
-        params["categorical_feature"] = [
-            i for i, col in enumerate(dX.columns) if col.startswith('cat_')
-        ]
 
     dask_regressor = lgb.DaskLGBMRegressor(
         client=client,
@@ -592,11 +567,6 @@ def test_ranker(output, client, listen_port, group):
         "num_leaves": 20,
         "min_child_samples": 1
     }
-
-    if output == 'dataframe-with-categorical':
-        params["categorical_feature"] = [
-            i for i, col in enumerate(dX.columns) if col.startswith('cat_')
-        ]
 
     dask_ranker = lgb.DaskLGBMRanker(
         client=client,


### PR DESCRIPTION
Based on thread starting at https://github.com/microsoft/LightGBM/pull/3930#discussion_r573107195.

#3908 added some tests that the `lightgbm.dask` estimators correctly handled Dask DataFrames where some columns are `pandas` "category" columns. That PR used the parameter `categorical_feature` to explicitly provide a list of which features should be treated as categorical.

This is unnecessary, since `auto` is the default behavior and `auto` tells LightGBM "treat 'category' columns as categorical features" (https://github.com/microsoft/LightGBM/blob/846b512d892426d34fac0749ccfd2d7a31eef877/python-package/lightgbm/basic.py#L513-L514).

This PR removes the unnecessary `categorical_features` parameter in tests. As of this PR, we'll now be testing not only that `lightgbm.dask` estimators correctly train on categorical features, but also that it also automatically 

