### PR TITLE
[dask] [python-package] include support for column array as label

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -134,8 +134,8 @@ def is_numpy_column_array(data):
     return len(shape) == 2 and shape[1] == 1
 
 
-def numpy_1d_array_to_dtype(array, dtype):
-    """Convert 1d array to dtype."""
+def cast_numpy_1d_array_to_dtype(array, dtype):
+    """Cast numpy 1d array to given dtype."""
     if array.dtype == dtype:
         return array
     return array.astype(dtype=dtype, copy=False)
@@ -149,11 +149,11 @@ def is_1d_list(data):
 def list_to_1d_numpy(data, dtype=np.float32, name='list'):
     """Convert data to numpy 1-D array."""
     if is_numpy_1d_array(data):
-        return numpy_1d_array_to_dtype(data, dtype)
+        return cast_numpy_1d_array_to_dtype(data, dtype)
     elif is_numpy_column_array(data):
         _log_warning('Converting column-vector to 1d array')
         array = data.ravel()
-        return numpy_1d_array_to_dtype(array, dtype)
+        return cast_numpy_1d_array_to_dtype(array, dtype)
     elif is_1d_list(data):
         return np.array(data, dtype=dtype, copy=False)
     elif isinstance(data, pd_Series):

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -135,7 +135,7 @@ def is_numpy_column_array(data):
 
 
 def numpy_1d_array_to_dtype(array, dtype):
-    """Convert 1d array to dtype"""
+    """Convert 1d array to dtype."""
     if array.dtype == dtype:
         return array
     return array.astype(dtype=dtype, copy=False)

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -151,7 +151,7 @@ def list_to_1d_numpy(data, dtype=np.float32, name='list'):
     if is_numpy_1d_array(data):
         return numpy_1d_array_to_dtype(data, dtype)
     elif is_numpy_column_array(data):
-        _log_warning('Converting column vector to 1d array')
+        _log_warning('Converting column-vector to 1d array')
         array = data.ravel()
         return numpy_1d_array_to_dtype(array, dtype)
     elif is_1d_list(data):

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -126,6 +126,20 @@ def is_numpy_1d_array(data):
     return isinstance(data, np.ndarray) and len(data.shape) == 1
 
 
+def is_numpy_column_array(data):
+    """Check whether data is a column numpy array."""
+    if not isinstance(data, np.ndarray):
+        return False
+    shape = data.shape
+    return len(shape) == 2 and shape[1] == 1
+
+
+def numpy_1d_array_to_dtype(array, dtype):
+    if array.dtype == dtype:
+        return array
+    return array.astype(dtype=dtype, copy=False)
+
+
 def is_1d_list(data):
     """Check whether data is a 1-D list."""
     return isinstance(data, list) and (not data or is_numeric(data[0]))
@@ -134,10 +148,11 @@ def is_1d_list(data):
 def list_to_1d_numpy(data, dtype=np.float32, name='list'):
     """Convert data to numpy 1-D array."""
     if is_numpy_1d_array(data):
-        if data.dtype == dtype:
-            return data
-        else:
-            return data.astype(dtype=dtype, copy=False)
+        return numpy_1d_array_to_dtype(data, dtype)
+    elif is_numpy_column_array(data):
+        _log_warning('Converting column vector to 1d array')
+        array = data.ravel()
+        return numpy_1d_array_to_dtype(array, dtype)
     elif is_1d_list(data):
         return np.array(data, dtype=dtype, copy=False)
     elif isinstance(data, pd_Series):

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -135,6 +135,7 @@ def is_numpy_column_array(data):
 
 
 def numpy_1d_array_to_dtype(array, dtype):
+    """Convert 1d array to dtype"""
     if array.dtype == dtype:
         return array
     return array.astype(dtype=dtype, copy=False)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -379,7 +379,7 @@ def test_choose_param_value():
 
 
 @pytest.mark.parametrize(
-    'y', 
+    'y',
     [
         np.random.rand(10),
         np.random.rand(10, 1),

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -378,30 +378,21 @@ def test_choose_param_value():
 
 
 @pytest.mark.parametrize(
-    ('y', 'is_series'),
+    'y',
     [
-        (np.random.rand(10), False),
-        (np.random.rand(10, 1), False),
-        ([1] * 10, False),
-        (np.random.rand(10), True),
-        (['a', 'b'], True),
-        ([[1], [2]], False)
+        np.random.rand(10),
+        np.random.rand(10, 1),
+        [1] * 10,
+        [[1], [2]]
     ])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-def test_list_to_1d_numpy(y, is_series, dtype):
-    if is_series:
-        pd = pytest.importorskip('pandas')
-        y = pd.Series(y)
+def test_list_to_1d_numpy(y, dtype):
     if isinstance(y, np.ndarray) and len(y.shape) == 2:
         with pytest.warns(UserWarning, match='column-vector'):
             lgb.basic.list_to_1d_numpy(y)
         return
     elif isinstance(y, list) and isinstance(y[0], list):
         with pytest.raises(TypeError):
-            lgb.basic.list_to_1d_numpy(y)
-        return
-    elif is_series and y.dtype == object:
-        with pytest.raises(ValueError):
             lgb.basic.list_to_1d_numpy(y)
         return
     result = lgb.basic.list_to_1d_numpy(y, dtype=dtype)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -390,22 +390,18 @@ def test_choose_param_value():
     ])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
 def test_list_to_1d_numpy(y, dtype):
-    if isinstance(y, np.ndarray):
-        if len(y.shape) == 2:
-            with pytest.warns(UserWarning, match='column vector to 1d array'):
-                lgb.basic.list_to_1d_numpy(y)
-            return
-    elif isinstance(y, list):
-        if isinstance(y[0], list):
-            with pytest.raises(TypeError):
-                lgb.basic.list_to_1d_numpy(y)
-            return
-    else:
-        if y.dtype == object:
-            with pytest.raises(ValueError):
-                lgb.basic.list_to_1d_numpy(y)
-            return
-
+    if isinstance(y, np.ndarray) and len(y.shape) == 2:
+        with pytest.warns(UserWarning, match='column vector to 1d array'):
+            lgb.basic.list_to_1d_numpy(y)
+        return
+    elif isinstance(y, list) and isinstance(y[0], list):
+        with pytest.raises(TypeError):
+            lgb.basic.list_to_1d_numpy(y)
+        return
+    elif isinstance(y, pd.Series) and y.dtype == object:
+        with pytest.raises(ValueError):
+            lgb.basic.list_to_1d_numpy(y)
+        return
     result = lgb.basic.list_to_1d_numpy(y, dtype=dtype)
     assert result.size == 10
     assert result.dtype == dtype

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1117,6 +1117,6 @@ def test_training_succeeds_when_data_is_dataframe_and_label_is_column_array(
         'time_out': 5
     }
     model = model_factory(**params)
-    model.fit(dX, dy, sample_weight=dw, group=dg)
+    model.fit(dX, dy_col_array, sample_weight=dw, group=dg)
     assert model.fitted_
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1088,7 +1088,6 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
 def test_training_succeeds_when_data_is_dataframe_and_label_is_column_array(
     task,
     client,
-    listen_port
 ):
     if task == 'ranking':
         _, _, _, _, dX, dy, dw, dg = _create_ranking_data(
@@ -1114,7 +1113,6 @@ def test_training_succeeds_when_data_is_dataframe_and_label_is_column_array(
         'n_estimators': 1,
         'num_leaves': 3,
         'random_state': 0,
-        'local_listen_port': listen_port,
         'time_out': 5
     }
     model = model_factory(**params)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1224,4 +1224,4 @@ def test_training_succeeds_when_data_is_dataframe_and_label_is_column_array(task
 
     preds_1d = model_1d.predict(X)
     preds_2d = model_2d.predict(X)
-    assert np.allclose(preds_1d, preds_2d)
+    np.testing.assert_array_equal(preds_1d, preds_2d)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -18,8 +18,7 @@ from sklearn.utils.validation import check_is_fitted
 
 import lightgbm as lgb
 
-from .utils import (load_boston, load_breast_cancer, load_digits, load_iris,
-                    load_linnerud, make_ranking)
+from .utils import load_boston, load_breast_cancer, load_digits, load_iris, load_linnerud, make_ranking
 
 sk_version = parse_version(sk_version)
 if sk_version < parse_version("0.23"):

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1191,3 +1191,12 @@ def test_parameters_default_constructible(estimator):
     name, Estimator = estimator.__class__.__name__, estimator.__class__
     # Test that estimators are default-constructible
     check_parameters_default_constructible(name, Estimator)
+
+
+def test_training_succeeds_when_data_is_dataframe_and_label_is_column_array():
+    pd = pytest.importorskip("pandas")
+    X, y = load_boston(return_X_y=True)
+    X = pd.DataFrame(X)
+    y = y.reshape(-1, 1)
+    with pytest.warns(UserWarning, match='column vector to 1d array'):
+        lgb.LGBMRegressor().fit(X, y)


### PR DESCRIPTION
This solves #3909 by allowing to have an `(n_samples, 1)` array as label when `data` is a `pandas.DataFrame`.