### PR TITLE
[docs][dask] add versionadded note to Dask docs

### DIFF
--- a/docs/Python-API.rst
+++ b/docs/Python-API.rst
@@ -36,6 +36,8 @@ Scikit-learn API
 Dask API
 --------
 
+.. versionadded:: 3.2.0
+
 .. autosummary::
     :toctree: pythonapi/
 


### PR DESCRIPTION
This proposes adding a `versionadded` note on the Dask API docs. Sorry I didn't think about it on #3822 .

![image](https://user-images.githubusercontent.com/7608904/107468214-331a6400-6b2d-11eb-8605-ad7f9eb6ab79.png)
