### PR TITLE
[dask] Early stopping

### DIFF
--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -114,13 +114,14 @@ try:
     from dask.array import Array as dask_Array
     from dask.dataframe import DataFrame as dask_DataFrame
     from dask.dataframe import Series as dask_Series
-    from dask.distributed import Client, default_client, wait
+    from dask.distributed import Client, default_client, get_worker, wait
     DASK_INSTALLED = True
 except ImportError:
     DASK_INSTALLED = False
     delayed = None
     Client = object
     default_client = None
+    get_worker = None
     wait = None
 
     class dask_Array:

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -251,8 +251,13 @@ def _train_part(
                 **kwargs
             )
         else:
-            model.fit(data, label, sample_weight=weight, eval_set=local_eval_set,
-                      eval_sample_weight=local_eval_sample_weight, **kwargs)
+            model.fit(
+                data,
+                label,
+                sample_weight=weight,
+                eval_set=local_eval_set,
+                eval_sample_weight=local_eval_sample_weight, **kwargs
+            )
 
     finally:
         _safe_call(_LIB.LGBM_NetworkFree())

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -408,7 +408,6 @@ def _train(
                         eval_sets[parts_idx].append(([x_e], [y_e]))
 
                     else:
-                        # n_evals = len(eval_sets[parts_idx]) - 1
                         eval_sets[parts_idx][-1][0].append(x_e)
                         eval_sets[parts_idx][-1][1].append(y_e)
 

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -193,7 +193,10 @@ def _train_part(
 
         # consolidate parts of each individual eval component.
         for i in range(n_evals):
-            x_e, y_e, w_e, g_e = [], [], [], []
+            x_e = []
+            y_e = []
+            w_e = []
+            g_e = []
             for part in list_of_parts:
 
                 if not part.get('eval_set'):

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -178,7 +178,9 @@ def _train_part(
         group = None
 
     # construct local eval_set data.
-    local_eval_set, local_eval_sample_weight, local_eval_group = None, None, None
+    local_eval_set = None
+    local_eval_sample_weight = None
+    local_eval_group = None
     n_evals = max([len(x.get('eval_set', [])) for x in list_of_parts])
     has_eval_weights = any([x.get('eval_sample_weight') is not None for x in list_of_parts])
     if n_evals:

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -418,7 +418,7 @@ def _train(
                         eval_sets[parts_idx][-1][1].append(y_e)
 
             if eval_sample_weight:
-                if id(eval_sample_weight[i]) == id(sample_weight):
+                if eval_sample_weight[i] is sample_weight:
                     for parts_idx in range(n_parts):
                         eval_sample_weights[parts_idx].append('__sample_weight__')
 
@@ -439,7 +439,7 @@ def _train(
                             eval_sample_weights[parts_idx][-1].append(w_e)
 
             if eval_group:
-                if id(eval_group[i]) == id(group):
+                if eval_group[i] is group:
                     for parts_idx in range(n_parts):
                         eval_groups[parts_idx].append('__group__')
 

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -240,8 +240,16 @@ def _train_part(
     try:
         model = model_factory(**params)
         if is_ranker:
-            model.fit(data, label, sample_weight=weight, group=group, eval_set=local_eval_set,
-                      eval_sample_weight=local_eval_sample_weight, eval_group=local_eval_group, **kwargs)
+            model.fit(
+                data,
+                label,
+                sample_weight=weight,
+                group=group,
+                eval_set=local_eval_set,
+                eval_sample_weight=local_eval_sample_weight,
+                eval_group=local_eval_group,
+                **kwargs
+            )
         else:
             model.fit(data, label, sample_weight=weight, eval_set=local_eval_set,
                       eval_sample_weight=local_eval_sample_weight, **kwargs)

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -9,7 +9,7 @@ It is based on dask-lightgbm, which was based on dask-xgboost.
 import socket
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Type, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
 from urllib.parse import urlparse
 
 import numpy as np

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -319,7 +319,7 @@ def _train(
     eval_set : List of (X, y) tuples of Dask data collections, or None, optional (default=None)
         List of (X, y) tuple pairs to use as validation sets.
     eval_sample_weight: List of Dask data collections or None, optional (default=None)
-        List of dask Array or dask Series, weights for each validation set in eval_set.
+        List of Dask Array or Dask Series, weights for each validation set in eval_set.
     eval_group: List of Dask data collections or None, optional (default=None)
         List of dask Array or dask Series, group/query for each validation set in eval_set.
     **kwargs

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -404,7 +404,8 @@ def _train(
                 for j in range(len(eval_x_parts)):
                     parts_idx = j % n_parts
 
-                    x_e, y_e = eval_x_parts[j], eval_y_parts[j]
+                    x_e = eval_x_parts[j]
+                    y_e = eval_y_parts[j]
 
                     if j < n_parts:
                         eval_sets[parts_idx].append(([x_e], [y_e]))

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -321,7 +321,7 @@ def _train(
     eval_sample_weight: List of Dask data collections or None, optional (default=None)
         List of Dask Array or Dask Series, weights for each validation set in eval_set.
     eval_group: List of Dask data collections or None, optional (default=None)
-        List of dask Array or dask Series, group/query for each validation set in eval_set.
+        List of Dask Array or Dask Series, group/query for each validation set in eval_set.
     **kwargs
         Other parameters passed to ``fit`` method of the local underlying model.
 

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -174,6 +174,7 @@ def _train_part(
 
     # construct local eval_set data.
     local_eval_set = None
+    local_eval_names = None
     local_eval_sample_weight = None
     local_eval_group = None
     n_evals = max([len(x.get('eval_set', [])) for x in list_of_parts])
@@ -181,7 +182,6 @@ def _train_part(
     if n_evals:
 
         local_eval_set = []
-        eval_names = []
         if has_eval_weights:
             local_eval_sample_weight = []
         if is_ranker:
@@ -225,10 +225,12 @@ def _train_part(
                     else:
                         g_e.extend(eval_group[i])
 
-                local_eval_names = part.get('eval_names')
-                if local_eval_names:
-                    if len(local_eval_names) > len(eval_names):
-                        eval_names = local_eval_names
+                eval_names = part.get('eval_names')
+                if eval_names:
+                    if not local_eval_names:
+                        local_eval_names = eval_names
+                    elif len(eval_names) > len(local_eval_names):
+                        local_eval_names = eval_names
 
             # _concat each eval component.
             local_eval_set.append((_concat(x_e), _concat(y_e)))
@@ -255,7 +257,7 @@ def _train_part(
                 eval_set=local_eval_set,
                 eval_sample_weight=local_eval_sample_weight,
                 eval_group=local_eval_group,
-                eval_names=eval_names if eval_names else None,
+                eval_names=local_eval_names,
                 **kwargs
             )
         else:
@@ -268,7 +270,7 @@ def _train_part(
                 sample_weight=weight,
                 eval_set=local_eval_set,
                 eval_sample_weight=local_eval_sample_weight,
-                eval_names=eval_names if eval_names else None,
+                eval_names=local_eval_names,
                 **kwargs
             )
 

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -17,7 +17,8 @@ import scipy.sparse as ss
 
 from .basic import _LIB, LightGBMError, _choose_param_value, _ConfigAliases, _log_info, _log_warning, _safe_call
 from .compat import (DASK_INSTALLED, PANDAS_INSTALLED, SKLEARN_INSTALLED, Client, LGBMNotFittedError, concat,
-                     dask_Array, dask_DataFrame, dask_Series, default_client, delayed, pd_DataFrame, pd_Series, wait)
+                     dask_Array, dask_DataFrame, dask_Series, default_client, delayed, get_worker, pd_DataFrame,
+                     pd_Series, wait)
 from .sklearn import LGBMClassifier, LGBMModel, LGBMRanker, LGBMRegressor, _lgbmmodel_doc_fit, _lgbmmodel_doc_predict
 
 _DaskCollection = Union[dask_Array, dask_DataFrame, dask_Series]
@@ -239,6 +240,7 @@ def _train_part(
     else:
         # when a worker receives no eval_set while other workers have eval data, causes LightGBMExceptions.
         if evals_provided:
+            local_worker_address = get_worker().address
             msg = "eval_set was provided but worker %s was not allocated validation data. Try rebalancing data across workers."
             raise RuntimeError(msg % local_worker_address)
 

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -809,7 +809,7 @@ class _DaskLGBMModel:
         eval_init_score: Optional[List[_DaskCollection]] = None,
         eval_group: Optional[List[_DaskCollection]] = None,
         eval_metric: Optional[Union[Callable, str, List[Union[Callable, str]]]] = None,
-        eval_stopping_rounds: Optional[int] = None,
+        early_stopping_rounds: Optional[int] = None,
         **kwargs: Any
     ) -> "_DaskLGBMModel":
         if not all((DASK_INSTALLED, PANDAS_INSTALLED, SKLEARN_INSTALLED)):
@@ -826,8 +826,8 @@ class _DaskLGBMModel:
         # easier to pass fit args as kwargs than to list_of_parts in _train.
         if eval_metric:
             kwargs['eval_metric'] = eval_metric
-        if eval_stopping_rounds:
-            kwargs['eval_stopping_rounds'] = eval_stopping_rounds
+        if early_stopping_rounds:
+            kwargs['early_stopping_rounds'] = early_stopping_rounds
 
         model = _train(
             client=_get_dask_client(self.client),
@@ -948,7 +948,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
         eval_class_weight: Optional[List[_DaskCollection]] = None,
         eval_init_score: Optional[List[_DaskCollection]] = None,
         eval_metric: Optional[Union[Callable, str, List[Union[Callable, str]]]] = None,
-        eval_stopping_rounds: Optional[int] = None,
+        early_stopping_rounds: Optional[int] = None,
         **kwargs: Any
     ) -> "DaskLGBMClassifier":
         """Docstring is inherited from the lightgbm.LGBMClassifier.fit."""
@@ -959,8 +959,8 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
 
         if eval_metric:
             kwargs['eval_metric'] = eval_metric
-        if eval_stopping_rounds:
-            kwargs['eval_stopping_rounds'] = eval_stopping_rounds
+        if early_stopping_rounds:
+            kwargs['early_stopping_rounds'] = early_stopping_rounds
 
         return self._lgb_dask_fit(
             model_factory=LGBMClassifier,
@@ -1125,7 +1125,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         eval_sample_weight: Optional[List[_DaskCollection]] = None,
         eval_init_score: Optional[List[_DaskCollection]] = None,
         eval_metric: Optional[Union[Callable, str, List[Union[Callable, str]]]] = None,
-        eval_stopping_rounds: Optional[int] = None,
+        early_stopping_rounds: Optional[int] = None,
         **kwargs: Any
     ) -> "DaskLGBMRegressor":
         """Docstring is inherited from the lightgbm.LGBMRegressor.fit."""
@@ -1136,8 +1136,8 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
 
         if eval_metric:
             kwargs['eval_metric'] = eval_metric
-        if eval_stopping_rounds:
-            kwargs['eval_stopping_rounds'] = eval_stopping_rounds
+        if early_stopping_rounds:
+            kwargs['early_stopping_rounds'] = early_stopping_rounds
 
         return self._lgb_dask_fit(
             model_factory=LGBMRegressor,
@@ -1282,16 +1282,15 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
         eval_set: Optional[List[Tuple[_DaskCollection, _DaskCollection]]] = None,
         eval_names: Optional[List[str]] = None,
         eval_sample_weight: Optional[List[_DaskCollection]] = None,
-        eval_class_weight: Optional[List[_DaskCollection]] = None,
         eval_init_score: Optional[List[_DaskCollection]] = None,
         eval_group: Optional[List[_DaskCollection]] = None,
         eval_metric: Optional[Union[Callable, str, List[Union[Callable, str]]]] = None,
         eval_at: Optional[List[int]] = None,
-        eval_stopping_rounds: Optional[int] = None,
+        early_stopping_rounds: Optional[int] = None,
         **kwargs: Any
     ) -> "DaskLGBMRanker":
         """Docstring is inherited from the lightgbm.LGBMRanker.fit."""
-        not_supported = ['init_score', 'eval_init_score', 'eval_class_weight']
+        not_supported = ['init_score', 'eval_init_score']
         for ns in not_supported:
             if eval(ns) is not None:
                 raise RuntimeError(f'{ns} is not currently supported in lightgbm.dask')
@@ -1300,8 +1299,8 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
             kwargs['eval_metric'] = eval_metric
         if eval_at:
             kwargs['eval_at'] = eval_at
-        if eval_stopping_rounds:
-            kwargs['eval_stopping_rounds'] = eval_stopping_rounds
+        if early_stopping_rounds:
+            kwargs['early_stopping_rounds'] = early_stopping_rounds
 
         return self._lgb_dask_fit(
             model_factory=LGBMRanker,

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -846,7 +846,8 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
     _base_doc = _lgbmmodel_doc_fit.format(
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",
         y_shape="Dask Array, Dask DataFrame or Dask Series of shape = [n_samples]",
-        sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
+        sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
+        group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
     )
 
     # DaskLGBMClassifier does not support init_score, evaluation data, or early stopping
@@ -1017,7 +1018,8 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
     _base_doc = _lgbmmodel_doc_fit.format(
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",
         y_shape="Dask Array, Dask DataFrame or Dask Series of shape = [n_samples]",
-        sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
+        sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
+        group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
     )
 
     # DaskLGBMRegressor does not support init_score, evaluation data, or early stopping

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -822,7 +822,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
         **kwargs: Any
     ) -> "DaskLGBMClassifier":
         """Docstring is inherited from the lightgbm.LGBMClassifier.fit."""
-        not_supported = ['init_score', 'eval_init_score', 'eval_class_weight']
+        not_supported = ['init_score', 'eval_class_weight', 'eval_init_score']
         for ns in not_supported:
             if eval(ns) is not None:
                 raise RuntimeError(f'{ns} is not currently supported in lightgbm.dask')
@@ -847,12 +847,18 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",
         y_shape="Dask Array, Dask DataFrame or Dask Series of shape = [n_samples]",
         sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
-        group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
+        group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
+        eval_sample_weight_shape='List of Dask Arrays, Dask DataFrames, Dask Series or None, optional (default=None)',
+        eval_init_score_shape='List of Dask Arrays, Dask DataFrames, Dask Series or None, optional (default=None)',
+        eval_group_shape='List of Dask Arrays, Dask DataFrames, Dask Series or None, optional (default=None)'
     )
 
-    # DaskLGBMClassifier does not support init_score, evaluation data, or early stopping
+    # DaskLGBMClassifier does not support init_score, eval_class_weight, or eval_init_score
     _base_doc = (_base_doc[:_base_doc.find('init_score :')]
-                 + _base_doc[_base_doc.find('verbose :'):])
+                 + _base_doc[_base_doc.find('init_score :'):])
+
+    _base_doc = (_base_doc[:_base_doc.find('eval_class_weight :')]
+                 + _base_doc[_base_doc.find('eval_init_score :'):])
 
     # DaskLGBMClassifier support for callbacks and init_model is not tested
     fit.__doc__ = (
@@ -987,14 +993,13 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         eval_set: Optional[List[Tuple[_DaskCollection, _DaskCollection]]] = None,
         eval_names: Optional[List[str]] = None,
         eval_sample_weight: Optional[List[_DaskCollection]] = None,
-        eval_class_weight: Optional[List[_DaskCollection]] = None,
         eval_init_score: Optional[List[_DaskCollection]] = None,
         eval_metric: Optional[Union[Callable, str, List[Union[Callable, str]]]] = None,
         eval_stopping_rounds: Optional[int] = None,
         **kwargs: Any
     ) -> "DaskLGBMRegressor":
         """Docstring is inherited from the lightgbm.LGBMRegressor.fit."""
-        not_supported = ['init_score', 'eval_init_score', 'eval_class_weight']
+        not_supported = ['init_score', 'eval_init_score']
         for ns in not_supported:
             if eval(ns) is not None:
                 raise RuntimeError(f'{ns} is not currently supported in lightgbm.dask')
@@ -1019,12 +1024,18 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",
         y_shape="Dask Array, Dask DataFrame or Dask Series of shape = [n_samples]",
         sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
-        group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
+        group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
+        eval_sample_weight_shape='List of Dask Arrays, Dask DataFrames, Dask Series or None, optional (default=None)',
+        eval_init_score_shape='List of Dask Arrays, Dask DataFrames, Dask Series or None, optional (default=None)',
+        eval_group_shape='List of Dask Arrays, Dask DataFrames, Dask Series or None, optional (default=None)'
     )
 
-    # DaskLGBMRegressor does not support init_score, evaluation data, or early stopping
+    # DaskLGBMRegressor does not support init_score or eval_init_score
     _base_doc = (_base_doc[:_base_doc.find('init_score :')]
-                 + _base_doc[_base_doc.find('verbose :'):])
+                 + _base_doc[_base_doc.find('init_score :'):])
+
+    _base_doc = (_base_doc[:_base_doc.find('eval_init_weight :')]
+                 + _base_doc[_base_doc.find('eval_init_score :'):])
 
     # DaskLGBMRegressor support for callbacks and init_model is not tested
     fit.__doc__ = (
@@ -1179,15 +1190,18 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",
         y_shape="Dask Array, Dask DataFrame or Dask Series of shape = [n_samples]",
         sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
-        group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
+        group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
+        eval_sample_weight_shape='List of Dask Arrays, Dask DataFrames, Dask Series or None, optional (default=None)',
+        eval_init_score_shape='List of Dask Arrays, Dask DataFrames, Dask Series or None, optional (default=None)',
+        eval_group_shape='List of Dask Arrays, Dask DataFrames, Dask Series or None, optional (default=None)'
     )
 
-    # DaskLGBMRanker does not support init_score, evaluation data, or early stopping
+    # DaskLGBMRanker does not support init_score or eval_init_score.
     _base_doc = (_base_doc[:_base_doc.find('init_score :')]
                  + _base_doc[_base_doc.find('init_score :'):])
 
-    _base_doc = (_base_doc[:_base_doc.find('eval_set :')]
-                 + _base_doc[_base_doc.find('verbose :'):])
+    _base_doc = (_base_doc[:_base_doc.find('eval_init_score :')]
+                 + _base_doc[_base_doc.find('eval_init_score :'):])
 
     # DaskLGBMRanker support for callbacks and init_model is not tested
     fit.__doc__ = (

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -391,7 +391,7 @@ def _train(
         for i, (X, y) in enumerate(eval_set):
 
             # when individual eval set is equivalent to training data, skip recomputing parts.
-            if id(X) == id(data) and id(y) == id(label):
+            if X is data and y is label
                 for parts_idx in range(n_parts):
                     eval_sets[parts_idx].append('__train__')
 

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -262,6 +262,9 @@ def _train_part(
                 **kwargs
             )
         else:
+            if 'eval_at' in kwargs:
+                kwargs.pop('eval_at')
+
             model.fit(
                 data,
                 label,
@@ -690,6 +693,7 @@ class _DaskLGBMModel:
         params = self.get_params(True)
         params.pop("client", None)
 
+        # easier to pass fit args as kwargs than to list_of_parts in _train.
         if eval_metric:
             kwargs['eval_metric'] = eval_metric
         if eval_stopping_rounds:
@@ -842,8 +846,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
     _base_doc = _lgbmmodel_doc_fit.format(
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",
         y_shape="Dask Array, Dask DataFrame or Dask Series of shape = [n_samples]",
-        sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
-        group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
+        sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
     )
 
     # DaskLGBMClassifier does not support init_score, evaluation data, or early stopping
@@ -1014,8 +1017,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
     _base_doc = _lgbmmodel_doc_fit.format(
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",
         y_shape="Dask Array, Dask DataFrame or Dask Series of shape = [n_samples]",
-        sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)",
-        group_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
+        sample_weight_shape="Dask Array, Dask DataFrame, Dask Series of shape = [n_samples] or None, optional (default=None)"
     )
 
     # DaskLGBMRegressor does not support init_score, evaluation data, or early stopping
@@ -1141,6 +1143,7 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
         eval_init_score: Optional[List[_DaskCollection]] = None,
         eval_group: Optional[List[_DaskCollection]] = None,
         eval_metric: Optional[Union[Callable, str, List[Union[Callable, str]]]] = None,
+        eval_at: Optional[List[int]] = None,
         eval_stopping_rounds: Optional[int] = None,
         **kwargs: Any
     ) -> "DaskLGBMRanker":
@@ -1152,6 +1155,8 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
 
         if eval_metric:
             kwargs['eval_metric'] = eval_metric
+        if eval_at:
+            kwargs['eval_at'] = eval_at
         if eval_stopping_rounds:
             kwargs['eval_stopping_rounds'] = eval_stopping_rounds
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -201,13 +201,13 @@ _lgbmmodel_doc_fit = (
         A list of (X, y) tuple pairs to use as validation sets.
     eval_names : list of strings or None, optional (default=None)
         Names of eval_set.
-    eval_sample_weight : list of arrays or None, optional (default=None)
+    eval_sample_weight : {eval_sample_weight_shape}
         Weights of eval data.
     eval_class_weight : list or None, optional (default=None)
         Class weights of eval data.
-    eval_init_score : list of arrays or None, optional (default=None)
+    eval_init_score : {eval_init_score_shape}
         Init score of eval data.
-    eval_group : list of arrays or None, optional (default=None)
+    eval_group : {eval_group_shape}
         Group data of eval data.
     eval_metric : string, callable, list or None, optional (default=None)
         If string, it should be a built-in evaluation metric to use.
@@ -706,7 +706,10 @@ class LGBMModel(_LGBMModelBase):
         X_shape="array-like or sparse matrix of shape = [n_samples, n_features]",
         y_shape="array-like of shape = [n_samples]",
         sample_weight_shape="array-like of shape = [n_samples] or None, optional (default=None)",
-        group_shape="array-like or None, optional (default=None)"
+        group_shape="array-like or None, optional (default=None)",
+        eval_sample_weight_shape="list of arrays or None, optional (default=None)",
+        eval_init_score_shape="list of arrays or None, optional (default=None)",
+        eval_group_shape="list of arrays or None, optional (default=None)"
     ) + "\n\n" + _lgbmmodel_doc_custom_eval_note
 
     def predict(self, X, raw_score=False, start_iteration=0, num_iteration=None,

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -716,9 +716,16 @@ def test_early_stopping(task, eval_sizes, client, listen_port):
                            eval_metric=eval_metric, early_stopping_rounds=5)
 
     else:
-        dask_model = dask_model.fit(dX, dy, group=dg, eval_set=eval_set,
-                                    eval_sample_weight=eval_sample_weight, eval_group=eval_group,
-                                    eval_metric=eval_metric, early_stopping_rounds=5)
+        dask_model = dask_model.fit(
+            dX,
+            dy,
+            group=dg,
+            eval_set=eval_set,
+            eval_sample_weight=eval_sample_weight,
+            eval_group=eval_group,
+            eval_metric=eval_metric,
+            early_stopping_rounds=5
+        )
         fitted_trees = dask_model.to_local().booster_.num_trees()
         assert fitted_trees < full_trees
 

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -623,7 +623,7 @@ def test_ranker(output, client, listen_port, group):
 
 
 @pytest.mark.parametrize('task', tasks)
-@pytest.mark.parametrize('eval_sizes', [[0.9], [1, 0.5], [0]])
+@pytest.mark.parametrize('eval_sizes', [[0.9], [0.5, 1], [0]])
 @pytest.mark.parametrize('eval_names_prefix', ['specified', None])
 def test_eval_set_with_early_stopping(task, eval_sizes, eval_names_prefix, client, listen_port):
 
@@ -666,6 +666,7 @@ def test_eval_set_with_early_stopping(task, eval_sizes, eval_names_prefix, clien
                     chunk_size=10,
                     random_gs=True
                 )
+
             eval_set.append((dX_e, dy_e))
             eval_sample_weight.append(dw_e)
             eval_group.append(dg_e)
@@ -761,7 +762,7 @@ def test_eval_set_with_early_stopping(task, eval_sizes, eval_names_prefix, clien
         elif task == 'regression':
             p1_r2 = _r2_score(dy, p1)
             msg = f'r2 score of predictions with actuals was <= 0.8 ({p1_r2})'
-            assert _r2_score(dy, p1) > 0.8, msg
+            assert p1_r2 > 0.8, msg
 
         else:
             p1_cor = spearmanr(p1.compute(), y).correlation
@@ -794,7 +795,7 @@ def test_eval_set_with_early_stopping(task, eval_sizes, eval_names_prefix, clien
                 # stopping decision should have been made based on the best score of the first of eval_metrics.
                 if i == 0:
                     best_score = dask_model.best_score_[evals_result_name][metric]
-                    assert_eq(best_score, min(evals_result[evals_result_name][metric]))
+                    assert_eq(best_score, min(evals_result[evals_result_name][metric]), atol=0.2)
 
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)
 

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -733,7 +733,7 @@ def test_early_stopping(task, eval_sizes, client, listen_port):
             eval_metric=eval_metric,
             early_stopping_rounds=5
         )
-        fitted_trees = dask_model.to_local().booster_.num_trees()
+        fitted_trees = dask_model.booster_.num_trees()
         assert fitted_trees < full_trees
 
         # be sure that model still produces decent output.

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -825,7 +825,7 @@ def test_eval_set_with_early_stopping(task, eval_sizes, eval_names_prefix, clien
 
                     else:
                         assert_eq(best_score, min(evals_result[evals_result_name][metric]), atol=0.03)
-                        assert abs(best_iter_zero_indexed- np.argin(evals_result[evals_result_name][metric])) \
+                        assert abs(best_iter_zero_indexed - np.argmin(evals_result[evals_result_name][metric])) \
                                <= early_stopping_rounds
 
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -712,8 +712,8 @@ def test_eval_set_with_early_stopping(task, eval_sizes, eval_names_prefix, clien
     }
 
     dask_model = model_factory(
-        client=client
-        , **params
+        client=client,
+        **params
     )
 
     # when eval_size is exactly 1 partition, not enough eval_set data to reach each worker.
@@ -863,8 +863,8 @@ def test_eval_set_without_early_stopping(task, eval_names_prefix, client, listen
     }
 
     dask_model = model_factory(
-        client=client
-        , **params
+        client=client,
+        **params
     )
 
     dask_model = dask_model.fit(

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -740,7 +740,7 @@ def test_early_stopping(task, eval_sizes, client, listen_port):
         p1 = dask_model.predict(dX)
         if task == 'classification':
             print(f'_accuracy_score(dy, p1) = {_accuracy_score(dy, p1)}')
-            _accuracy_score(dy, p1) > 0.8
+            assert _accuracy_score(dy, p1) > 0.8
 
         elif task == 'regression':
             print(f'_r2_score(dy, p1) = {_r2_score(dy, p1)}')

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -711,9 +711,16 @@ def test_early_stopping(task, eval_sizes, client, listen_port):
     # when eval_size is exactly 1 partition, not enough eval_set data to reach each worker.
     if eval_sizes == [0]:
         with pytest.raises(RuntimeError, match='eval_set was provided but worker .* was not allocated validation data'):
-            dask_model.fit(dX, dy, group=dg, eval_set=eval_set,
-                           eval_sample_weight=eval_sample_weight, eval_group=eval_group,
-                           eval_metric=eval_metric, early_stopping_rounds=5)
+            dask_model.fit(
+                dX,
+                dy,
+                group=dg,
+                eval_set=eval_set,
+                eval_sample_weight=eval_sample_weight,
+                eval_group=eval_group,
+                eval_metric=eval_metric,
+                early_stopping_rounds=5
+            )
 
     else:
         dask_model = dask_model.fit(

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -744,7 +744,7 @@ def test_early_stopping(task, eval_sizes, client, listen_port):
 
         elif task == 'regression':
             print(f'_r2_score(dy, p1) = {_r2_score(dy, p1)}')
-            _r2_score(dy, p1) > 0.8
+            assert _r2_score(dy, p1) > 0.8
 
         else:
             print(f'spearmanr(p1.compute(), y).correlation = {spearmanr(p1.compute(), y).correlation}')

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -928,11 +928,11 @@ def test_eval_set_without_early_stopping(task, eval_names_prefix, client):
     else:
         assert evals_result_name == 'valid_0'
 
-    assert all([metric in evals_result[evals_result_name] for metric in eval_metrics])
     for i, metric in enumerate(eval_metrics):
         if task == 'ranking':
             metric += f'@{eval_at[i]}'
 
+        assert metric in evals_result[evals_result_name]
         assert len(evals_result[evals_result_name][metric]) == full_trees
 
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)


### PR DESCRIPTION
Attempt to address #3712 - lightgbm.dask support for early stopping. Implemented this to work with multiple eval sets (i.e. multiple (X, y) pairs), sample weights, group lengths, and implemented so that when an individual `eval_set`, `eval_sample_weights`, or `eval_group` is the same as (`data`, `label`), `sample_weights`, or `group`, just use the latter instead of having to recompute the training set/weights/group lengths.

This is all that's going on, making little mini eval sets out of delayed parts in a consistent manner:
<img width="889" alt="dask_lgbm_eval_sets" src="https://user-images.githubusercontent.com/11701129/107843762-4890c780-6d93-11eb-89cc-4f7857a62ffb.png">

Note that our test cases actually uncovered a small data issue - when one worker isn't distributed any `eval_set` data (e.g. because the validation set has fewer parts than workers, or because the data distribution is very unbalanced), then LightGBM throws an exception (because other workers do have eval_set data). This is why I added the `RuntimeError` - check for whether a worker has not received any eval_set parts when `_train` has been provided an `eval_set`.
