### PR TITLE
[dask] Include support for init_score

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -305,9 +305,9 @@ def _train(
             parts[i]['group'] = group_parts[i]
 
     if init_score is not None:
-        group_parts = _split_to_parts(data=init_score, is_matrix=False)
-        for i in range(len(parts)):
-            parts[i]['init_score'] = group_parts[i]
+        init_score_parts = _split_to_parts(data=init_score, is_matrix=False)
+        for i in range(n_parts):
+            parts[i]['init_score'] = init_score_parts[i]
 
     # Start computation in the background
     parts = list(map(delayed, parts))
@@ -496,6 +496,7 @@ class _DaskLGBMModel:
         X: _DaskMatrixLike,
         y: _DaskCollection,
         sample_weight: Optional[_DaskCollection] = None,
+        init_score: Optional[_DaskCollection] = None,
         group: Optional[_DaskCollection] = None,
         **kwargs: Any
     ) -> "_DaskLGBMModel":
@@ -512,6 +513,7 @@ class _DaskLGBMModel:
             params=params,
             model_factory=model_factory,
             sample_weight=sample_weight,
+            init_score=init_score,
             group=group,
             **kwargs
         )
@@ -783,11 +785,12 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",
         y_shape="Dask Array, Dask DataFrame or Dask Series of shape = [n_samples]",
         sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
+        init_score_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
         group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
     )
 
     # DaskLGBMRegressor does not support init_score, evaluation data, or early stopping
-    _base_doc = (_base_doc[:_base_doc.find('init_score :')]
+    _base_doc = (_base_doc[:_base_doc.find('eval_set :')]
                  + _base_doc[_base_doc.find('verbose :'):])
 
     # DaskLGBMRegressor support for callbacks and init_model is not tested
@@ -919,11 +922,12 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",
         y_shape="Dask Array, Dask DataFrame or Dask Series of shape = [n_samples]",
         sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
+        init_score_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
         group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
     )
 
     # DaskLGBMRanker does not support init_score, evaluation data, or early stopping
-    _base_doc = (_base_doc[:_base_doc.find('init_score :')]
+    _base_doc = (_base_doc[:_base_doc.find('eval_set:')]
                  + _base_doc[_base_doc.find('init_score :'):])
 
     _base_doc = (_base_doc[:_base_doc.find('eval_set :')]

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -173,14 +173,20 @@ def _train_part(
     data = _concat([x['data'] for x in list_of_parts])
     label = _concat([x['label'] for x in list_of_parts])
 
-    def concat_if_is_in_parts(key):
-        if key not in list_of_parts[0]:
-            return None
-        return _concat([x[key] for x in list_of_parts])
+    if 'weight' in list_of_parts[0]:
+        weight = _concat([x['weight'] for x in list_of_parts])
+    else:
+        weight = None
 
-    weight = concat_if_is_in_parts('weight')
-    init_score = concat_if_is_in_parts('init_score')
-    group = concat_if_is_in_parts('group')
+    if 'group' in list_of_parts[0]:
+        group = _concat([x['group'] for x in list_of_parts])
+    else:
+        group = None
+
+    if 'init_score' in list_of_parts[0]:
+        init_score = _concat([x['init_score'] for x in list_of_parts])
+    else:
+        init_score = None
 
     try:
         model = model_factory(**params)
@@ -292,16 +298,20 @@ def _train(
     label_parts = _split_to_parts(data=label, is_matrix=False)
     parts = [{'data': x, 'label': y} for (x, y) in zip(data_parts, label_parts)]
 
-    def add_to_parts(data, name, is_matrix=False):
-        if data is None:
-            return
-        new_parts = _split_to_parts(data=data, is_matrix=is_matrix)
+    if sample_weight is not None:
+        weight_parts = _split_to_parts(data=sample_weight, is_matrix=False)
         for i in range(len(parts)):
-            parts[i][name] = new_parts[i]
+            parts[i]['weight'] = weight_parts[i]
 
-    add_to_parts(sample_weight, 'weight')
-    add_to_parts(init_score, 'init_score')
-    add_to_parts(group, 'group')
+    if group is not None:
+        group_parts = _split_to_parts(data=group, is_matrix=False)
+        for i in range(len(parts)):
+            parts[i]['group'] = group_parts[i]
+
+    if init_score is not None:
+        group_parts = _split_to_parts(data=init_score, is_matrix=False)
+        for i in range(len(parts)):
+            parts[i]['init_score'] = group_parts[i]
 
     # Start computation in the background
     parts = list(map(delayed, parts))

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -632,11 +632,12 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",
         y_shape="Dask Array, Dask DataFrame or Dask Series of shape = [n_samples]",
         sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
+        init_score_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
         group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
     )
 
-    # DaskLGBMClassifier does not support init_score, evaluation data, or early stopping
-    _base_doc = (_base_doc[:_base_doc.find('init_score :')]
+    # DaskLGBMClassifier does not support evaluation data, or early stopping
+    _base_doc = (_base_doc[:_base_doc.find('group :')]
                  + _base_doc[_base_doc.find('verbose :'):])
 
     # DaskLGBMClassifier support for callbacks and init_model is not tested
@@ -789,8 +790,8 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
     )
 
-    # DaskLGBMRegressor does not support init_score, evaluation data, or early stopping
-    _base_doc = (_base_doc[:_base_doc.find('eval_set :')]
+    # DaskLGBMRegressor does not support evaluation data, or early stopping
+    _base_doc = (_base_doc[:_base_doc.find('group :')]
                  + _base_doc[_base_doc.find('verbose :'):])
 
     # DaskLGBMRegressor support for callbacks and init_model is not tested
@@ -926,10 +927,7 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
         group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
     )
 
-    # DaskLGBMRanker does not support init_score, evaluation data, or early stopping
-    _base_doc = (_base_doc[:_base_doc.find('eval_set:')]
-                 + _base_doc[_base_doc.find('init_score :'):])
-
+    # DaskLGBMRanker does not support evaluation data, or early stopping
     _base_doc = (_base_doc[:_base_doc.find('eval_set :')]
                  + _base_doc[_base_doc.find('verbose :'):])
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -193,7 +193,7 @@ _lgbmmodel_doc_fit = (
         The target values (class labels in classification, real numbers in regression).
     sample_weight : {sample_weight_shape}
         Weights of training data.
-    init_score : array-like of shape = [n_samples] or None, optional (default=None)
+    init_score : {init_score_shape}
         Init score of training data.
     group : {group_shape}
         Group/query data.
@@ -710,6 +710,7 @@ class LGBMModel(_LGBMModelBase):
         X_shape="array-like or sparse matrix of shape = [n_samples, n_features]",
         y_shape="array-like of shape = [n_samples]",
         sample_weight_shape="array-like of shape = [n_samples] or None, optional (default=None)",
+        init_score_shape="array-like of shape = [n_samples] or None, optional (default=None)",
         group_shape="array-like or None, optional (default=None)"
     ) + "\n\n" + _lgbmmodel_doc_custom_eval_note
 

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1260,7 +1260,7 @@ def test_init_score(
     if output.startswith('dataframe'):
         init_scores = dy.map_partitions(lambda x: pd.Series([init_score] * x.size))
     else:
-        init_scores = da.full_like(dy, fill_value=init_score, dtype='float')
+        init_scores = da.full_like(dy, fill_value=init_score, dtype=np.float64)
     model = model_factory(client=client, **params)
     model.fit(dX, dy, sample_weight=dw, init_score=init_scores, group=dg)
     # value of the root node is 0 when init_score is set

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1186,6 +1186,7 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
         assert dask_params[param].default == sklearn_params[param].default, error_msg
 
 
+@pytest.mark.parametrize('task', tasks)
 def test_training_succeeds_when_data_is_dataframe_and_label_is_column_array(
     task,
     client,

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1188,7 +1188,7 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
 
 def test_training_succeeds_when_data_is_dataframe_and_label_is_column_array(
     task,
-    client
+    client,
 ):
     if task == 'ranking':
         _, _, _, _, dX, dy, dw, dg = _create_ranking_data(

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1226,6 +1226,7 @@ def test_training_succeeds_when_data_is_dataframe_and_label_is_column_array(
 
 @pytest.mark.parametrize('task', tasks)
 @pytest.mark.parametrize('output', data_output)
+@pytest.mark.parametrize('init_score', [0.25, 0.75])
 def test_init_score(
         task,
         output,
@@ -1236,6 +1237,13 @@ def test_init_score(
 
     if task == 'ranking':
         _, _, _, _, dX, dy, dw, dg = _create_ranking_data(
+            output=output,
+            group=None
+        )
+        model_factory = lgb.DaskLGBMRanker
+    else:
+        _, _, _, dX, dy, dw = _create_data(
+            objective=task,
             output=output,
         )
         dg = None


### PR DESCRIPTION
This solves #3807 by including the option to specify `init_score` as a dask collection to the `fit` methods of the dask estimators. A test is included to check that using `init_score` with dask and scikit-learn estimators results in the same result and that not using it results in a different one.