### PR TITLE
applied isort and black to python code for consistent styling and imports sorting order

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -57,7 +57,7 @@ if [[ $TASK == "lint" ]]; then
             "r-lintr>=2.0"
     pip install --user cpplint mypy
     echo "Linting Python code"
-    pycodestyle --ignore=E501,W503 --exclude=./.nuget,./external_libs . || exit -1
+    pycodestyle --ignore=E203,E501,W503 --exclude=./.nuget,./external_libs . || exit -1
     pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^external_libs|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1
     mypy --ignore-missing-imports python-package/ || true
     echo "Linting R code"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+# https://pycqa.github.io/isort/docs/configuration/black_compatibility/
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+known_first_party = ["lightgbm"]

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -36,14 +36,31 @@ except ImportError:
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-if os.path.isfile(os.path.join(dir_path, 'VERSION.txt')):
-    with open(os.path.join(dir_path, 'VERSION.txt')) as version_file:
+if os.path.isfile(os.path.join(dir_path, "VERSION.txt")):
+    with open(os.path.join(dir_path, "VERSION.txt")) as version_file:
         __version__ = version_file.read().strip()
 
-__all__ = ['Dataset', 'Booster', 'CVBooster',
-           'register_logger',
-           'train', 'cv',
-           'LGBMModel', 'LGBMRegressor', 'LGBMClassifier', 'LGBMRanker',
-           'DaskLGBMRegressor', 'DaskLGBMClassifier', 'DaskLGBMRanker',
-           'print_evaluation', 'record_evaluation', 'reset_parameter', 'early_stopping',
-           'plot_importance', 'plot_split_value_histogram', 'plot_metric', 'plot_tree', 'create_tree_digraph']
+__all__ = [
+    "Dataset",
+    "Booster",
+    "CVBooster",
+    "register_logger",
+    "train",
+    "cv",
+    "LGBMModel",
+    "LGBMRegressor",
+    "LGBMClassifier",
+    "LGBMRanker",
+    "DaskLGBMRegressor",
+    "DaskLGBMClassifier",
+    "DaskLGBMRanker",
+    "print_evaluation",
+    "record_evaluation",
+    "reset_parameter",
+    "early_stopping",
+    "plot_importance",
+    "plot_split_value_histogram",
+    "plot_metric",
+    "plot_tree",
+    "create_tree_digraph",
+]

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -3,24 +3,33 @@
 
 Contributors: https://github.com/microsoft/LightGBM/graphs/contributors.
 """
-from .basic import Booster, Dataset, register_logger
-from .callback import (early_stopping, print_evaluation, record_evaluation,
-                       reset_parameter)
-from .engine import cv, train, CVBooster
-
 import os
 
+from .basic import Booster, Dataset, register_logger
+from .callback import (
+    early_stopping,
+    print_evaluation,
+    record_evaluation,
+    reset_parameter,
+)
+from .engine import CVBooster, cv, train
+
 try:
-    from .sklearn import LGBMModel, LGBMRegressor, LGBMClassifier, LGBMRanker
+    from .sklearn import LGBMClassifier, LGBMModel, LGBMRanker, LGBMRegressor
 except ImportError:
     pass
 try:
-    from .plotting import (plot_importance, plot_split_value_histogram, plot_metric,
-                           plot_tree, create_tree_digraph)
+    from .plotting import (
+        create_tree_digraph,
+        plot_importance,
+        plot_metric,
+        plot_split_value_histogram,
+        plot_tree,
+    )
 except ImportError:
     pass
 try:
-    from .dask import DaskLGBMRegressor, DaskLGBMClassifier, DaskLGBMRanker
+    from .dask import DaskLGBMClassifier, DaskLGBMRanker, DaskLGBMRegressor
 except ImportError:
     pass
 

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -14,7 +14,14 @@ from typing import Any, Dict
 import numpy as np
 import scipy.sparse
 
-from .compat import PANDAS_INSTALLED, pd_DataFrame, pd_Series, concat, is_dtype_sparse, dt_DataTable
+from .compat import (
+    PANDAS_INSTALLED,
+    concat,
+    dt_DataTable,
+    is_dtype_sparse,
+    pd_DataFrame,
+    pd_Series,
+)
 from .libpath import find_lib_path
 
 

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -27,23 +27,26 @@ class EarlyStopException(Exception):
 # Callback environment used by callbacks
 CallbackEnv = collections.namedtuple(
     "LightGBMCallbackEnv",
-    ["model",
-     "params",
-     "iteration",
-     "begin_iteration",
-     "end_iteration",
-     "evaluation_result_list"])
+    [
+        "model",
+        "params",
+        "iteration",
+        "begin_iteration",
+        "end_iteration",
+        "evaluation_result_list",
+    ],
+)
 
 
 def _format_eval_result(value, show_stdv=True):
     """Format metric string."""
     if len(value) == 4:
-        return '%s\'s %s: %g' % (value[0], value[1], value[2])
+        return "%s's %s: %g" % (value[0], value[1], value[2])
     elif len(value) == 5:
         if show_stdv:
-            return '%s\'s %s: %g + %g' % (value[0], value[1], value[2], value[4])
+            return "%s's %s: %g + %g" % (value[0], value[1], value[2], value[4])
         else:
-            return '%s\'s %s: %g' % (value[0], value[1], value[2])
+            return "%s's %s: %g" % (value[0], value[1], value[2])
     else:
         raise ValueError("Wrong metric value")
 
@@ -63,10 +66,18 @@ def print_evaluation(period=1, show_stdv=True):
     callback : function
         The callback that prints the evaluation results every ``period`` iteration(s).
     """
+
     def _callback(env):
-        if period > 0 and env.evaluation_result_list and (env.iteration + 1) % period == 0:
-            result = '\t'.join([_format_eval_result(x, show_stdv) for x in env.evaluation_result_list])
-            _log_info('[%d]\t%s' % (env.iteration + 1, result))
+        if (
+            period > 0
+            and env.evaluation_result_list
+            and (env.iteration + 1) % period == 0
+        ):
+            result = "\t".join(
+                [_format_eval_result(x, show_stdv) for x in env.evaluation_result_list]
+            )
+            _log_info("[%d]\t%s" % (env.iteration + 1, result))
+
     _callback.order = 10
     return _callback
 
@@ -85,7 +96,7 @@ def record_evaluation(eval_result):
         The callback that records the evaluation history into the passed dictionary.
     """
     if not isinstance(eval_result, dict):
-        raise TypeError('eval_result should be a dictionary')
+        raise TypeError("eval_result should be a dictionary")
     eval_result.clear()
 
     def _init(env):
@@ -98,6 +109,7 @@ def record_evaluation(eval_result):
             _init(env)
         for data_name, eval_name, result, _ in env.evaluation_result_list:
             eval_result[data_name][eval_name].append(result)
+
     _callback.order = 20
     return _callback
 
@@ -123,13 +135,17 @@ def reset_parameter(**kwargs):
     callback : function
         The callback that resets the parameter after the first iteration.
     """
+
     def _callback(env):
         new_parameters = {}
         for key, value in kwargs.items():
             if isinstance(value, list):
                 if len(value) != env.end_iteration - env.begin_iteration:
-                    raise ValueError("Length of list {} has to equal to 'num_boost_round'."
-                                     .format(repr(key)))
+                    raise ValueError(
+                        "Length of list {} has to equal to 'num_boost_round'.".format(
+                            repr(key)
+                        )
+                    )
                 new_param = value[env.iteration - env.begin_iteration]
             else:
                 new_param = value(env.iteration - env.begin_iteration)
@@ -138,6 +154,7 @@ def reset_parameter(**kwargs):
         if new_parameters:
             env.model.reset_parameter(new_parameters)
             env.params.update(new_parameters)
+
     _callback.before_iteration = True
     _callback.order = 10
     return _callback
@@ -173,20 +190,28 @@ def early_stopping(stopping_rounds, first_metric_only=False, verbose=True):
     best_score_list = []
     cmp_op = []
     enabled = [True]
-    first_metric = ['']
+    first_metric = [""]
 
     def _init(env):
-        enabled[0] = not any(env.params.get(boost_alias, "") == 'dart' for boost_alias
-                             in _ConfigAliases.get("boosting"))
+        enabled[0] = not any(
+            env.params.get(boost_alias, "") == "dart"
+            for boost_alias in _ConfigAliases.get("boosting")
+        )
         if not enabled[0]:
-            _log_warning('Early stopping is not available in dart mode')
+            _log_warning("Early stopping is not available in dart mode")
             return
         if not env.evaluation_result_list:
-            raise ValueError('For early stopping, '
-                             'at least one dataset and eval metric is required for evaluation')
+            raise ValueError(
+                "For early stopping, "
+                "at least one dataset and eval metric is required for evaluation"
+            )
 
         if verbose:
-            _log_info("Training until validation scores don't improve for {} rounds".format(stopping_rounds))
+            _log_info(
+                "Training until validation scores don't improve for {} rounds".format(
+                    stopping_rounds
+                )
+            )
 
         # split is needed for "<dataset type> <metric>" case (e.g. "train l1")
         first_metric[0] = env.evaluation_result_list[0][1].split(" ")[-1]
@@ -194,17 +219,22 @@ def early_stopping(stopping_rounds, first_metric_only=False, verbose=True):
             best_iter.append(0)
             best_score_list.append(None)
             if eval_ret[3]:
-                best_score.append(float('-inf'))
+                best_score.append(float("-inf"))
                 cmp_op.append(gt)
             else:
-                best_score.append(float('inf'))
+                best_score.append(float("inf"))
                 cmp_op.append(lt)
 
     def _final_iteration_check(env, eval_name_splitted, i):
         if env.iteration == env.end_iteration - 1:
             if verbose:
-                _log_info('Did not meet early stopping. Best iteration is:\n[%d]\t%s' % (
-                    best_iter[i] + 1, '\t'.join([_format_eval_result(x) for x in best_score_list[i]])))
+                _log_info(
+                    "Did not meet early stopping. Best iteration is:\n[%d]\t%s"
+                    % (
+                        best_iter[i] + 1,
+                        "\t".join([_format_eval_result(x) for x in best_score_list[i]]),
+                    )
+                )
                 if first_metric_only:
                     _log_info("Evaluated only: {}".format(eval_name_splitted[-1]))
             raise EarlyStopException(best_iter[i], best_score_list[i])
@@ -224,17 +254,28 @@ def early_stopping(stopping_rounds, first_metric_only=False, verbose=True):
             eval_name_splitted = env.evaluation_result_list[i][1].split(" ")
             if first_metric_only and first_metric[0] != eval_name_splitted[-1]:
                 continue  # use only the first metric for early stopping
-            if ((env.evaluation_result_list[i][0] == "cv_agg" and eval_name_splitted[0] == "train"
-                 or env.evaluation_result_list[i][0] == env.model._train_data_name)):
+            if (
+                env.evaluation_result_list[i][0] == "cv_agg"
+                and eval_name_splitted[0] == "train"
+                or env.evaluation_result_list[i][0] == env.model._train_data_name
+            ):
                 _final_iteration_check(env, eval_name_splitted, i)
                 continue  # train data for lgb.cv or sklearn wrapper (underlying lgb.train)
             elif env.iteration - best_iter[i] >= stopping_rounds:
                 if verbose:
-                    _log_info('Early stopping, best iteration is:\n[%d]\t%s' % (
-                        best_iter[i] + 1, '\t'.join([_format_eval_result(x) for x in best_score_list[i]])))
+                    _log_info(
+                        "Early stopping, best iteration is:\n[%d]\t%s"
+                        % (
+                            best_iter[i] + 1,
+                            "\t".join(
+                                [_format_eval_result(x) for x in best_score_list[i]]
+                            ),
+                        )
+                    )
                     if first_metric_only:
                         _log_info("Evaluated only: {}".format(eval_name_splitted[-1]))
                 raise EarlyStopException(best_iter[i], best_score_list[i])
             _final_iteration_check(env, eval_name_splitted, i)
+
     _callback.order = 30
     return _callback

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -3,9 +3,9 @@
 
 """pandas"""
 try:
-    from pandas import concat
-    from pandas import Series as pd_Series
     from pandas import DataFrame as pd_DataFrame
+    from pandas import Series as pd_Series
+    from pandas import concat
     from pandas.api.types import is_sparse as is_dtype_sparse
     PANDAS_INSTALLED = True
 except ImportError:
@@ -57,17 +57,16 @@ except ImportError:
 
 """sklearn"""
 try:
-    from sklearn.base import BaseEstimator
-    from sklearn.base import RegressorMixin, ClassifierMixin
+    from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
     from sklearn.preprocessing import LabelEncoder
     from sklearn.utils.class_weight import compute_sample_weight
     from sklearn.utils.multiclass import check_classification_targets
-    from sklearn.utils.validation import assert_all_finite, check_X_y, check_array
+    from sklearn.utils.validation import assert_all_finite, check_array, check_X_y
     try:
-        from sklearn.model_selection import StratifiedKFold, GroupKFold
         from sklearn.exceptions import NotFittedError
+        from sklearn.model_selection import GroupKFold, StratifiedKFold
     except ImportError:
-        from sklearn.cross_validation import StratifiedKFold, GroupKFold
+        from sklearn.cross_validation import GroupKFold, StratifiedKFold
         from sklearn.utils.validation import NotFittedError
     try:
         from sklearn.utils.validation import _check_sample_weight

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -7,6 +7,7 @@ try:
     from pandas import Series as pd_Series
     from pandas import concat
     from pandas.api.types import is_sparse as is_dtype_sparse
+
     PANDAS_INSTALLED = True
 except ImportError:
     PANDAS_INSTALLED = False
@@ -27,6 +28,7 @@ except ImportError:
 """matplotlib"""
 try:
     import matplotlib
+
     MATPLOTLIB_INSTALLED = True
 except ImportError:
     MATPLOTLIB_INSTALLED = False
@@ -34,6 +36,7 @@ except ImportError:
 """graphviz"""
 try:
     import graphviz
+
     GRAPHVIZ_INSTALLED = True
 except ImportError:
     GRAPHVIZ_INSTALLED = False
@@ -41,6 +44,7 @@ except ImportError:
 """datatable"""
 try:
     import datatable
+
     if hasattr(datatable, "Frame"):
         dt_DataTable = datatable.Frame
     else:
@@ -62,6 +66,7 @@ try:
     from sklearn.utils.class_weight import compute_sample_weight
     from sklearn.utils.multiclass import check_classification_targets
     from sklearn.utils.validation import assert_all_finite, check_array, check_X_y
+
     try:
         from sklearn.exceptions import NotFittedError
         from sklearn.model_selection import GroupKFold, StratifiedKFold
@@ -115,6 +120,7 @@ try:
     from dask.dataframe import DataFrame as dask_DataFrame
     from dask.dataframe import Series as dask_Series
     from dask.distributed import Client, default_client, get_worker, wait
+
     DASK_INSTALLED = True
 except ImportError:
     DASK_INSTALLED = False

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -15,17 +15,38 @@ from urllib.parse import urlparse
 import numpy as np
 import scipy.sparse as ss
 
-from .basic import _choose_param_value, _ConfigAliases, _LIB, _log_warning, _safe_call, LightGBMError
-from .compat import (PANDAS_INSTALLED, pd_DataFrame, pd_Series, concat,
-                     SKLEARN_INSTALLED, LGBMNotFittedError,
-                     DASK_INSTALLED, dask_DataFrame, dask_Array, dask_Series, delayed, Client, default_client, get_worker, wait)
+from .basic import (
+    _LIB,
+    LightGBMError,
+    _choose_param_value,
+    _ConfigAliases,
+    _log_warning,
+    _safe_call,
+)
+from .compat import (
+    DASK_INSTALLED,
+    PANDAS_INSTALLED,
+    SKLEARN_INSTALLED,
+    Client,
+    LGBMNotFittedError,
+    concat,
+    dask_Array,
+    dask_DataFrame,
+    dask_Series,
+    default_client,
+    delayed,
+    get_worker,
+    pd_DataFrame,
+    pd_Series,
+    wait,
+)
 from .sklearn import (
-    _lgbmmodel_doc_fit,
-    _lgbmmodel_doc_predict,
     LGBMClassifier,
     LGBMModel,
+    LGBMRanker,
     LGBMRegressor,
-    LGBMRanker
+    _lgbmmodel_doc_fit,
+    _lgbmmodel_doc_predict,
 )
 
 _DaskCollection = Union[dask_Array, dask_DataFrame, dask_Series]

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -7,7 +7,14 @@ from operator import attrgetter
 import numpy as np
 
 from . import callback
-from .basic import Booster, Dataset, LightGBMError, _ConfigAliases, _InnerPredictor, _log_warning
+from .basic import (
+    Booster,
+    Dataset,
+    LightGBMError,
+    _ConfigAliases,
+    _InnerPredictor,
+    _log_warning,
+)
 from .compat import SKLEARN_INSTALLED, _LGBMGroupKFold, _LGBMStratifiedKFold
 
 

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -12,26 +12,31 @@ def find_lib_path():
     lib_path: list of strings
        List of all found library paths to LightGBM.
     """
-    if os.environ.get('LIGHTGBM_BUILD_DOC', False):
+    if os.environ.get("LIGHTGBM_BUILD_DOC", False):
         # we don't need lib_lightgbm while building docs
         return []
 
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-    dll_path = [curr_path,
-                os.path.join(curr_path, '../../'),
-                os.path.join(curr_path, 'compile'),
-                os.path.join(curr_path, '../compile'),
-                os.path.join(curr_path, '../../lib/')]
-    if system() in ('Windows', 'Microsoft'):
-        dll_path.append(os.path.join(curr_path, '../compile/Release/'))
-        dll_path.append(os.path.join(curr_path, '../compile/windows/x64/DLL/'))
-        dll_path.append(os.path.join(curr_path, '../../Release/'))
-        dll_path.append(os.path.join(curr_path, '../../windows/x64/DLL/'))
-        dll_path = [os.path.join(p, 'lib_lightgbm.dll') for p in dll_path]
+    dll_path = [
+        curr_path,
+        os.path.join(curr_path, "../../"),
+        os.path.join(curr_path, "compile"),
+        os.path.join(curr_path, "../compile"),
+        os.path.join(curr_path, "../../lib/"),
+    ]
+    if system() in ("Windows", "Microsoft"):
+        dll_path.append(os.path.join(curr_path, "../compile/Release/"))
+        dll_path.append(os.path.join(curr_path, "../compile/windows/x64/DLL/"))
+        dll_path.append(os.path.join(curr_path, "../../Release/"))
+        dll_path.append(os.path.join(curr_path, "../../windows/x64/DLL/"))
+        dll_path = [os.path.join(p, "lib_lightgbm.dll") for p in dll_path]
     else:
-        dll_path = [os.path.join(p, 'lib_lightgbm.so') for p in dll_path]
+        dll_path = [os.path.join(p, "lib_lightgbm.so") for p in dll_path]
     lib_path = [p for p in dll_path if os.path.exists(p) and os.path.isfile(p)]
     if not lib_path:
         dll_path = [os.path.realpath(p) for p in dll_path]
-        raise Exception('Cannot find lightgbm library file in following paths:\n' + '\n'.join(dll_path))
+        raise Exception(
+            "Cannot find lightgbm library file in following paths:\n"
+            + "\n".join(dll_path)
+        )
     return lib_path

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 """Find the path to LightGBM dynamic library files."""
 import os
-
 from platform import system
 
 

--- a/python-package/lightgbm/plotting.py
+++ b/python-package/lightgbm/plotting.py
@@ -6,7 +6,7 @@ from io import BytesIO
 import numpy as np
 
 from .basic import Booster, _log_warning
-from .compat import MATPLOTLIB_INSTALLED, GRAPHVIZ_INSTALLED
+from .compat import GRAPHVIZ_INSTALLED, MATPLOTLIB_INSTALLED
 from .sklearn import LGBMModel
 
 
@@ -599,8 +599,8 @@ def plot_tree(booster, ax=None, tree_index=0, figsize=None, dpi=None,
         The plot with single tree.
     """
     if MATPLOTLIB_INSTALLED:
-        import matplotlib.pyplot as plt
         import matplotlib.image as image
+        import matplotlib.pyplot as plt
     else:
         raise ImportError('You must install matplotlib to plot tree.')
 

--- a/python-package/lightgbm/plotting.py
+++ b/python-package/lightgbm/plotting.py
@@ -10,24 +10,38 @@ from .compat import GRAPHVIZ_INSTALLED, MATPLOTLIB_INSTALLED
 from .sklearn import LGBMModel
 
 
-def _check_not_tuple_of_2_elements(obj, obj_name='obj'):
+def _check_not_tuple_of_2_elements(obj, obj_name="obj"):
     """Check object is not tuple or does not have 2 elements."""
     if not isinstance(obj, tuple) or len(obj) != 2:
-        raise TypeError('%s must be a tuple of 2 elements.' % obj_name)
+        raise TypeError("%s must be a tuple of 2 elements." % obj_name)
 
 
 def _float2str(value, precision=None):
-    return ("{0:.{1}f}".format(value, precision)
-            if precision is not None and not isinstance(value, str)
-            else str(value))
+    return (
+        "{0:.{1}f}".format(value, precision)
+        if precision is not None and not isinstance(value, str)
+        else str(value)
+    )
 
 
-def plot_importance(booster, ax=None, height=0.2,
-                    xlim=None, ylim=None, title='Feature importance',
-                    xlabel='Feature importance', ylabel='Features',
-                    importance_type='split', max_num_features=None,
-                    ignore_zero=True, figsize=None, dpi=None, grid=True,
-                    precision=3, **kwargs):
+def plot_importance(
+    booster,
+    ax=None,
+    height=0.2,
+    xlim=None,
+    ylim=None,
+    title="Feature importance",
+    xlabel="Feature importance",
+    ylabel="Features",
+    importance_type="split",
+    max_num_features=None,
+    ignore_zero=True,
+    figsize=None,
+    dpi=None,
+    grid=True,
+    precision=3,
+    **kwargs
+):
     """Plot model's feature importances.
 
     Parameters
@@ -80,12 +94,12 @@ def plot_importance(booster, ax=None, height=0.2,
     if MATPLOTLIB_INSTALLED:
         import matplotlib.pyplot as plt
     else:
-        raise ImportError('You must install matplotlib to plot importance.')
+        raise ImportError("You must install matplotlib to plot importance.")
 
     if isinstance(booster, LGBMModel):
         booster = booster.booster_
     elif not isinstance(booster, Booster):
-        raise TypeError('booster must be Booster or LGBMModel.')
+        raise TypeError("booster must be Booster or LGBMModel.")
 
     importance = booster.feature_importance(importance_type=importance_type)
     feature_name = booster.feature_name()
@@ -102,28 +116,31 @@ def plot_importance(booster, ax=None, height=0.2,
 
     if ax is None:
         if figsize is not None:
-            _check_not_tuple_of_2_elements(figsize, 'figsize')
+            _check_not_tuple_of_2_elements(figsize, "figsize")
         _, ax = plt.subplots(1, 1, figsize=figsize, dpi=dpi)
 
     ylocs = np.arange(len(values))
-    ax.barh(ylocs, values, align='center', height=height, **kwargs)
+    ax.barh(ylocs, values, align="center", height=height, **kwargs)
 
     for x, y in zip(values, ylocs):
-        ax.text(x + 1, y,
-                _float2str(x, precision) if importance_type == 'gain' else x,
-                va='center')
+        ax.text(
+            x + 1,
+            y,
+            _float2str(x, precision) if importance_type == "gain" else x,
+            va="center",
+        )
 
     ax.set_yticks(ylocs)
     ax.set_yticklabels(labels)
 
     if xlim is not None:
-        _check_not_tuple_of_2_elements(xlim, 'xlim')
+        _check_not_tuple_of_2_elements(xlim, "xlim")
     else:
         xlim = (0, max(values) * 1.1)
     ax.set_xlim(xlim)
 
     if ylim is not None:
-        _check_not_tuple_of_2_elements(ylim, 'ylim')
+        _check_not_tuple_of_2_elements(ylim, "ylim")
     else:
         ylim = (-1, len(values))
     ax.set_ylim(ylim)
@@ -138,11 +155,22 @@ def plot_importance(booster, ax=None, height=0.2,
     return ax
 
 
-def plot_split_value_histogram(booster, feature, bins=None, ax=None, width_coef=0.8,
-                               xlim=None, ylim=None,
-                               title='Split value histogram for feature with @index/name@ @feature@',
-                               xlabel='Feature split value', ylabel='Count',
-                               figsize=None, dpi=None, grid=True, **kwargs):
+def plot_split_value_histogram(
+    booster,
+    feature,
+    bins=None,
+    ax=None,
+    width_coef=0.8,
+    xlim=None,
+    ylim=None,
+    title="Split value histogram for feature with @index/name@ @feature@",
+    xlabel="Feature split value",
+    ylabel="Count",
+    figsize=None,
+    dpi=None,
+    grid=True,
+    **kwargs
+):
     """Plot split value histogram for the specified feature of the model.
 
     Parameters
@@ -197,29 +225,33 @@ def plot_split_value_histogram(booster, feature, bins=None, ax=None, width_coef=
         import matplotlib.pyplot as plt
         from matplotlib.ticker import MaxNLocator
     else:
-        raise ImportError('You must install matplotlib to plot split value histogram.')
+        raise ImportError("You must install matplotlib to plot split value histogram.")
 
     if isinstance(booster, LGBMModel):
         booster = booster.booster_
     elif not isinstance(booster, Booster):
-        raise TypeError('booster must be Booster or LGBMModel.')
+        raise TypeError("booster must be Booster or LGBMModel.")
 
-    hist, bins = booster.get_split_value_histogram(feature=feature, bins=bins, xgboost_style=False)
+    hist, bins = booster.get_split_value_histogram(
+        feature=feature, bins=bins, xgboost_style=False
+    )
     if np.count_nonzero(hist) == 0:
-        raise ValueError('Cannot plot split value histogram, '
-                         'because feature {} was not used in splitting'.format(feature))
+        raise ValueError(
+            "Cannot plot split value histogram, "
+            "because feature {} was not used in splitting".format(feature)
+        )
     width = width_coef * (bins[1] - bins[0])
     centred = (bins[:-1] + bins[1:]) / 2
 
     if ax is None:
         if figsize is not None:
-            _check_not_tuple_of_2_elements(figsize, 'figsize')
+            _check_not_tuple_of_2_elements(figsize, "figsize")
         _, ax = plt.subplots(1, 1, figsize=figsize, dpi=dpi)
 
-    ax.bar(centred, hist, align='center', width=width, **kwargs)
+    ax.bar(centred, hist, align="center", width=width, **kwargs)
 
     if xlim is not None:
-        _check_not_tuple_of_2_elements(xlim, 'xlim')
+        _check_not_tuple_of_2_elements(xlim, "xlim")
     else:
         range_result = bins[-1] - bins[0]
         xlim = (bins[0] - range_result * 0.2, bins[-1] + range_result * 0.2)
@@ -227,14 +259,16 @@ def plot_split_value_histogram(booster, feature, bins=None, ax=None, width_coef=
 
     ax.yaxis.set_major_locator(MaxNLocator(integer=True))
     if ylim is not None:
-        _check_not_tuple_of_2_elements(ylim, 'ylim')
+        _check_not_tuple_of_2_elements(ylim, "ylim")
     else:
         ylim = (0, max(hist) * 1.1)
     ax.set_ylim(ylim)
 
     if title is not None:
-        title = title.replace('@feature@', str(feature))
-        title = title.replace('@index/name@', ('name' if isinstance(feature, str) else 'index'))
+        title = title.replace("@feature@", str(feature))
+        title = title.replace(
+            "@index/name@", ("name" if isinstance(feature, str) else "index")
+        )
         ax.set_title(title)
     if xlabel is not None:
         ax.set_xlabel(xlabel)
@@ -244,11 +278,20 @@ def plot_split_value_histogram(booster, feature, bins=None, ax=None, width_coef=
     return ax
 
 
-def plot_metric(booster, metric=None, dataset_names=None,
-                ax=None, xlim=None, ylim=None,
-                title='Metric during training',
-                xlabel='Iterations', ylabel='auto',
-                figsize=None, dpi=None, grid=True):
+def plot_metric(
+    booster,
+    metric=None,
+    dataset_names=None,
+    ax=None,
+    xlim=None,
+    ylim=None,
+    title="Metric during training",
+    xlabel="Iterations",
+    ylabel="auto",
+    figsize=None,
+    dpi=None,
+    grid=True,
+):
     """Plot one metric during training.
 
     Parameters
@@ -294,29 +337,29 @@ def plot_metric(booster, metric=None, dataset_names=None,
     if MATPLOTLIB_INSTALLED:
         import matplotlib.pyplot as plt
     else:
-        raise ImportError('You must install matplotlib to plot metric.')
+        raise ImportError("You must install matplotlib to plot metric.")
 
     if isinstance(booster, LGBMModel):
         eval_results = deepcopy(booster.evals_result_)
     elif isinstance(booster, dict):
         eval_results = deepcopy(booster)
     else:
-        raise TypeError('booster must be dict or LGBMModel.')
+        raise TypeError("booster must be dict or LGBMModel.")
 
     num_data = len(eval_results)
 
     if not num_data:
-        raise ValueError('eval results cannot be empty.')
+        raise ValueError("eval results cannot be empty.")
 
     if ax is None:
         if figsize is not None:
-            _check_not_tuple_of_2_elements(figsize, 'figsize')
+            _check_not_tuple_of_2_elements(figsize, "figsize")
         _, ax = plt.subplots(1, 1, figsize=figsize, dpi=dpi)
 
     if dataset_names is None:
         dataset_names = iter(eval_results.keys())
     elif not isinstance(dataset_names, (list, tuple, set)) or not dataset_names:
-        raise ValueError('dataset_names should be iterable and cannot be empty')
+        raise ValueError("dataset_names should be iterable and cannot be empty")
     else:
         dataset_names = iter(dataset_names)
 
@@ -329,7 +372,7 @@ def plot_metric(booster, metric=None, dataset_names=None,
         metric, results = metrics_for_one.popitem()
     else:
         if metric not in metrics_for_one:
-            raise KeyError('No given metric in eval results.')
+            raise KeyError("No given metric in eval results.")
         results = metrics_for_one[metric]
     num_iteration, max_result, min_result = len(results), max(results), min(results)
     x_ = range(num_iteration)
@@ -338,25 +381,27 @@ def plot_metric(booster, metric=None, dataset_names=None,
     for name in dataset_names:
         metrics_for_one = eval_results[name]
         results = metrics_for_one[metric]
-        max_result, min_result = max(max(results), max_result), min(min(results), min_result)
+        max_result, min_result = max(max(results), max_result), min(
+            min(results), min_result
+        )
         ax.plot(x_, results, label=name)
 
-    ax.legend(loc='best')
+    ax.legend(loc="best")
 
     if xlim is not None:
-        _check_not_tuple_of_2_elements(xlim, 'xlim')
+        _check_not_tuple_of_2_elements(xlim, "xlim")
     else:
         xlim = (0, num_iteration)
     ax.set_xlim(xlim)
 
     if ylim is not None:
-        _check_not_tuple_of_2_elements(ylim, 'ylim')
+        _check_not_tuple_of_2_elements(ylim, "ylim")
     else:
         range_result = max_result - min_result
         ylim = (min_result - range_result * 0.2, max_result + range_result * 0.2)
     ax.set_ylim(ylim)
 
-    if ylabel == 'auto':
+    if ylabel == "auto":
         ylabel = metric
 
     if title is not None:
@@ -369,8 +414,15 @@ def plot_metric(booster, metric=None, dataset_names=None,
     return ax
 
 
-def _to_graphviz(tree_info, show_info, feature_names, precision=3,
-                 orientation='horizontal', constraints=None, **kwargs):
+def _to_graphviz(
+    tree_info,
+    show_info,
+    feature_names,
+    precision=3,
+    orientation="horizontal",
+    constraints=None,
+    **kwargs
+):
     """Convert specified tree to graphviz instance.
 
     See:
@@ -379,58 +431,78 @@ def _to_graphviz(tree_info, show_info, feature_names, precision=3,
     if GRAPHVIZ_INSTALLED:
         from graphviz import Digraph
     else:
-        raise ImportError('You must install graphviz to plot tree.')
+        raise ImportError("You must install graphviz to plot tree.")
 
     def add(root, total_count, parent=None, decision=None):
         """Recursively add node or edge."""
-        if 'split_index' in root:  # non-leaf
-            l_dec = 'yes'
-            r_dec = 'no'
-            if root['decision_type'] == '<=':
+        if "split_index" in root:  # non-leaf
+            l_dec = "yes"
+            r_dec = "no"
+            if root["decision_type"] == "<=":
                 lte_symbol = "&#8804;"
                 operator = lte_symbol
-            elif root['decision_type'] == '==':
+            elif root["decision_type"] == "==":
                 operator = "="
             else:
-                raise ValueError('Invalid decision type in tree model.')
-            name = 'split{0}'.format(root['split_index'])
+                raise ValueError("Invalid decision type in tree model.")
+            name = "split{0}".format(root["split_index"])
             if feature_names is not None:
-                label = '<B>{0}</B> {1} '.format(feature_names[root['split_feature']], operator)
+                label = "<B>{0}</B> {1} ".format(
+                    feature_names[root["split_feature"]], operator
+                )
             else:
-                label = 'feature <B>{0}</B> {1} '.format(root['split_feature'], operator)
-            label += '<B>{0}</B>'.format(_float2str(root['threshold'], precision))
-            for info in ['split_gain', 'internal_value', 'internal_weight', "internal_count", "data_percentage"]:
+                label = "feature <B>{0}</B> {1} ".format(
+                    root["split_feature"], operator
+                )
+            label += "<B>{0}</B>".format(_float2str(root["threshold"], precision))
+            for info in [
+                "split_gain",
+                "internal_value",
+                "internal_weight",
+                "internal_count",
+                "data_percentage",
+            ]:
                 if info in show_info:
-                    output = info.split('_')[-1]
-                    if info in {'split_gain', 'internal_value', 'internal_weight'}:
-                        label += '<br/>{0} {1}'.format(_float2str(root[info], precision), output)
-                    elif info == 'internal_count':
-                        label += '<br/>{0}: {1}'.format(output, root[info])
+                    output = info.split("_")[-1]
+                    if info in {"split_gain", "internal_value", "internal_weight"}:
+                        label += "<br/>{0} {1}".format(
+                            _float2str(root[info], precision), output
+                        )
+                    elif info == "internal_count":
+                        label += "<br/>{0}: {1}".format(output, root[info])
                     elif info == "data_percentage":
-                        label += '<br/>{0}% of data'.format(_float2str(root['internal_count'] / total_count * 100, 2))
+                        label += "<br/>{0}% of data".format(
+                            _float2str(root["internal_count"] / total_count * 100, 2)
+                        )
 
             fillcolor = "white"
             style = ""
             if constraints:
-                if constraints[root['split_feature']] == 1:
+                if constraints[root["split_feature"]] == 1:
                     fillcolor = "#ddffdd"  # light green
-                if constraints[root['split_feature']] == -1:
+                if constraints[root["split_feature"]] == -1:
                     fillcolor = "#ffdddd"  # light red
                 style = "filled"
             label = "<" + label + ">"
-            graph.node(name, label=label, shape="rectangle", style=style, fillcolor=fillcolor)
-            add(root['left_child'], total_count, name, l_dec)
-            add(root['right_child'], total_count, name, r_dec)
+            graph.node(
+                name, label=label, shape="rectangle", style=style, fillcolor=fillcolor
+            )
+            add(root["left_child"], total_count, name, l_dec)
+            add(root["right_child"], total_count, name, r_dec)
         else:  # leaf
-            name = 'leaf{0}'.format(root['leaf_index'])
-            label = 'leaf {0}: '.format(root['leaf_index'])
-            label += '<B>{0}</B>'.format(_float2str(root['leaf_value'], precision))
-            if 'leaf_weight' in show_info:
-                label += '<br/>{0} weight'.format(_float2str(root['leaf_weight'], precision))
-            if 'leaf_count' in show_info:
-                label += '<br/>count: {0}'.format(root['leaf_count'])
+            name = "leaf{0}".format(root["leaf_index"])
+            label = "leaf {0}: ".format(root["leaf_index"])
+            label += "<B>{0}</B>".format(_float2str(root["leaf_value"], precision))
+            if "leaf_weight" in show_info:
+                label += "<br/>{0} weight".format(
+                    _float2str(root["leaf_weight"], precision)
+                )
+            if "leaf_count" in show_info:
+                label += "<br/>count: {0}".format(root["leaf_count"])
             if "data_percentage" in show_info:
-                label += '<br/>{0}% of data'.format(_float2str(root['leaf_count'] / total_count * 100, 2))
+                label += "<br/>{0}% of data".format(
+                    _float2str(root["leaf_count"] / total_count * 100, 2)
+                )
             label = "<" + label + ">"
             graph.node(name, label=label)
         if parent is not None:
@@ -439,8 +511,8 @@ def _to_graphviz(tree_info, show_info, feature_names, precision=3,
     graph = Digraph(**kwargs)
     rankdir = "LR" if orientation == "horizontal" else "TB"
     graph.attr("graph", nodesep="0.05", ranksep="0.3", rankdir=rankdir)
-    if "internal_count" in tree_info['tree_structure']:
-        add(tree_info['tree_structure'], tree_info['tree_structure']["internal_count"])
+    if "internal_count" in tree_info["tree_structure"]:
+        add(tree_info["tree_structure"], tree_info["tree_structure"]["internal_count"])
     else:
         raise Exception("Cannot plot trees with no split")
 
@@ -465,8 +537,14 @@ def _to_graphviz(tree_info, show_info, feature_names, precision=3,
     return graph
 
 
-def create_tree_digraph(booster, tree_index=0, show_info=None, precision=3,
-                        orientation='horizontal', **kwargs):
+def create_tree_digraph(
+    booster,
+    tree_index=0,
+    show_info=None,
+    precision=3,
+    orientation="horizontal",
+    **kwargs
+):
     """Create a digraph representation of specified tree.
 
     Each node in the graph represents a node in the tree.
@@ -517,33 +595,49 @@ def create_tree_digraph(booster, tree_index=0, show_info=None, precision=3,
     if isinstance(booster, LGBMModel):
         booster = booster.booster_
     elif not isinstance(booster, Booster):
-        raise TypeError('booster must be Booster or LGBMModel.')
+        raise TypeError("booster must be Booster or LGBMModel.")
 
     model = booster.dump_model()
-    tree_infos = model['tree_info']
-    if 'feature_names' in model:
-        feature_names = model['feature_names']
+    tree_infos = model["tree_info"]
+    if "feature_names" in model:
+        feature_names = model["feature_names"]
     else:
         feature_names = None
 
-    monotone_constraints = model.get('monotone_constraints', None)
+    monotone_constraints = model.get("monotone_constraints", None)
 
     if tree_index < len(tree_infos):
         tree_info = tree_infos[tree_index]
     else:
-        raise IndexError('tree_index is out of range.')
+        raise IndexError("tree_index is out of range.")
 
     if show_info is None:
         show_info = []
 
-    graph = _to_graphviz(tree_info, show_info, feature_names, precision,
-                         orientation, monotone_constraints, **kwargs)
+    graph = _to_graphviz(
+        tree_info,
+        show_info,
+        feature_names,
+        precision,
+        orientation,
+        monotone_constraints,
+        **kwargs
+    )
 
     return graph
 
 
-def plot_tree(booster, ax=None, tree_index=0, figsize=None, dpi=None,
-              show_info=None, precision=3, orientation='horizontal', **kwargs):
+def plot_tree(
+    booster,
+    ax=None,
+    tree_index=0,
+    figsize=None,
+    dpi=None,
+    show_info=None,
+    precision=3,
+    orientation="horizontal",
+    **kwargs
+):
     """Plot specified tree.
 
     Each node in the graph represents a node in the tree.
@@ -602,22 +696,27 @@ def plot_tree(booster, ax=None, tree_index=0, figsize=None, dpi=None,
         import matplotlib.image as image
         import matplotlib.pyplot as plt
     else:
-        raise ImportError('You must install matplotlib to plot tree.')
+        raise ImportError("You must install matplotlib to plot tree.")
 
     if ax is None:
         if figsize is not None:
-            _check_not_tuple_of_2_elements(figsize, 'figsize')
+            _check_not_tuple_of_2_elements(figsize, "figsize")
         _, ax = plt.subplots(1, 1, figsize=figsize, dpi=dpi)
 
-    graph = create_tree_digraph(booster=booster, tree_index=tree_index,
-                                show_info=show_info, precision=precision,
-                                orientation=orientation, **kwargs)
+    graph = create_tree_digraph(
+        booster=booster,
+        tree_index=tree_index,
+        show_info=show_info,
+        precision=precision,
+        orientation=orientation,
+        **kwargs
+    )
 
     s = BytesIO()
-    s.write(graph.pipe(format='png'))
+    s.write(graph.pipe(format="png"))
     s.seek(0)
     img = image.imread(s)
 
     ax.imshow(img)
-    ax.axis('off')
+    ax.axis("off")
     return ax

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1,17 +1,33 @@
 # coding: utf-8
 """Scikit-learn wrapper interface for LightGBM."""
 import copy
-
 from inspect import signature
 
 import numpy as np
 
-from .basic import Dataset, LightGBMError, _ConfigAliases, _choose_param_value, _log_warning
-from .compat import (SKLEARN_INSTALLED, _LGBMClassifierBase,
-                     LGBMNotFittedError, _LGBMLabelEncoder, _LGBMModelBase,
-                     _LGBMRegressorBase, _LGBMCheckXY, _LGBMCheckArray, _LGBMCheckSampleWeight,
-                     _LGBMAssertAllFinite, _LGBMCheckClassificationTargets, _LGBMComputeSampleWeight,
-                     pd_DataFrame, dt_DataTable)
+from .basic import (
+    Dataset,
+    LightGBMError,
+    _choose_param_value,
+    _ConfigAliases,
+    _log_warning,
+)
+from .compat import (
+    SKLEARN_INSTALLED,
+    LGBMNotFittedError,
+    _LGBMAssertAllFinite,
+    _LGBMCheckArray,
+    _LGBMCheckClassificationTargets,
+    _LGBMCheckSampleWeight,
+    _LGBMCheckXY,
+    _LGBMClassifierBase,
+    _LGBMComputeSampleWeight,
+    _LGBMLabelEncoder,
+    _LGBMModelBase,
+    _LGBMRegressorBase,
+    dt_DataTable,
+    pd_DataFrame,
+)
 from .engine import train
 
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -94,7 +94,10 @@ class _ObjectiveFunctionWrapper:
         elif argc == 3:
             grad, hess = self.func(labels, preds, dataset.get_group())
         else:
-            raise TypeError("Self-defined objective function should have 2 or 3 arguments, got %d" % argc)
+            raise TypeError(
+                "Self-defined objective function should have 2 or 3 arguments, got %d"
+                % argc
+            )
         """weighted for objective"""
         weight = dataset.get_weight()
         if weight is not None:
@@ -106,7 +109,9 @@ class _ObjectiveFunctionWrapper:
                 num_data = len(weight)
                 num_class = len(grad) // num_data
                 if num_class * num_data != len(grad):
-                    raise ValueError("Length of grad and hess should equal to num_class * num_data")
+                    raise ValueError(
+                        "Length of grad and hess should equal to num_class * num_data"
+                    )
                 for k in range(num_class):
                     for i in range(num_data):
                         idx = k * num_data + i
@@ -189,14 +194,16 @@ class _EvalFunctionWrapper:
         elif argc == 4:
             return self.func(labels, preds, dataset.get_weight(), dataset.get_group())
         else:
-            raise TypeError("Self-defined eval function should have 2, 3 or 4 arguments, got %d" % argc)
+            raise TypeError(
+                "Self-defined eval function should have 2, 3 or 4 arguments, got %d"
+                % argc
+            )
 
 
 # documentation templates for LGBMModel methods are shared between the classes in
 # this module and those in the ``dask`` module
 
-_lgbmmodel_doc_fit = (
-    """
+_lgbmmodel_doc_fit = """
     Build a gradient boosting model from the training set (X, y).
 
     Parameters
@@ -275,7 +282,6 @@ _lgbmmodel_doc_fit = (
     self : object
         Returns self.
     """
-)
 
 _lgbmmodel_doc_custom_eval_note = """
     Note
@@ -310,8 +316,7 @@ _lgbmmodel_doc_custom_eval_note = """
     If you want to get i-th row y_pred in j-th class, the access way is y_pred[j * num_data + i].
 """
 
-_lgbmmodel_doc_predict = (
-    """
+_lgbmmodel_doc_predict = """
     {description}
 
     Parameters
@@ -353,19 +358,35 @@ _lgbmmodel_doc_predict = (
     X_SHAP_values : {X_SHAP_values_shape}
         If ``pred_contrib=True``, the feature contributions for each sample.
     """
-)
 
 
 class LGBMModel(_LGBMModelBase):
     """Implementation of the scikit-learn API for LightGBM."""
 
-    def __init__(self, boosting_type='gbdt', num_leaves=31, max_depth=-1,
-                 learning_rate=0.1, n_estimators=100,
-                 subsample_for_bin=200000, objective=None, class_weight=None,
-                 min_split_gain=0., min_child_weight=1e-3, min_child_samples=20,
-                 subsample=1., subsample_freq=0, colsample_bytree=1.,
-                 reg_alpha=0., reg_lambda=0., random_state=None,
-                 n_jobs=-1, silent=True, importance_type='split', **kwargs):
+    def __init__(
+        self,
+        boosting_type="gbdt",
+        num_leaves=31,
+        max_depth=-1,
+        learning_rate=0.1,
+        n_estimators=100,
+        subsample_for_bin=200000,
+        objective=None,
+        class_weight=None,
+        min_split_gain=0.0,
+        min_child_weight=1e-3,
+        min_child_samples=20,
+        subsample=1.0,
+        subsample_freq=0,
+        colsample_bytree=1.0,
+        reg_alpha=0.0,
+        reg_lambda=0.0,
+        random_state=None,
+        n_jobs=-1,
+        silent=True,
+        importance_type="split",
+        **kwargs
+    ):
         r"""Construct a gradient boosting model.
 
         Parameters
@@ -469,7 +490,7 @@ class LGBMModel(_LGBMModelBase):
         and you should group grad and hess in this way as well.
         """
         if not SKLEARN_INSTALLED:
-            raise LightGBMError('scikit-learn is required for lightgbm.sklearn')
+            raise LightGBMError("scikit-learn is required for lightgbm.sklearn")
 
         self.boosting_type = boosting_type
         self.objective = objective
@@ -507,14 +528,13 @@ class LGBMModel(_LGBMModelBase):
 
     def _more_tags(self):
         return {
-            'allow_nan': True,
-            'X_types': ['2darray', 'sparse', '1dlabels'],
-            '_xfail_checks': {
-                'check_no_attributes_set_in_init':
-                'scikit-learn incorrectly asserts that private attributes '
-                'cannot be set in __init__: '
-                '(see https://github.com/microsoft/LightGBM/issues/2628)'
-            }
+            "allow_nan": True,
+            "X_types": ["2darray", "sparse", "1dlabels"],
+            "_xfail_checks": {
+                "check_no_attributes_set_in_init": "scikit-learn incorrectly asserts that private attributes "
+                "cannot be set in __init__: "
+                "(see https://github.com/microsoft/LightGBM/issues/2628)"
+            },
         }
 
     def get_params(self, deep=True):
@@ -550,18 +570,32 @@ class LGBMModel(_LGBMModelBase):
         """
         for key, value in params.items():
             setattr(self, key, value)
-            if hasattr(self, '_' + key):
-                setattr(self, '_' + key, value)
+            if hasattr(self, "_" + key):
+                setattr(self, "_" + key, value)
             self._other_params[key] = value
         return self
 
-    def fit(self, X, y,
-            sample_weight=None, init_score=None, group=None,
-            eval_set=None, eval_names=None, eval_sample_weight=None,
-            eval_class_weight=None, eval_init_score=None, eval_group=None,
-            eval_metric=None, early_stopping_rounds=None, verbose=True,
-            feature_name='auto', categorical_feature='auto',
-            callbacks=None, init_model=None):
+    def fit(
+        self,
+        X,
+        y,
+        sample_weight=None,
+        init_score=None,
+        group=None,
+        eval_set=None,
+        eval_names=None,
+        eval_sample_weight=None,
+        eval_class_weight=None,
+        eval_init_score=None,
+        eval_group=None,
+        eval_metric=None,
+        early_stopping_rounds=None,
+        verbose=True,
+        feature_name="auto",
+        categorical_feature="auto",
+        callbacks=None,
+        init_model=None,
+    ):
         """Docstring is set after definition, using a template."""
         if self._objective is None:
             if isinstance(self, LGBMRegressor):
@@ -579,27 +613,35 @@ class LGBMModel(_LGBMModelBase):
         evals_result = {}
         params = self.get_params()
         # user can set verbose with kwargs, it has higher priority
-        if not any(verbose_alias in params for verbose_alias in _ConfigAliases.get("verbosity")) and self.silent:
-            params['verbose'] = -1
-        params.pop('silent', None)
-        params.pop('importance_type', None)
-        params.pop('n_estimators', None)
-        params.pop('class_weight', None)
-        if isinstance(params['random_state'], np.random.RandomState):
-            params['random_state'] = params['random_state'].randint(np.iinfo(np.int32).max)
-        for alias in _ConfigAliases.get('objective'):
+        if (
+            not any(
+                verbose_alias in params
+                for verbose_alias in _ConfigAliases.get("verbosity")
+            )
+            and self.silent
+        ):
+            params["verbose"] = -1
+        params.pop("silent", None)
+        params.pop("importance_type", None)
+        params.pop("n_estimators", None)
+        params.pop("class_weight", None)
+        if isinstance(params["random_state"], np.random.RandomState):
+            params["random_state"] = params["random_state"].randint(
+                np.iinfo(np.int32).max
+            )
+        for alias in _ConfigAliases.get("objective"):
             params.pop(alias, None)
         if self._n_classes is not None and self._n_classes > 2:
-            for alias in _ConfigAliases.get('num_class'):
+            for alias in _ConfigAliases.get("num_class"):
                 params.pop(alias, None)
-            params['num_class'] = self._n_classes
-        if hasattr(self, '_eval_at'):
-            for alias in _ConfigAliases.get('eval_at'):
+            params["num_class"] = self._n_classes
+        if hasattr(self, "_eval_at"):
+            for alias in _ConfigAliases.get("eval_at"):
                 params.pop(alias, None)
-            params['eval_at'] = self._eval_at
-        params['objective'] = self._objective
+            params["eval_at"] = self._eval_at
+        params["objective"] = self._objective
         if self._fobj:
-            params['objective'] = 'None'  # objective = nullptr for unknown objective
+            params["objective"] = "None"  # objective = nullptr for unknown objective
 
         # Do not modify original args in fit function
         # Refer to https://github.com/microsoft/LightGBM/pull/2619
@@ -608,7 +650,9 @@ class LGBMModel(_LGBMModelBase):
             eval_metric_list = [eval_metric_list]
 
         # Separate built-in from callable evaluation metrics
-        eval_metrics_callable = [_EvalFunctionWrapper(f) for f in eval_metric_list if callable(f)]
+        eval_metrics_callable = [
+            _EvalFunctionWrapper(f) for f in eval_metric_list if callable(f)
+        ]
         eval_metrics_builtin = [m for m in eval_metric_list if isinstance(m, str)]
 
         # register default metric for consistency with callable eval_metric case
@@ -618,7 +662,9 @@ class LGBMModel(_LGBMModelBase):
             if isinstance(self, LGBMRegressor):
                 original_metric = "l2"
             elif isinstance(self, LGBMClassifier):
-                original_metric = "multi_logloss" if self._n_classes > 2 else "binary_logloss"
+                original_metric = (
+                    "multi_logloss" if self._n_classes > 2 else "binary_logloss"
+                )
             elif isinstance(self, LGBMRanker):
                 original_metric = "ndcg"
 
@@ -626,12 +672,20 @@ class LGBMModel(_LGBMModelBase):
         params = _choose_param_value("metric", params, original_metric)
 
         # concatenate metric from params (or default if not provided in params) and eval_metric
-        params['metric'] = [params['metric']] if isinstance(params['metric'], (str, type(None))) else params['metric']
-        params['metric'] = [e for e in eval_metrics_builtin if e not in params['metric']] + params['metric']
-        params['metric'] = [metric for metric in params['metric'] if metric is not None]
+        params["metric"] = (
+            [params["metric"]]
+            if isinstance(params["metric"], (str, type(None)))
+            else params["metric"]
+        )
+        params["metric"] = [
+            e for e in eval_metrics_builtin if e not in params["metric"]
+        ] + params["metric"]
+        params["metric"] = [metric for metric in params["metric"] if metric is not None]
 
         if not isinstance(X, (pd_DataFrame, dt_DataTable)):
-            _X, _y = _LGBMCheckXY(X, y, accept_sparse=True, force_all_finite=False, ensure_min_samples=2)
+            _X, _y = _LGBMCheckXY(
+                X, y, accept_sparse=True, force_all_finite=False, ensure_min_samples=2
+            )
             if sample_weight is not None:
                 sample_weight = _LGBMCheckSampleWeight(sample_weight, _X)
         else:
@@ -650,14 +704,28 @@ class LGBMModel(_LGBMModelBase):
         # copy for consistency
         self._n_features_in = self._n_features
 
-        def _construct_dataset(X, y, sample_weight, init_score, group, params,
-                               categorical_feature='auto'):
-            return Dataset(X, label=y, weight=sample_weight, group=group,
-                           init_score=init_score, params=params,
-                           categorical_feature=categorical_feature)
+        def _construct_dataset(
+            X, y, sample_weight, init_score, group, params, categorical_feature="auto"
+        ):
+            return Dataset(
+                X,
+                label=y,
+                weight=sample_weight,
+                group=group,
+                init_score=init_score,
+                params=params,
+                categorical_feature=categorical_feature,
+            )
 
-        train_set = _construct_dataset(_X, _y, sample_weight, init_score, group, params,
-                                       categorical_feature=categorical_feature)
+        train_set = _construct_dataset(
+            _X,
+            _y,
+            sample_weight,
+            init_score,
+            group,
+            params,
+            categorical_feature=categorical_feature,
+        )
 
         valid_sets = []
         if eval_set is not None:
@@ -670,7 +738,7 @@ class LGBMModel(_LGBMModelBase):
                 elif isinstance(collection, dict):
                     return collection.get(i, None)
                 else:
-                    raise TypeError('{} should be dict or list'.format(name))
+                    raise TypeError("{} should be dict or list".format(name))
 
             if isinstance(eval_set, tuple):
                 eval_set = [eval_set]
@@ -679,31 +747,62 @@ class LGBMModel(_LGBMModelBase):
                 if valid_data[0] is X and valid_data[1] is y:
                     valid_set = train_set
                 else:
-                    valid_weight = _get_meta_data(eval_sample_weight, 'eval_sample_weight', i)
-                    valid_class_weight = _get_meta_data(eval_class_weight, 'eval_class_weight', i)
+                    valid_weight = _get_meta_data(
+                        eval_sample_weight, "eval_sample_weight", i
+                    )
+                    valid_class_weight = _get_meta_data(
+                        eval_class_weight, "eval_class_weight", i
+                    )
                     if valid_class_weight is not None:
-                        if isinstance(valid_class_weight, dict) and self._class_map is not None:
-                            valid_class_weight = {self._class_map[k]: v for k, v in valid_class_weight.items()}
-                        valid_class_sample_weight = _LGBMComputeSampleWeight(valid_class_weight, valid_data[1])
+                        if (
+                            isinstance(valid_class_weight, dict)
+                            and self._class_map is not None
+                        ):
+                            valid_class_weight = {
+                                self._class_map[k]: v
+                                for k, v in valid_class_weight.items()
+                            }
+                        valid_class_sample_weight = _LGBMComputeSampleWeight(
+                            valid_class_weight, valid_data[1]
+                        )
                         if valid_weight is None or len(valid_weight) == 0:
                             valid_weight = valid_class_sample_weight
                         else:
-                            valid_weight = np.multiply(valid_weight, valid_class_sample_weight)
-                    valid_init_score = _get_meta_data(eval_init_score, 'eval_init_score', i)
-                    valid_group = _get_meta_data(eval_group, 'eval_group', i)
-                    valid_set = _construct_dataset(valid_data[0], valid_data[1],
-                                                   valid_weight, valid_init_score, valid_group, params)
+                            valid_weight = np.multiply(
+                                valid_weight, valid_class_sample_weight
+                            )
+                    valid_init_score = _get_meta_data(
+                        eval_init_score, "eval_init_score", i
+                    )
+                    valid_group = _get_meta_data(eval_group, "eval_group", i)
+                    valid_set = _construct_dataset(
+                        valid_data[0],
+                        valid_data[1],
+                        valid_weight,
+                        valid_init_score,
+                        valid_group,
+                        params,
+                    )
                 valid_sets.append(valid_set)
 
         if isinstance(init_model, LGBMModel):
             init_model = init_model.booster_
 
-        self._Booster = train(params, train_set,
-                              self.n_estimators, valid_sets=valid_sets, valid_names=eval_names,
-                              early_stopping_rounds=early_stopping_rounds,
-                              evals_result=evals_result, fobj=self._fobj, feval=eval_metrics_callable,
-                              verbose_eval=verbose, feature_name=feature_name,
-                              callbacks=callbacks, init_model=init_model)
+        self._Booster = train(
+            params,
+            train_set,
+            self.n_estimators,
+            valid_sets=valid_sets,
+            valid_names=eval_names,
+            early_stopping_rounds=early_stopping_rounds,
+            evals_result=evals_result,
+            fobj=self._fobj,
+            feval=eval_metrics_callable,
+            verbose_eval=verbose,
+            feature_name=feature_name,
+            callbacks=callbacks,
+            init_model=init_model,
+        )
 
         if evals_result:
             self._evals_result = evals_result
@@ -720,28 +819,50 @@ class LGBMModel(_LGBMModelBase):
         del train_set, valid_sets
         return self
 
-    fit.__doc__ = _lgbmmodel_doc_fit.format(
-        X_shape="array-like or sparse matrix of shape = [n_samples, n_features]",
-        y_shape="array-like of shape = [n_samples]",
-        sample_weight_shape="array-like of shape = [n_samples] or None, optional (default=None)",
-        group_shape="array-like or None, optional (default=None)"
-    ) + "\n\n" + _lgbmmodel_doc_custom_eval_note
+    fit.__doc__ = (
+        _lgbmmodel_doc_fit.format(
+            X_shape="array-like or sparse matrix of shape = [n_samples, n_features]",
+            y_shape="array-like of shape = [n_samples]",
+            sample_weight_shape="array-like of shape = [n_samples] or None, optional (default=None)",
+            group_shape="array-like or None, optional (default=None)",
+        )
+        + "\n\n"
+        + _lgbmmodel_doc_custom_eval_note
+    )
 
-    def predict(self, X, raw_score=False, start_iteration=0, num_iteration=None,
-                pred_leaf=False, pred_contrib=False, **kwargs):
+    def predict(
+        self,
+        X,
+        raw_score=False,
+        start_iteration=0,
+        num_iteration=None,
+        pred_leaf=False,
+        pred_contrib=False,
+        **kwargs
+    ):
         """Docstring is set after definition, using a template."""
         if self._n_features is None:
-            raise LGBMNotFittedError("Estimator not fitted, call `fit` before exploiting the model.")
+            raise LGBMNotFittedError(
+                "Estimator not fitted, call `fit` before exploiting the model."
+            )
         if not isinstance(X, (pd_DataFrame, dt_DataTable)):
             X = _LGBMCheckArray(X, accept_sparse=True, force_all_finite=False)
         n_features = X.shape[1]
         if self._n_features != n_features:
-            raise ValueError("Number of features of the model must "
-                             "match the input. Model n_features_ is %s and "
-                             "input n_features is %s "
-                             % (self._n_features, n_features))
-        return self._Booster.predict(X, raw_score=raw_score, start_iteration=start_iteration, num_iteration=num_iteration,
-                                     pred_leaf=pred_leaf, pred_contrib=pred_contrib, **kwargs)
+            raise ValueError(
+                "Number of features of the model must "
+                "match the input. Model n_features_ is %s and "
+                "input n_features is %s " % (self._n_features, n_features)
+            )
+        return self._Booster.predict(
+            X,
+            raw_score=raw_score,
+            start_iteration=start_iteration,
+            num_iteration=num_iteration,
+            pred_leaf=pred_leaf,
+            pred_contrib=pred_contrib,
+            **kwargs
+        )
 
     predict.__doc__ = _lgbmmodel_doc_predict.format(
         description="Return the predicted value for each sample.",
@@ -749,56 +870,66 @@ class LGBMModel(_LGBMModelBase):
         output_name="predicted_result",
         predicted_result_shape="array-like of shape = [n_samples] or shape = [n_samples, n_classes]",
         X_leaves_shape="array-like of shape = [n_samples, n_trees] or shape = [n_samples, n_trees * n_classes]",
-        X_SHAP_values_shape="array-like of shape = [n_samples, n_features + 1] or shape = [n_samples, (n_features + 1) * n_classes] or list with n_classes length of such objects"
+        X_SHAP_values_shape="array-like of shape = [n_samples, n_features + 1] or shape = [n_samples, (n_features + 1) * n_classes] or list with n_classes length of such objects",
     )
 
     @property
     def n_features_(self):
         """:obj:`int`: The number of features of fitted model."""
         if self._n_features is None:
-            raise LGBMNotFittedError('No n_features found. Need to call fit beforehand.')
+            raise LGBMNotFittedError(
+                "No n_features found. Need to call fit beforehand."
+            )
         return self._n_features
 
     @property
     def n_features_in_(self):
         """:obj:`int`: The number of features of fitted model."""
         if self._n_features_in is None:
-            raise LGBMNotFittedError('No n_features_in found. Need to call fit beforehand.')
+            raise LGBMNotFittedError(
+                "No n_features_in found. Need to call fit beforehand."
+            )
         return self._n_features_in
 
     @property
     def best_score_(self):
         """:obj:`dict` or :obj:`None`: The best score of fitted model."""
         if self._n_features is None:
-            raise LGBMNotFittedError('No best_score found. Need to call fit beforehand.')
+            raise LGBMNotFittedError(
+                "No best_score found. Need to call fit beforehand."
+            )
         return self._best_score
 
     @property
     def best_iteration_(self):
         """:obj:`int` or :obj:`None`: The best iteration of fitted model if ``early_stopping_rounds`` has been specified."""
         if self._n_features is None:
-            raise LGBMNotFittedError('No best_iteration found. Need to call fit with early_stopping_rounds beforehand.')
+            raise LGBMNotFittedError(
+                "No best_iteration found. Need to call fit with early_stopping_rounds beforehand."
+            )
         return self._best_iteration
 
     @property
     def objective_(self):
         """:obj:`string` or :obj:`callable`: The concrete objective used while fitting this model."""
         if self._n_features is None:
-            raise LGBMNotFittedError('No objective found. Need to call fit beforehand.')
+            raise LGBMNotFittedError("No objective found. Need to call fit beforehand.")
         return self._objective
 
     @property
     def booster_(self):
         """Booster: The underlying Booster of this model."""
         if self._Booster is None:
-            raise LGBMNotFittedError('No booster found. Need to call fit beforehand.')
+            raise LGBMNotFittedError("No booster found. Need to call fit beforehand.")
         return self._Booster
 
     @property
     def evals_result_(self):
         """:obj:`dict` or :obj:`None`: The evaluation results if ``early_stopping_rounds`` has been specified."""
         if self._n_features is None:
-            raise LGBMNotFittedError('No results found. Need to call fit with eval_set beforehand.')
+            raise LGBMNotFittedError(
+                "No results found. Need to call fit with eval_set beforehand."
+            )
         return self._evals_result
 
     @property
@@ -811,61 +942,111 @@ class LGBMModel(_LGBMModelBase):
             to configure the type of importance values to be extracted.
         """
         if self._n_features is None:
-            raise LGBMNotFittedError('No feature_importances found. Need to call fit beforehand.')
+            raise LGBMNotFittedError(
+                "No feature_importances found. Need to call fit beforehand."
+            )
         return self._Booster.feature_importance(importance_type=self.importance_type)
 
     @property
     def feature_name_(self):
         """:obj:`array` of shape = [n_features]: The names of features."""
         if self._n_features is None:
-            raise LGBMNotFittedError('No feature_name found. Need to call fit beforehand.')
+            raise LGBMNotFittedError(
+                "No feature_name found. Need to call fit beforehand."
+            )
         return self._Booster.feature_name()
 
 
 class LGBMRegressor(LGBMModel, _LGBMRegressorBase):
     """LightGBM regressor."""
 
-    def fit(self, X, y,
-            sample_weight=None, init_score=None,
-            eval_set=None, eval_names=None, eval_sample_weight=None,
-            eval_init_score=None, eval_metric=None, early_stopping_rounds=None,
-            verbose=True, feature_name='auto', categorical_feature='auto',
-            callbacks=None, init_model=None):
+    def fit(
+        self,
+        X,
+        y,
+        sample_weight=None,
+        init_score=None,
+        eval_set=None,
+        eval_names=None,
+        eval_sample_weight=None,
+        eval_init_score=None,
+        eval_metric=None,
+        early_stopping_rounds=None,
+        verbose=True,
+        feature_name="auto",
+        categorical_feature="auto",
+        callbacks=None,
+        init_model=None,
+    ):
         """Docstring is inherited from the LGBMModel."""
-        super().fit(X, y, sample_weight=sample_weight, init_score=init_score,
-                    eval_set=eval_set, eval_names=eval_names, eval_sample_weight=eval_sample_weight,
-                    eval_init_score=eval_init_score, eval_metric=eval_metric,
-                    early_stopping_rounds=early_stopping_rounds, verbose=verbose, feature_name=feature_name,
-                    categorical_feature=categorical_feature, callbacks=callbacks, init_model=init_model)
+        super().fit(
+            X,
+            y,
+            sample_weight=sample_weight,
+            init_score=init_score,
+            eval_set=eval_set,
+            eval_names=eval_names,
+            eval_sample_weight=eval_sample_weight,
+            eval_init_score=eval_init_score,
+            eval_metric=eval_metric,
+            early_stopping_rounds=early_stopping_rounds,
+            verbose=verbose,
+            feature_name=feature_name,
+            categorical_feature=categorical_feature,
+            callbacks=callbacks,
+            init_model=init_model,
+        )
         return self
 
     _base_doc = LGBMModel.fit.__doc__
-    _base_doc = (_base_doc[:_base_doc.find('group :')]
-                 + _base_doc[_base_doc.find('eval_set :'):])
-    _base_doc = (_base_doc[:_base_doc.find('eval_class_weight :')]
-                 + _base_doc[_base_doc.find('eval_init_score :'):])
-    fit.__doc__ = (_base_doc[:_base_doc.find('eval_group :')]
-                   + _base_doc[_base_doc.find('eval_metric :'):])
+    _base_doc = (
+        _base_doc[: _base_doc.find("group :")]
+        + _base_doc[_base_doc.find("eval_set :") :]
+    )
+    _base_doc = (
+        _base_doc[: _base_doc.find("eval_class_weight :")]
+        + _base_doc[_base_doc.find("eval_init_score :") :]
+    )
+    fit.__doc__ = (
+        _base_doc[: _base_doc.find("eval_group :")]
+        + _base_doc[_base_doc.find("eval_metric :") :]
+    )
 
 
 class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
     """LightGBM classifier."""
 
-    def fit(self, X, y,
-            sample_weight=None, init_score=None,
-            eval_set=None, eval_names=None, eval_sample_weight=None,
-            eval_class_weight=None, eval_init_score=None, eval_metric=None,
-            early_stopping_rounds=None, verbose=True,
-            feature_name='auto', categorical_feature='auto',
-            callbacks=None, init_model=None):
+    def fit(
+        self,
+        X,
+        y,
+        sample_weight=None,
+        init_score=None,
+        eval_set=None,
+        eval_names=None,
+        eval_sample_weight=None,
+        eval_class_weight=None,
+        eval_init_score=None,
+        eval_metric=None,
+        early_stopping_rounds=None,
+        verbose=True,
+        feature_name="auto",
+        categorical_feature="auto",
+        callbacks=None,
+        init_model=None,
+    ):
         """Docstring is inherited from the LGBMModel."""
         _LGBMAssertAllFinite(y)
         _LGBMCheckClassificationTargets(y)
         self._le = _LGBMLabelEncoder().fit(y)
         _y = self._le.transform(y)
-        self._class_map = dict(zip(self._le.classes_, self._le.transform(self._le.classes_)))
+        self._class_map = dict(
+            zip(self._le.classes_, self._le.transform(self._le.classes_))
+        )
         if isinstance(self.class_weight, dict):
-            self._class_weight = {self._class_map[k]: v for k, v in self.class_weight.items()}
+            self._class_weight = {
+                self._class_map[k]: v for k, v in self.class_weight.items()
+            }
 
         self._classes = self._le.classes_
         self._n_classes = len(self._classes)
@@ -881,16 +1062,16 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
                 eval_metric = [eval_metric]
             if self._n_classes > 2:
                 for index, metric in enumerate(eval_metric):
-                    if metric in {'logloss', 'binary_logloss'}:
+                    if metric in {"logloss", "binary_logloss"}:
                         eval_metric[index] = "multi_logloss"
-                    elif metric in {'error', 'binary_error'}:
+                    elif metric in {"error", "binary_error"}:
                         eval_metric[index] = "multi_error"
             else:
                 for index, metric in enumerate(eval_metric):
-                    if metric in {'logloss', 'multi_logloss'}:
-                        eval_metric[index] = 'binary_logloss'
-                    elif metric in {'error', 'multi_error'}:
-                        eval_metric[index] = 'binary_error'
+                    if metric in {"logloss", "multi_logloss"}:
+                        eval_metric[index] = "binary_logloss"
+                    elif metric in {"error", "multi_error"}:
+                        eval_metric[index] = "binary_error"
 
         # do not modify args, as it causes errors in model selection tools
         valid_sets = None
@@ -904,25 +1085,56 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
                 else:
                     valid_sets[i] = (valid_x, self._le.transform(valid_y))
 
-        super().fit(X, _y, sample_weight=sample_weight, init_score=init_score, eval_set=valid_sets,
-                    eval_names=eval_names, eval_sample_weight=eval_sample_weight,
-                    eval_class_weight=eval_class_weight, eval_init_score=eval_init_score,
-                    eval_metric=eval_metric, early_stopping_rounds=early_stopping_rounds,
-                    verbose=verbose, feature_name=feature_name, categorical_feature=categorical_feature,
-                    callbacks=callbacks, init_model=init_model)
+        super().fit(
+            X,
+            _y,
+            sample_weight=sample_weight,
+            init_score=init_score,
+            eval_set=valid_sets,
+            eval_names=eval_names,
+            eval_sample_weight=eval_sample_weight,
+            eval_class_weight=eval_class_weight,
+            eval_init_score=eval_init_score,
+            eval_metric=eval_metric,
+            early_stopping_rounds=early_stopping_rounds,
+            verbose=verbose,
+            feature_name=feature_name,
+            categorical_feature=categorical_feature,
+            callbacks=callbacks,
+            init_model=init_model,
+        )
         return self
 
     _base_doc = LGBMModel.fit.__doc__
-    _base_doc = (_base_doc[:_base_doc.find('group :')]
-                 + _base_doc[_base_doc.find('eval_set :'):])
-    fit.__doc__ = (_base_doc[:_base_doc.find('eval_group :')]
-                   + _base_doc[_base_doc.find('eval_metric :'):])
+    _base_doc = (
+        _base_doc[: _base_doc.find("group :")]
+        + _base_doc[_base_doc.find("eval_set :") :]
+    )
+    fit.__doc__ = (
+        _base_doc[: _base_doc.find("eval_group :")]
+        + _base_doc[_base_doc.find("eval_metric :") :]
+    )
 
-    def predict(self, X, raw_score=False, start_iteration=0, num_iteration=None,
-                pred_leaf=False, pred_contrib=False, **kwargs):
+    def predict(
+        self,
+        X,
+        raw_score=False,
+        start_iteration=0,
+        num_iteration=None,
+        pred_leaf=False,
+        pred_contrib=False,
+        **kwargs
+    ):
         """Docstring is inherited from the LGBMModel."""
-        result = self.predict_proba(X, raw_score, start_iteration, num_iteration,
-                                    pred_leaf, pred_contrib, **kwargs)
+        result = self.predict_proba(
+            X,
+            raw_score,
+            start_iteration,
+            num_iteration,
+            pred_leaf,
+            pred_contrib,
+            **kwargs
+        )
         if callable(self._objective) or raw_score or pred_leaf or pred_contrib:
             return result
         else:
@@ -931,19 +1143,37 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
 
     predict.__doc__ = LGBMModel.predict.__doc__
 
-    def predict_proba(self, X, raw_score=False, start_iteration=0, num_iteration=None,
-                      pred_leaf=False, pred_contrib=False, **kwargs):
+    def predict_proba(
+        self,
+        X,
+        raw_score=False,
+        start_iteration=0,
+        num_iteration=None,
+        pred_leaf=False,
+        pred_contrib=False,
+        **kwargs
+    ):
         """Docstring is set after definition, using a template."""
-        result = super().predict(X, raw_score, start_iteration, num_iteration, pred_leaf, pred_contrib, **kwargs)
+        result = super().predict(
+            X,
+            raw_score,
+            start_iteration,
+            num_iteration,
+            pred_leaf,
+            pred_contrib,
+            **kwargs
+        )
         if callable(self._objective) and not (raw_score or pred_leaf or pred_contrib):
-            _log_warning("Cannot compute class probabilities or labels "
-                         "due to the usage of customized objective function.\n"
-                         "Returning raw scores instead.")
+            _log_warning(
+                "Cannot compute class probabilities or labels "
+                "due to the usage of customized objective function.\n"
+                "Returning raw scores instead."
+            )
             return result
         elif self._n_classes > 2 or raw_score or pred_leaf or pred_contrib:
             return result
         else:
-            return np.vstack((1. - result, result)).transpose()
+            return np.vstack((1.0 - result, result)).transpose()
 
     predict_proba.__doc__ = _lgbmmodel_doc_predict.format(
         description="Return the predicted probability for each class for each sample.",
@@ -951,34 +1181,48 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
         output_name="predicted_probability",
         predicted_result_shape="array-like of shape = [n_samples] or shape = [n_samples, n_classes]",
         X_leaves_shape="array-like of shape = [n_samples, n_trees] or shape = [n_samples, n_trees * n_classes]",
-        X_SHAP_values_shape="array-like of shape = [n_samples, n_features + 1] or shape = [n_samples, (n_features + 1) * n_classes] or list with n_classes length of such objects"
+        X_SHAP_values_shape="array-like of shape = [n_samples, n_features + 1] or shape = [n_samples, (n_features + 1) * n_classes] or list with n_classes length of such objects",
     )
 
     @property
     def classes_(self):
         """:obj:`array` of shape = [n_classes]: The class label array."""
         if self._classes is None:
-            raise LGBMNotFittedError('No classes found. Need to call fit beforehand.')
+            raise LGBMNotFittedError("No classes found. Need to call fit beforehand.")
         return self._classes
 
     @property
     def n_classes_(self):
         """:obj:`int`: The number of classes."""
         if self._n_classes is None:
-            raise LGBMNotFittedError('No classes found. Need to call fit beforehand.')
+            raise LGBMNotFittedError("No classes found. Need to call fit beforehand.")
         return self._n_classes
 
 
 class LGBMRanker(LGBMModel):
     """LightGBM ranker."""
 
-    def fit(self, X, y,
-            sample_weight=None, init_score=None, group=None,
-            eval_set=None, eval_names=None, eval_sample_weight=None,
-            eval_init_score=None, eval_group=None, eval_metric=None,
-            eval_at=(1, 2, 3, 4, 5), early_stopping_rounds=None, verbose=True,
-            feature_name='auto', categorical_feature='auto',
-            callbacks=None, init_model=None):
+    def fit(
+        self,
+        X,
+        y,
+        sample_weight=None,
+        init_score=None,
+        group=None,
+        eval_set=None,
+        eval_names=None,
+        eval_sample_weight=None,
+        eval_init_score=None,
+        eval_group=None,
+        eval_metric=None,
+        eval_at=(1, 2, 3, 4, 5),
+        early_stopping_rounds=None,
+        verbose=True,
+        feature_name="auto",
+        categorical_feature="auto",
+        callbacks=None,
+        init_model=None,
+    ):
         """Docstring is inherited from the LGBMModel."""
         # check group data
         if group is None:
@@ -989,27 +1233,57 @@ class LGBMRanker(LGBMModel):
                 raise ValueError("Eval_group cannot be None when eval_set is not None")
             elif len(eval_group) != len(eval_set):
                 raise ValueError("Length of eval_group should be equal to eval_set")
-            elif (isinstance(eval_group, dict)
-                  and any(i not in eval_group or eval_group[i] is None for i in range(len(eval_group)))
-                  or isinstance(eval_group, list)
-                  and any(group is None for group in eval_group)):
-                raise ValueError("Should set group for all eval datasets for ranking task; "
-                                 "if you use dict, the index should start from 0")
+            elif (
+                isinstance(eval_group, dict)
+                and any(
+                    i not in eval_group or eval_group[i] is None
+                    for i in range(len(eval_group))
+                )
+                or isinstance(eval_group, list)
+                and any(group is None for group in eval_group)
+            ):
+                raise ValueError(
+                    "Should set group for all eval datasets for ranking task; "
+                    "if you use dict, the index should start from 0"
+                )
 
         self._eval_at = eval_at
-        super().fit(X, y, sample_weight=sample_weight, init_score=init_score, group=group,
-                    eval_set=eval_set, eval_names=eval_names, eval_sample_weight=eval_sample_weight,
-                    eval_init_score=eval_init_score, eval_group=eval_group, eval_metric=eval_metric,
-                    early_stopping_rounds=early_stopping_rounds, verbose=verbose, feature_name=feature_name,
-                    categorical_feature=categorical_feature, callbacks=callbacks, init_model=init_model)
+        super().fit(
+            X,
+            y,
+            sample_weight=sample_weight,
+            init_score=init_score,
+            group=group,
+            eval_set=eval_set,
+            eval_names=eval_names,
+            eval_sample_weight=eval_sample_weight,
+            eval_init_score=eval_init_score,
+            eval_group=eval_group,
+            eval_metric=eval_metric,
+            early_stopping_rounds=early_stopping_rounds,
+            verbose=verbose,
+            feature_name=feature_name,
+            categorical_feature=categorical_feature,
+            callbacks=callbacks,
+            init_model=init_model,
+        )
         return self
 
     _base_doc = LGBMModel.fit.__doc__
-    fit.__doc__ = (_base_doc[:_base_doc.find('eval_class_weight :')]
-                   + _base_doc[_base_doc.find('eval_init_score :'):])
+    fit.__doc__ = (
+        _base_doc[: _base_doc.find("eval_class_weight :")]
+        + _base_doc[_base_doc.find("eval_init_score :") :]
+    )
     _base_doc = fit.__doc__
-    _before_early_stop, _early_stop, _after_early_stop = _base_doc.partition('early_stopping_rounds :')
-    fit.__doc__ = (_before_early_stop
-                   + 'eval_at : iterable of int, optional (default=(1, 2, 3, 4, 5))\n'
-                   + ' ' * 12 + 'The evaluation positions of the specified metric.\n'
-                   + ' ' * 8 + _early_stop + _after_early_stop)
+    _before_early_stop, _early_stop, _after_early_stop = _base_doc.partition(
+        "early_stopping_rounds :"
+    )
+    fit.__doc__ = (
+        _before_early_stop
+        + "eval_at : iterable of int, optional (default=(1, 2, 3, 4, 5))\n"
+        + " " * 12
+        + "The evaluation positions of the specified metric.\n"
+        + " " * 8
+        + _early_stop
+        + _after_early_stop
+    )

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -5,52 +5,52 @@ import os
 import struct
 import subprocess
 import sys
-
+from distutils.dir_util import copy_tree, create_tree, remove_tree
+from distutils.file_util import copy_file
 from platform import system
+
 from setuptools import find_packages, setup
 from setuptools.command.install import install
 from setuptools.command.install_lib import install_lib
 from setuptools.command.sdist import sdist
-from distutils.dir_util import copy_tree, create_tree, remove_tree
-from distutils.file_util import copy_file
 from wheel.bdist_wheel import bdist_wheel
 
-
 LIGHTGBM_OPTIONS = [
-    ('mingw', 'm', 'Compile with MinGW'),
-    ('integrated-opencl', None, 'Compile integrated OpenCL version'),
-    ('gpu', 'g', 'Compile GPU version'),
-    ('cuda', None, 'Compile CUDA version'),
-    ('mpi', None, 'Compile MPI version'),
-    ('nomp', None, 'Compile version without OpenMP support'),
-    ('hdfs', 'h', 'Compile HDFS version'),
-    ('bit32', None, 'Compile 32-bit version'),
-    ('precompile', 'p', 'Use precompiled library'),
-    ('boost-root=', None, 'Boost preferred installation prefix'),
-    ('boost-dir=', None, 'Directory with Boost package configuration file'),
-    ('boost-include-dir=', None, 'Directory containing Boost headers'),
-    ('boost-librarydir=', None, 'Preferred Boost library directory'),
-    ('opencl-include-dir=', None, 'OpenCL include directory'),
-    ('opencl-library=', None, 'Path to OpenCL library')
+    ("mingw", "m", "Compile with MinGW"),
+    ("integrated-opencl", None, "Compile integrated OpenCL version"),
+    ("gpu", "g", "Compile GPU version"),
+    ("cuda", None, "Compile CUDA version"),
+    ("mpi", None, "Compile MPI version"),
+    ("nomp", None, "Compile version without OpenMP support"),
+    ("hdfs", "h", "Compile HDFS version"),
+    ("bit32", None, "Compile 32-bit version"),
+    ("precompile", "p", "Use precompiled library"),
+    ("boost-root=", None, "Boost preferred installation prefix"),
+    ("boost-dir=", None, "Directory with Boost package configuration file"),
+    ("boost-include-dir=", None, "Directory containing Boost headers"),
+    ("boost-librarydir=", None, "Preferred Boost library directory"),
+    ("opencl-include-dir=", None, "OpenCL include directory"),
+    ("opencl-library=", None, "Path to OpenCL library"),
 ]
 
 
 def find_lib():
-    libpath_py = os.path.join(CURRENT_DIR, 'lightgbm', 'libpath.py')
-    libpath = {'__file__': libpath_py}
-    exec(compile(open(libpath_py, "rb").read(), libpath_py, 'exec'), libpath, libpath)
+    libpath_py = os.path.join(CURRENT_DIR, "lightgbm", "libpath.py")
+    libpath = {"__file__": libpath_py}
+    exec(compile(open(libpath_py, "rb").read(), libpath_py, "exec"), libpath, libpath)
 
-    LIB_PATH = [os.path.relpath(path, CURRENT_DIR) for path in libpath['find_lib_path']()]
+    LIB_PATH = [
+        os.path.relpath(path, CURRENT_DIR) for path in libpath["find_lib_path"]()
+    ]
     logger.info("Installing lib_lightgbm from: %s" % LIB_PATH)
     return LIB_PATH
 
 
 def copy_files(integrated_opencl=False, use_gpu=False):
-
     def copy_files_helper(folder_name):
         src = os.path.join(CURRENT_DIR, os.path.pardir, folder_name)
         if os.path.exists(src):
-            dst = os.path.join(CURRENT_DIR, 'compile', folder_name)
+            dst = os.path.join(CURRENT_DIR, "compile", folder_name)
             if os.path.exists(dst):
                 if os.path.isdir:
                     # see https://github.com/pypa/distutils/pull/21
@@ -60,33 +60,47 @@ def copy_files(integrated_opencl=False, use_gpu=False):
             create_tree(src, dst, verbose=0)
             copy_tree(src, dst, verbose=0)
         else:
-            raise Exception('Cannot copy {0} folder'.format(src))
+            raise Exception("Cannot copy {0} folder".format(src))
 
-    if not os.path.isfile(os.path.join(CURRENT_DIR, '_IS_SOURCE_PACKAGE.txt')):
-        copy_files_helper('include')
-        copy_files_helper('src')
-        for submodule in os.listdir(os.path.join(CURRENT_DIR, os.path.pardir, 'external_libs')):
-            if submodule == 'compute' and not use_gpu:
+    if not os.path.isfile(os.path.join(CURRENT_DIR, "_IS_SOURCE_PACKAGE.txt")):
+        copy_files_helper("include")
+        copy_files_helper("src")
+        for submodule in os.listdir(
+            os.path.join(CURRENT_DIR, os.path.pardir, "external_libs")
+        ):
+            if submodule == "compute" and not use_gpu:
                 continue
-            copy_files_helper(os.path.join('external_libs', submodule))
+            copy_files_helper(os.path.join("external_libs", submodule))
         if not os.path.exists(os.path.join(CURRENT_DIR, "compile", "windows")):
             os.makedirs(os.path.join(CURRENT_DIR, "compile", "windows"))
-        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.sln"),
-                  os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.sln"),
-                  verbose=0)
-        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.vcxproj"),
-                  os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.vcxproj"),
-                  verbose=0)
-        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "LICENSE"),
-                  os.path.join(CURRENT_DIR, "LICENSE"),
-                  verbose=0)
-        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "CMakeLists.txt"),
-                  os.path.join(CURRENT_DIR, "compile", "CMakeLists.txt"),
-                  verbose=0)
+        copy_file(
+            os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.sln"),
+            os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.sln"),
+            verbose=0,
+        )
+        copy_file(
+            os.path.join(CURRENT_DIR, os.path.pardir, "windows", "LightGBM.vcxproj"),
+            os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.vcxproj"),
+            verbose=0,
+        )
+        copy_file(
+            os.path.join(CURRENT_DIR, os.path.pardir, "LICENSE"),
+            os.path.join(CURRENT_DIR, "LICENSE"),
+            verbose=0,
+        )
+        copy_file(
+            os.path.join(CURRENT_DIR, os.path.pardir, "CMakeLists.txt"),
+            os.path.join(CURRENT_DIR, "compile", "CMakeLists.txt"),
+            verbose=0,
+        )
         if integrated_opencl:
-            copy_file(os.path.join(CURRENT_DIR, os.path.pardir, "CMakeIntegratedOpenCL.cmake"),
-                      os.path.join(CURRENT_DIR, "compile", "CMakeIntegratedOpenCL.cmake"),
-                      verbose=0)
+            copy_file(
+                os.path.join(
+                    CURRENT_DIR, os.path.pardir, "CMakeIntegratedOpenCL.cmake"
+                ),
+                os.path.join(CURRENT_DIR, "compile", "CMakeIntegratedOpenCL.cmake"),
+                verbose=0,
+            )
 
 
 def clear_path(path):
@@ -100,7 +114,7 @@ def clear_path(path):
                 remove_tree(file_path)
 
 
-def silent_call(cmd, raise_error=False, error_msg=''):
+def silent_call(cmd, raise_error=False, error_msg=""):
     try:
         with open(LOG_PATH, "ab") as log:
             subprocess.check_call(cmd, stderr=log, stdout=log)
@@ -111,11 +125,22 @@ def silent_call(cmd, raise_error=False, error_msg=''):
         return 1
 
 
-def compile_cpp(use_mingw=False, use_gpu=False, use_cuda=False, use_mpi=False,
-                use_hdfs=False, boost_root=None, boost_dir=None,
-                boost_include_dir=None, boost_librarydir=None,
-                opencl_include_dir=None, opencl_library=None,
-                nomp=False, bit32=False, integrated_opencl=False):
+def compile_cpp(
+    use_mingw=False,
+    use_gpu=False,
+    use_cuda=False,
+    use_mpi=False,
+    use_hdfs=False,
+    boost_root=None,
+    boost_dir=None,
+    boost_include_dir=None,
+    boost_librarydir=None,
+    opencl_include_dir=None,
+    opencl_library=None,
+    nomp=False,
+    bit32=False,
+    integrated_opencl=False,
+):
 
     if os.path.exists(os.path.join(CURRENT_DIR, "build_cpp")):
         remove_tree(os.path.join(CURRENT_DIR, "build_cpp"))
@@ -151,36 +176,64 @@ def compile_cpp(use_mingw=False, use_gpu=False, use_cuda=False, use_mpi=False,
     if use_hdfs:
         cmake_cmd.append("-DUSE_HDFS=ON")
 
-    if system() in {'Windows', 'Microsoft'}:
+    if system() in {"Windows", "Microsoft"}:
         if use_mingw:
             if use_mpi:
-                raise Exception('MPI version cannot be compiled by MinGW due to the miss of MPI library in it')
+                raise Exception(
+                    "MPI version cannot be compiled by MinGW due to the miss of MPI library in it"
+                )
             logger.info("Starting to compile with CMake and MinGW.")
-            silent_call(cmake_cmd + ["-G", "MinGW Makefiles"], raise_error=True,
-                        error_msg='Please install CMake and all required dependencies first')
-            silent_call(["mingw32-make.exe", "_lightgbm"], raise_error=True,
-                        error_msg='Please install MinGW first')
+            silent_call(
+                cmake_cmd + ["-G", "MinGW Makefiles"],
+                raise_error=True,
+                error_msg="Please install CMake and all required dependencies first",
+            )
+            silent_call(
+                ["mingw32-make.exe", "_lightgbm"],
+                raise_error=True,
+                error_msg="Please install MinGW first",
+            )
         else:
             status = 1
-            lib_path = os.path.join(CURRENT_DIR, "compile", "windows", "x64", "DLL", "lib_lightgbm.dll")
-            if not any((use_gpu, use_cuda, use_mpi, use_hdfs, nomp, bit32, integrated_opencl)):
-                logger.info("Starting to compile with MSBuild from existing solution file.")
+            lib_path = os.path.join(
+                CURRENT_DIR, "compile", "windows", "x64", "DLL", "lib_lightgbm.dll"
+            )
+            if not any(
+                (use_gpu, use_cuda, use_mpi, use_hdfs, nomp, bit32, integrated_opencl)
+            ):
+                logger.info(
+                    "Starting to compile with MSBuild from existing solution file."
+                )
                 platform_toolsets = ("v142", "v141", "v140")
                 for pt in platform_toolsets:
-                    status = silent_call(["MSBuild",
-                                          os.path.join(CURRENT_DIR, "compile", "windows", "LightGBM.sln"),
-                                          "/p:Configuration=DLL",
-                                          "/p:Platform=x64",
-                                          "/p:PlatformToolset={0}".format(pt)])
+                    status = silent_call(
+                        [
+                            "MSBuild",
+                            os.path.join(
+                                CURRENT_DIR, "compile", "windows", "LightGBM.sln"
+                            ),
+                            "/p:Configuration=DLL",
+                            "/p:Platform=x64",
+                            "/p:PlatformToolset={0}".format(pt),
+                        ]
+                    )
                     if status == 0 and os.path.exists(lib_path):
                         break
                     else:
-                        clear_path(os.path.join(CURRENT_DIR, "compile", "windows", "x64"))
+                        clear_path(
+                            os.path.join(CURRENT_DIR, "compile", "windows", "x64")
+                        )
                 if status != 0 or not os.path.exists(lib_path):
-                    logger.warning("Compilation with MSBuild from existing solution file failed.")
+                    logger.warning(
+                        "Compilation with MSBuild from existing solution file failed."
+                    )
             if status != 0 or not os.path.exists(lib_path):
                 arch = "Win32" if bit32 else "x64"
-                vs_versions = ("Visual Studio 16 2019", "Visual Studio 15 2017", "Visual Studio 14 2015")
+                vs_versions = (
+                    "Visual Studio 16 2019",
+                    "Visual Studio 15 2017",
+                    "Visual Studio 14 2015",
+                )
                 for vs in vs_versions:
                     logger.info("Starting to compile with %s (%s).", vs, arch)
                     status = silent_call(cmake_cmd + ["-G", vs, "-A", arch])
@@ -189,24 +242,47 @@ def compile_cpp(use_mingw=False, use_gpu=False, use_cuda=False, use_mpi=False,
                     else:
                         clear_path(os.path.join(CURRENT_DIR, "build_cpp"))
                 if status != 0:
-                    raise Exception("\n".join(('Please install Visual Studio or MS Build and all required dependencies first',
-                                    LOG_NOTICE)))
-                silent_call(["cmake", "--build", ".", "--target", "_lightgbm", "--config", "Release"], raise_error=True,
-                            error_msg='Please install CMake first')
+                    raise Exception(
+                        "\n".join(
+                            (
+                                "Please install Visual Studio or MS Build and all required dependencies first",
+                                LOG_NOTICE,
+                            )
+                        )
+                    )
+                silent_call(
+                    [
+                        "cmake",
+                        "--build",
+                        ".",
+                        "--target",
+                        "_lightgbm",
+                        "--config",
+                        "Release",
+                    ],
+                    raise_error=True,
+                    error_msg="Please install CMake first",
+                )
     else:  # Linux, Darwin (macOS), etc.
         logger.info("Starting to compile with CMake.")
-        silent_call(cmake_cmd, raise_error=True, error_msg='Please install CMake and all required dependencies first')
-        silent_call(["make", "_lightgbm", "-j4"], raise_error=True,
-                    error_msg='An error has occurred while building lightgbm library file')
+        silent_call(
+            cmake_cmd,
+            raise_error=True,
+            error_msg="Please install CMake and all required dependencies first",
+        )
+        silent_call(
+            ["make", "_lightgbm", "-j4"],
+            raise_error=True,
+            error_msg="An error has occurred while building lightgbm library file",
+        )
     os.chdir(CURRENT_DIR)
 
 
 class CustomInstallLib(install_lib):
-
     def install(self):
         outfiles = install_lib.install(self)
         src = find_lib()[0]
-        dst = os.path.join(self.install_dir, 'lightgbm')
+        dst = os.path.join(self.install_dir, "lightgbm")
         dst, _ = self.copy_file(src, dst)
         outfiles.append(dst)
         return outfiles
@@ -237,19 +313,34 @@ class CustomInstall(install):
     def run(self):
         if (8 * struct.calcsize("P")) != 64:
             if self.bit32:
-                logger.warning("You're installing 32-bit version. "
-                               "This version is slow and untested, so use it on your own risk.")
+                logger.warning(
+                    "You're installing 32-bit version. "
+                    "This version is slow and untested, so use it on your own risk."
+                )
             else:
-                raise Exception("Cannot install LightGBM in 32-bit Python, "
-                                "please use 64-bit Python instead.")
-        open(LOG_PATH, 'wb').close()
+                raise Exception(
+                    "Cannot install LightGBM in 32-bit Python, "
+                    "please use 64-bit Python instead."
+                )
+        open(LOG_PATH, "wb").close()
         if not self.precompile:
             copy_files(integrated_opencl=self.integrated_opencl, use_gpu=self.gpu)
-            compile_cpp(use_mingw=self.mingw, use_gpu=self.gpu, use_cuda=self.cuda, use_mpi=self.mpi,
-                        use_hdfs=self.hdfs, boost_root=self.boost_root, boost_dir=self.boost_dir,
-                        boost_include_dir=self.boost_include_dir, boost_librarydir=self.boost_librarydir,
-                        opencl_include_dir=self.opencl_include_dir, opencl_library=self.opencl_library,
-                        nomp=self.nomp, bit32=self.bit32, integrated_opencl=self.integrated_opencl)
+            compile_cpp(
+                use_mingw=self.mingw,
+                use_gpu=self.gpu,
+                use_cuda=self.cuda,
+                use_mpi=self.mpi,
+                use_hdfs=self.hdfs,
+                boost_root=self.boost_root,
+                boost_dir=self.boost_dir,
+                boost_include_dir=self.boost_include_dir,
+                boost_librarydir=self.boost_librarydir,
+                opencl_include_dir=self.opencl_include_dir,
+                opencl_library=self.opencl_library,
+                nomp=self.nomp,
+                bit32=self.bit32,
+                integrated_opencl=self.integrated_opencl,
+            )
         install.run(self)
         if os.path.isfile(LOG_PATH):
             os.remove(LOG_PATH)
@@ -280,7 +371,7 @@ class CustomBdistWheel(bdist_wheel):
     def finalize_options(self):
         bdist_wheel.finalize_options(self)
 
-        install = self.reinitialize_command('install')
+        install = self.reinitialize_command("install")
 
         install.mingw = self.mingw
         install.integrated_opencl = self.integrated_opencl
@@ -300,79 +391,83 @@ class CustomBdistWheel(bdist_wheel):
 
 
 class CustomSdist(sdist):
-
     def run(self):
         copy_files(integrated_opencl=True, use_gpu=True)
-        open(os.path.join(CURRENT_DIR, '_IS_SOURCE_PACKAGE.txt'), 'w').close()
-        if os.path.exists(os.path.join(CURRENT_DIR, 'lightgbm', 'Release')):
-            remove_tree(os.path.join(CURRENT_DIR, 'lightgbm', 'Release'))
-        if os.path.exists(os.path.join(CURRENT_DIR, 'lightgbm', 'windows', 'x64')):
-            remove_tree(os.path.join(CURRENT_DIR, 'lightgbm', 'windows', 'x64'))
-        if os.path.isfile(os.path.join(CURRENT_DIR, 'lightgbm', 'lib_lightgbm.so')):
-            os.remove(os.path.join(CURRENT_DIR, 'lightgbm', 'lib_lightgbm.so'))
+        open(os.path.join(CURRENT_DIR, "_IS_SOURCE_PACKAGE.txt"), "w").close()
+        if os.path.exists(os.path.join(CURRENT_DIR, "lightgbm", "Release")):
+            remove_tree(os.path.join(CURRENT_DIR, "lightgbm", "Release"))
+        if os.path.exists(os.path.join(CURRENT_DIR, "lightgbm", "windows", "x64")):
+            remove_tree(os.path.join(CURRENT_DIR, "lightgbm", "windows", "x64"))
+        if os.path.isfile(os.path.join(CURRENT_DIR, "lightgbm", "lib_lightgbm.so")):
+            os.remove(os.path.join(CURRENT_DIR, "lightgbm", "lib_lightgbm.so"))
         sdist.run(self)
-        if os.path.isfile(os.path.join(CURRENT_DIR, '_IS_SOURCE_PACKAGE.txt')):
-            os.remove(os.path.join(CURRENT_DIR, '_IS_SOURCE_PACKAGE.txt'))
+        if os.path.isfile(os.path.join(CURRENT_DIR, "_IS_SOURCE_PACKAGE.txt")):
+            os.remove(os.path.join(CURRENT_DIR, "_IS_SOURCE_PACKAGE.txt"))
 
 
 if __name__ == "__main__":
     CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
-    LOG_PATH = os.path.join(os.path.expanduser('~'), 'LightGBM_compilation.log')
+    LOG_PATH = os.path.join(os.path.expanduser("~"), "LightGBM_compilation.log")
     LOG_NOTICE = "The full version of error log was saved into {0}".format(LOG_PATH)
-    if os.path.isfile(os.path.join(CURRENT_DIR, os.path.pardir, 'VERSION.txt')):
-        copy_file(os.path.join(CURRENT_DIR, os.path.pardir, 'VERSION.txt'),
-                  os.path.join(CURRENT_DIR, 'lightgbm', 'VERSION.txt'),
-                  verbose=0)
-    version = open(os.path.join(CURRENT_DIR, 'lightgbm', 'VERSION.txt'), encoding='utf-8').read().strip()
-    readme = open(os.path.join(CURRENT_DIR, 'README.rst'), encoding='utf-8').read()
+    if os.path.isfile(os.path.join(CURRENT_DIR, os.path.pardir, "VERSION.txt")):
+        copy_file(
+            os.path.join(CURRENT_DIR, os.path.pardir, "VERSION.txt"),
+            os.path.join(CURRENT_DIR, "lightgbm", "VERSION.txt"),
+            verbose=0,
+        )
+    version = (
+        open(os.path.join(CURRENT_DIR, "lightgbm", "VERSION.txt"), encoding="utf-8")
+        .read()
+        .strip()
+    )
+    readme = open(os.path.join(CURRENT_DIR, "README.rst"), encoding="utf-8").read()
 
     sys.path.insert(0, CURRENT_DIR)
 
     logging.basicConfig(level=logging.INFO)
-    logger = logging.getLogger('LightGBM')
+    logger = logging.getLogger("LightGBM")
 
-    setup(name='lightgbm',
-          version=version,
-          description='LightGBM Python Package',
-          long_description=readme,
-          install_requires=[
-              'wheel',
-              'numpy',
-              'scipy',
-              'scikit-learn!=0.22.0'
-          ],
-          extras_require={
-              'dask': [
-                  'dask[array]>=2.0.0',
-                  'dask[dataframe]>=2.0.0',
-                  'dask[distributed]>=2.0.0',
-                  'pandas',
-              ],
-          },
-          maintainer='Guolin Ke',
-          maintainer_email='guolin.ke@microsoft.com',
-          zip_safe=False,
-          cmdclass={
-              'install': CustomInstall,
-              'install_lib': CustomInstallLib,
-              'bdist_wheel': CustomBdistWheel,
-              'sdist': CustomSdist,
-          },
-          packages=find_packages(),
-          include_package_data=True,
-          license='The MIT License (Microsoft)',
-          url='https://github.com/microsoft/LightGBM',
-          classifiers=['Development Status :: 5 - Production/Stable',
-                       'Intended Audience :: Science/Research',
-                       'License :: OSI Approved :: MIT License',
-                       'Natural Language :: English',
-                       'Operating System :: MacOS',
-                       'Operating System :: Microsoft :: Windows',
-                       'Operating System :: POSIX',
-                       'Operating System :: Unix',
-                       'Programming Language :: Python :: 3',
-                       'Programming Language :: Python :: 3.6',
-                       'Programming Language :: Python :: 3.7',
-                       'Programming Language :: Python :: 3.8',
-                       'Programming Language :: Python :: 3.9',
-                       'Topic :: Scientific/Engineering :: Artificial Intelligence'])
+    setup(
+        name="lightgbm",
+        version=version,
+        description="LightGBM Python Package",
+        long_description=readme,
+        install_requires=["wheel", "numpy", "scipy", "scikit-learn!=0.22.0"],
+        extras_require={
+            "dask": [
+                "dask[array]>=2.0.0",
+                "dask[dataframe]>=2.0.0",
+                "dask[distributed]>=2.0.0",
+                "pandas",
+            ],
+        },
+        maintainer="Guolin Ke",
+        maintainer_email="guolin.ke@microsoft.com",
+        zip_safe=False,
+        cmdclass={
+            "install": CustomInstall,
+            "install_lib": CustomInstallLib,
+            "bdist_wheel": CustomBdistWheel,
+            "sdist": CustomSdist,
+        },
+        packages=find_packages(),
+        include_package_data=True,
+        license="The MIT License (Microsoft)",
+        url="https://github.com/microsoft/LightGBM",
+        classifiers=[
+            "Development Status :: 5 - Production/Stable",
+            "Intended Audience :: Science/Research",
+            "License :: OSI Approved :: MIT License",
+            "Natural Language :: English",
+            "Operating System :: MacOS",
+            "Operating System :: Microsoft :: Windows",
+            "Operating System :: POSIX",
+            "Operating System :: Unix",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
+            "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        ],
+    )

--- a/tests/python_package_test/test_consistency.py
+++ b/tests/python_package_test/test_consistency.py
@@ -1,25 +1,25 @@
 # coding: utf-8
 import os
 
-import lightgbm as lgb
 import numpy as np
 from sklearn.datasets import load_svmlight_file
 
+import lightgbm as lgb
+
 
 class FileLoader:
-
-    def __init__(self, directory, prefix, config_file='train.conf'):
+    def __init__(self, directory, prefix, config_file="train.conf"):
         directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), directory)
         self.directory = directory
         self.prefix = prefix
-        self.params = {'gpu_use_dp': True}
-        with open(os.path.join(directory, config_file), 'r') as f:
+        self.params = {"gpu_use_dp": True}
+        with open(os.path.join(directory, config_file), "r") as f:
             for line in f.readlines():
                 line = line.strip()
-                if line and not line.startswith('#'):
-                    key, value = [token.strip() for token in line.split('=')]
-                    if 'early_stopping' not in key:  # disable early_stopping
-                        self.params[key] = value if key != 'num_trees' else int(value)
+                if line and not line.startswith("#"):
+                    key, value = [token.strip() for token in line.split("=")]
+                    if "early_stopping" not in key:  # disable early_stopping
+                        self.params[key] = value if key != "num_trees" else int(value)
 
     def load_dataset(self, suffix, is_sparse=False):
         filename = self.path(suffix)
@@ -33,12 +33,12 @@ class FileLoader:
     def load_field(self, suffix):
         return np.loadtxt(os.path.join(self.directory, self.prefix + suffix))
 
-    def load_cpp_result(self, result_file='LightGBM_predict_result.txt'):
+    def load_cpp_result(self, result_file="LightGBM_predict_result.txt"):
         return np.loadtxt(os.path.join(self.directory, result_file))
 
     def train_predict_check(self, lgb_train, X_test, X_test_fn, sk_pred):
         params = dict(self.params)
-        params['force_row_wise'] = True
+        params["force_row_wise"] = True
         gbm = lgb.train(params, lgb_train)
         y_pred = gbm.predict(X_test)
         cpp_pred = gbm.predict(X_test_fn)
@@ -47,7 +47,14 @@ class FileLoader:
 
     def file_load_check(self, lgb_train, name):
         lgb_train_f = lgb.Dataset(self.path(name), params=self.params).construct()
-        for f in ('num_data', 'num_feature', 'get_label', 'get_weight', 'get_init_score', 'get_group'):
+        for f in (
+            "num_data",
+            "num_feature",
+            "get_label",
+            "get_weight",
+            "get_init_score",
+            "get_group",
+        ):
             a = getattr(lgb_train, f)()
             b = getattr(lgb_train_f, f)()
             if a is None and b is None:
@@ -64,79 +71,81 @@ class FileLoader:
 
 
 def test_binary():
-    fd = FileLoader('../../examples/binary_classification', 'binary')
-    X_train, y_train, _ = fd.load_dataset('.train')
-    X_test, _, X_test_fn = fd.load_dataset('.test')
-    weight_train = fd.load_field('.train.weight')
+    fd = FileLoader("../../examples/binary_classification", "binary")
+    X_train, y_train, _ = fd.load_dataset(".train")
+    X_test, _, X_test_fn = fd.load_dataset(".test")
+    weight_train = fd.load_field(".train.weight")
     lgb_train = lgb.Dataset(X_train, y_train, params=fd.params, weight=weight_train)
     gbm = lgb.LGBMClassifier(**fd.params)
     gbm.fit(X_train, y_train, sample_weight=weight_train)
     sk_pred = gbm.predict_proba(X_test)[:, 1]
     fd.train_predict_check(lgb_train, X_test, X_test_fn, sk_pred)
-    fd.file_load_check(lgb_train, '.train')
+    fd.file_load_check(lgb_train, ".train")
 
 
 def test_binary_linear():
-    fd = FileLoader('../../examples/binary_classification', 'binary', 'train_linear.conf')
-    X_train, y_train, _ = fd.load_dataset('.train')
-    X_test, _, X_test_fn = fd.load_dataset('.test')
-    weight_train = fd.load_field('.train.weight')
+    fd = FileLoader(
+        "../../examples/binary_classification", "binary", "train_linear.conf"
+    )
+    X_train, y_train, _ = fd.load_dataset(".train")
+    X_test, _, X_test_fn = fd.load_dataset(".test")
+    weight_train = fd.load_field(".train.weight")
     lgb_train = lgb.Dataset(X_train, y_train, params=fd.params, weight=weight_train)
     gbm = lgb.LGBMClassifier(**fd.params)
     gbm.fit(X_train, y_train, sample_weight=weight_train)
     sk_pred = gbm.predict_proba(X_test)[:, 1]
     fd.train_predict_check(lgb_train, X_test, X_test_fn, sk_pred)
-    fd.file_load_check(lgb_train, '.train')
+    fd.file_load_check(lgb_train, ".train")
 
 
 def test_multiclass():
-    fd = FileLoader('../../examples/multiclass_classification', 'multiclass')
-    X_train, y_train, _ = fd.load_dataset('.train')
-    X_test, _, X_test_fn = fd.load_dataset('.test')
+    fd = FileLoader("../../examples/multiclass_classification", "multiclass")
+    X_train, y_train, _ = fd.load_dataset(".train")
+    X_test, _, X_test_fn = fd.load_dataset(".test")
     lgb_train = lgb.Dataset(X_train, y_train)
     gbm = lgb.LGBMClassifier(**fd.params)
     gbm.fit(X_train, y_train)
     sk_pred = gbm.predict_proba(X_test)
     fd.train_predict_check(lgb_train, X_test, X_test_fn, sk_pred)
-    fd.file_load_check(lgb_train, '.train')
+    fd.file_load_check(lgb_train, ".train")
 
 
 def test_regression():
-    fd = FileLoader('../../examples/regression', 'regression')
-    X_train, y_train, _ = fd.load_dataset('.train')
-    X_test, _, X_test_fn = fd.load_dataset('.test')
-    init_score_train = fd.load_field('.train.init')
+    fd = FileLoader("../../examples/regression", "regression")
+    X_train, y_train, _ = fd.load_dataset(".train")
+    X_test, _, X_test_fn = fd.load_dataset(".test")
+    init_score_train = fd.load_field(".train.init")
     lgb_train = lgb.Dataset(X_train, y_train, init_score=init_score_train)
     gbm = lgb.LGBMRegressor(**fd.params)
     gbm.fit(X_train, y_train, init_score=init_score_train)
     sk_pred = gbm.predict(X_test)
     fd.train_predict_check(lgb_train, X_test, X_test_fn, sk_pred)
-    fd.file_load_check(lgb_train, '.train')
+    fd.file_load_check(lgb_train, ".train")
 
 
 def test_lambdarank():
-    fd = FileLoader('../../examples/lambdarank', 'rank')
-    X_train, y_train, _ = fd.load_dataset('.train', is_sparse=True)
-    X_test, _, X_test_fn = fd.load_dataset('.test', is_sparse=True)
-    group_train = fd.load_field('.train.query')
+    fd = FileLoader("../../examples/lambdarank", "rank")
+    X_train, y_train, _ = fd.load_dataset(".train", is_sparse=True)
+    X_test, _, X_test_fn = fd.load_dataset(".test", is_sparse=True)
+    group_train = fd.load_field(".train.query")
     lgb_train = lgb.Dataset(X_train, y_train, group=group_train)
     params = dict(fd.params)
-    params['force_col_wise'] = True
+    params["force_col_wise"] = True
     gbm = lgb.LGBMRanker(**params)
     gbm.fit(X_train, y_train, group=group_train)
     sk_pred = gbm.predict(X_test)
     fd.train_predict_check(lgb_train, X_test, X_test_fn, sk_pred)
-    fd.file_load_check(lgb_train, '.train')
+    fd.file_load_check(lgb_train, ".train")
 
 
 def test_xendcg():
-    fd = FileLoader('../../examples/xendcg', 'rank')
-    X_train, y_train, _ = fd.load_dataset('.train', is_sparse=True)
-    X_test, _, X_test_fn = fd.load_dataset('.test', is_sparse=True)
-    group_train = fd.load_field('.train.query')
+    fd = FileLoader("../../examples/xendcg", "rank")
+    X_train, y_train, _ = fd.load_dataset(".train", is_sparse=True)
+    X_test, _, X_test_fn = fd.load_dataset(".test", is_sparse=True)
+    group_train = fd.load_field(".train.query")
     lgb_train = lgb.Dataset(X_train, y_train, group=group_train)
     gbm = lgb.LGBMRanker(**fd.params)
     gbm.fit(X_train, y_train, group=group_train)
     sk_pred = gbm.predict(X_test)
     fd.train_predict_check(lgb_train, X_test, X_test_fn, sk_pred)
-    fd.file_load_check(lgb_train, '.train')
+    fd.file_load_check(lgb_train, ".train")

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -8,12 +8,17 @@ from itertools import groupby
 from os import getenv
 from sys import platform
 
-import lightgbm as lgb
 import pytest
-if not platform.startswith('linux'):
-    pytest.skip('lightgbm.dask is currently supported in Linux environments', allow_module_level=True)
+
+import lightgbm as lgb
+
+if not platform.startswith("linux"):
+    pytest.skip(
+        "lightgbm.dask is currently supported in Linux environments",
+        allow_module_level=True,
+    )
 if not lgb.compat.DASK_INSTALLED:
-    pytest.skip('Dask is not installed', allow_module_level=True)
+    pytest.skip("Dask is not installed", allow_module_level=True)
 
 import cloudpickle
 import dask.array as da
@@ -21,28 +26,31 @@ import dask.dataframe as dd
 import joblib
 import numpy as np
 import pandas as pd
-from scipy.stats import spearmanr
 from dask.array.utils import assert_eq
-from dask.distributed import default_client, Client, LocalCluster, wait
+from dask.distributed import Client, LocalCluster, default_client, wait
 from distributed.utils_test import client, cluster_fixture, gen_cluster, loop
 from scipy.sparse import csr_matrix
+from scipy.stats import spearmanr
 from sklearn.datasets import make_blobs, make_regression
 
 from .utils import make_ranking
-
 
 # time, in seconds, to wait for the Dask client to close. Used to avoid teardown errors
 # see https://distributed.dask.org/en/latest/api.html#distributed.Client.close
 CLIENT_CLOSE_TIMEOUT = 120
 
-tasks = ['classification', 'regression', 'ranking']
-data_output = ['array', 'scipy_csr_matrix', 'dataframe', 'dataframe-with-categorical']
+tasks = ["classification", "regression", "ranking"]
+data_output = ["array", "scipy_csr_matrix", "dataframe", "dataframe-with-categorical"]
 data_centers = [[[-4, -4], [4, 4]], [[-4, -4], [4, 4], [-4, 4]]]
 group_sizes = [5, 5, 5, 10, 10, 10, 20, 20, 20, 50, 50]
 
 pytestmark = [
-    pytest.mark.skipif(getenv('TASK', '') == 'mpi', reason='Fails to run with MPI interface'),
-    pytest.mark.skipif(getenv('TASK', '') == 'gpu', reason='Fails to run with GPU interface')
+    pytest.mark.skipif(
+        getenv("TASK", "") == "mpi", reason="Fails to run with MPI interface"
+    ),
+    pytest.mark.skipif(
+        getenv("TASK", "") == "gpu", reason="Fails to run with GPU interface"
+    ),
 ]
 
 
@@ -55,42 +63,41 @@ def listen_port():
 listen_port.port = 13000
 
 
-def _create_ranking_data(n_samples=100, output='array', chunk_size=50, **kwargs):
+def _create_ranking_data(n_samples=100, output="array", chunk_size=50, **kwargs):
     X, y, g = make_ranking(n_samples=n_samples, random_state=42, **kwargs)
     rnd = np.random.RandomState(42)
     w = rnd.rand(X.shape[0]) * 0.01
     g_rle = np.array([len(list(grp)) for _, grp in groupby(g)])
 
-    if output.startswith('dataframe'):
+    if output.startswith("dataframe"):
         # add target, weight, and group to DataFrame so that partitions abide by group boundaries.
-        X_df = pd.DataFrame(X, columns=[f'feature_{i}' for i in range(X.shape[1])])
-        if output == 'dataframe-with-categorical':
+        X_df = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(X.shape[1])])
+        if output == "dataframe-with-categorical":
             for i in range(5):
                 col_name = "cat_col" + str(i)
-                cat_values = rnd.choice(['a', 'b'], X.shape[0])
-                cat_series = pd.Series(
-                    cat_values,
-                    dtype='category'
-                )
+                cat_values = rnd.choice(["a", "b"], X.shape[0])
+                cat_series = pd.Series(cat_values, dtype="category")
                 X_df[col_name] = cat_series
         X = X_df.copy()
         X_df = X_df.assign(y=y, g=g, w=w)
 
         # set_index ensures partitions are based on group id.
         # See https://stackoverflow.com/questions/49532824/dask-dataframe-split-partitions-based-on-a-column-or-function.
-        X_df.set_index('g', inplace=True)
+        X_df.set_index("g", inplace=True)
         dX = dd.from_pandas(X_df, chunksize=chunk_size)
 
         # separate target, weight from features.
-        dy = dX['y']
-        dw = dX['w']
-        dX = dX.drop(columns=['y', 'w'])
+        dy = dX["y"]
+        dw = dX["w"]
+        dX = dX.drop(columns=["y", "w"])
         dg = dX.index.to_series()
 
         # encode group identifiers into run-length encoding, the format LightGBMRanker is expecting
         # so that within each partition, sum(g) = n_samples.
-        dg = dg.map_partitions(lambda p: p.groupby('g', sort=False).apply(lambda z: z.shape[0]))
-    elif output == 'array':
+        dg = dg.map_partitions(
+            lambda p: p.groupby("g", sort=False).apply(lambda z: z.shape[0])
+        )
+    elif output == "array":
         # ranking arrays: one chunk per group. Each chunk must include all columns.
         p = X.shape[1]
         dX, dy, dw, dg = [], [], [], []
@@ -106,51 +113,50 @@ def _create_ranking_data(n_samples=100, output='array', chunk_size=50, **kwargs)
         dw = da.concatenate(dw, axis=0)
         dg = da.concatenate(dg, axis=0)
     else:
-        raise ValueError('Ranking data creation only supported for Dask arrays and dataframes')
+        raise ValueError(
+            "Ranking data creation only supported for Dask arrays and dataframes"
+        )
 
     return X, y, w, g_rle, dX, dy, dw, dg
 
 
-def _create_data(objective, n_samples=100, centers=2, output='array', chunk_size=50):
-    if objective == 'classification':
+def _create_data(objective, n_samples=100, centers=2, output="array", chunk_size=50):
+    if objective == "classification":
         X, y = make_blobs(n_samples=n_samples, centers=centers, random_state=42)
-    elif objective == 'regression':
+    elif objective == "regression":
         X, y = make_regression(n_samples=n_samples, random_state=42)
     else:
         raise ValueError("Unknown objective '%s'" % objective)
     rnd = np.random.RandomState(42)
     weights = rnd.random(X.shape[0]) * 0.01
 
-    if output == 'array':
+    if output == "array":
         dX = da.from_array(X, (chunk_size, X.shape[1]))
         dy = da.from_array(y, chunk_size)
         dw = da.from_array(weights, chunk_size)
-    elif output.startswith('dataframe'):
-        X_df = pd.DataFrame(X, columns=['feature_%d' % i for i in range(X.shape[1])])
-        if output == 'dataframe-with-categorical':
+    elif output.startswith("dataframe"):
+        X_df = pd.DataFrame(X, columns=["feature_%d" % i for i in range(X.shape[1])])
+        if output == "dataframe-with-categorical":
             num_cat_cols = 5
             for i in range(num_cat_cols):
                 col_name = "cat_col" + str(i)
-                cat_values = rnd.choice(['a', 'b'], X.shape[0])
-                cat_series = pd.Series(
-                    cat_values,
-                    dtype='category'
-                )
+                cat_values = rnd.choice(["a", "b"], X.shape[0])
+                cat_series = pd.Series(cat_values, dtype="category")
                 X_df[col_name] = cat_series
                 X = np.hstack((X, cat_series.cat.codes.values.reshape(-1, 1)))
 
             # for the small data sizes used in tests, it's hard to get LGBMRegressor to choose
             # categorical features for splits. So for regression tests with categorical features,
             # _create_data() returns a DataFrame with ONLY categorical features
-            if objective == 'regression':
-                cat_cols = [col for col in X_df.columns if col.startswith('cat_col')]
+            if objective == "regression":
+                cat_cols = [col for col in X_df.columns if col.startswith("cat_col")]
                 X_df = X_df[cat_cols]
                 X = X[:, -num_cat_cols:]
-        y_df = pd.Series(y, name='target')
+        y_df = pd.Series(y, name="target")
         dX = dd.from_pandas(X_df, chunksize=chunk_size)
         dy = dd.from_pandas(y_df, chunksize=chunk_size)
         dw = dd.from_array(weights, chunksize=chunk_size)
-    elif output == 'scipy_csr_matrix':
+    elif output == "scipy_csr_matrix":
         dX = da.from_array(X, chunks=(chunk_size, X.shape[1])).map_blocks(csr_matrix)
         dy = da.from_array(y, chunks=chunk_size)
         dw = da.from_array(weights, chunk_size)
@@ -171,50 +177,42 @@ def _accuracy_score(dy_true, dy_pred):
 
 
 def _pickle(obj, filepath, serializer):
-    if serializer == 'pickle':
-        with open(filepath, 'wb') as f:
+    if serializer == "pickle":
+        with open(filepath, "wb") as f:
             pickle.dump(obj, f)
-    elif serializer == 'joblib':
+    elif serializer == "joblib":
         joblib.dump(obj, filepath)
-    elif serializer == 'cloudpickle':
-        with open(filepath, 'wb') as f:
+    elif serializer == "cloudpickle":
+        with open(filepath, "wb") as f:
             cloudpickle.dump(obj, f)
     else:
-        raise ValueError(f'Unrecognized serializer type: {serializer}')
+        raise ValueError(f"Unrecognized serializer type: {serializer}")
 
 
 def _unpickle(filepath, serializer):
-    if serializer == 'pickle':
-        with open(filepath, 'rb') as f:
+    if serializer == "pickle":
+        with open(filepath, "rb") as f:
             return pickle.load(f)
-    elif serializer == 'joblib':
+    elif serializer == "joblib":
         return joblib.load(filepath)
-    elif serializer == 'cloudpickle':
-        with open(filepath, 'rb') as f:
+    elif serializer == "cloudpickle":
+        with open(filepath, "rb") as f:
             return cloudpickle.load(f)
     else:
-        raise ValueError(f'Unrecognized serializer type: {serializer}')
+        raise ValueError(f"Unrecognized serializer type: {serializer}")
 
 
-@pytest.mark.parametrize('output', data_output)
-@pytest.mark.parametrize('centers', data_centers)
+@pytest.mark.parametrize("output", data_output)
+@pytest.mark.parametrize("centers", data_centers)
 def test_classifier(output, centers, client, listen_port):
     X, y, w, dX, dy, dw = _create_data(
-        objective='classification',
-        output=output,
-        centers=centers
+        objective="classification", output=output, centers=centers
     )
 
-    params = {
-        "n_estimators": 10,
-        "num_leaves": 10
-    }
+    params = {"n_estimators": 10, "num_leaves": 10}
 
     dask_classifier = lgb.DaskLGBMClassifier(
-        client=client,
-        time_out=5,
-        local_listen_port=listen_port,
-        **params
+        client=client, time_out=5, local_listen_port=listen_port, **params
     )
     dask_classifier = dask_classifier.fit(dX, dy, sample_weight=dw)
     p1 = dask_classifier.predict(dX)
@@ -241,49 +239,38 @@ def test_classifier(output, centers, client, listen_port):
     # pref_leaf values should have the right shape
     # and values that look like valid tree nodes
     pred_leaf_vals = p1_pred_leaf.compute()
-    assert pred_leaf_vals.shape == (
-        X.shape[0],
-        dask_classifier.booster_.num_trees()
-    )
-    assert np.max(pred_leaf_vals) <= params['num_leaves']
+    assert pred_leaf_vals.shape == (X.shape[0], dask_classifier.booster_.num_trees())
+    assert np.max(pred_leaf_vals) <= params["num_leaves"]
     assert np.min(pred_leaf_vals) >= 0
-    assert len(np.unique(pred_leaf_vals)) <= params['num_leaves']
+    assert len(np.unique(pred_leaf_vals)) <= params["num_leaves"]
 
     # be sure LightGBM actually used at least one categorical column,
     # and that it was correctly treated as a categorical feature
-    if output == 'dataframe-with-categorical':
-        cat_cols = [
-            col for col in dX.columns
-            if dX.dtypes[col].name == 'category'
-        ]
+    if output == "dataframe-with-categorical":
+        cat_cols = [col for col in dX.columns if dX.dtypes[col].name == "category"]
         tree_df = dask_classifier.booster_.trees_to_dataframe()
-        node_uses_cat_col = tree_df['split_feature'].isin(cat_cols)
+        node_uses_cat_col = tree_df["split_feature"].isin(cat_cols)
         assert node_uses_cat_col.sum() > 0
-        assert tree_df.loc[node_uses_cat_col, "decision_type"].unique()[0] == '=='
+        assert tree_df.loc[node_uses_cat_col, "decision_type"].unique()[0] == "=="
 
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)
 
 
-@pytest.mark.parametrize('output', data_output)
-@pytest.mark.parametrize('centers', data_centers)
+@pytest.mark.parametrize("output", data_output)
+@pytest.mark.parametrize("centers", data_centers)
 def test_classifier_pred_contrib(output, centers, client, listen_port):
     X, y, w, dX, dy, dw = _create_data(
-        objective='classification',
-        output=output,
-        centers=centers
+        objective="classification", output=output, centers=centers
     )
 
-    params = {
-        "n_estimators": 10,
-        "num_leaves": 10
-    }
+    params = {"n_estimators": 10, "num_leaves": 10}
 
     dask_classifier = lgb.DaskLGBMClassifier(
         client=client,
         time_out=5,
         local_listen_port=listen_port,
-        tree_learner='data',
-        **params
+        tree_learner="data",
+        **params,
     )
     dask_classifier = dask_classifier.fit(dX, dy, sample_weight=dw)
     preds_with_contrib = dask_classifier.predict(dX, pred_contrib=True).compute()
@@ -292,20 +279,17 @@ def test_classifier_pred_contrib(output, centers, client, listen_port):
     local_classifier.fit(X, y, sample_weight=w)
     local_preds_with_contrib = local_classifier.predict(X, pred_contrib=True)
 
-    if output == 'scipy_csr_matrix':
+    if output == "scipy_csr_matrix":
         preds_with_contrib = np.array(preds_with_contrib.todense())
 
     # be sure LightGBM actually used at least one categorical column,
     # and that it was correctly treated as a categorical feature
-    if output == 'dataframe-with-categorical':
-        cat_cols = [
-            col for col in dX.columns
-            if dX.dtypes[col].name == 'category'
-        ]
+    if output == "dataframe-with-categorical":
+        cat_cols = [col for col in dX.columns if dX.dtypes[col].name == "category"]
         tree_df = dask_classifier.booster_.trees_to_dataframe()
-        node_uses_cat_col = tree_df['split_feature'].isin(cat_cols)
+        node_uses_cat_col = tree_df["split_feature"].isin(cat_cols)
         assert node_uses_cat_col.sum() > 0
-        assert tree_df.loc[node_uses_cat_col, "decision_type"].unique()[0] == '=='
+        assert tree_df.loc[node_uses_cat_col, "decision_type"].unique()[0] == "=="
 
     # shape depends on whether it is binary or multiclass classification
     num_features = dask_classifier.n_features_
@@ -334,17 +318,17 @@ def test_classifier_pred_contrib(output, centers, client, listen_port):
 
 
 def test_training_does_not_fail_on_port_conflicts(client):
-    _, _, _, dX, dy, dw = _create_data('classification', output='array')
+    _, _, _, dX, dy, dw = _create_data("classification", output="array")
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(('127.0.0.1', 12400))
+        s.bind(("127.0.0.1", 12400))
 
         dask_classifier = lgb.DaskLGBMClassifier(
             client=client,
             time_out=5,
             local_listen_port=12400,
             n_estimators=5,
-            num_leaves=5
+            num_leaves=5,
         )
         for _ in range(5):
             dask_classifier.fit(
@@ -357,30 +341,20 @@ def test_training_does_not_fail_on_port_conflicts(client):
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)
 
 
-@pytest.mark.parametrize('output', data_output)
+@pytest.mark.parametrize("output", data_output)
 def test_regressor(output, client, listen_port):
-    X, y, w, dX, dy, dw = _create_data(
-        objective='regression',
-        output=output
-    )
+    X, y, w, dX, dy, dw = _create_data(objective="regression", output=output)
 
-    params = {
-        "random_state": 42,
-        "num_leaves": 10
-    }
+    params = {"random_state": 42, "num_leaves": 10}
 
     dask_regressor = lgb.DaskLGBMRegressor(
-        client=client,
-        time_out=5,
-        local_listen_port=listen_port,
-        tree='data',
-        **params
+        client=client, time_out=5, local_listen_port=listen_port, tree="data", **params
     )
     dask_regressor = dask_regressor.fit(dX, dy, sample_weight=dw)
     p1 = dask_regressor.predict(dX)
     p1_pred_leaf = dask_regressor.predict(dX, pred_leaf=True)
 
-    if not output.startswith('dataframe'):
+    if not output.startswith("dataframe"):
         s1 = _r2_score(dy, p1)
     p1 = p1.compute()
     p1_local = dask_regressor.to_local().predict(X)
@@ -392,9 +366,9 @@ def test_regressor(output, client, listen_port):
     p2 = local_regressor.predict(X)
 
     # Scores should be the same
-    if not output.startswith('dataframe'):
-        assert_eq(s1, s2, atol=.01)
-        assert_eq(s1, s1_local, atol=.003)
+    if not output.startswith("dataframe"):
+        assert_eq(s1, s2, atol=0.01)
+        assert_eq(s1, s1_local, atol=0.003)
 
     # Predictions should be roughly the same.
     assert_eq(p1, p1_local)
@@ -402,55 +376,43 @@ def test_regressor(output, client, listen_port):
     # pref_leaf values should have the right shape
     # and values that look like valid tree nodes
     pred_leaf_vals = p1_pred_leaf.compute()
-    assert pred_leaf_vals.shape == (
-        X.shape[0],
-        dask_regressor.booster_.num_trees()
-    )
-    assert np.max(pred_leaf_vals) <= params['num_leaves']
+    assert pred_leaf_vals.shape == (X.shape[0], dask_regressor.booster_.num_trees())
+    assert np.max(pred_leaf_vals) <= params["num_leaves"]
     assert np.min(pred_leaf_vals) >= 0
-    assert len(np.unique(pred_leaf_vals)) <= params['num_leaves']
+    assert len(np.unique(pred_leaf_vals)) <= params["num_leaves"]
 
     # The checks below are skipped
     # for the categorical data case because it's difficult to get
     # a good fit from just categoricals for a regression problem
     # with small data
-    if output != 'dataframe-with-categorical':
-        assert_eq(y, p1, rtol=1., atol=100.)
-        assert_eq(y, p2, rtol=1., atol=50.)
+    if output != "dataframe-with-categorical":
+        assert_eq(y, p1, rtol=1.0, atol=100.0)
+        assert_eq(y, p2, rtol=1.0, atol=50.0)
 
     # be sure LightGBM actually used at least one categorical column,
     # and that it was correctly treated as a categorical feature
-    if output == 'dataframe-with-categorical':
-        cat_cols = [
-            col for col in dX.columns
-            if dX.dtypes[col].name == 'category'
-        ]
+    if output == "dataframe-with-categorical":
+        cat_cols = [col for col in dX.columns if dX.dtypes[col].name == "category"]
         tree_df = dask_regressor.booster_.trees_to_dataframe()
-        node_uses_cat_col = tree_df['split_feature'].isin(cat_cols)
+        node_uses_cat_col = tree_df["split_feature"].isin(cat_cols)
         assert node_uses_cat_col.sum() > 0
-        assert tree_df.loc[node_uses_cat_col, "decision_type"].unique()[0] == '=='
+        assert tree_df.loc[node_uses_cat_col, "decision_type"].unique()[0] == "=="
 
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)
 
 
-@pytest.mark.parametrize('output', data_output)
+@pytest.mark.parametrize("output", data_output)
 def test_regressor_pred_contrib(output, client, listen_port):
-    X, y, w, dX, dy, dw = _create_data(
-        objective='regression',
-        output=output
-    )
+    X, y, w, dX, dy, dw = _create_data(objective="regression", output=output)
 
-    params = {
-        "n_estimators": 10,
-        "num_leaves": 10
-    }
+    params = {"n_estimators": 10, "num_leaves": 10}
 
     dask_regressor = lgb.DaskLGBMRegressor(
         client=client,
         time_out=5,
         local_listen_port=listen_port,
-        tree_learner='data',
-        **params
+        tree_learner="data",
+        **params,
     )
     dask_regressor = dask_regressor.fit(dX, dy, sample_weight=dw)
     preds_with_contrib = dask_regressor.predict(dX, pred_contrib=True).compute()
@@ -470,40 +432,34 @@ def test_regressor_pred_contrib(output, client, listen_port):
 
     # be sure LightGBM actually used at least one categorical column,
     # and that it was correctly treated as a categorical feature
-    if output == 'dataframe-with-categorical':
-        cat_cols = [
-            col for col in dX.columns
-            if dX.dtypes[col].name == 'category'
-        ]
+    if output == "dataframe-with-categorical":
+        cat_cols = [col for col in dX.columns if dX.dtypes[col].name == "category"]
         tree_df = dask_regressor.booster_.trees_to_dataframe()
-        node_uses_cat_col = tree_df['split_feature'].isin(cat_cols)
+        node_uses_cat_col = tree_df["split_feature"].isin(cat_cols)
         assert node_uses_cat_col.sum() > 0
-        assert tree_df.loc[node_uses_cat_col, "decision_type"].unique()[0] == '=='
+        assert tree_df.loc[node_uses_cat_col, "decision_type"].unique()[0] == "=="
 
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)
 
 
-@pytest.mark.parametrize('output', data_output)
-@pytest.mark.parametrize('alpha', [.1, .5, .9])
+@pytest.mark.parametrize("output", data_output)
+@pytest.mark.parametrize("alpha", [0.1, 0.5, 0.9])
 def test_regressor_quantile(output, client, listen_port, alpha):
-    X, y, w, dX, dy, dw = _create_data(
-        objective='regression',
-        output=output
-    )
+    X, y, w, dX, dy, dw = _create_data(objective="regression", output=output)
 
     params = {
         "objective": "quantile",
         "alpha": alpha,
         "random_state": 42,
         "n_estimators": 10,
-        "num_leaves": 10
+        "num_leaves": 10,
     }
 
     dask_regressor = lgb.DaskLGBMRegressor(
         client=client,
         local_listen_port=listen_port,
-        tree_learner_type='data_parallel',
-        **params
+        tree_learner_type="data_parallel",
+        **params,
     )
     dask_regressor = dask_regressor.fit(dX, dy, sample_weight=dw)
     p1 = dask_regressor.predict(dX).compute()
@@ -520,29 +476,23 @@ def test_regressor_quantile(output, client, listen_port, alpha):
 
     # be sure LightGBM actually used at least one categorical column,
     # and that it was correctly treated as a categorical feature
-    if output == 'dataframe-with-categorical':
-        cat_cols = [
-            col for col in dX.columns
-            if dX.dtypes[col].name == 'category'
-        ]
+    if output == "dataframe-with-categorical":
+        cat_cols = [col for col in dX.columns if dX.dtypes[col].name == "category"]
         tree_df = dask_regressor.booster_.trees_to_dataframe()
-        node_uses_cat_col = tree_df['split_feature'].isin(cat_cols)
+        node_uses_cat_col = tree_df["split_feature"].isin(cat_cols)
         assert node_uses_cat_col.sum() > 0
-        assert tree_df.loc[node_uses_cat_col, "decision_type"].unique()[0] == '=='
+        assert tree_df.loc[node_uses_cat_col, "decision_type"].unique()[0] == "=="
 
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)
 
 
-@pytest.mark.parametrize('output', ['array', 'dataframe', 'dataframe-with-categorical'])
-@pytest.mark.parametrize('group', [None, group_sizes])
+@pytest.mark.parametrize("output", ["array", "dataframe", "dataframe-with-categorical"])
+@pytest.mark.parametrize("group", [None, group_sizes])
 def test_ranker(output, client, listen_port, group):
 
-    if output == 'dataframe-with-categorical':
+    if output == "dataframe-with-categorical":
         X, y, w, g, dX, dy, dw, dg = _create_ranking_data(
-            output=output,
-            group=group,
-            n_features=1,
-            n_informative=1
+            output=output, group=group, n_features=1, n_informative=1
         )
     else:
         X, y, w, g, dX, dy, dw, dg = _create_ranking_data(
@@ -551,7 +501,7 @@ def test_ranker(output, client, listen_port, group):
         )
 
     # rebalance small dask.Array dataset for better performance.
-    if output == 'array':
+    if output == "array":
         dX = dX.persist()
         dy = dy.persist()
         dw = dw.persist()
@@ -565,15 +515,15 @@ def test_ranker(output, client, listen_port, group):
         "random_state": 42,
         "n_estimators": 50,
         "num_leaves": 20,
-        "min_child_samples": 1
+        "min_child_samples": 1,
     }
 
     dask_ranker = lgb.DaskLGBMRanker(
         client=client,
         time_out=5,
         local_listen_port=listen_port,
-        tree_learner_type='data_parallel',
-        **params
+        tree_learner_type="data_parallel",
+        **params,
     )
     dask_ranker = dask_ranker.fit(dX, dy, sample_weight=dw, group=dg)
     rnkvec_dask = dask_ranker.predict(dX)
@@ -595,59 +545,55 @@ def test_ranker(output, client, listen_port, group):
     # pref_leaf values should have the right shape
     # and values that look like valid tree nodes
     pred_leaf_vals = p1_pred_leaf.compute()
-    assert pred_leaf_vals.shape == (
-        X.shape[0],
-        dask_ranker.booster_.num_trees()
-    )
-    assert np.max(pred_leaf_vals) <= params['num_leaves']
+    assert pred_leaf_vals.shape == (X.shape[0], dask_ranker.booster_.num_trees())
+    assert np.max(pred_leaf_vals) <= params["num_leaves"]
     assert np.min(pred_leaf_vals) >= 0
-    assert len(np.unique(pred_leaf_vals)) <= params['num_leaves']
+    assert len(np.unique(pred_leaf_vals)) <= params["num_leaves"]
 
     # be sure LightGBM actually used at least one categorical column,
     # and that it was correctly treated as a categorical feature
-    if output == 'dataframe-with-categorical':
-        cat_cols = [
-            col for col in dX.columns
-            if dX.dtypes[col].name == 'category'
-        ]
+    if output == "dataframe-with-categorical":
+        cat_cols = [col for col in dX.columns if dX.dtypes[col].name == "category"]
         tree_df = dask_ranker.booster_.trees_to_dataframe()
-        node_uses_cat_col = tree_df['split_feature'].isin(cat_cols)
+        node_uses_cat_col = tree_df["split_feature"].isin(cat_cols)
         assert node_uses_cat_col.sum() > 0
-        assert tree_df.loc[node_uses_cat_col, "decision_type"].unique()[0] == '=='
+        assert tree_df.loc[node_uses_cat_col, "decision_type"].unique()[0] == "=="
 
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)
 
 
-@pytest.mark.parametrize('task', tasks)
-def test_training_works_if_client_not_provided_or_set_after_construction(task, listen_port, client):
-    if task == 'ranking':
-        _, _, _, _, dX, dy, _, dg = _create_ranking_data(
-            output='array',
-            group=None
-        )
+@pytest.mark.parametrize("task", tasks)
+def test_training_works_if_client_not_provided_or_set_after_construction(
+    task, listen_port, client
+):
+    if task == "ranking":
+        _, _, _, _, dX, dy, _, dg = _create_ranking_data(output="array", group=None)
         model_factory = lgb.DaskLGBMRanker
     else:
         _, _, _, dX, dy, _ = _create_data(
             objective=task,
-            output='array',
+            output="array",
         )
         dg = None
-        if task == 'classification':
+        if task == "classification":
             model_factory = lgb.DaskLGBMClassifier
-        elif task == 'regression':
+        elif task == "regression":
             model_factory = lgb.DaskLGBMRegressor
 
     params = {
         "time_out": 5,
         "local_listen_port": listen_port,
         "n_estimators": 1,
-        "num_leaves": 2
+        "num_leaves": 2,
     }
 
     # should be able to use the class without specifying a client
     dask_model = model_factory(**params)
     assert dask_model.client is None
-    with pytest.raises(lgb.compat.LGBMNotFittedError, match='Cannot access property client_ before calling fit'):
+    with pytest.raises(
+        lgb.compat.LGBMNotFittedError,
+        match="Cannot access property client_ before calling fit",
+    ):
         dask_model.client_
 
     dask_model.fit(dX, dy, group=dg)
@@ -671,7 +617,10 @@ def test_training_works_if_client_not_provided_or_set_after_construction(task, l
     dask_model.set_params(client=client)
     assert dask_model.client == client
 
-    with pytest.raises(lgb.compat.LGBMNotFittedError, match='Cannot access property client_ before calling fit'):
+    with pytest.raises(
+        lgb.compat.LGBMNotFittedError,
+        match="Cannot access property client_ before calling fit",
+    ):
         dask_model.client_
 
     dask_model.fit(dX, dy, group=dg)
@@ -693,24 +642,25 @@ def test_training_works_if_client_not_provided_or_set_after_construction(task, l
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)
 
 
-@pytest.mark.parametrize('serializer', ['pickle', 'joblib', 'cloudpickle'])
-@pytest.mark.parametrize('task', tasks)
-@pytest.mark.parametrize('set_client', [True, False])
-def test_model_and_local_version_are_picklable_whether_or_not_client_set_explicitly(serializer, task, set_client, listen_port, tmp_path):
+@pytest.mark.parametrize("serializer", ["pickle", "joblib", "cloudpickle"])
+@pytest.mark.parametrize("task", tasks)
+@pytest.mark.parametrize("set_client", [True, False])
+def test_model_and_local_version_are_picklable_whether_or_not_client_set_explicitly(
+    serializer, task, set_client, listen_port, tmp_path
+):
 
     with LocalCluster(n_workers=2, threads_per_worker=1) as cluster1:
         with Client(cluster1) as client1:
 
             # data on cluster1
-            if task == 'ranking':
+            if task == "ranking":
                 X_1, _, _, _, dX_1, dy_1, _, dg_1 = _create_ranking_data(
-                    output='array',
-                    group=None
+                    output="array", group=None
                 )
             else:
                 X_1, _, _, dX_1, dy_1, _ = _create_data(
                     objective=task,
-                    output='array',
+                    output="array",
                 )
                 dg_1 = None
 
@@ -718,30 +668,29 @@ def test_model_and_local_version_are_picklable_whether_or_not_client_set_explici
                 with Client(cluster2) as client2:
 
                     # create identical data on cluster2
-                    if task == 'ranking':
+                    if task == "ranking":
                         X_2, _, _, _, dX_2, dy_2, _, dg_2 = _create_ranking_data(
-                            output='array',
-                            group=None
+                            output="array", group=None
                         )
                     else:
                         X_2, _, _, dX_2, dy_2, _ = _create_data(
                             objective=task,
-                            output='array',
+                            output="array",
                         )
                         dg_2 = None
 
-                    if task == 'ranking':
+                    if task == "ranking":
                         model_factory = lgb.DaskLGBMRanker
-                    elif task == 'classification':
+                    elif task == "classification":
                         model_factory = lgb.DaskLGBMClassifier
-                    elif task == 'regression':
+                    elif task == "regression":
                         model_factory = lgb.DaskLGBMRegressor
 
                     params = {
                         "time_out": 5,
                         "local_listen_port": listen_port,
                         "n_estimators": 1,
-                        "num_leaves": 2
+                        "num_leaves": 2,
                     }
 
                     # at this point, the result of default_client() is client2 since it was the most recently
@@ -759,32 +708,27 @@ def test_model_and_local_version_are_picklable_whether_or_not_client_set_explici
                     else:
                         assert dask_model.client is None
 
-                    with pytest.raises(lgb.compat.LGBMNotFittedError, match='Cannot access property client_ before calling fit'):
+                    with pytest.raises(
+                        lgb.compat.LGBMNotFittedError,
+                        match="Cannot access property client_ before calling fit",
+                    ):
                         dask_model.client_
 
                     assert "client" not in local_model.get_params()
                     assert getattr(local_model, "client", None) is None
 
                     tmp_file = str(tmp_path / "model-1.pkl")
-                    _pickle(
-                        obj=dask_model,
-                        filepath=tmp_file,
-                        serializer=serializer
-                    )
+                    _pickle(obj=dask_model, filepath=tmp_file, serializer=serializer)
                     model_from_disk = _unpickle(
-                        filepath=tmp_file,
-                        serializer=serializer
+                        filepath=tmp_file, serializer=serializer
                     )
 
                     local_tmp_file = str(tmp_path / "local-model-1.pkl")
                     _pickle(
-                        obj=local_model,
-                        filepath=local_tmp_file,
-                        serializer=serializer
+                        obj=local_model, filepath=local_tmp_file, serializer=serializer
                     )
                     local_model_from_disk = _unpickle(
-                        filepath=local_tmp_file,
-                        serializer=serializer
+                        filepath=local_tmp_file, serializer=serializer
                     )
 
                     assert model_from_disk.client is None
@@ -794,7 +738,10 @@ def test_model_and_local_version_are_picklable_whether_or_not_client_set_explici
                     else:
                         assert dask_model.client is None
 
-                    with pytest.raises(lgb.compat.LGBMNotFittedError, match='Cannot access property client_ before calling fit'):
+                    with pytest.raises(
+                        lgb.compat.LGBMNotFittedError,
+                        match="Cannot access property client_ before calling fit",
+                    ):
                         dask_model.client_
 
                     # client will always be None after unpickling
@@ -806,7 +753,9 @@ def test_model_and_local_version_are_picklable_whether_or_not_client_set_explici
                         assert from_disk_params == dask_params
                     else:
                         assert model_from_disk.get_params() == dask_model.get_params()
-                    assert local_model_from_disk.get_params() == local_model.get_params()
+                    assert (
+                        local_model_from_disk.get_params() == local_model.get_params()
+                    )
 
                     # fitted model should survive pickling round trip, and pickling
                     # shouldn't have side effects on the model object
@@ -822,25 +771,17 @@ def test_model_and_local_version_are_picklable_whether_or_not_client_set_explici
                         local_model.client_
 
                     tmp_file2 = str(tmp_path / "model-2.pkl")
-                    _pickle(
-                        obj=dask_model,
-                        filepath=tmp_file2,
-                        serializer=serializer
-                    )
+                    _pickle(obj=dask_model, filepath=tmp_file2, serializer=serializer)
                     fitted_model_from_disk = _unpickle(
-                        filepath=tmp_file2,
-                        serializer=serializer
+                        filepath=tmp_file2, serializer=serializer
                     )
 
                     local_tmp_file2 = str(tmp_path / "local-model-2.pkl")
                     _pickle(
-                        obj=local_model,
-                        filepath=local_tmp_file2,
-                        serializer=serializer
+                        obj=local_model, filepath=local_tmp_file2, serializer=serializer
                     )
                     local_fitted_model_from_disk = _unpickle(
-                        filepath=local_tmp_file2,
-                        serializer=serializer
+                        filepath=local_tmp_file2, serializer=serializer
                     )
 
                     if set_client:
@@ -864,32 +805,44 @@ def test_model_and_local_version_are_picklable_whether_or_not_client_set_explici
                         dask_params.pop("client", None)
                         assert from_disk_params == dask_params
                     else:
-                        assert fitted_model_from_disk.get_params() == dask_model.get_params()
-                    assert local_fitted_model_from_disk.get_params() == local_model.get_params()
+                        assert (
+                            fitted_model_from_disk.get_params()
+                            == dask_model.get_params()
+                        )
+                    assert (
+                        local_fitted_model_from_disk.get_params()
+                        == local_model.get_params()
+                    )
 
                     if set_client:
                         preds_orig = dask_model.predict(dX_1).compute()
-                        preds_loaded_model = fitted_model_from_disk.predict(dX_1).compute()
+                        preds_loaded_model = fitted_model_from_disk.predict(
+                            dX_1
+                        ).compute()
                         preds_orig_local = local_model.predict(X_1)
-                        preds_loaded_model_local = local_fitted_model_from_disk.predict(X_1)
+                        preds_loaded_model_local = local_fitted_model_from_disk.predict(
+                            X_1
+                        )
                     else:
                         preds_orig = dask_model.predict(dX_2).compute()
-                        preds_loaded_model = fitted_model_from_disk.predict(dX_2).compute()
+                        preds_loaded_model = fitted_model_from_disk.predict(
+                            dX_2
+                        ).compute()
                         preds_orig_local = local_model.predict(X_2)
-                        preds_loaded_model_local = local_fitted_model_from_disk.predict(X_2)
+                        preds_loaded_model_local = local_fitted_model_from_disk.predict(
+                            X_2
+                        )
 
                     assert_eq(preds_orig, preds_loaded_model)
                     assert_eq(preds_orig_local, preds_loaded_model_local)
 
 
 def test_find_open_port_works():
-    worker_ip = '127.0.0.1'
+    worker_ip = "127.0.0.1"
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind((worker_ip, 12400))
         new_port = lgb.dask._find_open_port(
-            worker_ip=worker_ip,
-            local_listen_port=12400,
-            ports_to_skip=set()
+            worker_ip=worker_ip, local_listen_port=12400, ports_to_skip=set()
         )
         assert new_port == 12401
 
@@ -898,9 +851,7 @@ def test_find_open_port_works():
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s_2:
             s_2.bind((worker_ip, 12401))
             new_port = lgb.dask._find_open_port(
-                worker_ip=worker_ip,
-                local_listen_port=12400,
-                ports_to_skip=set()
+                worker_ip=worker_ip, local_listen_port=12400, ports_to_skip=set()
             )
             assert new_port == 12402
 
@@ -912,11 +863,13 @@ def test_warns_and_continues_on_unrecognized_tree_learner(client):
         client=client,
         time_out=5,
         local_listen_port=1234,
-        tree_learner='some-nonsense-value',
+        tree_learner="some-nonsense-value",
         n_estimators=1,
-        num_leaves=2
+        num_leaves=2,
     )
-    with pytest.warns(UserWarning, match='Parameter tree_learner set to some-nonsense-value'):
+    with pytest.warns(
+        UserWarning, match="Parameter tree_learner set to some-nonsense-value"
+    ):
         dask_regressor = dask_regressor.fit(X, y)
 
     assert dask_regressor.fitted_
@@ -927,20 +880,22 @@ def test_warns_and_continues_on_unrecognized_tree_learner(client):
 def test_warns_but_makes_no_changes_for_feature_or_voting_tree_learner(client):
     X = da.random.random((1e3, 10))
     y = da.random.random((1e3, 1))
-    for tree_learner in ['feature_parallel', 'voting']:
+    for tree_learner in ["feature_parallel", "voting"]:
         dask_regressor = lgb.DaskLGBMRegressor(
             client=client,
             time_out=5,
             local_listen_port=1234,
             tree_learner=tree_learner,
             n_estimators=1,
-            num_leaves=2
+            num_leaves=2,
         )
-        with pytest.warns(UserWarning, match='Support for tree_learner %s in lightgbm' % tree_learner):
+        with pytest.warns(
+            UserWarning, match="Support for tree_learner %s in lightgbm" % tree_learner
+        ):
             dask_regressor = dask_regressor.fit(X, y)
 
         assert dask_regressor.fitted_
-        assert dask_regressor.get_params()['tree_learner'] == tree_learner
+        assert dask_regressor.get_params()["tree_learner"] == tree_learner
 
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)
 
@@ -948,26 +903,24 @@ def test_warns_but_makes_no_changes_for_feature_or_voting_tree_learner(client):
 @gen_cluster(client=True, timeout=None)
 def test_errors(c, s, a, b):
     def f(part):
-        raise Exception('foo')
+        raise Exception("foo")
 
     df = dd.demo.make_timeseries()
     df = df.map_partitions(f, meta=df._meta)
     with pytest.raises(Exception) as info:
         yield lgb.dask._train(
-            client=c,
-            data=df,
-            label=df.x,
-            params={},
-            model_factory=lgb.LGBMClassifier
+            client=c, data=df, label=df.x, params={}, model_factory=lgb.LGBMClassifier
         )
-        assert 'foo' in str(info.value)
+        assert "foo" in str(info.value)
 
 
-@pytest.mark.parametrize('task', tasks)
-@pytest.mark.parametrize('output', data_output)
-def test_training_succeeds_even_if_some_workers_do_not_have_any_data(client, task, output):
-    if task == 'ranking' and output == 'scipy_csr_matrix':
-        pytest.skip('LGBMRanker is not currently tested on sparse matrices')
+@pytest.mark.parametrize("task", tasks)
+@pytest.mark.parametrize("output", data_output)
+def test_training_succeeds_even_if_some_workers_do_not_have_any_data(
+    client, task, output
+):
+    if task == "ranking" and output == "scipy_csr_matrix":
+        pytest.skip("LGBMRanker is not currently tested on sparse matrices")
 
     def collection_to_single_partition(collection):
         """Merge the parts of a Dask collection into a single partition."""
@@ -977,24 +930,18 @@ def test_training_succeeds_even_if_some_workers_do_not_have_any_data(client, tas
             return collection.rechunk(*collection.shape)
         return collection.repartition(npartitions=1)
 
-    if task == 'ranking':
-        X, y, w, g, dX, dy, dw, dg = _create_ranking_data(
-            output=output,
-            group=None
-        )
+    if task == "ranking":
+        X, y, w, g, dX, dy, dw, dg = _create_ranking_data(output=output, group=None)
         dask_model_factory = lgb.DaskLGBMRanker
         local_model_factory = lgb.LGBMRanker
     else:
-        X, y, w, dX, dy, dw = _create_data(
-            objective=task,
-            output=output
-        )
+        X, y, w, dX, dy, dw = _create_data(objective=task, output=output)
         g = None
         dg = None
-        if task == 'classification':
+        if task == "classification":
             dask_model_factory = lgb.DaskLGBMClassifier
             local_model_factory = lgb.LGBMClassifier
-        elif task == 'regression':
+        elif task == "regression":
             dask_model_factory = lgb.DaskLGBMRegressor
             local_model_factory = lgb.LGBMRegressor
 
@@ -1003,22 +950,18 @@ def test_training_succeeds_even_if_some_workers_do_not_have_any_data(client, tas
     dw = collection_to_single_partition(dw)
     dg = collection_to_single_partition(dg)
 
-    n_workers = len(client.scheduler_info()['workers'])
+    n_workers = len(client.scheduler_info()["workers"])
     assert n_workers > 1
     assert dX.npartitions == 1
 
-    params = {
-        'time_out': 5,
-        'random_state': 42,
-        'num_leaves': 10
-    }
+    params = {"time_out": 5, "random_state": 42, "num_leaves": 10}
 
-    dask_model = dask_model_factory(tree='data', client=client, **params)
+    dask_model = dask_model_factory(tree="data", client=client, **params)
     dask_model.fit(dX, dy, group=dg, sample_weight=dw)
     dask_preds = dask_model.predict(dX).compute()
 
     local_model = local_model_factory(**params)
-    if task == 'ranking':
+    if task == "ranking":
         local_model.fit(X, y, group=g, sample_weight=w)
     else:
         local_model.fit(X, y, sample_weight=w)
@@ -1034,10 +977,12 @@ def test_training_succeeds_even_if_some_workers_do_not_have_any_data(client, tas
     [
         (lgb.DaskLGBMClassifier, lgb.LGBMClassifier),
         (lgb.DaskLGBMRegressor, lgb.LGBMRegressor),
-        (lgb.DaskLGBMRanker, lgb.LGBMRanker)
-    ]
+        (lgb.DaskLGBMRanker, lgb.LGBMRanker),
+    ],
 )
-def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except_client_arg(classes):
+def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except_client_arg(
+    classes,
+):
     dask_spec = inspect.getfullargspec(classes[0])
     sklearn_spec = inspect.getfullargspec(classes[1])
     assert dask_spec.varargs == sklearn_spec.varargs
@@ -1048,7 +993,7 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
     # "client" should be the only different, and the final argument
     assert dask_spec.args[:-1] == sklearn_spec.args
     assert dask_spec.defaults[:-1] == sklearn_spec.defaults
-    assert dask_spec.args[-1] == 'client'
+    assert dask_spec.args[-1] == "client"
     assert dask_spec.defaults[-1] is None
 
 
@@ -1061,18 +1006,18 @@ def test_dask_classes_and_sklearn_equivalents_have_identical_constructors_except
         (lgb.DaskLGBMRegressor.fit, lgb.LGBMRegressor.fit),
         (lgb.DaskLGBMRegressor.predict, lgb.LGBMRegressor.predict),
         (lgb.DaskLGBMRanker.fit, lgb.LGBMRanker.fit),
-        (lgb.DaskLGBMRanker.predict, lgb.LGBMRanker.predict)
-    ]
+        (lgb.DaskLGBMRanker.predict, lgb.LGBMRanker.predict),
+    ],
 )
 def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
     dask_spec = inspect.getfullargspec(methods[0])
     sklearn_spec = inspect.getfullargspec(methods[1])
     dask_params = inspect.signature(methods[0]).parameters
     sklearn_params = inspect.signature(methods[1]).parameters
-    assert dask_spec.args == sklearn_spec.args[:len(dask_spec.args)]
+    assert dask_spec.args == sklearn_spec.args[: len(dask_spec.args)]
     assert dask_spec.varargs == sklearn_spec.varargs
     if sklearn_spec.varkw:
-        assert dask_spec.varkw == sklearn_spec.varkw[:len(dask_spec.varkw)]
+        assert dask_spec.varkw == sklearn_spec.varkw[: len(dask_spec.varkw)]
     assert dask_spec.kwonlyargs == sklearn_spec.kwonlyargs
     assert dask_spec.kwonlydefaults == sklearn_spec.kwonlydefaults
     for param in dask_spec.args:

--- a/tests/python_package_test/test_dual.py
+++ b/tests/python_package_test/test_dual.py
@@ -2,12 +2,12 @@
 """Tests for dual GPU+CPU support."""
 
 import os
+
+import numpy as np
 import pytest
+from sklearn.metrics import log_loss
 
 import lightgbm as lgb
-import numpy as np
-
-from sklearn.metrics import log_loss
 
 from .utils import load_breast_cancer
 
@@ -21,7 +21,12 @@ def test_cpu_and_gpu_work():
     X, y = load_breast_cancer(return_X_y=True)
     data = lgb.Dataset(X, y)
 
-    params_cpu = {"verbosity": -1, "num_leaves": 31, "objective": "binary", "device": "cpu"}
+    params_cpu = {
+        "verbosity": -1,
+        "num_leaves": 31,
+        "objective": "binary",
+        "device": "cpu",
+    }
     cpu_bst = lgb.train(params_cpu, data, num_boost_round=10)
     cpu_score = log_loss(y, cpu_bst.predict(X))
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -4,19 +4,25 @@ import itertools
 import math
 import os
 import pickle
-import psutil
 import random
 
-import lightgbm as lgb
 import numpy as np
-from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_csc
-from sklearn.datasets import load_svmlight_file, make_multilabel_classification
-from sklearn.metrics import log_loss, mean_absolute_error, mean_squared_error, roc_auc_score, average_precision_score
-from sklearn.model_selection import train_test_split, TimeSeriesSplit, GroupKFold
+import psutil
 import pytest
+from scipy.sparse import csr_matrix, isspmatrix_csc, isspmatrix_csr
+from sklearn.datasets import load_svmlight_file, make_multilabel_classification
+from sklearn.metrics import (
+    average_precision_score,
+    log_loss,
+    mean_absolute_error,
+    mean_squared_error,
+    roc_auc_score,
+)
+from sklearn.model_selection import GroupKFold, TimeSeriesSplit, train_test_split
+
+import lightgbm as lgb
 
 from .utils import load_boston, load_breast_cancer, load_digits, load_iris
-
 
 decreasing_generator = itertools.count(0, -1)
 
@@ -37,11 +43,11 @@ def top_k_error(y_true, y_pred, k):
 
 
 def constant_metric(preds, train_data):
-    return ('error', 0.0, False)
+    return ("error", 0.0, False)
 
 
 def decreasing_metric(preds, train_data):
-    return ('decreasing_metric', next(decreasing_generator), False)
+    return ("decreasing_metric", next(decreasing_generator), False)
 
 
 def categorize(continuous_x):
@@ -50,71 +56,83 @@ def categorize(continuous_x):
 
 def test_binary():
     X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'objective': 'binary',
-        'metric': 'binary_logloss',
-        'verbose': -1,
-        'num_iteration': 50  # test num_iteration in dict here
+        "objective": "binary",
+        "metric": "binary_logloss",
+        "verbose": -1,
+        "num_iteration": 50,  # test num_iteration in dict here
     }
     lgb_train = lgb.Dataset(X_train, y_train)
     lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train)
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=20,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=20,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     ret = log_loss(y_test, gbm.predict(X_test))
     assert ret < 0.14
-    assert len(evals_result['valid_0']['binary_logloss']) == 50
-    assert evals_result['valid_0']['binary_logloss'][-1] == pytest.approx(ret)
+    assert len(evals_result["valid_0"]["binary_logloss"]) == 50
+    assert evals_result["valid_0"]["binary_logloss"][-1] == pytest.approx(ret)
 
 
 def test_rf():
     X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'boosting_type': 'rf',
-        'objective': 'binary',
-        'bagging_freq': 1,
-        'bagging_fraction': 0.5,
-        'feature_fraction': 0.5,
-        'num_leaves': 50,
-        'metric': 'binary_logloss',
-        'verbose': -1
+        "boosting_type": "rf",
+        "objective": "binary",
+        "bagging_freq": 1,
+        "bagging_fraction": 0.5,
+        "feature_fraction": 0.5,
+        "num_leaves": 50,
+        "metric": "binary_logloss",
+        "verbose": -1,
     }
     lgb_train = lgb.Dataset(X_train, y_train)
     lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train)
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=50,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=50,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     ret = log_loss(y_test, gbm.predict(X_test))
     assert ret < 0.19
-    assert evals_result['valid_0']['binary_logloss'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["binary_logloss"][-1] == pytest.approx(ret)
 
 
 def test_regression():
     X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
-    params = {
-        'metric': 'l2',
-        'verbose': -1
-    }
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
+    params = {"metric": "l2", "verbose": -1}
     lgb_train = lgb.Dataset(X_train, y_train)
     lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train)
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=50,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=50,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     ret = mean_squared_error(y_test, gbm.predict(X_test))
     assert ret < 7
-    assert evals_result['valid_0']['l2'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["l2"][-1] == pytest.approx(ret)
 
 
 def test_missing_value_handle():
@@ -127,20 +145,19 @@ def test_missing_value_handle():
     lgb_train = lgb.Dataset(X_train, y_train)
     lgb_eval = lgb.Dataset(X_train, y_train)
 
-    params = {
-        'metric': 'l2',
-        'verbose': -1,
-        'boost_from_average': False
-    }
+    params = {"metric": "l2", "verbose": -1, "boost_from_average": False}
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=20,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=20,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     ret = mean_squared_error(y_train, gbm.predict(X_train))
     assert ret < 0.005
-    assert evals_result['valid_0']['l2'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["l2"][-1] == pytest.approx(ret)
 
 
 def test_missing_value_handle_more_na():
@@ -153,20 +170,19 @@ def test_missing_value_handle_more_na():
     lgb_train = lgb.Dataset(X_train, y_train)
     lgb_eval = lgb.Dataset(X_train, y_train)
 
-    params = {
-        'metric': 'l2',
-        'verbose': -1,
-        'boost_from_average': False
-    }
+    params = {"metric": "l2", "verbose": -1, "boost_from_average": False}
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=20,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=20,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     ret = mean_squared_error(y_train, gbm.predict(X_train))
     assert ret < 0.005
-    assert evals_result['valid_0']['l2'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["l2"][-1] == pytest.approx(ret)
 
 
 def test_missing_value_handle_na():
@@ -179,27 +195,30 @@ def test_missing_value_handle_na():
     lgb_eval = lgb.Dataset(X_train, y_train)
 
     params = {
-        'objective': 'regression',
-        'metric': 'auc',
-        'verbose': -1,
-        'boost_from_average': False,
-        'min_data': 1,
-        'num_leaves': 2,
-        'learning_rate': 1,
-        'min_data_in_bin': 1,
-        'zero_as_missing': False
+        "objective": "regression",
+        "metric": "auc",
+        "verbose": -1,
+        "boost_from_average": False,
+        "min_data": 1,
+        "num_leaves": 2,
+        "learning_rate": 1,
+        "min_data_in_bin": 1,
+        "zero_as_missing": False,
     }
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=1,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=1,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     pred = gbm.predict(X_train)
     np.testing.assert_allclose(pred, y)
     ret = roc_auc_score(y_train, pred)
     assert ret > 0.999
-    assert evals_result['valid_0']['auc'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["auc"][-1] == pytest.approx(ret)
 
 
 def test_missing_value_handle_zero():
@@ -212,27 +231,30 @@ def test_missing_value_handle_zero():
     lgb_eval = lgb.Dataset(X_train, y_train)
 
     params = {
-        'objective': 'regression',
-        'metric': 'auc',
-        'verbose': -1,
-        'boost_from_average': False,
-        'min_data': 1,
-        'num_leaves': 2,
-        'learning_rate': 1,
-        'min_data_in_bin': 1,
-        'zero_as_missing': True
+        "objective": "regression",
+        "metric": "auc",
+        "verbose": -1,
+        "boost_from_average": False,
+        "min_data": 1,
+        "num_leaves": 2,
+        "learning_rate": 1,
+        "min_data_in_bin": 1,
+        "zero_as_missing": True,
     }
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=1,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=1,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     pred = gbm.predict(X_train)
     np.testing.assert_allclose(pred, y)
     ret = roc_auc_score(y_train, pred)
     assert ret > 0.999
-    assert evals_result['valid_0']['auc'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["auc"][-1] == pytest.approx(ret)
 
 
 def test_missing_value_handle_none():
@@ -245,28 +267,31 @@ def test_missing_value_handle_none():
     lgb_eval = lgb.Dataset(X_train, y_train)
 
     params = {
-        'objective': 'regression',
-        'metric': 'auc',
-        'verbose': -1,
-        'boost_from_average': False,
-        'min_data': 1,
-        'num_leaves': 2,
-        'learning_rate': 1,
-        'min_data_in_bin': 1,
-        'use_missing': False
+        "objective": "regression",
+        "metric": "auc",
+        "verbose": -1,
+        "boost_from_average": False,
+        "min_data": 1,
+        "num_leaves": 2,
+        "learning_rate": 1,
+        "min_data_in_bin": 1,
+        "use_missing": False,
     }
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=1,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=1,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     pred = gbm.predict(X_train)
     assert pred[0] == pytest.approx(pred[1])
     assert pred[-1] == pytest.approx(pred[0])
     ret = roc_auc_score(y_train, pred)
     assert ret > 0.83
-    assert evals_result['valid_0']['auc'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["auc"][-1] == pytest.approx(ret)
 
 
 def test_categorical_handle():
@@ -279,32 +304,35 @@ def test_categorical_handle():
     lgb_eval = lgb.Dataset(X_train, y_train)
 
     params = {
-        'objective': 'regression',
-        'metric': 'auc',
-        'verbose': -1,
-        'boost_from_average': False,
-        'min_data': 1,
-        'num_leaves': 2,
-        'learning_rate': 1,
-        'min_data_in_bin': 1,
-        'min_data_per_group': 1,
-        'cat_smooth': 1,
-        'cat_l2': 0,
-        'max_cat_to_onehot': 1,
-        'zero_as_missing': True,
-        'categorical_column': 0
+        "objective": "regression",
+        "metric": "auc",
+        "verbose": -1,
+        "boost_from_average": False,
+        "min_data": 1,
+        "num_leaves": 2,
+        "learning_rate": 1,
+        "min_data_in_bin": 1,
+        "min_data_per_group": 1,
+        "cat_smooth": 1,
+        "cat_l2": 0,
+        "max_cat_to_onehot": 1,
+        "zero_as_missing": True,
+        "categorical_column": 0,
     }
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=1,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=1,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     pred = gbm.predict(X_train)
     np.testing.assert_allclose(pred, y)
     ret = roc_auc_score(y_train, pred)
     assert ret > 0.999
-    assert evals_result['valid_0']['auc'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["auc"][-1] == pytest.approx(ret)
 
 
 def test_categorical_handle_na():
@@ -317,32 +345,35 @@ def test_categorical_handle_na():
     lgb_eval = lgb.Dataset(X_train, y_train)
 
     params = {
-        'objective': 'regression',
-        'metric': 'auc',
-        'verbose': -1,
-        'boost_from_average': False,
-        'min_data': 1,
-        'num_leaves': 2,
-        'learning_rate': 1,
-        'min_data_in_bin': 1,
-        'min_data_per_group': 1,
-        'cat_smooth': 1,
-        'cat_l2': 0,
-        'max_cat_to_onehot': 1,
-        'zero_as_missing': False,
-        'categorical_column': 0
+        "objective": "regression",
+        "metric": "auc",
+        "verbose": -1,
+        "boost_from_average": False,
+        "min_data": 1,
+        "num_leaves": 2,
+        "learning_rate": 1,
+        "min_data_in_bin": 1,
+        "min_data_per_group": 1,
+        "cat_smooth": 1,
+        "cat_l2": 0,
+        "max_cat_to_onehot": 1,
+        "zero_as_missing": False,
+        "categorical_column": 0,
     }
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=1,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=1,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     pred = gbm.predict(X_train)
     np.testing.assert_allclose(pred, y)
     ret = roc_auc_score(y_train, pred)
     assert ret > 0.999
-    assert evals_result['valid_0']['auc'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["auc"][-1] == pytest.approx(ret)
 
 
 def test_categorical_non_zero_inputs():
@@ -355,155 +386,208 @@ def test_categorical_non_zero_inputs():
     lgb_eval = lgb.Dataset(X_train, y_train)
 
     params = {
-        'objective': 'regression',
-        'metric': 'auc',
-        'verbose': -1,
-        'boost_from_average': False,
-        'min_data': 1,
-        'num_leaves': 2,
-        'learning_rate': 1,
-        'min_data_in_bin': 1,
-        'min_data_per_group': 1,
-        'cat_smooth': 1,
-        'cat_l2': 0,
-        'max_cat_to_onehot': 1,
-        'zero_as_missing': False,
-        'categorical_column': 0
+        "objective": "regression",
+        "metric": "auc",
+        "verbose": -1,
+        "boost_from_average": False,
+        "min_data": 1,
+        "num_leaves": 2,
+        "learning_rate": 1,
+        "min_data_in_bin": 1,
+        "min_data_per_group": 1,
+        "cat_smooth": 1,
+        "cat_l2": 0,
+        "max_cat_to_onehot": 1,
+        "zero_as_missing": False,
+        "categorical_column": 0,
     }
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=1,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=1,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     pred = gbm.predict(X_train)
     np.testing.assert_allclose(pred, y)
     ret = roc_auc_score(y_train, pred)
     assert ret > 0.999
-    assert evals_result['valid_0']['auc'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["auc"][-1] == pytest.approx(ret)
 
 
 def test_multiclass():
     X, y = load_digits(n_class=10, return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'objective': 'multiclass',
-        'metric': 'multi_logloss',
-        'num_class': 10,
-        'verbose': -1
+        "objective": "multiclass",
+        "metric": "multi_logloss",
+        "num_class": 10,
+        "verbose": -1,
     }
     lgb_train = lgb.Dataset(X_train, y_train, params=params)
     lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train, params=params)
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=50,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=50,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     ret = multi_logloss(y_test, gbm.predict(X_test))
     assert ret < 0.16
-    assert evals_result['valid_0']['multi_logloss'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["multi_logloss"][-1] == pytest.approx(ret)
 
 
 def test_multiclass_rf():
     X, y = load_digits(n_class=10, return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'boosting_type': 'rf',
-        'objective': 'multiclass',
-        'metric': 'multi_logloss',
-        'bagging_freq': 1,
-        'bagging_fraction': 0.6,
-        'feature_fraction': 0.6,
-        'num_class': 10,
-        'num_leaves': 50,
-        'min_data': 1,
-        'verbose': -1,
-        'gpu_use_dp': True
+        "boosting_type": "rf",
+        "objective": "multiclass",
+        "metric": "multi_logloss",
+        "bagging_freq": 1,
+        "bagging_fraction": 0.6,
+        "feature_fraction": 0.6,
+        "num_class": 10,
+        "num_leaves": 50,
+        "min_data": 1,
+        "verbose": -1,
+        "gpu_use_dp": True,
     }
     lgb_train = lgb.Dataset(X_train, y_train, params=params)
     lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train, params=params)
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=50,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=50,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     ret = multi_logloss(y_test, gbm.predict(X_test))
     assert ret < 0.23
-    assert evals_result['valid_0']['multi_logloss'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["multi_logloss"][-1] == pytest.approx(ret)
 
 
 def test_multiclass_prediction_early_stopping():
     X, y = load_digits(n_class=10, return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'objective': 'multiclass',
-        'metric': 'multi_logloss',
-        'num_class': 10,
-        'verbose': -1
+        "objective": "multiclass",
+        "metric": "multi_logloss",
+        "num_class": 10,
+        "verbose": -1,
     }
     lgb_train = lgb.Dataset(X_train, y_train, params=params)
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=50)
+    gbm = lgb.train(params, lgb_train, num_boost_round=50)
 
-    pred_parameter = {"pred_early_stop": True,
-                      "pred_early_stop_freq": 5,
-                      "pred_early_stop_margin": 1.5}
+    pred_parameter = {
+        "pred_early_stop": True,
+        "pred_early_stop_freq": 5,
+        "pred_early_stop_margin": 1.5,
+    }
     ret = multi_logloss(y_test, gbm.predict(X_test, **pred_parameter))
     assert ret < 0.8
     assert ret > 0.6  # loss will be higher than when evaluating the full model
 
-    pred_parameter = {"pred_early_stop": True,
-                      "pred_early_stop_freq": 5,
-                      "pred_early_stop_margin": 5.5}
+    pred_parameter = {
+        "pred_early_stop": True,
+        "pred_early_stop_freq": 5,
+        "pred_early_stop_margin": 5.5,
+    }
     ret = multi_logloss(y_test, gbm.predict(X_test, **pred_parameter))
     assert ret < 0.2
 
 
 def test_multi_class_error():
     X, y = load_digits(n_class=10, return_X_y=True)
-    params = {'objective': 'multiclass', 'num_classes': 10, 'metric': 'multi_error',
-              'num_leaves': 4, 'verbose': -1}
+    params = {
+        "objective": "multiclass",
+        "num_classes": 10,
+        "metric": "multi_error",
+        "num_leaves": 4,
+        "verbose": -1,
+    }
     lgb_data = lgb.Dataset(X, label=y)
     est = lgb.train(params, lgb_data, num_boost_round=10)
     predict_default = est.predict(X)
     results = {}
-    est = lgb.train(dict(params, multi_error_top_k=1), lgb_data, num_boost_round=10,
-                    valid_sets=[lgb_data], evals_result=results, verbose_eval=False)
+    est = lgb.train(
+        dict(params, multi_error_top_k=1),
+        lgb_data,
+        num_boost_round=10,
+        valid_sets=[lgb_data],
+        evals_result=results,
+        verbose_eval=False,
+    )
     predict_1 = est.predict(X)
     # check that default gives same result as k = 1
     np.testing.assert_allclose(predict_1, predict_default)
     # check against independent calculation for k = 1
     err = top_k_error(y, predict_1, 1)
-    assert results['training']['multi_error'][-1] == pytest.approx(err)
+    assert results["training"]["multi_error"][-1] == pytest.approx(err)
     # check against independent calculation for k = 2
     results = {}
-    est = lgb.train(dict(params, multi_error_top_k=2), lgb_data, num_boost_round=10,
-                    valid_sets=[lgb_data], evals_result=results, verbose_eval=False)
+    est = lgb.train(
+        dict(params, multi_error_top_k=2),
+        lgb_data,
+        num_boost_round=10,
+        valid_sets=[lgb_data],
+        evals_result=results,
+        verbose_eval=False,
+    )
     predict_2 = est.predict(X)
     err = top_k_error(y, predict_2, 2)
-    assert results['training']['multi_error@2'][-1] == pytest.approx(err)
+    assert results["training"]["multi_error@2"][-1] == pytest.approx(err)
     # check against independent calculation for k = 10
     results = {}
-    est = lgb.train(dict(params, multi_error_top_k=10), lgb_data, num_boost_round=10,
-                    valid_sets=[lgb_data], evals_result=results, verbose_eval=False)
+    est = lgb.train(
+        dict(params, multi_error_top_k=10),
+        lgb_data,
+        num_boost_round=10,
+        valid_sets=[lgb_data],
+        evals_result=results,
+        verbose_eval=False,
+    )
     predict_3 = est.predict(X)
     err = top_k_error(y, predict_3, 10)
-    assert results['training']['multi_error@10'][-1] == pytest.approx(err)
+    assert results["training"]["multi_error@10"][-1] == pytest.approx(err)
     # check cases where predictions are equal
     X = np.array([[0, 0], [0, 0]])
     y = np.array([0, 1])
     lgb_data = lgb.Dataset(X, label=y)
-    params['num_classes'] = 2
+    params["num_classes"] = 2
     results = {}
-    lgb.train(params, lgb_data, num_boost_round=10,
-              valid_sets=[lgb_data], evals_result=results, verbose_eval=False)
-    assert results['training']['multi_error'][-1] == pytest.approx(1)
+    lgb.train(
+        params,
+        lgb_data,
+        num_boost_round=10,
+        valid_sets=[lgb_data],
+        evals_result=results,
+        verbose_eval=False,
+    )
+    assert results["training"]["multi_error"][-1] == pytest.approx(1)
     results = {}
-    lgb.train(dict(params, multi_error_top_k=2), lgb_data, num_boost_round=10,
-              valid_sets=[lgb_data], evals_result=results, verbose_eval=False)
-    assert results['training']['multi_error@2'][-1] == pytest.approx(0)
+    lgb.train(
+        dict(params, multi_error_top_k=2),
+        lgb_data,
+        num_boost_round=10,
+        valid_sets=[lgb_data],
+        evals_result=results,
+        verbose_eval=False,
+    )
+    assert results["training"]["multi_error@2"][-1] == pytest.approx(0)
 
 
 def test_auc_mu():
@@ -512,148 +596,244 @@ def test_auc_mu():
     y_new = np.zeros((len(y)))
     y_new[y != 0] = 1
     lgb_X = lgb.Dataset(X, label=y_new)
-    params = {'objective': 'multiclass',
-              'metric': 'auc_mu',
-              'verbose': -1,
-              'num_classes': 2,
-              'seed': 0}
+    params = {
+        "objective": "multiclass",
+        "metric": "auc_mu",
+        "verbose": -1,
+        "num_classes": 2,
+        "seed": 0,
+    }
     results_auc_mu = {}
-    lgb.train(params, lgb_X, num_boost_round=10, valid_sets=[lgb_X], evals_result=results_auc_mu)
-    params = {'objective': 'binary',
-              'metric': 'auc',
-              'verbose': -1,
-              'seed': 0}
+    lgb.train(
+        params,
+        lgb_X,
+        num_boost_round=10,
+        valid_sets=[lgb_X],
+        evals_result=results_auc_mu,
+    )
+    params = {"objective": "binary", "metric": "auc", "verbose": -1, "seed": 0}
     results_auc = {}
-    lgb.train(params, lgb_X, num_boost_round=10, valid_sets=[lgb_X], evals_result=results_auc)
-    np.testing.assert_allclose(results_auc_mu['training']['auc_mu'], results_auc['training']['auc'])
+    lgb.train(
+        params, lgb_X, num_boost_round=10, valid_sets=[lgb_X], evals_result=results_auc
+    )
+    np.testing.assert_allclose(
+        results_auc_mu["training"]["auc_mu"], results_auc["training"]["auc"]
+    )
     # test the case where all predictions are equal
     lgb_X = lgb.Dataset(X[:10], label=y_new[:10])
-    params = {'objective': 'multiclass',
-              'metric': 'auc_mu',
-              'verbose': -1,
-              'num_classes': 2,
-              'min_data_in_leaf': 20,
-              'seed': 0}
+    params = {
+        "objective": "multiclass",
+        "metric": "auc_mu",
+        "verbose": -1,
+        "num_classes": 2,
+        "min_data_in_leaf": 20,
+        "seed": 0,
+    }
     results_auc_mu = {}
-    lgb.train(params, lgb_X, num_boost_round=10, valid_sets=[lgb_X], evals_result=results_auc_mu)
-    assert results_auc_mu['training']['auc_mu'][-1] == pytest.approx(0.5)
+    lgb.train(
+        params,
+        lgb_X,
+        num_boost_round=10,
+        valid_sets=[lgb_X],
+        evals_result=results_auc_mu,
+    )
+    assert results_auc_mu["training"]["auc_mu"][-1] == pytest.approx(0.5)
     # test that weighted data gives different auc_mu
     lgb_X = lgb.Dataset(X, label=y)
-    lgb_X_weighted = lgb.Dataset(X, label=y, weight=np.abs(np.random.normal(size=y.shape)))
+    lgb_X_weighted = lgb.Dataset(
+        X, label=y, weight=np.abs(np.random.normal(size=y.shape))
+    )
     results_unweighted = {}
     results_weighted = {}
     params = dict(params, num_classes=10, num_leaves=5)
-    lgb.train(params, lgb_X, num_boost_round=10, valid_sets=[lgb_X], evals_result=results_unweighted)
-    lgb.train(params, lgb_X_weighted, num_boost_round=10, valid_sets=[lgb_X_weighted],
-              evals_result=results_weighted)
-    assert results_weighted['training']['auc_mu'][-1] < 1
-    assert results_unweighted['training']['auc_mu'][-1] != results_weighted['training']['auc_mu'][-1]
+    lgb.train(
+        params,
+        lgb_X,
+        num_boost_round=10,
+        valid_sets=[lgb_X],
+        evals_result=results_unweighted,
+    )
+    lgb.train(
+        params,
+        lgb_X_weighted,
+        num_boost_round=10,
+        valid_sets=[lgb_X_weighted],
+        evals_result=results_weighted,
+    )
+    assert results_weighted["training"]["auc_mu"][-1] < 1
+    assert (
+        results_unweighted["training"]["auc_mu"][-1]
+        != results_weighted["training"]["auc_mu"][-1]
+    )
     # test that equal data weights give same auc_mu as unweighted data
     lgb_X_weighted = lgb.Dataset(X, label=y, weight=np.ones(y.shape) * 0.5)
-    lgb.train(params, lgb_X_weighted, num_boost_round=10, valid_sets=[lgb_X_weighted],
-              evals_result=results_weighted)
-    assert results_unweighted['training']['auc_mu'][-1] == pytest.approx(
-        results_weighted['training']['auc_mu'][-1], abs=1e-5)
+    lgb.train(
+        params,
+        lgb_X_weighted,
+        num_boost_round=10,
+        valid_sets=[lgb_X_weighted],
+        evals_result=results_weighted,
+    )
+    assert results_unweighted["training"]["auc_mu"][-1] == pytest.approx(
+        results_weighted["training"]["auc_mu"][-1], abs=1e-5
+    )
     # should give 1 when accuracy = 1
     X = X[:10, :]
     y = y[:10]
     lgb_X = lgb.Dataset(X, label=y)
-    params = {'objective': 'multiclass',
-              'metric': 'auc_mu',
-              'num_classes': 10,
-              'min_data_in_leaf': 1,
-              'verbose': -1}
+    params = {
+        "objective": "multiclass",
+        "metric": "auc_mu",
+        "num_classes": 10,
+        "min_data_in_leaf": 1,
+        "verbose": -1,
+    }
     results = {}
-    lgb.train(params, lgb_X, num_boost_round=100, valid_sets=[lgb_X], evals_result=results)
-    assert results['training']['auc_mu'][-1] == pytest.approx(1)
+    lgb.train(
+        params, lgb_X, num_boost_round=100, valid_sets=[lgb_X], evals_result=results
+    )
+    assert results["training"]["auc_mu"][-1] == pytest.approx(1)
     # test loading class weights
-    Xy = np.loadtxt(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                 '../../examples/multiclass_classification/multiclass.train'))
+    Xy = np.loadtxt(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../examples/multiclass_classification/multiclass.train",
+        )
+    )
     y = Xy[:, 0]
     X = Xy[:, 1:]
     lgb_X = lgb.Dataset(X, label=y)
-    params = {'objective': 'multiclass',
-              'metric': 'auc_mu',
-              'auc_mu_weights': [0, 2, 2, 2, 2, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0],
-              'num_classes': 5,
-              'verbose': -1,
-              'seed': 0}
+    params = {
+        "objective": "multiclass",
+        "metric": "auc_mu",
+        "auc_mu_weights": [
+            0,
+            2,
+            2,
+            2,
+            2,
+            1,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+        ],
+        "num_classes": 5,
+        "verbose": -1,
+        "seed": 0,
+    }
     results_weight = {}
-    lgb.train(params, lgb_X, num_boost_round=5, valid_sets=[lgb_X], evals_result=results_weight)
-    params['auc_mu_weights'] = []
+    lgb.train(
+        params,
+        lgb_X,
+        num_boost_round=5,
+        valid_sets=[lgb_X],
+        evals_result=results_weight,
+    )
+    params["auc_mu_weights"] = []
     results_no_weight = {}
-    lgb.train(params, lgb_X, num_boost_round=5, valid_sets=[lgb_X], evals_result=results_no_weight)
-    assert results_weight['training']['auc_mu'][-1] != results_no_weight['training']['auc_mu'][-1]
+    lgb.train(
+        params,
+        lgb_X,
+        num_boost_round=5,
+        valid_sets=[lgb_X],
+        evals_result=results_no_weight,
+    )
+    assert (
+        results_weight["training"]["auc_mu"][-1]
+        != results_no_weight["training"]["auc_mu"][-1]
+    )
 
 
 def test_early_stopping():
     X, y = load_breast_cancer(return_X_y=True)
-    params = {
-        'objective': 'binary',
-        'metric': 'binary_logloss',
-        'verbose': -1
-    }
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    params = {"objective": "binary", "metric": "binary_logloss", "verbose": -1}
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     lgb_train = lgb.Dataset(X_train, y_train)
     lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train)
-    valid_set_name = 'valid_set'
+    valid_set_name = "valid_set"
     # no early stopping
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=10,
-                    valid_sets=lgb_eval,
-                    valid_names=valid_set_name,
-                    verbose_eval=False,
-                    early_stopping_rounds=5)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=10,
+        valid_sets=lgb_eval,
+        valid_names=valid_set_name,
+        verbose_eval=False,
+        early_stopping_rounds=5,
+    )
     assert gbm.best_iteration == 10
     assert valid_set_name in gbm.best_score
-    assert 'binary_logloss' in gbm.best_score[valid_set_name]
+    assert "binary_logloss" in gbm.best_score[valid_set_name]
     # early stopping occurs
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=40,
-                    valid_sets=lgb_eval,
-                    valid_names=valid_set_name,
-                    verbose_eval=False,
-                    early_stopping_rounds=5)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=40,
+        valid_sets=lgb_eval,
+        valid_names=valid_set_name,
+        verbose_eval=False,
+        early_stopping_rounds=5,
+    )
     assert gbm.best_iteration <= 39
     assert valid_set_name in gbm.best_score
-    assert 'binary_logloss' in gbm.best_score[valid_set_name]
+    assert "binary_logloss" in gbm.best_score[valid_set_name]
 
 
 def test_continue_train():
     X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
-    params = {
-        'objective': 'regression',
-        'metric': 'l1',
-        'verbose': -1
-    }
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
+    params = {"objective": "regression", "metric": "l1", "verbose": -1}
     lgb_train = lgb.Dataset(X_train, y_train, free_raw_data=False)
     lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train, free_raw_data=False)
     init_gbm = lgb.train(params, lgb_train, num_boost_round=20)
-    model_name = 'model.txt'
+    model_name = "model.txt"
     init_gbm.save_model(model_name)
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=30,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    # test custom eval metrics
-                    feval=(lambda p, d: ('custom_mae', mean_absolute_error(p, d.get_label()), False)),
-                    evals_result=evals_result,
-                    init_model='model.txt')
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=30,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        # test custom eval metrics
+        feval=(
+            lambda p, d: ("custom_mae", mean_absolute_error(p, d.get_label()), False)
+        ),
+        evals_result=evals_result,
+        init_model="model.txt",
+    )
     ret = mean_absolute_error(y_test, gbm.predict(X_test))
     assert ret < 2.0
-    assert evals_result['valid_0']['l1'][-1] == pytest.approx(ret)
-    np.testing.assert_allclose(evals_result['valid_0']['l1'], evals_result['valid_0']['custom_mae'])
+    assert evals_result["valid_0"]["l1"][-1] == pytest.approx(ret)
+    np.testing.assert_allclose(
+        evals_result["valid_0"]["l1"], evals_result["valid_0"]["custom_mae"]
+    )
     os.remove(model_name)
 
 
 def test_continue_train_reused_dataset():
     X, y = load_boston(return_X_y=True)
-    params = {
-        'objective': 'regression',
-        'verbose': -1
-    }
+    params = {"objective": "regression", "verbose": -1}
     lgb_train = lgb.Dataset(X, y, free_raw_data=False)
     init_gbm = lgb.train(params, lgb_train, num_boost_round=5)
     init_gbm_2 = lgb.train(params, lgb_train, num_boost_round=5, init_model=init_gbm)
@@ -664,130 +844,197 @@ def test_continue_train_reused_dataset():
 
 def test_continue_train_dart():
     X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'boosting_type': 'dart',
-        'objective': 'regression',
-        'metric': 'l1',
-        'verbose': -1
+        "boosting_type": "dart",
+        "objective": "regression",
+        "metric": "l1",
+        "verbose": -1,
     }
     lgb_train = lgb.Dataset(X_train, y_train, free_raw_data=False)
     lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train, free_raw_data=False)
     init_gbm = lgb.train(params, lgb_train, num_boost_round=50)
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=50,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result,
-                    init_model=init_gbm)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=50,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+        init_model=init_gbm,
+    )
     ret = mean_absolute_error(y_test, gbm.predict(X_test))
     assert ret < 2.0
-    assert evals_result['valid_0']['l1'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["l1"][-1] == pytest.approx(ret)
 
 
 def test_continue_train_multiclass():
     X, y = load_iris(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'objective': 'multiclass',
-        'metric': 'multi_logloss',
-        'num_class': 3,
-        'verbose': -1
+        "objective": "multiclass",
+        "metric": "multi_logloss",
+        "num_class": 3,
+        "verbose": -1,
     }
     lgb_train = lgb.Dataset(X_train, y_train, params=params, free_raw_data=False)
-    lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train, params=params, free_raw_data=False)
+    lgb_eval = lgb.Dataset(
+        X_test, y_test, reference=lgb_train, params=params, free_raw_data=False
+    )
     init_gbm = lgb.train(params, lgb_train, num_boost_round=20)
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=30,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result,
-                    init_model=init_gbm)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=30,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+        init_model=init_gbm,
+    )
     ret = multi_logloss(y_test, gbm.predict(X_test))
     assert ret < 0.1
-    assert evals_result['valid_0']['multi_logloss'][-1] == pytest.approx(ret)
+    assert evals_result["valid_0"]["multi_logloss"][-1] == pytest.approx(ret)
 
 
 def test_cv():
     X_train, y_train = load_boston(return_X_y=True)
-    params = {'verbose': -1}
+    params = {"verbose": -1}
     lgb_train = lgb.Dataset(X_train, y_train)
     # shuffle = False, override metric in params
-    params_with_metric = {'metric': 'l2', 'verbose': -1}
-    cv_res = lgb.cv(params_with_metric, lgb_train, num_boost_round=10,
-                    nfold=3, stratified=False, shuffle=False,
-                    metrics='l1', verbose_eval=False)
-    assert 'l1-mean' in cv_res
-    assert 'l2-mean' not in cv_res
-    assert len(cv_res['l1-mean']) == 10
+    params_with_metric = {"metric": "l2", "verbose": -1}
+    cv_res = lgb.cv(
+        params_with_metric,
+        lgb_train,
+        num_boost_round=10,
+        nfold=3,
+        stratified=False,
+        shuffle=False,
+        metrics="l1",
+        verbose_eval=False,
+    )
+    assert "l1-mean" in cv_res
+    assert "l2-mean" not in cv_res
+    assert len(cv_res["l1-mean"]) == 10
     # shuffle = True, callbacks
-    cv_res = lgb.cv(params, lgb_train, num_boost_round=10, nfold=3, stratified=False, shuffle=True,
-                    metrics='l1', verbose_eval=False,
-                    callbacks=[lgb.reset_parameter(learning_rate=lambda i: 0.1 - 0.001 * i)])
-    assert 'l1-mean' in cv_res
-    assert len(cv_res['l1-mean']) == 10
+    cv_res = lgb.cv(
+        params,
+        lgb_train,
+        num_boost_round=10,
+        nfold=3,
+        stratified=False,
+        shuffle=True,
+        metrics="l1",
+        verbose_eval=False,
+        callbacks=[lgb.reset_parameter(learning_rate=lambda i: 0.1 - 0.001 * i)],
+    )
+    assert "l1-mean" in cv_res
+    assert len(cv_res["l1-mean"]) == 10
     # enable display training loss
-    cv_res = lgb.cv(params_with_metric, lgb_train, num_boost_round=10,
-                    nfold=3, stratified=False, shuffle=False,
-                    metrics='l1', verbose_eval=False, eval_train_metric=True)
-    assert 'train l1-mean' in cv_res
-    assert 'valid l1-mean' in cv_res
-    assert 'train l2-mean' not in cv_res
-    assert 'valid l2-mean' not in cv_res
-    assert len(cv_res['train l1-mean']) == 10
-    assert len(cv_res['valid l1-mean']) == 10
+    cv_res = lgb.cv(
+        params_with_metric,
+        lgb_train,
+        num_boost_round=10,
+        nfold=3,
+        stratified=False,
+        shuffle=False,
+        metrics="l1",
+        verbose_eval=False,
+        eval_train_metric=True,
+    )
+    assert "train l1-mean" in cv_res
+    assert "valid l1-mean" in cv_res
+    assert "train l2-mean" not in cv_res
+    assert "valid l2-mean" not in cv_res
+    assert len(cv_res["train l1-mean"]) == 10
+    assert len(cv_res["valid l1-mean"]) == 10
     # self defined folds
     tss = TimeSeriesSplit(3)
     folds = tss.split(X_train)
-    cv_res_gen = lgb.cv(params_with_metric, lgb_train, num_boost_round=10, folds=folds,
-                        verbose_eval=False)
-    cv_res_obj = lgb.cv(params_with_metric, lgb_train, num_boost_round=10, folds=tss,
-                        verbose_eval=False)
-    np.testing.assert_allclose(cv_res_gen['l2-mean'], cv_res_obj['l2-mean'])
+    cv_res_gen = lgb.cv(
+        params_with_metric,
+        lgb_train,
+        num_boost_round=10,
+        folds=folds,
+        verbose_eval=False,
+    )
+    cv_res_obj = lgb.cv(
+        params_with_metric, lgb_train, num_boost_round=10, folds=tss, verbose_eval=False
+    )
+    np.testing.assert_allclose(cv_res_gen["l2-mean"], cv_res_obj["l2-mean"])
     # lambdarank
-    X_train, y_train = load_svmlight_file(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                                       '../../examples/lambdarank/rank.train'))
-    q_train = np.loadtxt(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                      '../../examples/lambdarank/rank.train.query'))
-    params_lambdarank = {'objective': 'lambdarank', 'verbose': -1, 'eval_at': 3}
+    X_train, y_train = load_svmlight_file(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../examples/lambdarank/rank.train",
+        )
+    )
+    q_train = np.loadtxt(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../examples/lambdarank/rank.train.query",
+        )
+    )
+    params_lambdarank = {"objective": "lambdarank", "verbose": -1, "eval_at": 3}
     lgb_train = lgb.Dataset(X_train, y_train, group=q_train)
     # ... with l2 metric
-    cv_res_lambda = lgb.cv(params_lambdarank, lgb_train, num_boost_round=10, nfold=3,
-                           metrics='l2', verbose_eval=False)
+    cv_res_lambda = lgb.cv(
+        params_lambdarank,
+        lgb_train,
+        num_boost_round=10,
+        nfold=3,
+        metrics="l2",
+        verbose_eval=False,
+    )
     assert len(cv_res_lambda) == 2
-    assert not np.isnan(cv_res_lambda['l2-mean']).any()
+    assert not np.isnan(cv_res_lambda["l2-mean"]).any()
     # ... with NDCG (default) metric
-    cv_res_lambda = lgb.cv(params_lambdarank, lgb_train, num_boost_round=10, nfold=3,
-                           verbose_eval=False)
+    cv_res_lambda = lgb.cv(
+        params_lambdarank, lgb_train, num_boost_round=10, nfold=3, verbose_eval=False
+    )
     assert len(cv_res_lambda) == 2
-    assert not np.isnan(cv_res_lambda['ndcg@3-mean']).any()
+    assert not np.isnan(cv_res_lambda["ndcg@3-mean"]).any()
     # self defined folds with lambdarank
-    cv_res_lambda_obj = lgb.cv(params_lambdarank, lgb_train, num_boost_round=10,
-                               folds=GroupKFold(n_splits=3),
-                               verbose_eval=False)
-    np.testing.assert_allclose(cv_res_lambda['ndcg@3-mean'], cv_res_lambda_obj['ndcg@3-mean'])
+    cv_res_lambda_obj = lgb.cv(
+        params_lambdarank,
+        lgb_train,
+        num_boost_round=10,
+        folds=GroupKFold(n_splits=3),
+        verbose_eval=False,
+    )
+    np.testing.assert_allclose(
+        cv_res_lambda["ndcg@3-mean"], cv_res_lambda_obj["ndcg@3-mean"]
+    )
 
 
 def test_cvbooster():
     X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'objective': 'binary',
-        'metric': 'binary_logloss',
-        'verbose': -1,
+        "objective": "binary",
+        "metric": "binary_logloss",
+        "verbose": -1,
     }
     lgb_train = lgb.Dataset(X_train, y_train)
     # with early stopping
-    cv_res = lgb.cv(params, lgb_train,
-                    num_boost_round=25,
-                    early_stopping_rounds=5,
-                    verbose_eval=False,
-                    nfold=3,
-                    return_cvbooster=True)
-    assert 'cvbooster' in cv_res
-    cvb = cv_res['cvbooster']
+    cv_res = lgb.cv(
+        params,
+        lgb_train,
+        num_boost_round=25,
+        early_stopping_rounds=5,
+        verbose_eval=False,
+        nfold=3,
+        return_cvbooster=True,
+    )
+    assert "cvbooster" in cv_res
+    cvb = cv_res["cvbooster"]
     assert isinstance(cvb, lgb.CVBooster)
     assert isinstance(cvb.boosters, list)
     assert len(cvb.boosters) == 3
@@ -802,12 +1049,15 @@ def test_cvbooster():
     ret = log_loss(y_test, avg_pred)
     assert ret < 0.13
     # without early stopping
-    cv_res = lgb.cv(params, lgb_train,
-                    num_boost_round=20,
-                    verbose_eval=False,
-                    nfold=3,
-                    return_cvbooster=True)
-    cvb = cv_res['cvbooster']
+    cv_res = lgb.cv(
+        params,
+        lgb_train,
+        num_boost_round=20,
+        verbose_eval=False,
+        nfold=3,
+        return_cvbooster=True,
+    )
+    cvb = cv_res["cvbooster"]
     assert cvb.best_iteration == -1
     preds = cvb.predict(X_test)
     avg_pred = np.mean(preds, axis=0)
@@ -817,14 +1067,16 @@ def test_cvbooster():
 
 def test_feature_name():
     X_train, y_train = load_boston(return_X_y=True)
-    params = {'verbose': -1}
+    params = {"verbose": -1}
     lgb_train = lgb.Dataset(X_train, y_train)
-    feature_names = ['f_' + str(i) for i in range(X_train.shape[-1])]
+    feature_names = ["f_" + str(i) for i in range(X_train.shape[-1])]
     gbm = lgb.train(params, lgb_train, num_boost_round=5, feature_name=feature_names)
     assert feature_names == gbm.feature_name()
     # test feature_names with whitespaces
-    feature_names_with_space = ['f ' + str(i) for i in range(X_train.shape[-1])]
-    gbm = lgb.train(params, lgb_train, num_boost_round=5, feature_name=feature_names_with_space)
+    feature_names_with_space = ["f " + str(i) for i in range(X_train.shape[-1])]
+    gbm = lgb.train(
+        params, lgb_train, num_boost_round=5, feature_name=feature_names_with_space
+    )
     assert feature_names == gbm.feature_name()
 
 
@@ -832,45 +1084,51 @@ def test_feature_name_with_non_ascii():
     X_train = np.random.normal(size=(100, 4))
     y_train = np.random.random(100)
     # This has non-ascii strings.
-    feature_names = [u'F_零', u'F_一', u'F_二', u'F_三']
-    params = {'verbose': -1}
+    feature_names = [u"F_零", u"F_一", u"F_二", u"F_三"]
+    params = {"verbose": -1}
     lgb_train = lgb.Dataset(X_train, y_train)
 
     gbm = lgb.train(params, lgb_train, num_boost_round=5, feature_name=feature_names)
     assert feature_names == gbm.feature_name()
-    gbm.save_model('lgb.model')
+    gbm.save_model("lgb.model")
 
-    gbm2 = lgb.Booster(model_file='lgb.model')
+    gbm2 = lgb.Booster(model_file="lgb.model")
     assert feature_names == gbm2.feature_name()
 
 
 def test_save_load_copy_pickle():
     def train_and_predict(init_model=None, return_model=False):
         X, y = load_boston(return_X_y=True)
-        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
-        params = {
-            'objective': 'regression',
-            'metric': 'l2',
-            'verbose': -1
-        }
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.1, random_state=42
+        )
+        params = {"objective": "regression", "metric": "l2", "verbose": -1}
         lgb_train = lgb.Dataset(X_train, y_train)
-        gbm_template = lgb.train(params, lgb_train, num_boost_round=10, init_model=init_model)
-        return gbm_template if return_model else mean_squared_error(y_test, gbm_template.predict(X_test))
+        gbm_template = lgb.train(
+            params, lgb_train, num_boost_round=10, init_model=init_model
+        )
+        return (
+            gbm_template
+            if return_model
+            else mean_squared_error(y_test, gbm_template.predict(X_test))
+        )
 
     gbm = train_and_predict(return_model=True)
     ret_origin = train_and_predict(init_model=gbm)
     other_ret = []
-    gbm.save_model('lgb.model')
-    with open('lgb.model') as f:  # check all params are logged into model file correctly
+    gbm.save_model("lgb.model")
+    with open(
+        "lgb.model"
+    ) as f:  # check all params are logged into model file correctly
         assert f.read().find("[num_iterations: 10]") != -1
-    other_ret.append(train_and_predict(init_model='lgb.model'))
-    gbm_load = lgb.Booster(model_file='lgb.model')
+    other_ret.append(train_and_predict(init_model="lgb.model"))
+    gbm_load = lgb.Booster(model_file="lgb.model")
     other_ret.append(train_and_predict(init_model=gbm_load))
     other_ret.append(train_and_predict(init_model=copy.copy(gbm)))
     other_ret.append(train_and_predict(init_model=copy.deepcopy(gbm)))
-    with open('lgb.pkl', 'wb') as f:
+    with open("lgb.pkl", "wb") as f:
         pickle.dump(gbm, f)
-    with open('lgb.pkl', 'rb') as f:
+    with open("lgb.pkl", "rb") as f:
         gbm_pickle = pickle.load(f)
     other_ret.append(train_and_predict(init_model=gbm_pickle))
     gbm_pickles = pickle.loads(pickle.dumps(gbm))
@@ -881,49 +1139,59 @@ def test_save_load_copy_pickle():
 
 def test_pandas_categorical():
     pd = pytest.importorskip("pandas")
-    np.random.seed(42)  # sometimes there is no difference how cols are treated (cat or not cat)
-    X = pd.DataFrame({"A": np.random.permutation(['a', 'b', 'c', 'd'] * 75),  # str
-                      "B": np.random.permutation([1, 2, 3] * 100),  # int
-                      "C": np.random.permutation([0.1, 0.2, -0.1, -0.1, 0.2] * 60),  # float
-                      "D": np.random.permutation([True, False] * 150),  # bool
-                      "E": pd.Categorical(np.random.permutation(['z', 'y', 'x', 'w', 'v'] * 60),
-                                          ordered=True)})  # str and ordered categorical
+    np.random.seed(
+        42
+    )  # sometimes there is no difference how cols are treated (cat or not cat)
+    X = pd.DataFrame(
+        {
+            "A": np.random.permutation(["a", "b", "c", "d"] * 75),  # str
+            "B": np.random.permutation([1, 2, 3] * 100),  # int
+            "C": np.random.permutation([0.1, 0.2, -0.1, -0.1, 0.2] * 60),  # float
+            "D": np.random.permutation([True, False] * 150),  # bool
+            "E": pd.Categorical(
+                np.random.permutation(["z", "y", "x", "w", "v"] * 60), ordered=True
+            ),
+        }
+    )  # str and ordered categorical
     y = np.random.permutation([0, 1] * 150)
-    X_test = pd.DataFrame({"A": np.random.permutation(['a', 'b', 'e'] * 20),  # unseen category
-                           "B": np.random.permutation([1, 3] * 30),
-                           "C": np.random.permutation([0.1, -0.1, 0.2, 0.2] * 15),
-                           "D": np.random.permutation([True, False] * 30),
-                           "E": pd.Categorical(np.random.permutation(['z', 'y'] * 30),
-                                               ordered=True)})
+    X_test = pd.DataFrame(
+        {
+            "A": np.random.permutation(["a", "b", "e"] * 20),  # unseen category
+            "B": np.random.permutation([1, 3] * 30),
+            "C": np.random.permutation([0.1, -0.1, 0.2, 0.2] * 15),
+            "D": np.random.permutation([True, False] * 30),
+            "E": pd.Categorical(np.random.permutation(["z", "y"] * 30), ordered=True),
+        }
+    )
     np.random.seed()  # reset seed
     cat_cols_actual = ["A", "B", "C", "D"]
     cat_cols_to_store = cat_cols_actual + ["E"]
-    X[cat_cols_actual] = X[cat_cols_actual].astype('category')
-    X_test[cat_cols_actual] = X_test[cat_cols_actual].astype('category')
+    X[cat_cols_actual] = X[cat_cols_actual].astype("category")
+    X_test[cat_cols_actual] = X_test[cat_cols_actual].astype("category")
     cat_values = [X[col].cat.categories.tolist() for col in cat_cols_to_store]
-    params = {
-        'objective': 'binary',
-        'metric': 'binary_logloss',
-        'verbose': -1
-    }
+    params = {"objective": "binary", "metric": "binary_logloss", "verbose": -1}
     lgb_train = lgb.Dataset(X, y)
     gbm0 = lgb.train(params, lgb_train, num_boost_round=10)
     pred0 = gbm0.predict(X_test)
-    assert lgb_train.categorical_feature == 'auto'
-    lgb_train = lgb.Dataset(X, pd.DataFrame(y))  # also test that label can be one-column pd.DataFrame
+    assert lgb_train.categorical_feature == "auto"
+    lgb_train = lgb.Dataset(
+        X, pd.DataFrame(y)
+    )  # also test that label can be one-column pd.DataFrame
     gbm1 = lgb.train(params, lgb_train, num_boost_round=10, categorical_feature=[0])
     pred1 = gbm1.predict(X_test)
     assert lgb_train.categorical_feature == [0]
     lgb_train = lgb.Dataset(X, pd.Series(y))  # also test that label can be pd.Series
-    gbm2 = lgb.train(params, lgb_train, num_boost_round=10, categorical_feature=['A'])
+    gbm2 = lgb.train(params, lgb_train, num_boost_round=10, categorical_feature=["A"])
     pred2 = gbm2.predict(X_test)
-    assert lgb_train.categorical_feature == ['A']
+    assert lgb_train.categorical_feature == ["A"]
     lgb_train = lgb.Dataset(X, y)
-    gbm3 = lgb.train(params, lgb_train, num_boost_round=10, categorical_feature=['A', 'B', 'C', 'D'])
+    gbm3 = lgb.train(
+        params, lgb_train, num_boost_round=10, categorical_feature=["A", "B", "C", "D"]
+    )
     pred3 = gbm3.predict(X_test)
-    assert lgb_train.categorical_feature == ['A', 'B', 'C', 'D']
-    gbm3.save_model('categorical.model')
-    gbm4 = lgb.Booster(model_file='categorical.model')
+    assert lgb_train.categorical_feature == ["A", "B", "C", "D"]
+    gbm3.save_model("categorical.model")
+    gbm4 = lgb.Booster(model_file="categorical.model")
     pred4 = gbm4.predict(X_test)
     model_str = gbm4.model_to_string()
     gbm4.model_from_string(model_str, False)
@@ -931,9 +1199,14 @@ def test_pandas_categorical():
     gbm5 = lgb.Booster(model_str=model_str)
     pred6 = gbm5.predict(X_test)
     lgb_train = lgb.Dataset(X, y)
-    gbm6 = lgb.train(params, lgb_train, num_boost_round=10, categorical_feature=['A', 'B', 'C', 'D', 'E'])
+    gbm6 = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=10,
+        categorical_feature=["A", "B", "C", "D", "E"],
+    )
     pred7 = gbm6.predict(X_test)
-    assert lgb_train.categorical_feature == ['A', 'B', 'C', 'D', 'E']
+    assert lgb_train.categorical_feature == ["A", "B", "C", "D", "E"]
     lgb_train = lgb.Dataset(X, y)
     gbm7 = lgb.train(params, lgb_train, num_boost_round=10, categorical_feature=[])
     pred8 = gbm7.predict(X_test)
@@ -948,7 +1221,9 @@ def test_pandas_categorical():
     np.testing.assert_allclose(pred0, pred5)
     np.testing.assert_allclose(pred0, pred6)
     with pytest.raises(AssertionError):
-        np.testing.assert_allclose(pred0, pred7)  # ordered cat features aren't treated as cat features by default
+        np.testing.assert_allclose(
+            pred0, pred7
+        )  # ordered cat features aren't treated as cat features by default
     with pytest.raises(AssertionError):
         np.testing.assert_allclose(pred0, pred8)
     assert gbm0.pandas_categorical == cat_values
@@ -967,24 +1242,29 @@ def test_pandas_sparse():
         from pandas.arrays import SparseArray
     except ImportError:  # support old versions
         from pandas import SparseArray
-    X = pd.DataFrame({"A": SparseArray(np.random.permutation([0, 1, 2] * 100)),
-                      "B": SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
-                      "C": SparseArray(np.random.permutation([True, False] * 150))})
+    X = pd.DataFrame(
+        {
+            "A": SparseArray(np.random.permutation([0, 1, 2] * 100)),
+            "B": SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
+            "C": SparseArray(np.random.permutation([True, False] * 150)),
+        }
+    )
     y = pd.Series(SparseArray(np.random.permutation([0, 1] * 150)))
-    X_test = pd.DataFrame({"A": SparseArray(np.random.permutation([0, 2] * 30)),
-                           "B": SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
-                           "C": SparseArray(np.random.permutation([True, False] * 30))})
-    if pd.__version__ >= '0.24.0':
+    X_test = pd.DataFrame(
+        {
+            "A": SparseArray(np.random.permutation([0, 2] * 30)),
+            "B": SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
+            "C": SparseArray(np.random.permutation([True, False] * 30)),
+        }
+    )
+    if pd.__version__ >= "0.24.0":
         for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
             assert pd.api.types.is_sparse(dtype)
-    params = {
-        'objective': 'binary',
-        'verbose': -1
-    }
+    params = {"objective": "binary", "verbose": -1}
     lgb_train = lgb.Dataset(X, y)
     gbm = lgb.train(params, lgb_train, num_boost_round=10)
     pred_sparse = gbm.predict(X_test, raw_score=True)
-    if hasattr(X_test, 'sparse'):
+    if hasattr(X_test, "sparse"):
         pred_dense = gbm.predict(X_test.sparse.to_dense(), raw_score=True)
     else:
         pred_dense = gbm.predict(X_test.to_dense(), raw_score=True)
@@ -998,44 +1278,56 @@ def test_reference_chain():
     # take subsets and train
     tmp_dat_train = tmp_dat.subset(np.arange(80))
     tmp_dat_val = tmp_dat.subset(np.arange(80, 100)).subset(np.arange(18))
-    params = {'objective': 'regression_l2', 'metric': 'rmse'}
+    params = {"objective": "regression_l2", "metric": "rmse"}
     evals_result = {}
-    lgb.train(params, tmp_dat_train, num_boost_round=20,
-              valid_sets=[tmp_dat_train, tmp_dat_val],
-              verbose_eval=False, evals_result=evals_result)
-    assert len(evals_result['training']['rmse']) == 20
-    assert len(evals_result['valid_1']['rmse']) == 20
+    lgb.train(
+        params,
+        tmp_dat_train,
+        num_boost_round=20,
+        valid_sets=[tmp_dat_train, tmp_dat_val],
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
+    assert len(evals_result["training"]["rmse"]) == 20
+    assert len(evals_result["valid_1"]["rmse"]) == 20
 
 
 def test_contribs():
     X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'objective': 'binary',
-        'metric': 'binary_logloss',
-        'verbose': -1,
+        "objective": "binary",
+        "metric": "binary_logloss",
+        "verbose": -1,
     }
     lgb_train = lgb.Dataset(X_train, y_train)
     gbm = lgb.train(params, lgb_train, num_boost_round=20)
 
-    assert (np.linalg.norm(gbm.predict(X_test, raw_score=True)
-                           - np.sum(gbm.predict(X_test, pred_contrib=True), axis=1)) < 1e-4)
+    assert (
+        np.linalg.norm(
+            gbm.predict(X_test, raw_score=True)
+            - np.sum(gbm.predict(X_test, pred_contrib=True), axis=1)
+        )
+        < 1e-4
+    )
 
 
 def test_contribs_sparse():
     n_features = 20
     n_samples = 100
     # generate CSR sparse dataset
-    X, y = make_multilabel_classification(n_samples=n_samples,
-                                          sparse=True,
-                                          n_features=n_features,
-                                          n_classes=1,
-                                          n_labels=2)
+    X, y = make_multilabel_classification(
+        n_samples=n_samples, sparse=True, n_features=n_features, n_classes=1, n_labels=2
+    )
     y = y.flatten()
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'objective': 'binary',
-        'verbose': -1,
+        "objective": "binary",
+        "verbose": -1,
     }
     lgb_train = lgb.Dataset(X_train, y_train)
     gbm = lgb.train(params, lgb_train, num_boost_round=20)
@@ -1045,8 +1337,12 @@ def test_contribs_sparse():
     contribs_dense = gbm.predict(X_test.toarray(), pred_contrib=True)
     # validate the values are the same
     np.testing.assert_allclose(contribs_csr.toarray(), contribs_dense)
-    assert (np.linalg.norm(gbm.predict(X_test, raw_score=True)
-                           - np.sum(contribs_dense, axis=1)) < 1e-4)
+    assert (
+        np.linalg.norm(
+            gbm.predict(X_test, raw_score=True) - np.sum(contribs_dense, axis=1)
+        )
+        < 1e-4
+    )
     # validate using CSC matrix
     X_test_csc = X_test.tocsc()
     contribs_csc = gbm.predict(X_test_csc, pred_contrib=True)
@@ -1060,17 +1356,21 @@ def test_contribs_sparse_multiclass():
     n_samples = 100
     n_labels = 4
     # generate CSR sparse dataset
-    X, y = make_multilabel_classification(n_samples=n_samples,
-                                          sparse=True,
-                                          n_features=n_features,
-                                          n_classes=1,
-                                          n_labels=n_labels)
+    X, y = make_multilabel_classification(
+        n_samples=n_samples,
+        sparse=True,
+        n_features=n_features,
+        n_classes=1,
+        n_labels=n_labels,
+    )
     y = y.flatten()
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'objective': 'multiclass',
-        'num_class': n_labels,
-        'verbose': -1,
+        "objective": "multiclass",
+        "num_class": n_labels,
+        "verbose": -1,
     }
     lgb_train = lgb.Dataset(X_train, y_train)
     gbm = lgb.train(params, lgb_train, num_boost_round=20)
@@ -1081,12 +1381,23 @@ def test_contribs_sparse_multiclass():
     # convert data to dense and get back same contribs
     contribs_dense = gbm.predict(X_test.toarray(), pred_contrib=True)
     # validate the values are the same
-    contribs_csr_array = np.swapaxes(np.array([sparse_array.todense() for sparse_array in contribs_csr]), 0, 1)
-    contribs_csr_arr_re = contribs_csr_array.reshape((contribs_csr_array.shape[0],
-                                                      contribs_csr_array.shape[1] * contribs_csr_array.shape[2]))
+    contribs_csr_array = np.swapaxes(
+        np.array([sparse_array.todense() for sparse_array in contribs_csr]), 0, 1
+    )
+    contribs_csr_arr_re = contribs_csr_array.reshape(
+        (
+            contribs_csr_array.shape[0],
+            contribs_csr_array.shape[1] * contribs_csr_array.shape[2],
+        )
+    )
     np.testing.assert_allclose(contribs_csr_arr_re, contribs_dense)
     contribs_dense_re = contribs_dense.reshape(contribs_csr_array.shape)
-    assert np.linalg.norm(gbm.predict(X_test, raw_score=True) - np.sum(contribs_dense_re, axis=2)) < 1e-4
+    assert (
+        np.linalg.norm(
+            gbm.predict(X_test, raw_score=True) - np.sum(contribs_dense_re, axis=2)
+        )
+        < 1e-4
+    )
     # validate using CSC matrix
     X_test_csc = X_test.tocsc()
     contribs_csc = gbm.predict(X_test_csc, pred_contrib=True)
@@ -1094,17 +1405,23 @@ def test_contribs_sparse_multiclass():
     for perclass_contribs_csc in contribs_csc:
         assert isspmatrix_csc(perclass_contribs_csc)
     # validate the values are the same
-    contribs_csc_array = np.swapaxes(np.array([sparse_array.todense() for sparse_array in contribs_csc]), 0, 1)
-    contribs_csc_array = contribs_csc_array.reshape((contribs_csc_array.shape[0],
-                                                     contribs_csc_array.shape[1] * contribs_csc_array.shape[2]))
+    contribs_csc_array = np.swapaxes(
+        np.array([sparse_array.todense() for sparse_array in contribs_csc]), 0, 1
+    )
+    contribs_csc_array = contribs_csc_array.reshape(
+        (
+            contribs_csc_array.shape[0],
+            contribs_csc_array.shape[1] * contribs_csc_array.shape[2],
+        )
+    )
     np.testing.assert_allclose(contribs_csc_array, contribs_dense)
 
 
-@pytest.mark.skipif(psutil.virtual_memory().available / 1024 / 1024 / 1024 < 3, reason='not enough RAM')
+@pytest.mark.skipif(
+    psutil.virtual_memory().available / 1024 / 1024 / 1024 < 3, reason="not enough RAM"
+)
 def test_int32_max_sparse_contribs():
-    params = {
-        'objective': 'binary'
-    }
+    params = {"objective": "binary"}
     train_features = np.random.rand(100, 1000)
     train_targets = [0] * 50 + [1] * 50
     lgb_train = lgb.Dataset(train_features, train_targets)
@@ -1127,9 +1444,9 @@ def test_sliced_data():
     def train_and_get_predictions(features, labels):
         dataset = lgb.Dataset(features, label=labels)
         lgb_params = {
-            'application': 'binary',
-            'verbose': -1,
-            'min_data': 5,
+            "application": "binary",
+            "verbose": -1,
+            "min_data": 5,
         }
         gbm = lgb.train(
             params=lgb_params,
@@ -1141,8 +1458,10 @@ def test_sliced_data():
     num_samples = 100
     features = np.random.rand(num_samples, 5)
     positive_samples = int(num_samples * 0.25)
-    labels = np.append(np.ones(positive_samples, dtype=np.float32),
-                       np.zeros(num_samples - positive_samples, dtype=np.float32))
+    labels = np.append(
+        np.ones(positive_samples, dtype=np.float32),
+        np.zeros(num_samples - positive_samples, dtype=np.float32),
+    )
     # test sliced labels
     origin_pred = train_and_get_predictions(features, labels)
     stacked_labels = np.column_stack((labels, np.ones(num_samples, dtype=np.float32)))
@@ -1150,15 +1469,31 @@ def test_sliced_data():
     sliced_pred = train_and_get_predictions(features, sliced_labels)
     np.testing.assert_allclose(origin_pred, sliced_pred)
     # append some columns
-    stacked_features = np.column_stack((np.ones(num_samples, dtype=np.float32), features))
-    stacked_features = np.column_stack((np.ones(num_samples, dtype=np.float32), stacked_features))
-    stacked_features = np.column_stack((stacked_features, np.ones(num_samples, dtype=np.float32)))
-    stacked_features = np.column_stack((stacked_features, np.ones(num_samples, dtype=np.float32)))
+    stacked_features = np.column_stack(
+        (np.ones(num_samples, dtype=np.float32), features)
+    )
+    stacked_features = np.column_stack(
+        (np.ones(num_samples, dtype=np.float32), stacked_features)
+    )
+    stacked_features = np.column_stack(
+        (stacked_features, np.ones(num_samples, dtype=np.float32))
+    )
+    stacked_features = np.column_stack(
+        (stacked_features, np.ones(num_samples, dtype=np.float32))
+    )
     # append some rows
-    stacked_features = np.concatenate((np.ones(9, dtype=np.float32).reshape((1, 9)), stacked_features), axis=0)
-    stacked_features = np.concatenate((np.ones(9, dtype=np.float32).reshape((1, 9)), stacked_features), axis=0)
-    stacked_features = np.concatenate((stacked_features, np.ones(9, dtype=np.float32).reshape((1, 9))), axis=0)
-    stacked_features = np.concatenate((stacked_features, np.ones(9, dtype=np.float32).reshape((1, 9))), axis=0)
+    stacked_features = np.concatenate(
+        (np.ones(9, dtype=np.float32).reshape((1, 9)), stacked_features), axis=0
+    )
+    stacked_features = np.concatenate(
+        (np.ones(9, dtype=np.float32).reshape((1, 9)), stacked_features), axis=0
+    )
+    stacked_features = np.concatenate(
+        (stacked_features, np.ones(9, dtype=np.float32).reshape((1, 9))), axis=0
+    )
+    stacked_features = np.concatenate(
+        (stacked_features, np.ones(9, dtype=np.float32).reshape((1, 9))), axis=0
+    )
     # test sliced 2d matrix
     sliced_features = stacked_features[2:102, 2:7]
     assert np.all(sliced_features == features)
@@ -1180,34 +1515,38 @@ def test_init_with_subset():
     subset_data_1 = lgb_train.subset(subset_index_1)
     subset_index_2 = np.random.choice(np.arange(50), 20, replace=False)
     subset_data_2 = lgb_train.subset(subset_index_2)
-    params = {
-        'objective': 'binary',
-        'verbose': -1
-    }
-    init_gbm = lgb.train(params=params,
-                         train_set=subset_data_1,
-                         num_boost_round=10,
-                         keep_training_booster=True)
-    lgb.train(params=params,
-              train_set=subset_data_2,
-              num_boost_round=10,
-              init_model=init_gbm)
+    params = {"objective": "binary", "verbose": -1}
+    init_gbm = lgb.train(
+        params=params,
+        train_set=subset_data_1,
+        num_boost_round=10,
+        keep_training_booster=True,
+    )
+    lgb.train(
+        params=params, train_set=subset_data_2, num_boost_round=10, init_model=init_gbm
+    )
     assert lgb_train.get_data().shape[0] == 50
     assert subset_data_1.get_data().shape[0] == 30
     assert subset_data_2.get_data().shape[0] == 20
     lgb_train.save_binary("lgb_train_data.bin")
-    lgb_train_from_file = lgb.Dataset('lgb_train_data.bin', free_raw_data=False)
+    lgb_train_from_file = lgb.Dataset("lgb_train_data.bin", free_raw_data=False)
     subset_data_3 = lgb_train_from_file.subset(subset_index_1)
     subset_data_4 = lgb_train_from_file.subset(subset_index_2)
-    init_gbm_2 = lgb.train(params=params,
-                           train_set=subset_data_3,
-                           num_boost_round=10,
-                           keep_training_booster=True)
-    with np.testing.assert_raises_regex(lgb.basic.LightGBMError, "Unknown format of training data"):
-        lgb.train(params=params,
-                  train_set=subset_data_4,
-                  num_boost_round=10,
-                  init_model=init_gbm_2)
+    init_gbm_2 = lgb.train(
+        params=params,
+        train_set=subset_data_3,
+        num_boost_round=10,
+        keep_training_booster=True,
+    )
+    with np.testing.assert_raises_regex(
+        lgb.basic.LightGBMError, "Unknown format of training data"
+    ):
+        lgb.train(
+            params=params,
+            train_set=subset_data_4,
+            num_boost_round=10,
+            init_model=init_gbm_2,
+        )
     assert lgb_train_from_file.get_data() == "lgb_train_data.bin"
     assert subset_data_3.get_data() == "lgb_train_data.bin"
     assert subset_data_4.get_data() == "lgb_train_data.bin"
@@ -1219,23 +1558,32 @@ def generate_trainset_for_monotone_constraints_tests(x3_to_category=True):
     x2_negatively_correlated_with_y = np.random.random(size=number_of_dpoints)
     x3_negatively_correlated_with_y = np.random.random(size=number_of_dpoints)
     x = np.column_stack(
-        (x1_positively_correlated_with_y,
+        (
+            x1_positively_correlated_with_y,
             x2_negatively_correlated_with_y,
-            categorize(x3_negatively_correlated_with_y) if x3_to_category else x3_negatively_correlated_with_y))
+            categorize(x3_negatively_correlated_with_y)
+            if x3_to_category
+            else x3_negatively_correlated_with_y,
+        )
+    )
 
     zs = np.random.normal(loc=0.0, scale=0.01, size=number_of_dpoints)
-    scales = 10. * (np.random.random(6) + 0.5)
-    y = (scales[0] * x1_positively_correlated_with_y
-         + np.sin(scales[1] * np.pi * x1_positively_correlated_with_y)
-         - scales[2] * x2_negatively_correlated_with_y
-         - np.cos(scales[3] * np.pi * x2_negatively_correlated_with_y)
-         - scales[4] * x3_negatively_correlated_with_y
-         - np.cos(scales[5] * np.pi * x3_negatively_correlated_with_y)
-         + zs)
+    scales = 10.0 * (np.random.random(6) + 0.5)
+    y = (
+        scales[0] * x1_positively_correlated_with_y
+        + np.sin(scales[1] * np.pi * x1_positively_correlated_with_y)
+        - scales[2] * x2_negatively_correlated_with_y
+        - np.cos(scales[3] * np.pi * x2_negatively_correlated_with_y)
+        - scales[4] * x3_negatively_correlated_with_y
+        - np.cos(scales[5] * np.pi * x3_negatively_correlated_with_y)
+        + zs
+    )
     categorical_features = []
     if x3_to_category:
         categorical_features = [2]
-    trainset = lgb.Dataset(x, label=y, categorical_feature=categorical_features, free_raw_data=False)
+    trainset = lgb.Dataset(
+        x, label=y, categorical_feature=categorical_features, free_raw_data=False
+    )
     return trainset
 
 
@@ -1260,28 +1608,38 @@ def test_monotone_constraints():
             monotonically_increasing_y = learner.predict(monotonically_increasing_x)
             monotonically_decreasing_x = np.column_stack((fixed_x, variable_x, fixed_x))
             monotonically_decreasing_y = learner.predict(monotonically_decreasing_x)
-            non_monotone_x = np.column_stack((fixed_x,
-                                              fixed_x,
-                                              categorize(variable_x) if x3_to_category else variable_x))
+            non_monotone_x = np.column_stack(
+                (
+                    fixed_x,
+                    fixed_x,
+                    categorize(variable_x) if x3_to_category else variable_x,
+                )
+            )
             non_monotone_y = learner.predict(non_monotone_x)
-            if not (is_increasing(monotonically_increasing_y)
-                    and is_decreasing(monotonically_decreasing_y)
-                    and is_non_monotone(non_monotone_y)):
+            if not (
+                is_increasing(monotonically_increasing_y)
+                and is_decreasing(monotonically_decreasing_y)
+                and is_non_monotone(non_monotone_y)
+            ):
                 return False
         return True
 
     for test_with_categorical_variable in [True, False]:
-        trainset = generate_trainset_for_monotone_constraints_tests(test_with_categorical_variable)
+        trainset = generate_trainset_for_monotone_constraints_tests(
+            test_with_categorical_variable
+        )
         for monotone_constraints_method in ["basic", "intermediate", "advanced"]:
             params = {
-                'min_data': 20,
-                'num_leaves': 20,
-                'monotone_constraints': [1, -1, 0],
+                "min_data": 20,
+                "num_leaves": 20,
+                "monotone_constraints": [1, -1, 0],
                 "monotone_constraints_method": monotone_constraints_method,
                 "use_missing": False,
             }
             constrained_model = lgb.train(params, trainset)
-            assert is_correctly_constrained(constrained_model, test_with_categorical_variable)
+            assert is_correctly_constrained(
+                constrained_model, test_with_categorical_variable
+            )
 
 
 def test_monotone_penalty():
@@ -1292,16 +1650,20 @@ def test_monotone_penalty():
             return True
         if monotone_constraints[tree["split_feature"]] != 0:
             return False
-        return (are_first_splits_non_monotone(tree["left_child"], n - 1, monotone_constraints)
-                and are_first_splits_non_monotone(tree["right_child"], n - 1, monotone_constraints))
+        return are_first_splits_non_monotone(
+            tree["left_child"], n - 1, monotone_constraints
+        ) and are_first_splits_non_monotone(
+            tree["right_child"], n - 1, monotone_constraints
+        )
 
     def are_there_monotone_splits(tree, monotone_constraints):
         if "leaf_value" in tree:
             return False
         if monotone_constraints[tree["split_feature"]] != 0:
             return True
-        return (are_there_monotone_splits(tree["left_child"], monotone_constraints)
-                or are_there_monotone_splits(tree["right_child"], monotone_constraints))
+        return are_there_monotone_splits(
+            tree["left_child"], monotone_constraints
+        ) or are_there_monotone_splits(tree["right_child"], monotone_constraints)
 
     max_depth = 5
     monotone_constraints = [1, -1, 0]
@@ -1309,17 +1671,22 @@ def test_monotone_penalty():
     trainset = generate_trainset_for_monotone_constraints_tests(x3_to_category=False)
     for monotone_constraints_method in ["basic", "intermediate", "advanced"]:
         params = {
-            'max_depth': max_depth,
-            'monotone_constraints': monotone_constraints,
-            'monotone_penalty': penalization_parameter,
+            "max_depth": max_depth,
+            "monotone_constraints": monotone_constraints,
+            "monotone_penalty": penalization_parameter,
             "monotone_constraints_method": monotone_constraints_method,
         }
         constrained_model = lgb.train(params, trainset, 10)
         dumped_model = constrained_model.dump_model()["tree_info"]
         for tree in dumped_model:
-            assert are_first_splits_non_monotone(tree["tree_structure"], int(penalization_parameter),
-                                                 monotone_constraints)
-            assert are_there_monotone_splits(tree["tree_structure"], monotone_constraints)
+            assert are_first_splits_non_monotone(
+                tree["tree_structure"],
+                int(penalization_parameter),
+                monotone_constraints,
+            )
+            assert are_there_monotone_splits(
+                tree["tree_structure"], monotone_constraints
+            )
 
 
 # test if a penalty as high as the depth indeed prohibits all monotone splits
@@ -1327,14 +1694,18 @@ def test_monotone_penalty_max():
     max_depth = 5
     monotone_constraints = [1, -1, 0]
     penalization_parameter = max_depth
-    trainset_constrained_model = generate_trainset_for_monotone_constraints_tests(x3_to_category=False)
+    trainset_constrained_model = generate_trainset_for_monotone_constraints_tests(
+        x3_to_category=False
+    )
     x = trainset_constrained_model.data
     y = trainset_constrained_model.label
     x3_negatively_correlated_with_y = x[:, 2]
-    trainset_unconstrained_model = lgb.Dataset(x3_negatively_correlated_with_y.reshape(-1, 1), label=y)
+    trainset_unconstrained_model = lgb.Dataset(
+        x3_negatively_correlated_with_y.reshape(-1, 1), label=y
+    )
     params_constrained_model = {
-        'monotone_constraints': monotone_constraints,
-        'monotone_penalty': penalization_parameter,
+        "monotone_constraints": monotone_constraints,
+        "monotone_penalty": penalization_parameter,
         "max_depth": max_depth,
         "gpu_use_dp": True,
     }
@@ -1343,17 +1714,26 @@ def test_monotone_penalty_max():
         "gpu_use_dp": True,
     }
 
-    unconstrained_model = lgb.train(params_unconstrained_model, trainset_unconstrained_model, 10)
-    unconstrained_model_predictions = unconstrained_model.\
-        predict(x3_negatively_correlated_with_y.reshape(-1, 1))
+    unconstrained_model = lgb.train(
+        params_unconstrained_model, trainset_unconstrained_model, 10
+    )
+    unconstrained_model_predictions = unconstrained_model.predict(
+        x3_negatively_correlated_with_y.reshape(-1, 1)
+    )
 
     for monotone_constraints_method in ["basic", "intermediate", "advanced"]:
-        params_constrained_model["monotone_constraints_method"] = monotone_constraints_method
+        params_constrained_model[
+            "monotone_constraints_method"
+        ] = monotone_constraints_method
         # The penalization is so high that the first 2 features should not be used here
-        constrained_model = lgb.train(params_constrained_model, trainset_constrained_model, 10)
+        constrained_model = lgb.train(
+            params_constrained_model, trainset_constrained_model, 10
+        )
 
         # Check that a very high penalization is the same as not using the features at all
-        np.testing.assert_array_equal(constrained_model.predict(x), unconstrained_model_predictions)
+        np.testing.assert_array_equal(
+            constrained_model.predict(x), unconstrained_model_predictions
+        )
 
 
 def test_max_bin_by_feature():
@@ -1363,18 +1743,18 @@ def test_max_bin_by_feature():
     X = np.concatenate([col1, col2], axis=1)
     y = np.arange(0, 100)
     params = {
-        'objective': 'regression_l2',
-        'verbose': -1,
-        'num_leaves': 100,
-        'min_data_in_leaf': 1,
-        'min_sum_hessian_in_leaf': 0,
-        'min_data_in_bin': 1,
-        'max_bin_by_feature': [100, 2]
+        "objective": "regression_l2",
+        "verbose": -1,
+        "num_leaves": 100,
+        "min_data_in_leaf": 1,
+        "min_sum_hessian_in_leaf": 0,
+        "min_data_in_bin": 1,
+        "max_bin_by_feature": [100, 2],
     }
     lgb_data = lgb.Dataset(X, label=y)
     est = lgb.train(params, lgb_data, num_boost_round=1)
     assert len(np.unique(est.predict(X))) == 100
-    params['max_bin_by_feature'] = [2, 100]
+    params["max_bin_by_feature"] = [2, 100]
     lgb_data = lgb.Dataset(X, label=y)
     est = lgb.train(params, lgb_data, num_boost_round=1)
     assert len(np.unique(est.predict(X))) == 3
@@ -1387,15 +1767,17 @@ def test_small_max_bin():
     x[:30, 0] = -1
     x[30:60, 0] = 1
     x[60:, 0] = 2
-    params = {'objective': 'binary',
-              'seed': 0,
-              'min_data_in_leaf': 1,
-              'verbose': -1,
-              'max_bin': 2}
+    params = {
+        "objective": "binary",
+        "seed": 0,
+        "min_data_in_leaf": 1,
+        "verbose": -1,
+        "max_bin": 2,
+    }
     lgb_x = lgb.Dataset(x, label=y)
     lgb.train(params, lgb_x, num_boost_round=5)
     x[0, 0] = np.nan
-    params['max_bin'] = 3
+    params["max_bin"] = 3
     lgb_x = lgb.Dataset(x, label=y)
     lgb.train(params, lgb_x, num_boost_round=5)
     np.random.seed()  # reset seed
@@ -1403,12 +1785,14 @@ def test_small_max_bin():
 
 def test_refit():
     X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'objective': 'binary',
-        'metric': 'binary_logloss',
-        'verbose': -1,
-        'min_data': 10
+        "objective": "binary",
+        "metric": "binary_logloss",
+        "verbose": -1,
+        "min_data": 10,
     }
     lgb_train = lgb.Dataset(X_train, y_train)
     gbm = lgb.train(params, lgb_train, num_boost_round=20)
@@ -1421,13 +1805,13 @@ def test_refit():
 def test_mape_rf():
     X, y = load_boston(return_X_y=True)
     params = {
-        'boosting_type': 'rf',
-        'objective': 'mape',
-        'verbose': -1,
-        'bagging_freq': 1,
-        'bagging_fraction': 0.8,
-        'feature_fraction': 0.8,
-        'boost_from_average': True
+        "boosting_type": "rf",
+        "objective": "mape",
+        "verbose": -1,
+        "bagging_freq": 1,
+        "bagging_fraction": 0.8,
+        "feature_fraction": 0.8,
+        "boost_from_average": True,
     }
     lgb_train = lgb.Dataset(X, y)
     gbm = lgb.train(params, lgb_train, num_boost_round=20)
@@ -1439,13 +1823,13 @@ def test_mape_rf():
 def test_mape_dart():
     X, y = load_boston(return_X_y=True)
     params = {
-        'boosting_type': 'dart',
-        'objective': 'mape',
-        'verbose': -1,
-        'bagging_freq': 1,
-        'bagging_fraction': 0.8,
-        'feature_fraction': 0.8,
-        'boost_from_average': False
+        "boosting_type": "dart",
+        "objective": "mape",
+        "verbose": -1,
+        "bagging_freq": 1,
+        "bagging_fraction": 0.8,
+        "feature_fraction": 0.8,
+        "boost_from_average": False,
     }
     lgb_train = lgb.Dataset(X, y)
     gbm = lgb.train(params, lgb_train, num_boost_round=40)
@@ -1458,14 +1842,14 @@ def check_constant_features(y_true, expected_pred, more_params):
     X_train = np.ones((len(y_true), 1))
     y_train = np.array(y_true)
     params = {
-        'objective': 'regression',
-        'num_class': 1,
-        'verbose': -1,
-        'min_data': 1,
-        'num_leaves': 2,
-        'learning_rate': 1,
-        'min_data_in_bin': 1,
-        'boost_from_average': True
+        "objective": "regression",
+        "num_class": 1,
+        "verbose": -1,
+        "min_data": 1,
+        "num_leaves": 2,
+        "learning_rate": 1,
+        "min_data_in_bin": 1,
+        "boost_from_average": True,
     }
     params.update(more_params)
     lgb_train = lgb.Dataset(X_train, y_train, params=params)
@@ -1475,36 +1859,26 @@ def check_constant_features(y_true, expected_pred, more_params):
 
 
 def test_constant_features_regression():
-    params = {
-        'objective': 'regression'
-    }
+    params = {"objective": "regression"}
     check_constant_features([0.0, 10.0, 0.0, 10.0], 5.0, params)
     check_constant_features([0.0, 1.0, 2.0, 3.0], 1.5, params)
     check_constant_features([-1.0, 1.0, -2.0, 2.0], 0.0, params)
 
 
 def test_constant_features_binary():
-    params = {
-        'objective': 'binary'
-    }
+    params = {"objective": "binary"}
     check_constant_features([0.0, 10.0, 0.0, 10.0], 0.5, params)
     check_constant_features([0.0, 1.0, 2.0, 3.0], 0.75, params)
 
 
 def test_constant_features_multiclass():
-    params = {
-        'objective': 'multiclass',
-        'num_class': 3
-    }
+    params = {"objective": "multiclass", "num_class": 3}
     check_constant_features([0.0, 1.0, 2.0, 0.0], [0.5, 0.25, 0.25], params)
     check_constant_features([0.0, 1.0, 2.0, 1.0], [0.25, 0.5, 0.25], params)
 
 
 def test_constant_features_multiclassova():
-    params = {
-        'objective': 'multiclassova',
-        'num_class': 3
-    }
+    params = {"objective": "multiclassova", "num_class": 3}
     check_constant_features([0.0, 1.0, 2.0, 0.0], [0.5, 0.25, 0.25], params)
     check_constant_features([0.0, 1.0, 2.0, 1.0], [0.25, 0.5, 0.25], params)
 
@@ -1519,93 +1893,122 @@ def test_fpreproc():
         dtest.label[-5:] = 3
         dtrain = lgb.Dataset(train_data, dtrain.label)
         dtest = lgb.Dataset(test_data, dtest.label, reference=dtrain)
-        params['num_class'] = 4
+        params["num_class"] = 4
         return dtrain, dtest, params
 
     X, y = load_iris(return_X_y=True)
     dataset = lgb.Dataset(X, y, free_raw_data=False)
-    params = {'objective': 'multiclass', 'num_class': 3, 'verbose': -1}
+    params = {"objective": "multiclass", "num_class": 3, "verbose": -1}
     results = lgb.cv(params, dataset, num_boost_round=10, fpreproc=preprocess_data)
-    assert 'multi_logloss-mean' in results
-    assert len(results['multi_logloss-mean']) == 10
+    assert "multi_logloss-mean" in results
+    assert len(results["multi_logloss-mean"]) == 10
 
 
 def test_metrics():
     X, y = load_digits(n_class=2, return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     lgb_train = lgb.Dataset(X_train, y_train, silent=True)
     lgb_valid = lgb.Dataset(X_test, y_test, reference=lgb_train, silent=True)
 
     evals_result = {}
-    params_verbose = {'verbose': -1}
-    params_obj_verbose = {'objective': 'binary', 'verbose': -1}
-    params_obj_metric_log_verbose = {'objective': 'binary', 'metric': 'binary_logloss', 'verbose': -1}
-    params_obj_metric_err_verbose = {'objective': 'binary', 'metric': 'binary_error', 'verbose': -1}
-    params_obj_metric_inv_verbose = {'objective': 'binary', 'metric': 'invalid_metric', 'verbose': -1}
-    params_obj_metric_multi_verbose = {'objective': 'binary',
-                                       'metric': ['binary_logloss', 'binary_error'],
-                                       'verbose': -1}
-    params_obj_metric_none_verbose = {'objective': 'binary', 'metric': 'None', 'verbose': -1}
-    params_metric_log_verbose = {'metric': 'binary_logloss', 'verbose': -1}
-    params_metric_err_verbose = {'metric': 'binary_error', 'verbose': -1}
-    params_metric_inv_verbose = {'metric_types': 'invalid_metric', 'verbose': -1}
-    params_metric_multi_verbose = {'metric': ['binary_logloss', 'binary_error'], 'verbose': -1}
-    params_metric_none_verbose = {'metric': 'None', 'verbose': -1}
+    params_verbose = {"verbose": -1}
+    params_obj_verbose = {"objective": "binary", "verbose": -1}
+    params_obj_metric_log_verbose = {
+        "objective": "binary",
+        "metric": "binary_logloss",
+        "verbose": -1,
+    }
+    params_obj_metric_err_verbose = {
+        "objective": "binary",
+        "metric": "binary_error",
+        "verbose": -1,
+    }
+    params_obj_metric_inv_verbose = {
+        "objective": "binary",
+        "metric": "invalid_metric",
+        "verbose": -1,
+    }
+    params_obj_metric_multi_verbose = {
+        "objective": "binary",
+        "metric": ["binary_logloss", "binary_error"],
+        "verbose": -1,
+    }
+    params_obj_metric_none_verbose = {
+        "objective": "binary",
+        "metric": "None",
+        "verbose": -1,
+    }
+    params_metric_log_verbose = {"metric": "binary_logloss", "verbose": -1}
+    params_metric_err_verbose = {"metric": "binary_error", "verbose": -1}
+    params_metric_inv_verbose = {"metric_types": "invalid_metric", "verbose": -1}
+    params_metric_multi_verbose = {
+        "metric": ["binary_logloss", "binary_error"],
+        "verbose": -1,
+    }
+    params_metric_none_verbose = {"metric": "None", "verbose": -1}
 
     def get_cv_result(params=params_obj_verbose, **kwargs):
-        return lgb.cv(params, lgb_train, num_boost_round=2, verbose_eval=False, **kwargs)
+        return lgb.cv(
+            params, lgb_train, num_boost_round=2, verbose_eval=False, **kwargs
+        )
 
     def train_booster(params=params_obj_verbose, **kwargs):
-        lgb.train(params, lgb_train,
-                  num_boost_round=2,
-                  valid_sets=[lgb_valid],
-                  evals_result=evals_result,
-                  verbose_eval=False, **kwargs)
+        lgb.train(
+            params,
+            lgb_train,
+            num_boost_round=2,
+            valid_sets=[lgb_valid],
+            evals_result=evals_result,
+            verbose_eval=False,
+            **kwargs
+        )
 
     # no fobj, no feval
     # default metric
     res = get_cv_result()
     assert len(res) == 2
-    assert 'binary_logloss-mean' in res
+    assert "binary_logloss-mean" in res
 
     # non-default metric in params
     res = get_cv_result(params=params_obj_metric_err_verbose)
     assert len(res) == 2
-    assert 'binary_error-mean' in res
+    assert "binary_error-mean" in res
 
     # default metric in args
-    res = get_cv_result(metrics='binary_logloss')
+    res = get_cv_result(metrics="binary_logloss")
     assert len(res) == 2
-    assert 'binary_logloss-mean' in res
+    assert "binary_logloss-mean" in res
 
     # non-default metric in args
-    res = get_cv_result(metrics='binary_error')
+    res = get_cv_result(metrics="binary_error")
     assert len(res) == 2
-    assert 'binary_error-mean' in res
+    assert "binary_error-mean" in res
 
     # metric in args overwrites one in params
-    res = get_cv_result(params=params_obj_metric_inv_verbose, metrics='binary_error')
+    res = get_cv_result(params=params_obj_metric_inv_verbose, metrics="binary_error")
     assert len(res) == 2
-    assert 'binary_error-mean' in res
+    assert "binary_error-mean" in res
 
     # multiple metrics in params
     res = get_cv_result(params=params_obj_metric_multi_verbose)
     assert len(res) == 4
-    assert 'binary_logloss-mean' in res
-    assert 'binary_error-mean' in res
+    assert "binary_logloss-mean" in res
+    assert "binary_error-mean" in res
 
     # multiple metrics in args
-    res = get_cv_result(metrics=['binary_logloss', 'binary_error'])
+    res = get_cv_result(metrics=["binary_logloss", "binary_error"])
     assert len(res) == 4
-    assert 'binary_logloss-mean' in res
-    assert 'binary_error-mean' in res
+    assert "binary_logloss-mean" in res
+    assert "binary_error-mean" in res
 
     # remove default metric by 'None' in list
-    res = get_cv_result(metrics=['None'])
+    res = get_cv_result(metrics=["None"])
     assert len(res) == 0
 
     # remove default metric by 'None' aliases
-    for na_alias in ('None', 'na', 'null', 'custom'):
+    for na_alias in ("None", "na", "null", "custom"):
         res = get_cv_result(metrics=na_alias)
         assert len(res) == 0
 
@@ -1617,152 +2020,181 @@ def test_metrics():
     # metric in params
     res = get_cv_result(params=params_metric_err_verbose, fobj=dummy_obj)
     assert len(res) == 2
-    assert 'binary_error-mean' in res
+    assert "binary_error-mean" in res
 
     # metric in args
-    res = get_cv_result(params=params_verbose, fobj=dummy_obj, metrics='binary_error')
+    res = get_cv_result(params=params_verbose, fobj=dummy_obj, metrics="binary_error")
     assert len(res) == 2
-    assert 'binary_error-mean' in res
+    assert "binary_error-mean" in res
 
     # metric in args overwrites its' alias in params
-    res = get_cv_result(params=params_metric_inv_verbose, fobj=dummy_obj, metrics='binary_error')
+    res = get_cv_result(
+        params=params_metric_inv_verbose, fobj=dummy_obj, metrics="binary_error"
+    )
     assert len(res) == 2
-    assert 'binary_error-mean' in res
+    assert "binary_error-mean" in res
 
     # multiple metrics in params
     res = get_cv_result(params=params_metric_multi_verbose, fobj=dummy_obj)
     assert len(res) == 4
-    assert 'binary_logloss-mean' in res
-    assert 'binary_error-mean' in res
+    assert "binary_logloss-mean" in res
+    assert "binary_error-mean" in res
 
     # multiple metrics in args
-    res = get_cv_result(params=params_verbose, fobj=dummy_obj,
-                        metrics=['binary_logloss', 'binary_error'])
+    res = get_cv_result(
+        params=params_verbose,
+        fobj=dummy_obj,
+        metrics=["binary_logloss", "binary_error"],
+    )
     assert len(res) == 4
-    assert 'binary_logloss-mean' in res
-    assert 'binary_error-mean' in res
+    assert "binary_logloss-mean" in res
+    assert "binary_error-mean" in res
 
     # no fobj, feval
     # default metric with custom one
     res = get_cv_result(feval=constant_metric)
     assert len(res) == 4
-    assert 'binary_logloss-mean' in res
-    assert 'error-mean' in res
+    assert "binary_logloss-mean" in res
+    assert "error-mean" in res
 
     # non-default metric in params with custom one
     res = get_cv_result(params=params_obj_metric_err_verbose, feval=constant_metric)
     assert len(res) == 4
-    assert 'binary_error-mean' in res
-    assert 'error-mean' in res
+    assert "binary_error-mean" in res
+    assert "error-mean" in res
 
     # default metric in args with custom one
-    res = get_cv_result(metrics='binary_logloss', feval=constant_metric)
+    res = get_cv_result(metrics="binary_logloss", feval=constant_metric)
     assert len(res) == 4
-    assert 'binary_logloss-mean' in res
-    assert 'error-mean' in res
+    assert "binary_logloss-mean" in res
+    assert "error-mean" in res
 
     # non-default metric in args with custom one
-    res = get_cv_result(metrics='binary_error', feval=constant_metric)
+    res = get_cv_result(metrics="binary_error", feval=constant_metric)
     assert len(res) == 4
-    assert 'binary_error-mean' in res
-    assert 'error-mean' in res
+    assert "binary_error-mean" in res
+    assert "error-mean" in res
 
     # metric in args overwrites one in params, custom one is evaluated too
-    res = get_cv_result(params=params_obj_metric_inv_verbose, metrics='binary_error', feval=constant_metric)
+    res = get_cv_result(
+        params=params_obj_metric_inv_verbose,
+        metrics="binary_error",
+        feval=constant_metric,
+    )
     assert len(res) == 4
-    assert 'binary_error-mean' in res
-    assert 'error-mean' in res
+    assert "binary_error-mean" in res
+    assert "error-mean" in res
 
     # multiple metrics in params with custom one
     res = get_cv_result(params=params_obj_metric_multi_verbose, feval=constant_metric)
     assert len(res) == 6
-    assert 'binary_logloss-mean' in res
-    assert 'binary_error-mean' in res
-    assert 'error-mean' in res
+    assert "binary_logloss-mean" in res
+    assert "binary_error-mean" in res
+    assert "error-mean" in res
 
     # multiple metrics in args with custom one
-    res = get_cv_result(metrics=['binary_logloss', 'binary_error'], feval=constant_metric)
+    res = get_cv_result(
+        metrics=["binary_logloss", "binary_error"], feval=constant_metric
+    )
     assert len(res) == 6
-    assert 'binary_logloss-mean' in res
-    assert 'binary_error-mean' in res
-    assert 'error-mean' in res
+    assert "binary_logloss-mean" in res
+    assert "binary_error-mean" in res
+    assert "error-mean" in res
 
     # custom metric is evaluated despite 'None' is passed
-    res = get_cv_result(metrics=['None'], feval=constant_metric)
+    res = get_cv_result(metrics=["None"], feval=constant_metric)
     assert len(res) == 2
-    assert 'error-mean' in res
+    assert "error-mean" in res
 
     # fobj, feval
     # no default metric, only custom one
     res = get_cv_result(params=params_verbose, fobj=dummy_obj, feval=constant_metric)
     assert len(res) == 2
-    assert 'error-mean' in res
+    assert "error-mean" in res
 
     # metric in params with custom one
-    res = get_cv_result(params=params_metric_err_verbose, fobj=dummy_obj, feval=constant_metric)
+    res = get_cv_result(
+        params=params_metric_err_verbose, fobj=dummy_obj, feval=constant_metric
+    )
     assert len(res) == 4
-    assert 'binary_error-mean' in res
-    assert 'error-mean' in res
+    assert "binary_error-mean" in res
+    assert "error-mean" in res
 
     # metric in args with custom one
-    res = get_cv_result(params=params_verbose, fobj=dummy_obj,
-                        feval=constant_metric, metrics='binary_error')
+    res = get_cv_result(
+        params=params_verbose,
+        fobj=dummy_obj,
+        feval=constant_metric,
+        metrics="binary_error",
+    )
     assert len(res) == 4
-    assert 'binary_error-mean' in res
-    assert 'error-mean' in res
+    assert "binary_error-mean" in res
+    assert "error-mean" in res
 
     # metric in args overwrites one in params, custom one is evaluated too
-    res = get_cv_result(params=params_metric_inv_verbose, fobj=dummy_obj,
-                        feval=constant_metric, metrics='binary_error')
+    res = get_cv_result(
+        params=params_metric_inv_verbose,
+        fobj=dummy_obj,
+        feval=constant_metric,
+        metrics="binary_error",
+    )
     assert len(res) == 4
-    assert 'binary_error-mean' in res
-    assert 'error-mean' in res
+    assert "binary_error-mean" in res
+    assert "error-mean" in res
 
     # multiple metrics in params with custom one
-    res = get_cv_result(params=params_metric_multi_verbose, fobj=dummy_obj, feval=constant_metric)
+    res = get_cv_result(
+        params=params_metric_multi_verbose, fobj=dummy_obj, feval=constant_metric
+    )
     assert len(res) == 6
-    assert 'binary_logloss-mean' in res
-    assert 'binary_error-mean' in res
-    assert 'error-mean' in res
+    assert "binary_logloss-mean" in res
+    assert "binary_error-mean" in res
+    assert "error-mean" in res
 
     # multiple metrics in args with custom one
-    res = get_cv_result(params=params_verbose, fobj=dummy_obj, feval=constant_metric,
-                        metrics=['binary_logloss', 'binary_error'])
+    res = get_cv_result(
+        params=params_verbose,
+        fobj=dummy_obj,
+        feval=constant_metric,
+        metrics=["binary_logloss", "binary_error"],
+    )
     assert len(res) == 6
-    assert 'binary_logloss-mean' in res
-    assert 'binary_error-mean' in res
-    assert 'error-mean' in res
+    assert "binary_logloss-mean" in res
+    assert "binary_error-mean" in res
+    assert "error-mean" in res
 
     # custom metric is evaluated despite 'None' is passed
-    res = get_cv_result(params=params_metric_none_verbose, fobj=dummy_obj, feval=constant_metric)
+    res = get_cv_result(
+        params=params_metric_none_verbose, fobj=dummy_obj, feval=constant_metric
+    )
     assert len(res) == 2
-    assert 'error-mean' in res
+    assert "error-mean" in res
 
     # no fobj, no feval
     # default metric
     train_booster()
-    assert len(evals_result['valid_0']) == 1
-    assert 'binary_logloss' in evals_result['valid_0']
+    assert len(evals_result["valid_0"]) == 1
+    assert "binary_logloss" in evals_result["valid_0"]
 
     # default metric in params
     train_booster(params=params_obj_metric_log_verbose)
-    assert len(evals_result['valid_0']) == 1
-    assert 'binary_logloss' in evals_result['valid_0']
+    assert len(evals_result["valid_0"]) == 1
+    assert "binary_logloss" in evals_result["valid_0"]
 
     # non-default metric in params
     train_booster(params=params_obj_metric_err_verbose)
-    assert len(evals_result['valid_0']) == 1
-    assert 'binary_error' in evals_result['valid_0']
+    assert len(evals_result["valid_0"]) == 1
+    assert "binary_error" in evals_result["valid_0"]
 
     # multiple metrics in params
     train_booster(params=params_obj_metric_multi_verbose)
-    assert len(evals_result['valid_0']) == 2
-    assert 'binary_logloss' in evals_result['valid_0']
-    assert 'binary_error' in evals_result['valid_0']
+    assert len(evals_result["valid_0"]) == 2
+    assert "binary_logloss" in evals_result["valid_0"]
+    assert "binary_error" in evals_result["valid_0"]
 
     # remove default metric by 'None' aliases
-    for na_alias in ('None', 'na', 'null', 'custom'):
-        params = {'objective': 'binary', 'metric': na_alias, 'verbose': -1}
+    for na_alias in ("None", "na", "null", "custom"):
+        params = {"objective": "binary", "metric": na_alias, "verbose": -1}
         train_booster(params=params)
         assert len(evals_result) == 0
 
@@ -1773,147 +2205,180 @@ def test_metrics():
 
     # metric in params
     train_booster(params=params_metric_log_verbose, fobj=dummy_obj)
-    assert len(evals_result['valid_0']) == 1
-    assert 'binary_logloss' in evals_result['valid_0']
+    assert len(evals_result["valid_0"]) == 1
+    assert "binary_logloss" in evals_result["valid_0"]
 
     # multiple metrics in params
     train_booster(params=params_metric_multi_verbose, fobj=dummy_obj)
-    assert len(evals_result['valid_0']) == 2
-    assert 'binary_logloss' in evals_result['valid_0']
-    assert 'binary_error' in evals_result['valid_0']
+    assert len(evals_result["valid_0"]) == 2
+    assert "binary_logloss" in evals_result["valid_0"]
+    assert "binary_error" in evals_result["valid_0"]
 
     # no fobj, feval
     # default metric with custom one
     train_booster(feval=constant_metric)
-    assert len(evals_result['valid_0']) == 2
-    assert 'binary_logloss' in evals_result['valid_0']
-    assert 'error' in evals_result['valid_0']
+    assert len(evals_result["valid_0"]) == 2
+    assert "binary_logloss" in evals_result["valid_0"]
+    assert "error" in evals_result["valid_0"]
 
     # default metric in params with custom one
     train_booster(params=params_obj_metric_log_verbose, feval=constant_metric)
-    assert len(evals_result['valid_0']) == 2
-    assert 'binary_logloss' in evals_result['valid_0']
-    assert 'error' in evals_result['valid_0']
+    assert len(evals_result["valid_0"]) == 2
+    assert "binary_logloss" in evals_result["valid_0"]
+    assert "error" in evals_result["valid_0"]
 
     # non-default metric in params with custom one
     train_booster(params=params_obj_metric_err_verbose, feval=constant_metric)
-    assert len(evals_result['valid_0']) == 2
-    assert 'binary_error' in evals_result['valid_0']
-    assert 'error' in evals_result['valid_0']
+    assert len(evals_result["valid_0"]) == 2
+    assert "binary_error" in evals_result["valid_0"]
+    assert "error" in evals_result["valid_0"]
 
     # multiple metrics in params with custom one
     train_booster(params=params_obj_metric_multi_verbose, feval=constant_metric)
-    assert len(evals_result['valid_0']) == 3
-    assert 'binary_logloss' in evals_result['valid_0']
-    assert 'binary_error' in evals_result['valid_0']
-    assert 'error' in evals_result['valid_0']
+    assert len(evals_result["valid_0"]) == 3
+    assert "binary_logloss" in evals_result["valid_0"]
+    assert "binary_error" in evals_result["valid_0"]
+    assert "error" in evals_result["valid_0"]
 
     # custom metric is evaluated despite 'None' is passed
     train_booster(params=params_obj_metric_none_verbose, feval=constant_metric)
     assert len(evals_result) == 1
-    assert 'error' in evals_result['valid_0']
+    assert "error" in evals_result["valid_0"]
 
     # fobj, feval
     # no default metric, only custom one
     train_booster(params=params_verbose, fobj=dummy_obj, feval=constant_metric)
-    assert len(evals_result['valid_0']) == 1
-    assert 'error' in evals_result['valid_0']
+    assert len(evals_result["valid_0"]) == 1
+    assert "error" in evals_result["valid_0"]
 
     # metric in params with custom one
-    train_booster(params=params_metric_log_verbose, fobj=dummy_obj, feval=constant_metric)
-    assert len(evals_result['valid_0']) == 2
-    assert 'binary_logloss' in evals_result['valid_0']
-    assert 'error' in evals_result['valid_0']
+    train_booster(
+        params=params_metric_log_verbose, fobj=dummy_obj, feval=constant_metric
+    )
+    assert len(evals_result["valid_0"]) == 2
+    assert "binary_logloss" in evals_result["valid_0"]
+    assert "error" in evals_result["valid_0"]
 
     # multiple metrics in params with custom one
-    train_booster(params=params_metric_multi_verbose, fobj=dummy_obj, feval=constant_metric)
-    assert len(evals_result['valid_0']) == 3
-    assert 'binary_logloss' in evals_result['valid_0']
-    assert 'binary_error' in evals_result['valid_0']
-    assert 'error' in evals_result['valid_0']
+    train_booster(
+        params=params_metric_multi_verbose, fobj=dummy_obj, feval=constant_metric
+    )
+    assert len(evals_result["valid_0"]) == 3
+    assert "binary_logloss" in evals_result["valid_0"]
+    assert "binary_error" in evals_result["valid_0"]
+    assert "error" in evals_result["valid_0"]
 
     # custom metric is evaluated despite 'None' is passed
-    train_booster(params=params_metric_none_verbose, fobj=dummy_obj, feval=constant_metric)
+    train_booster(
+        params=params_metric_none_verbose, fobj=dummy_obj, feval=constant_metric
+    )
     assert len(evals_result) == 1
-    assert 'error' in evals_result['valid_0']
+    assert "error" in evals_result["valid_0"]
 
     X, y = load_digits(n_class=3, return_X_y=True)
     lgb_train = lgb.Dataset(X, y, silent=True)
 
-    obj_multi_aliases = ['multiclass', 'softmax', 'multiclassova', 'multiclass_ova', 'ova', 'ovr']
+    obj_multi_aliases = [
+        "multiclass",
+        "softmax",
+        "multiclassova",
+        "multiclass_ova",
+        "ova",
+        "ovr",
+    ]
     for obj_multi_alias in obj_multi_aliases:
-        params_obj_class_3_verbose = {'objective': obj_multi_alias, 'num_class': 3, 'verbose': -1}
-        params_obj_class_1_verbose = {'objective': obj_multi_alias, 'num_class': 1, 'verbose': -1}
-        params_obj_verbose = {'objective': obj_multi_alias, 'verbose': -1}
+        params_obj_class_3_verbose = {
+            "objective": obj_multi_alias,
+            "num_class": 3,
+            "verbose": -1,
+        }
+        params_obj_class_1_verbose = {
+            "objective": obj_multi_alias,
+            "num_class": 1,
+            "verbose": -1,
+        }
+        params_obj_verbose = {"objective": obj_multi_alias, "verbose": -1}
         # multiclass default metric
         res = get_cv_result(params_obj_class_3_verbose)
         assert len(res) == 2
-        assert 'multi_logloss-mean' in res
+        assert "multi_logloss-mean" in res
         # multiclass default metric with custom one
         res = get_cv_result(params_obj_class_3_verbose, feval=constant_metric)
         assert len(res) == 4
-        assert 'multi_logloss-mean' in res
-        assert 'error-mean' in res
+        assert "multi_logloss-mean" in res
+        assert "error-mean" in res
         # multiclass metric alias with custom one for custom objective
-        res = get_cv_result(params_obj_class_3_verbose, fobj=dummy_obj, feval=constant_metric)
+        res = get_cv_result(
+            params_obj_class_3_verbose, fobj=dummy_obj, feval=constant_metric
+        )
         assert len(res) == 2
-        assert 'error-mean' in res
+        assert "error-mean" in res
         # no metric for invalid class_num
         res = get_cv_result(params_obj_class_1_verbose, fobj=dummy_obj)
         assert len(res) == 0
         # custom metric for invalid class_num
-        res = get_cv_result(params_obj_class_1_verbose, fobj=dummy_obj, feval=constant_metric)
+        res = get_cv_result(
+            params_obj_class_1_verbose, fobj=dummy_obj, feval=constant_metric
+        )
         assert len(res) == 2
-        assert 'error-mean' in res
+        assert "error-mean" in res
         # multiclass metric alias with custom one with invalid class_num
         with pytest.raises(lgb.basic.LightGBMError):
-            get_cv_result(params_obj_class_1_verbose, metrics=obj_multi_alias,
-                          fobj=dummy_obj, feval=constant_metric)
+            get_cv_result(
+                params_obj_class_1_verbose,
+                metrics=obj_multi_alias,
+                fobj=dummy_obj,
+                feval=constant_metric,
+            )
         # multiclass default metric without num_class
         with pytest.raises(lgb.basic.LightGBMError):
             get_cv_result(params_obj_verbose)
-        for metric_multi_alias in obj_multi_aliases + ['multi_logloss']:
+        for metric_multi_alias in obj_multi_aliases + ["multi_logloss"]:
             # multiclass metric alias
             res = get_cv_result(params_obj_class_3_verbose, metrics=metric_multi_alias)
             assert len(res) == 2
-            assert 'multi_logloss-mean' in res
+            assert "multi_logloss-mean" in res
         # multiclass metric
-        res = get_cv_result(params_obj_class_3_verbose, metrics='multi_error')
+        res = get_cv_result(params_obj_class_3_verbose, metrics="multi_error")
         assert len(res) == 2
-        assert 'multi_error-mean' in res
+        assert "multi_error-mean" in res
         # non-valid metric for multiclass objective
         with pytest.raises(lgb.basic.LightGBMError):
-            get_cv_result(params_obj_class_3_verbose, metrics='binary_logloss')
-    params_class_3_verbose = {'num_class': 3, 'verbose': -1}
+            get_cv_result(params_obj_class_3_verbose, metrics="binary_logloss")
+    params_class_3_verbose = {"num_class": 3, "verbose": -1}
     # non-default num_class for default objective
     with pytest.raises(lgb.basic.LightGBMError):
         get_cv_result(params_class_3_verbose)
     # no metric with non-default num_class for custom objective
     res = get_cv_result(params_class_3_verbose, fobj=dummy_obj)
     assert len(res) == 0
-    for metric_multi_alias in obj_multi_aliases + ['multi_logloss']:
+    for metric_multi_alias in obj_multi_aliases + ["multi_logloss"]:
         # multiclass metric alias for custom objective
-        res = get_cv_result(params_class_3_verbose, metrics=metric_multi_alias, fobj=dummy_obj)
+        res = get_cv_result(
+            params_class_3_verbose, metrics=metric_multi_alias, fobj=dummy_obj
+        )
         assert len(res) == 2
-        assert 'multi_logloss-mean' in res
+        assert "multi_logloss-mean" in res
     # multiclass metric for custom objective
-    res = get_cv_result(params_class_3_verbose, metrics='multi_error', fobj=dummy_obj)
+    res = get_cv_result(params_class_3_verbose, metrics="multi_error", fobj=dummy_obj)
     assert len(res) == 2
-    assert 'multi_error-mean' in res
+    assert "multi_error-mean" in res
     # binary metric with non-default num_class for custom objective
     with pytest.raises(lgb.basic.LightGBMError):
-        get_cv_result(params_class_3_verbose, metrics='binary_error', fobj=dummy_obj)
+        get_cv_result(params_class_3_verbose, metrics="binary_error", fobj=dummy_obj)
 
 
 def test_multiple_feval_train():
     X, y = load_breast_cancer(return_X_y=True)
 
-    params = {'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
+    params = {"verbose": -1, "objective": "binary", "metric": "binary_logloss"}
 
     X_train, X_validation, y_train, y_validation = train_test_split(X, y, test_size=0.2)
 
     train_dataset = lgb.Dataset(data=X_train, label=y_train, silent=True)
-    validation_dataset = lgb.Dataset(data=X_validation, label=y_validation, reference=train_dataset, silent=True)
+    validation_dataset = lgb.Dataset(
+        data=X_validation, label=y_validation, reference=train_dataset, silent=True
+    )
     evals_result = {}
     lgb.train(
         params=params,
@@ -1921,18 +2386,19 @@ def test_multiple_feval_train():
         valid_sets=validation_dataset,
         num_boost_round=5,
         feval=[constant_metric, decreasing_metric],
-        evals_result=evals_result)
+        evals_result=evals_result,
+    )
 
-    assert len(evals_result['valid_0']) == 3
-    assert 'binary_logloss' in evals_result['valid_0']
-    assert 'error' in evals_result['valid_0']
-    assert 'decreasing_metric' in evals_result['valid_0']
+    assert len(evals_result["valid_0"]) == 3
+    assert "binary_logloss" in evals_result["valid_0"]
+    assert "error" in evals_result["valid_0"]
+    assert "decreasing_metric" in evals_result["valid_0"]
 
 
 def test_multiple_feval_cv():
     X, y = load_breast_cancer(return_X_y=True)
 
-    params = {'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
+    params = {"verbose": -1, "objective": "binary", "metric": "binary_logloss"}
 
     train_dataset = lgb.Dataset(data=X, label=y, silent=True)
 
@@ -1940,52 +2406,57 @@ def test_multiple_feval_cv():
         params=params,
         train_set=train_dataset,
         num_boost_round=5,
-        feval=[constant_metric, decreasing_metric])
+        feval=[constant_metric, decreasing_metric],
+    )
 
     # Expect three metrics but mean and stdv for each metric
     assert len(cv_results) == 6
-    assert 'binary_logloss-mean' in cv_results
-    assert 'error-mean' in cv_results
-    assert 'decreasing_metric-mean' in cv_results
-    assert 'binary_logloss-stdv' in cv_results
-    assert 'error-stdv' in cv_results
-    assert 'decreasing_metric-stdv' in cv_results
+    assert "binary_logloss-mean" in cv_results
+    assert "error-mean" in cv_results
+    assert "decreasing_metric-mean" in cv_results
+    assert "binary_logloss-stdv" in cv_results
+    assert "error-stdv" in cv_results
+    assert "decreasing_metric-stdv" in cv_results
 
 
-@pytest.mark.skipif(psutil.virtual_memory().available / 1024 / 1024 / 1024 < 3, reason='not enough RAM')
+@pytest.mark.skipif(
+    psutil.virtual_memory().available / 1024 / 1024 / 1024 < 3, reason="not enough RAM"
+)
 def test_model_size():
     X, y = load_boston(return_X_y=True)
     data = lgb.Dataset(X, y)
-    bst = lgb.train({'verbose': -1}, data, num_boost_round=2)
+    bst = lgb.train({"verbose": -1}, data, num_boost_round=2)
     y_pred = bst.predict(X)
     model_str = bst.model_to_string()
-    one_tree = model_str[model_str.find('Tree=1'):model_str.find('end of trees')]
+    one_tree = model_str[model_str.find("Tree=1") : model_str.find("end of trees")]
     one_tree_size = len(one_tree)
-    one_tree = one_tree.replace('Tree=1', 'Tree={}')
+    one_tree = one_tree.replace("Tree=1", "Tree={}")
     multiplier = 100
     total_trees = multiplier + 2
     try:
-        new_model_str = (model_str[:model_str.find('tree_sizes')]
-                         + '\n\n'
-                         + model_str[model_str.find('Tree=0'):model_str.find('end of trees')]
-                         + (one_tree * multiplier).format(*range(2, total_trees))
-                         + model_str[model_str.find('end of trees'):]
-                         + ' ' * (2**31 - one_tree_size * total_trees))
-        assert len(new_model_str) > 2**31
+        new_model_str = (
+            model_str[: model_str.find("tree_sizes")]
+            + "\n\n"
+            + model_str[model_str.find("Tree=0") : model_str.find("end of trees")]
+            + (one_tree * multiplier).format(*range(2, total_trees))
+            + model_str[model_str.find("end of trees") :]
+            + " " * (2 ** 31 - one_tree_size * total_trees)
+        )
+        assert len(new_model_str) > 2 ** 31
         bst.model_from_string(new_model_str, verbose=False)
         assert bst.num_trees() == total_trees
         y_pred_new = bst.predict(X, num_iteration=2)
         np.testing.assert_allclose(y_pred, y_pred_new)
     except MemoryError:
-        pytest.skipTest('not enough RAM')
+        pytest.skipTest("not enough RAM")
 
 
 def test_get_split_value_histogram():
     X, y = load_boston(return_X_y=True)
     lgb_train = lgb.Dataset(X, y, categorical_feature=[2])
-    gbm = lgb.train({'verbose': -1}, lgb_train, num_boost_round=20)
+    gbm = lgb.train({"verbose": -1}, lgb_train, num_boost_round=20)
     # test XGBoost-style return value
-    params = {'feature': 0, 'xgboost_style': True}
+    params = {"feature": 0, "xgboost_style": True}
     assert gbm.get_split_value_histogram(**params).shape == (9, 2)
     assert gbm.get_split_value_histogram(bins=999, **params).shape == (9, 2)
     assert gbm.get_split_value_histogram(bins=-1, **params).shape == (1, 2)
@@ -1997,20 +2468,26 @@ def test_get_split_value_histogram():
     if lgb.compat.PANDAS_INSTALLED:
         np.testing.assert_allclose(
             gbm.get_split_value_histogram(0, xgboost_style=True).values,
-            gbm.get_split_value_histogram(gbm.feature_name()[0], xgboost_style=True).values
+            gbm.get_split_value_histogram(
+                gbm.feature_name()[0], xgboost_style=True
+            ).values,
         )
         np.testing.assert_allclose(
             gbm.get_split_value_histogram(X.shape[-1] - 1, xgboost_style=True).values,
-            gbm.get_split_value_histogram(gbm.feature_name()[X.shape[-1] - 1], xgboost_style=True).values
+            gbm.get_split_value_histogram(
+                gbm.feature_name()[X.shape[-1] - 1], xgboost_style=True
+            ).values,
         )
     else:
         np.testing.assert_allclose(
             gbm.get_split_value_histogram(0, xgboost_style=True),
-            gbm.get_split_value_histogram(gbm.feature_name()[0], xgboost_style=True)
+            gbm.get_split_value_histogram(gbm.feature_name()[0], xgboost_style=True),
         )
         np.testing.assert_allclose(
             gbm.get_split_value_histogram(X.shape[-1] - 1, xgboost_style=True),
-            gbm.get_split_value_histogram(gbm.feature_name()[X.shape[-1] - 1], xgboost_style=True)
+            gbm.get_split_value_histogram(
+                gbm.feature_name()[X.shape[-1] - 1], xgboost_style=True
+            ),
         )
     # test numpy-style return value
     hist, bins = gbm.get_split_value_histogram(0)
@@ -2040,17 +2517,19 @@ def test_get_split_value_histogram():
     np.testing.assert_array_equal(hist_idx, hist_name)
     np.testing.assert_allclose(bins_idx, bins_name)
     hist_idx, bins_idx = gbm.get_split_value_histogram(X.shape[-1] - 1)
-    hist_name, bins_name = gbm.get_split_value_histogram(gbm.feature_name()[X.shape[-1] - 1])
+    hist_name, bins_name = gbm.get_split_value_histogram(
+        gbm.feature_name()[X.shape[-1] - 1]
+    )
     np.testing.assert_array_equal(hist_idx, hist_name)
     np.testing.assert_allclose(bins_idx, bins_name)
     # test bins string type
-    if np.__version__ > '1.11.0':
-        hist_vals, bin_edges = gbm.get_split_value_histogram(0, bins='auto')
-        hist = gbm.get_split_value_histogram(0, bins='auto', xgboost_style=True)
+    if np.__version__ > "1.11.0":
+        hist_vals, bin_edges = gbm.get_split_value_histogram(0, bins="auto")
+        hist = gbm.get_split_value_histogram(0, bins="auto", xgboost_style=True)
         if lgb.compat.PANDAS_INSTALLED:
             mask = hist_vals > 0
-            np.testing.assert_array_equal(hist_vals[mask], hist['Count'].values)
-            np.testing.assert_allclose(bin_edges[1:][mask], hist['SplitValue'].values)
+            np.testing.assert_array_equal(hist_vals[mask], hist["Count"].values)
+            np.testing.assert_allclose(bin_edges[1:][mask], hist["SplitValue"].values)
         else:
             mask = hist_vals > 0
             np.testing.assert_array_equal(hist_vals[mask], hist[:, 1])
@@ -2061,43 +2540,59 @@ def test_get_split_value_histogram():
 
 
 def test_early_stopping_for_only_first_metric():
-
-    def metrics_combination_train_regression(valid_sets, metric_list, assumed_iteration,
-                                             first_metric_only, feval=None):
+    def metrics_combination_train_regression(
+        valid_sets, metric_list, assumed_iteration, first_metric_only, feval=None
+    ):
         params = {
-            'objective': 'regression',
-            'learning_rate': 1.1,
-            'num_leaves': 10,
-            'metric': metric_list,
-            'verbose': -1,
-            'seed': 123
+            "objective": "regression",
+            "learning_rate": 1.1,
+            "num_leaves": 10,
+            "metric": metric_list,
+            "verbose": -1,
+            "seed": 123,
         }
-        gbm = lgb.train(dict(params, first_metric_only=first_metric_only), lgb_train,
-                        num_boost_round=25, valid_sets=valid_sets, feval=feval,
-                        early_stopping_rounds=5, verbose_eval=False)
+        gbm = lgb.train(
+            dict(params, first_metric_only=first_metric_only),
+            lgb_train,
+            num_boost_round=25,
+            valid_sets=valid_sets,
+            feval=feval,
+            early_stopping_rounds=5,
+            verbose_eval=False,
+        )
         assert assumed_iteration == gbm.best_iteration
 
-    def metrics_combination_cv_regression(metric_list, assumed_iteration,
-                                          first_metric_only, eval_train_metric, feval=None):
+    def metrics_combination_cv_regression(
+        metric_list, assumed_iteration, first_metric_only, eval_train_metric, feval=None
+    ):
         params = {
-            'objective': 'regression',
-            'learning_rate': 0.9,
-            'num_leaves': 10,
-            'metric': metric_list,
-            'verbose': -1,
-            'seed': 123,
-            'gpu_use_dp': True
+            "objective": "regression",
+            "learning_rate": 0.9,
+            "num_leaves": 10,
+            "metric": metric_list,
+            "verbose": -1,
+            "seed": 123,
+            "gpu_use_dp": True,
         }
-        ret = lgb.cv(dict(params, first_metric_only=first_metric_only),
-                     train_set=lgb_train, num_boost_round=25,
-                     stratified=False, feval=feval,
-                     early_stopping_rounds=5, verbose_eval=False,
-                     eval_train_metric=eval_train_metric)
+        ret = lgb.cv(
+            dict(params, first_metric_only=first_metric_only),
+            train_set=lgb_train,
+            num_boost_round=25,
+            stratified=False,
+            feval=feval,
+            early_stopping_rounds=5,
+            verbose_eval=False,
+            eval_train_metric=eval_train_metric,
+        )
         assert assumed_iteration == len(ret[list(ret.keys())[0]])
 
     X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
-    X_test1, X_test2, y_test1, y_test2 = train_test_split(X_test, y_test, test_size=0.5, random_state=73)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+    X_test1, X_test2, y_test1, y_test2 = train_test_split(
+        X_test, y_test, test_size=0.5, random_state=73
+    )
     lgb_train = lgb.Dataset(X_train, y_train)
     lgb_valid1 = lgb.Dataset(X_test1, y_test1, reference=lgb_train)
     lgb_valid2 = lgb.Dataset(X_test2, y_test2, reference=lgb_train)
@@ -2106,7 +2601,9 @@ def test_early_stopping_for_only_first_metric():
     iter_valid1_l2 = 14
     iter_valid2_l1 = 2
     iter_valid2_l2 = 15
-    assert len(set([iter_valid1_l1, iter_valid1_l2, iter_valid2_l1, iter_valid2_l2])) == 4
+    assert (
+        len(set([iter_valid1_l1, iter_valid1_l2, iter_valid2_l1, iter_valid2_l2])) == 4
+    )
     iter_min_l1 = min([iter_valid1_l1, iter_valid2_l1])
     iter_min_l2 = min([iter_valid1_l2, iter_valid2_l2])
     iter_min_valid1 = min([iter_valid1_l1, iter_valid1_l2])
@@ -2121,80 +2618,139 @@ def test_early_stopping_for_only_first_metric():
     metrics_combination_train_regression(lgb_valid1, [], iter_valid1_l2, True)
     metrics_combination_train_regression(lgb_valid1, None, iter_valid1_l2, False)
     metrics_combination_train_regression(lgb_valid1, None, iter_valid1_l2, True)
-    metrics_combination_train_regression(lgb_valid1, 'l2', iter_valid1_l2, True)
-    metrics_combination_train_regression(lgb_valid1, 'l1', iter_valid1_l1, True)
-    metrics_combination_train_regression(lgb_valid1, ['l2', 'l1'], iter_valid1_l2, True)
-    metrics_combination_train_regression(lgb_valid1, ['l1', 'l2'], iter_valid1_l1, True)
-    metrics_combination_train_regression(lgb_valid1, ['l2', 'l1'], iter_min_valid1, False)
-    metrics_combination_train_regression(lgb_valid1, ['l1', 'l2'], iter_min_valid1, False)
+    metrics_combination_train_regression(lgb_valid1, "l2", iter_valid1_l2, True)
+    metrics_combination_train_regression(lgb_valid1, "l1", iter_valid1_l1, True)
+    metrics_combination_train_regression(lgb_valid1, ["l2", "l1"], iter_valid1_l2, True)
+    metrics_combination_train_regression(lgb_valid1, ["l1", "l2"], iter_valid1_l1, True)
+    metrics_combination_train_regression(
+        lgb_valid1, ["l2", "l1"], iter_min_valid1, False
+    )
+    metrics_combination_train_regression(
+        lgb_valid1, ["l1", "l2"], iter_min_valid1, False
+    )
 
     # test feval for lgb.train
-    metrics_combination_train_regression(lgb_valid1, 'None', 1, False,
-                                         feval=lambda preds, train_data: [decreasing_metric(preds, train_data),
-                                                                          constant_metric(preds, train_data)])
-    metrics_combination_train_regression(lgb_valid1, 'None', 25, True,
-                                         feval=lambda preds, train_data: [decreasing_metric(preds, train_data),
-                                                                          constant_metric(preds, train_data)])
-    metrics_combination_train_regression(lgb_valid1, 'None', 1, True,
-                                         feval=lambda preds, train_data: [constant_metric(preds, train_data),
-                                                                          decreasing_metric(preds, train_data)])
+    metrics_combination_train_regression(
+        lgb_valid1,
+        "None",
+        1,
+        False,
+        feval=lambda preds, train_data: [
+            decreasing_metric(preds, train_data),
+            constant_metric(preds, train_data),
+        ],
+    )
+    metrics_combination_train_regression(
+        lgb_valid1,
+        "None",
+        25,
+        True,
+        feval=lambda preds, train_data: [
+            decreasing_metric(preds, train_data),
+            constant_metric(preds, train_data),
+        ],
+    )
+    metrics_combination_train_regression(
+        lgb_valid1,
+        "None",
+        1,
+        True,
+        feval=lambda preds, train_data: [
+            constant_metric(preds, train_data),
+            decreasing_metric(preds, train_data),
+        ],
+    )
 
     # test with two valid data for lgb.train
-    metrics_combination_train_regression([lgb_valid1, lgb_valid2], ['l2', 'l1'], iter_min_l2, True)
-    metrics_combination_train_regression([lgb_valid2, lgb_valid1], ['l2', 'l1'], iter_min_l2, True)
-    metrics_combination_train_regression([lgb_valid1, lgb_valid2], ['l1', 'l2'], iter_min_l1, True)
-    metrics_combination_train_regression([lgb_valid2, lgb_valid1], ['l1', 'l2'], iter_min_l1, True)
+    metrics_combination_train_regression(
+        [lgb_valid1, lgb_valid2], ["l2", "l1"], iter_min_l2, True
+    )
+    metrics_combination_train_regression(
+        [lgb_valid2, lgb_valid1], ["l2", "l1"], iter_min_l2, True
+    )
+    metrics_combination_train_regression(
+        [lgb_valid1, lgb_valid2], ["l1", "l2"], iter_min_l1, True
+    )
+    metrics_combination_train_regression(
+        [lgb_valid2, lgb_valid1], ["l1", "l2"], iter_min_l1, True
+    )
 
     # test for lgb.cv
     metrics_combination_cv_regression(None, iter_cv_l2, True, False)
-    metrics_combination_cv_regression('l2', iter_cv_l2, True, False)
-    metrics_combination_cv_regression('l1', iter_cv_l1, True, False)
-    metrics_combination_cv_regression(['l2', 'l1'], iter_cv_l2, True, False)
-    metrics_combination_cv_regression(['l1', 'l2'], iter_cv_l1, True, False)
-    metrics_combination_cv_regression(['l2', 'l1'], iter_cv_min, False, False)
-    metrics_combination_cv_regression(['l1', 'l2'], iter_cv_min, False, False)
+    metrics_combination_cv_regression("l2", iter_cv_l2, True, False)
+    metrics_combination_cv_regression("l1", iter_cv_l1, True, False)
+    metrics_combination_cv_regression(["l2", "l1"], iter_cv_l2, True, False)
+    metrics_combination_cv_regression(["l1", "l2"], iter_cv_l1, True, False)
+    metrics_combination_cv_regression(["l2", "l1"], iter_cv_min, False, False)
+    metrics_combination_cv_regression(["l1", "l2"], iter_cv_min, False, False)
     metrics_combination_cv_regression(None, iter_cv_l2, True, True)
-    metrics_combination_cv_regression('l2', iter_cv_l2, True, True)
-    metrics_combination_cv_regression('l1', iter_cv_l1, True, True)
-    metrics_combination_cv_regression(['l2', 'l1'], iter_cv_l2, True, True)
-    metrics_combination_cv_regression(['l1', 'l2'], iter_cv_l1, True, True)
-    metrics_combination_cv_regression(['l2', 'l1'], iter_cv_min, False, True)
-    metrics_combination_cv_regression(['l1', 'l2'], iter_cv_min, False, True)
+    metrics_combination_cv_regression("l2", iter_cv_l2, True, True)
+    metrics_combination_cv_regression("l1", iter_cv_l1, True, True)
+    metrics_combination_cv_regression(["l2", "l1"], iter_cv_l2, True, True)
+    metrics_combination_cv_regression(["l1", "l2"], iter_cv_l1, True, True)
+    metrics_combination_cv_regression(["l2", "l1"], iter_cv_min, False, True)
+    metrics_combination_cv_regression(["l1", "l2"], iter_cv_min, False, True)
 
     # test feval for lgb.cv
-    metrics_combination_cv_regression('None', 1, False, False,
-                                      feval=lambda preds, train_data: [decreasing_metric(preds, train_data),
-                                                                       constant_metric(preds, train_data)])
-    metrics_combination_cv_regression('None', 25, True, False,
-                                      feval=lambda preds, train_data: [decreasing_metric(preds, train_data),
-                                                                       constant_metric(preds, train_data)])
-    metrics_combination_cv_regression('None', 1, True, False,
-                                      feval=lambda preds, train_data: [constant_metric(preds, train_data),
-                                                                       decreasing_metric(preds, train_data)])
+    metrics_combination_cv_regression(
+        "None",
+        1,
+        False,
+        False,
+        feval=lambda preds, train_data: [
+            decreasing_metric(preds, train_data),
+            constant_metric(preds, train_data),
+        ],
+    )
+    metrics_combination_cv_regression(
+        "None",
+        25,
+        True,
+        False,
+        feval=lambda preds, train_data: [
+            decreasing_metric(preds, train_data),
+            constant_metric(preds, train_data),
+        ],
+    )
+    metrics_combination_cv_regression(
+        "None",
+        1,
+        True,
+        False,
+        feval=lambda preds, train_data: [
+            constant_metric(preds, train_data),
+            decreasing_metric(preds, train_data),
+        ],
+    )
 
 
 def test_node_level_subcol():
     X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     params = {
-        'objective': 'binary',
-        'metric': 'binary_logloss',
-        'feature_fraction_bynode': 0.8,
-        'feature_fraction': 1.0,
-        'verbose': -1
+        "objective": "binary",
+        "metric": "binary_logloss",
+        "feature_fraction_bynode": 0.8,
+        "feature_fraction": 1.0,
+        "verbose": -1,
     }
     lgb_train = lgb.Dataset(X_train, y_train)
     lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train)
     evals_result = {}
-    gbm = lgb.train(params, lgb_train,
-                    num_boost_round=25,
-                    valid_sets=lgb_eval,
-                    verbose_eval=False,
-                    evals_result=evals_result)
+    gbm = lgb.train(
+        params,
+        lgb_train,
+        num_boost_round=25,
+        valid_sets=lgb_eval,
+        verbose_eval=False,
+        evals_result=evals_result,
+    )
     ret = log_loss(y_test, gbm.predict(X_test))
     assert ret < 0.14
-    assert evals_result['valid_0']['binary_logloss'][-1] == pytest.approx(ret)
-    params['feature_fraction'] = 0.5
+    assert evals_result["valid_0"]["binary_logloss"][-1] == pytest.approx(ret)
+    params["feature_fraction"] = 0.5
     gbm2 = lgb.train(params, lgb_train, num_boost_round=25)
     ret2 = log_loss(y_test, gbm2.predict(X_test))
     assert ret != ret2
@@ -2205,14 +2761,18 @@ def test_forced_bins():
     x[:, 0] = np.arange(0, 1, 0.01)
     x[:, 1] = -np.arange(0, 1, 0.01)
     y = np.arange(0, 1, 0.01)
-    forcedbins_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                       '../../examples/regression/forced_bins.json')
-    params = {'objective': 'regression_l1',
-              'max_bin': 5,
-              'forcedbins_filename': forcedbins_filename,
-              'num_leaves': 2,
-              'min_data_in_leaf': 1,
-              'verbose': -1}
+    forcedbins_filename = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "../../examples/regression/forced_bins.json",
+    )
+    params = {
+        "objective": "regression_l1",
+        "max_bin": 5,
+        "forcedbins_filename": forcedbins_filename,
+        "num_leaves": 2,
+        "min_data_in_leaf": 1,
+        "verbose": -1,
+    }
     lgb_x = lgb.Dataset(x, label=y)
     est = lgb.train(params, lgb_x, num_boost_round=20)
     new_x = np.zeros((3, x.shape[1]))
@@ -2224,14 +2784,16 @@ def test_forced_bins():
     new_x[:, 1] = [-0.9, -0.6, -0.3]
     predicted = est.predict(new_x)
     assert len(np.unique(predicted)) == 1
-    params['forcedbins_filename'] = ''
+    params["forcedbins_filename"] = ""
     lgb_x = lgb.Dataset(x, label=y)
     est = lgb.train(params, lgb_x, num_boost_round=20)
     predicted = est.predict(new_x)
     assert len(np.unique(predicted)) == 3
-    params['forcedbins_filename'] = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                                 '../../examples/regression/forced_bins2.json')
-    params['max_bin'] = 11
+    params["forcedbins_filename"] = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "../../examples/regression/forced_bins2.json",
+    )
+    params["max_bin"] = 11
     lgb_x = lgb.Dataset(x[:, :1], label=y)
     est = lgb.train(params, lgb_x, num_boost_round=50)
     predicted = est.predict(x[1:, :1])
@@ -2246,12 +2808,14 @@ def test_binning_same_sign():
     x[:, 0] = np.arange(0.01, 1, 0.01)
     x[:, 1] = -np.arange(0.01, 1, 0.01)
     y = np.arange(0.01, 1, 0.01)
-    params = {'objective': 'regression_l1',
-              'max_bin': 5,
-              'num_leaves': 2,
-              'min_data_in_leaf': 1,
-              'verbose': -1,
-              'seed': 0}
+    params = {
+        "objective": "regression_l1",
+        "max_bin": 5,
+        "num_leaves": 2,
+        "min_data_in_leaf": 1,
+        "verbose": -1,
+        "seed": 0,
+    }
     lgb_x = lgb.Dataset(x, label=y)
     est = lgb.train(params, lgb_x, num_boost_round=20)
     new_x = np.zeros((3, 2))
@@ -2267,48 +2831,52 @@ def test_binning_same_sign():
 
 
 def test_dataset_update_params():
-    default_params = {"max_bin": 100,
-                      "max_bin_by_feature": [20, 10],
-                      "bin_construct_sample_cnt": 10000,
-                      "min_data_in_bin": 1,
-                      "use_missing": False,
-                      "zero_as_missing": False,
-                      "categorical_feature": [0],
-                      "feature_pre_filter": True,
-                      "pre_partition": False,
-                      "enable_bundle": True,
-                      "data_random_seed": 0,
-                      "is_enable_sparse": True,
-                      "header": True,
-                      "two_round": True,
-                      "label_column": 0,
-                      "weight_column": 0,
-                      "group_column": 0,
-                      "ignore_column": 0,
-                      "min_data_in_leaf": 10,
-                      "linear_tree": False,
-                      "verbose": -1}
-    unchangeable_params = {"max_bin": 150,
-                           "max_bin_by_feature": [30, 5],
-                           "bin_construct_sample_cnt": 5000,
-                           "min_data_in_bin": 2,
-                           "use_missing": True,
-                           "zero_as_missing": True,
-                           "categorical_feature": [0, 1],
-                           "feature_pre_filter": False,
-                           "pre_partition": True,
-                           "enable_bundle": False,
-                           "data_random_seed": 1,
-                           "is_enable_sparse": False,
-                           "header": False,
-                           "two_round": False,
-                           "label_column": 1,
-                           "weight_column": 1,
-                           "group_column": 1,
-                           "ignore_column": 1,
-                           "forcedbins_filename": "/some/path/forcedbins.json",
-                           "min_data_in_leaf": 2,
-                           "linear_tree": True}
+    default_params = {
+        "max_bin": 100,
+        "max_bin_by_feature": [20, 10],
+        "bin_construct_sample_cnt": 10000,
+        "min_data_in_bin": 1,
+        "use_missing": False,
+        "zero_as_missing": False,
+        "categorical_feature": [0],
+        "feature_pre_filter": True,
+        "pre_partition": False,
+        "enable_bundle": True,
+        "data_random_seed": 0,
+        "is_enable_sparse": True,
+        "header": True,
+        "two_round": True,
+        "label_column": 0,
+        "weight_column": 0,
+        "group_column": 0,
+        "ignore_column": 0,
+        "min_data_in_leaf": 10,
+        "linear_tree": False,
+        "verbose": -1,
+    }
+    unchangeable_params = {
+        "max_bin": 150,
+        "max_bin_by_feature": [30, 5],
+        "bin_construct_sample_cnt": 5000,
+        "min_data_in_bin": 2,
+        "use_missing": True,
+        "zero_as_missing": True,
+        "categorical_feature": [0, 1],
+        "feature_pre_filter": False,
+        "pre_partition": True,
+        "enable_bundle": False,
+        "data_random_seed": 1,
+        "is_enable_sparse": False,
+        "header": False,
+        "two_round": False,
+        "label_column": 1,
+        "weight_column": 1,
+        "group_column": 1,
+        "ignore_column": 1,
+        "forcedbins_filename": "/some/path/forcedbins.json",
+        "min_data_in_leaf": 2,
+        "linear_tree": True,
+    }
     X = np.random.random((100, 2))
     y = np.random.random(100)
 
@@ -2339,10 +2907,13 @@ def test_dataset_update_params():
     for key, value in unchangeable_params.items():
         new_params = default_params.copy()
         new_params[key] = value
-        err_msg = ("Reducing `min_data_in_leaf` with `feature_pre_filter=true` may cause *"
-                   if key == "min_data_in_leaf"
-                   else "Cannot change {} *".format(key if key != "forcedbins_filename"
-                                                    else "forced bins"))
+        err_msg = (
+            "Reducing `min_data_in_leaf` with `feature_pre_filter=true` may cause *"
+            if key == "min_data_in_leaf"
+            else "Cannot change {} *".format(
+                key if key != "forcedbins_filename" else "forced bins"
+            )
+        )
         with np.testing.assert_raises_regex(lgb.basic.LightGBMError, err_msg):
             lgb.train(new_params, lgb_data, num_boost_round=3)
 
@@ -2353,8 +2924,12 @@ def test_dataset_params_with_reference():
     y = np.random.random(100)
     X_val = np.random.random((100, 2))
     y_val = np.random.random(100)
-    lgb_train = lgb.Dataset(X, y, params=default_params, free_raw_data=False).construct()
-    lgb_val = lgb.Dataset(X_val, y_val, reference=lgb_train, free_raw_data=False).construct()
+    lgb_train = lgb.Dataset(
+        X, y, params=default_params, free_raw_data=False
+    ).construct()
+    lgb_val = lgb.Dataset(
+        X_val, y_val, reference=lgb_train, free_raw_data=False
+    ).construct()
     assert lgb_train.get_params() == default_params
     assert lgb_val.get_params() == default_params
     lgb.train(default_params, lgb_train, valid_sets=[lgb_val])
@@ -2364,15 +2939,17 @@ def test_extra_trees():
     # check extra trees increases regularization
     X, y = load_boston(return_X_y=True)
     lgb_x = lgb.Dataset(X, label=y)
-    params = {'objective': 'regression',
-              'num_leaves': 32,
-              'verbose': -1,
-              'extra_trees': False,
-              'seed': 0}
+    params = {
+        "objective": "regression",
+        "num_leaves": 32,
+        "verbose": -1,
+        "extra_trees": False,
+        "seed": 0,
+    }
     est = lgb.train(params, lgb_x, num_boost_round=10)
     predicted = est.predict(X)
     err = mean_squared_error(y, predicted)
-    params['extra_trees'] = True
+    params["extra_trees"] = True
     est = lgb.train(params, lgb_x, num_boost_round=10)
     predicted_new = est.predict(X)
     err_new = mean_squared_error(y, predicted_new)
@@ -2383,14 +2960,11 @@ def test_path_smoothing():
     # check path smoothing increases regularization
     X, y = load_boston(return_X_y=True)
     lgb_x = lgb.Dataset(X, label=y)
-    params = {'objective': 'regression',
-              'num_leaves': 32,
-              'verbose': -1,
-              'seed': 0}
+    params = {"objective": "regression", "num_leaves": 32, "verbose": -1, "seed": 0}
     est = lgb.train(params, lgb_x, num_boost_round=10)
     predicted = est.predict(X)
     err = mean_squared_error(y, predicted)
-    params['path_smooth'] = 1
+    params["path_smooth"] = 1
     est = lgb.train(params, lgb_x, num_boost_round=10)
     predicted_new = est.predict(X)
     err_new = mean_squared_error(y, predicted_new)
@@ -2401,30 +2975,29 @@ def test_trees_to_dataframe():
     pytest.importorskip("pandas")
 
     def _imptcs_to_numpy(X, impcts_dict):
-        cols = ['Column_' + str(i) for i in range(X.shape[1])]
-        return [impcts_dict.get(col, 0.) for col in cols]
+        cols = ["Column_" + str(i) for i in range(X.shape[1])]
+        return [impcts_dict.get(col, 0.0) for col in cols]
 
     X, y = load_breast_cancer(return_X_y=True)
     data = lgb.Dataset(X, label=y)
     num_trees = 10
     bst = lgb.train({"objective": "binary", "verbose": -1}, data, num_trees)
     tree_df = bst.trees_to_dataframe()
-    split_dict = (tree_df[~tree_df['split_gain'].isnull()]
-                  .groupby('split_feature')
-                  .size()
-                  .to_dict())
+    split_dict = (
+        tree_df[~tree_df["split_gain"].isnull()]
+        .groupby("split_feature")
+        .size()
+        .to_dict()
+    )
 
-    gains_dict = (tree_df
-                  .groupby('split_feature')['split_gain']
-                  .sum()
-                  .to_dict())
+    gains_dict = tree_df.groupby("split_feature")["split_gain"].sum().to_dict()
 
     tree_split = _imptcs_to_numpy(X, split_dict)
     tree_gains = _imptcs_to_numpy(X, gains_dict)
-    mod_split = bst.feature_importance('split')
-    mod_gains = bst.feature_importance('gain')
-    num_trees_from_df = tree_df['tree_index'].nunique()
-    obs_counts_from_df = tree_df.loc[tree_df['node_depth'] == 1, 'count'].values
+    mod_split = bst.feature_importance("split")
+    mod_gains = bst.feature_importance("gain")
+    num_trees_from_df = tree_df["tree_index"].nunique()
+    obs_counts_from_df = tree_df.loc[tree_df["node_depth"] == 1, "count"].values
 
     np.testing.assert_equal(tree_split, mod_split)
     np.testing.assert_allclose(tree_gains, mod_gains)
@@ -2439,13 +3012,23 @@ def test_trees_to_dataframe():
     tree_df = bst.trees_to_dataframe()
 
     assert len(tree_df) == 1
-    assert tree_df.loc[0, 'tree_index'] == 0
-    assert tree_df.loc[0, 'node_depth'] == 1
-    assert tree_df.loc[0, 'node_index'] == "0-L0"
-    assert tree_df.loc[0, 'value'] is not None
-    for col in ('left_child', 'right_child', 'parent_index', 'split_feature',
-                'split_gain', 'threshold', 'decision_type', 'missing_direction',
-                'missing_type', 'weight', 'count'):
+    assert tree_df.loc[0, "tree_index"] == 0
+    assert tree_df.loc[0, "node_depth"] == 1
+    assert tree_df.loc[0, "node_index"] == "0-L0"
+    assert tree_df.loc[0, "value"] is not None
+    for col in (
+        "left_child",
+        "right_child",
+        "parent_index",
+        "split_feature",
+        "split_gain",
+        "threshold",
+        "decision_type",
+        "missing_direction",
+        "missing_type",
+        "weight",
+        "count",
+    ):
         assert tree_df.loc[0, col] is None
 
 
@@ -2454,32 +3037,53 @@ def test_interaction_constraints():
     num_features = X.shape[1]
     train_data = lgb.Dataset(X, label=y)
     # check that constraint containing all features is equivalent to no constraint
-    params = {'verbose': -1,
-              'seed': 0}
+    params = {"verbose": -1, "seed": 0}
     est = lgb.train(params, train_data, num_boost_round=10)
     pred1 = est.predict(X)
-    est = lgb.train(dict(params, interaction_constraints=[list(range(num_features))]), train_data,
-                    num_boost_round=10)
+    est = lgb.train(
+        dict(params, interaction_constraints=[list(range(num_features))]),
+        train_data,
+        num_boost_round=10,
+    )
     pred2 = est.predict(X)
     np.testing.assert_allclose(pred1, pred2)
     # check that constraint partitioning the features reduces train accuracy
-    est = lgb.train(dict(params, interaction_constraints=[list(range(num_features // 2)),
-                                                          list(range(num_features // 2, num_features))]),
-                    train_data, num_boost_round=10)
+    est = lgb.train(
+        dict(
+            params,
+            interaction_constraints=[
+                list(range(num_features // 2)),
+                list(range(num_features // 2, num_features)),
+            ],
+        ),
+        train_data,
+        num_boost_round=10,
+    )
     pred3 = est.predict(X)
     assert mean_squared_error(y, pred1) < mean_squared_error(y, pred3)
     # check that constraints consisting of single features reduce accuracy further
-    est = lgb.train(dict(params, interaction_constraints=[[i] for i in range(num_features)]), train_data,
-                    num_boost_round=10)
+    est = lgb.train(
+        dict(params, interaction_constraints=[[i] for i in range(num_features)]),
+        train_data,
+        num_boost_round=10,
+    )
     pred4 = est.predict(X)
     assert mean_squared_error(y, pred3) < mean_squared_error(y, pred4)
     # test that interaction constraints work when not all features are used
     X = np.concatenate([np.zeros((X.shape[0], 1)), X], axis=1)
     num_features = X.shape[1]
     train_data = lgb.Dataset(X, label=y)
-    est = lgb.train(dict(params, interaction_constraints=[[0] + list(range(2, num_features)),
-                                                          [1] + list(range(2, num_features))]),
-                    train_data, num_boost_round=10)
+    est = lgb.train(
+        dict(
+            params,
+            interaction_constraints=[
+                [0] + list(range(2, num_features)),
+                [1] + list(range(2, num_features)),
+            ],
+        ),
+        train_data,
+        num_boost_round=10,
+    )
 
 
 def test_linear_trees(tmp_path):
@@ -2489,18 +3093,23 @@ def test_linear_trees(tmp_path):
     y = 2 * x + np.random.normal(0, 0.1, len(x))
     x = x[:, np.newaxis]
     lgb_train = lgb.Dataset(x, label=y)
-    params = {'verbose': -1,
-              'metric': 'mse',
-              'seed': 0,
-              'num_leaves': 2}
+    params = {"verbose": -1, "metric": "mse", "seed": 0, "num_leaves": 2}
     est = lgb.train(params, lgb_train, num_boost_round=10)
     pred1 = est.predict(x)
     lgb_train = lgb.Dataset(x, label=y)
     res = {}
-    est = lgb.train(dict(params, linear_tree=True), lgb_train, num_boost_round=10, evals_result=res,
-                    valid_sets=[lgb_train], valid_names=['train'])
+    est = lgb.train(
+        dict(params, linear_tree=True),
+        lgb_train,
+        num_boost_round=10,
+        evals_result=res,
+        valid_sets=[lgb_train],
+        valid_names=["train"],
+    )
     pred2 = est.predict(x)
-    assert res['train']['l2'][-1] == pytest.approx(mean_squared_error(y, pred2), abs=1e-1)
+    assert res["train"]["l2"][-1] == pytest.approx(
+        mean_squared_error(y, pred2), abs=1e-1
+    )
     assert mean_squared_error(y, pred2) < mean_squared_error(y, pred1)
     # test again with nans in data
     x[:10] = np.nan
@@ -2509,33 +3118,61 @@ def test_linear_trees(tmp_path):
     pred1 = est.predict(x)
     lgb_train = lgb.Dataset(x, label=y)
     res = {}
-    est = lgb.train(dict(params, linear_tree=True), lgb_train, num_boost_round=10, evals_result=res,
-                    valid_sets=[lgb_train], valid_names=['train'])
+    est = lgb.train(
+        dict(params, linear_tree=True),
+        lgb_train,
+        num_boost_round=10,
+        evals_result=res,
+        valid_sets=[lgb_train],
+        valid_names=["train"],
+    )
     pred2 = est.predict(x)
-    assert res['train']['l2'][-1] == pytest.approx(mean_squared_error(y, pred2), abs=1e-1)
+    assert res["train"]["l2"][-1] == pytest.approx(
+        mean_squared_error(y, pred2), abs=1e-1
+    )
     assert mean_squared_error(y, pred2) < mean_squared_error(y, pred1)
     # test again with bagging
     res = {}
-    est = lgb.train(dict(params, linear_tree=True, subsample=0.8, bagging_freq=1), lgb_train,
-                    num_boost_round=10, evals_result=res, valid_sets=[lgb_train], valid_names=['train'])
+    est = lgb.train(
+        dict(params, linear_tree=True, subsample=0.8, bagging_freq=1),
+        lgb_train,
+        num_boost_round=10,
+        evals_result=res,
+        valid_sets=[lgb_train],
+        valid_names=["train"],
+    )
     pred = est.predict(x)
-    assert res['train']['l2'][-1] == pytest.approx(mean_squared_error(y, pred), abs=1e-1)
+    assert res["train"]["l2"][-1] == pytest.approx(
+        mean_squared_error(y, pred), abs=1e-1
+    )
     # test with a feature that has only one non-nan value
     x = np.concatenate([np.ones([x.shape[0], 1]), x], 1)
     x[500:, 1] = np.nan
     y[500:] += 10
     lgb_train = lgb.Dataset(x, label=y)
     res = {}
-    est = lgb.train(dict(params, linear_tree=True, subsample=0.8, bagging_freq=1), lgb_train,
-                    num_boost_round=10, evals_result=res, valid_sets=[lgb_train], valid_names=['train'])
+    est = lgb.train(
+        dict(params, linear_tree=True, subsample=0.8, bagging_freq=1),
+        lgb_train,
+        num_boost_round=10,
+        evals_result=res,
+        valid_sets=[lgb_train],
+        valid_names=["train"],
+    )
     pred = est.predict(x)
-    assert res['train']['l2'][-1] == pytest.approx(mean_squared_error(y, pred), abs=1e-1)
+    assert res["train"]["l2"][-1] == pytest.approx(
+        mean_squared_error(y, pred), abs=1e-1
+    )
     # test with a categorical feature
     x[:250, 0] = 0
     y[:250] += 10
     lgb_train = lgb.Dataset(x, label=y)
-    est = lgb.train(dict(params, linear_tree=True, subsample=0.8, bagging_freq=1), lgb_train,
-                    num_boost_round=10, categorical_feature=[0])
+    est = lgb.train(
+        dict(params, linear_tree=True, subsample=0.8, bagging_freq=1),
+        lgb_train,
+        num_boost_round=10,
+        categorical_feature=[0],
+    )
     # test refit: same results on same data
     est2 = est.refit(x, label=y)
     p1 = est.predict(x)
@@ -2555,11 +3192,10 @@ def test_linear_trees(tmp_path):
     p3 = est3.predict(x)
     assert np.mean(np.abs(p2 - p1)) > np.abs(np.max(p3 - p1))
     # test when num_leaves - 1 < num_features and when num_leaves - 1 > num_features
-    X_train, _, y_train, _ = train_test_split(*load_breast_cancer(return_X_y=True), test_size=0.1, random_state=2)
-    params = {'linear_tree': True,
-              'verbose': -1,
-              'metric': 'mse',
-              'seed': 0}
+    X_train, _, y_train, _ = train_test_split(
+        *load_breast_cancer(return_X_y=True), test_size=0.1, random_state=2
+    )
+    params = {"linear_tree": True, "verbose": -1, "metric": "mse", "seed": 0}
     train_data = lgb.Dataset(X_train, label=y_train, params=dict(params, num_leaves=2))
     est = lgb.train(params, train_data, num_boost_round=10, categorical_feature=[0])
     train_data = lgb.Dataset(X_train, label=y_train, params=dict(params, num_leaves=60))
@@ -2567,24 +3203,25 @@ def test_linear_trees(tmp_path):
 
 
 def test_save_and_load_linear(tmp_path):
-    X_train, X_test, y_train, y_test = train_test_split(*load_breast_cancer(return_X_y=True), test_size=0.1,
-                                                        random_state=2)
+    X_train, X_test, y_train, y_test = train_test_split(
+        *load_breast_cancer(return_X_y=True), test_size=0.1, random_state=2
+    )
     X_train = np.concatenate([np.ones((X_train.shape[0], 1)), X_train], 1)
-    X_train[:X_train.shape[0] // 2, 0] = 0
-    y_train[:X_train.shape[0] // 2] = 1
-    params = {'linear_tree': True}
+    X_train[: X_train.shape[0] // 2, 0] = 0
+    y_train[: X_train.shape[0] // 2] = 1
+    params = {"linear_tree": True}
     train_data_1 = lgb.Dataset(X_train, label=y_train, params=params)
     est_1 = lgb.train(params, train_data_1, num_boost_round=10, categorical_feature=[0])
     pred_1 = est_1.predict(X_train)
 
-    tmp_dataset = str(tmp_path / 'temp_dataset.bin')
+    tmp_dataset = str(tmp_path / "temp_dataset.bin")
     train_data_1.save_binary(tmp_dataset)
     train_data_2 = lgb.Dataset(tmp_dataset)
     est_2 = lgb.train(params, train_data_2, num_boost_round=10)
     pred_2 = est_2.predict(X_train)
     np.testing.assert_allclose(pred_1, pred_2)
 
-    model_file = str(tmp_path / 'model.txt')
+    model_file = str(tmp_path / "model.txt")
     est_2.save_model(model_file)
     est_3 = lgb.Booster(model_file=model_file)
     pred_3 = est_3.predict(X_train)
@@ -2593,11 +3230,18 @@ def test_save_and_load_linear(tmp_path):
 
 def test_predict_with_start_iteration():
     def inner_test(X, y, params, early_stopping_rounds):
-        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.1, random_state=42
+        )
         train_data = lgb.Dataset(X_train, label=y_train)
         valid_data = lgb.Dataset(X_test, label=y_test)
-        booster = lgb.train(params, train_data, num_boost_round=50, early_stopping_rounds=early_stopping_rounds,
-                            valid_sets=[valid_data])
+        booster = lgb.train(
+            params,
+            train_data,
+            num_boost_round=50,
+            early_stopping_rounds=early_stopping_rounds,
+            valid_sets=[valid_data],
+        )
 
         # test that the predict once with all iterations equals summed results with start_iteration and num_iteration
         all_pred = booster.predict(X, raw_score=True)
@@ -2607,8 +3251,12 @@ def test_predict_with_start_iteration():
             pred = np.zeros_like(all_pred)
             pred_contrib = np.zeros_like(all_pred_contrib)
             for start_iter in range(0, 50, step):
-                pred += booster.predict(X, start_iteration=start_iter, num_iteration=step, raw_score=True)
-                pred_contrib += booster.predict(X, start_iteration=start_iter, num_iteration=step, pred_contrib=True)
+                pred += booster.predict(
+                    X, start_iteration=start_iter, num_iteration=step, raw_score=True
+                )
+                pred_contrib += booster.predict(
+                    X, start_iteration=start_iter, num_iteration=step, pred_contrib=True
+                )
             np.testing.assert_allclose(all_pred, pred)
             np.testing.assert_allclose(all_pred_contrib, pred_contrib)
         # test the case where start_iteration <= 0, and num_iteration is None
@@ -2631,19 +3279,25 @@ def test_predict_with_start_iteration():
         np.testing.assert_allclose(pred4, pred6)
 
         # test the case where start_iteration > 0, and num_iteration <= 0, with pred_contrib=True
-        pred4 = booster.predict(X, start_iteration=10, num_iteration=-1, pred_contrib=True)
-        pred5 = booster.predict(X, start_iteration=10, num_iteration=40, pred_contrib=True)
-        pred6 = booster.predict(X, start_iteration=10, num_iteration=0, pred_contrib=True)
+        pred4 = booster.predict(
+            X, start_iteration=10, num_iteration=-1, pred_contrib=True
+        )
+        pred5 = booster.predict(
+            X, start_iteration=10, num_iteration=40, pred_contrib=True
+        )
+        pred6 = booster.predict(
+            X, start_iteration=10, num_iteration=0, pred_contrib=True
+        )
         np.testing.assert_allclose(pred4, pred5)
         np.testing.assert_allclose(pred4, pred6)
 
     # test for regression
     X, y = load_boston(return_X_y=True)
     params = {
-        'objective': 'regression',
-        'verbose': -1,
-        'metric': 'l2',
-        'learning_rate': 0.5
+        "objective": "regression",
+        "verbose": -1,
+        "metric": "l2",
+        "learning_rate": 0.5,
     }
     # test both with and without early stopping
     inner_test(X, y, params, early_stopping_rounds=1)
@@ -2653,10 +3307,10 @@ def test_predict_with_start_iteration():
     # test for multi-class
     X, y = load_iris(return_X_y=True)
     params = {
-        'objective': 'multiclass',
-        'num_class': 3,
-        'verbose': -1,
-        'metric': 'multi_error'
+        "objective": "multiclass",
+        "num_class": 3,
+        "verbose": -1,
+        "metric": "multi_error",
     }
     # test both with and without early stopping
     inner_test(X, y, params, early_stopping_rounds=1)
@@ -2665,11 +3319,7 @@ def test_predict_with_start_iteration():
 
     # test for binary
     X, y = load_breast_cancer(return_X_y=True)
-    params = {
-        'objective': 'binary',
-        'verbose': -1,
-        'metric': 'auc'
-    }
+    params = {"objective": "binary", "verbose": -1, "metric": "auc"}
     # test both with and without early stopping
     inner_test(X, y, params, early_stopping_rounds=1)
     inner_test(X, y, params, early_stopping_rounds=5)
@@ -2679,15 +3329,13 @@ def test_predict_with_start_iteration():
 def test_average_precision_metric():
     # test against sklearn average precision metric
     X, y = load_breast_cancer(return_X_y=True)
-    params = {
-        'objective': 'binary',
-        'metric': 'average_precision',
-        'verbose': -1
-    }
+    params = {"objective": "binary", "metric": "average_precision", "verbose": -1}
     res = {}
     lgb_X = lgb.Dataset(X, label=y)
-    est = lgb.train(params, lgb_X, num_boost_round=10, valid_sets=[lgb_X], evals_result=res)
-    ap = res['training']['average_precision'][-1]
+    est = lgb.train(
+        params, lgb_X, num_boost_round=10, valid_sets=[lgb_X], evals_result=res
+    )
+    ap = res["training"]["average_precision"][-1]
     pred = est.predict(X)
     sklearn_ap = average_precision_score(y, pred)
     assert ap == pytest.approx(sklearn_ap)
@@ -2696,30 +3344,27 @@ def test_average_precision_metric():
     y[:] = 1
     lgb_X = lgb.Dataset(X, label=y)
     lgb.train(params, lgb_X, num_boost_round=1, valid_sets=[lgb_X], evals_result=res)
-    assert res['training']['average_precision'][-1] == pytest.approx(1)
+    assert res["training"]["average_precision"][-1] == pytest.approx(1)
 
 
 def test_reset_params_works_with_metric_num_class_and_boosting():
     X, y = load_breast_cancer(return_X_y=True)
     dataset_params = {"max_bin": 150}
     booster_params = {
-        'objective': 'multiclass',
-        'max_depth': 4,
-        'bagging_fraction': 0.8,
-        'metric': ['multi_logloss', 'multi_error'],
-        'boosting': 'gbdt',
-        'num_class': 5
+        "objective": "multiclass",
+        "max_depth": 4,
+        "bagging_fraction": 0.8,
+        "metric": ["multi_logloss", "multi_error"],
+        "boosting": "gbdt",
+        "num_class": 5,
     }
     dtrain = lgb.Dataset(X, y, params=dataset_params)
-    bst = lgb.Booster(
-        params=booster_params,
-        train_set=dtrain
-    )
+    bst = lgb.Booster(params=booster_params, train_set=dtrain)
 
     expected_params = dict(dataset_params, **booster_params)
     assert bst.params == expected_params
 
-    booster_params['bagging_fraction'] += 0.1
+    booster_params["bagging_fraction"] += 0.1
     new_bst = bst.reset_parameter(booster_params)
 
     expected_params = dict(dataset_params, **booster_params)

--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -1,12 +1,14 @@
 # coding: utf-8
-import lightgbm as lgb
-from lightgbm.compat import MATPLOTLIB_INSTALLED, GRAPHVIZ_INSTALLED
-from sklearn.model_selection import train_test_split
 import pytest
+from sklearn.model_selection import train_test_split
+
+import lightgbm as lgb
+from lightgbm.compat import GRAPHVIZ_INSTALLED, MATPLOTLIB_INSTALLED
 
 if MATPLOTLIB_INSTALLED:
     import matplotlib
-    matplotlib.use('Agg')
+
+    matplotlib.use("Agg")
 if GRAPHVIZ_INSTALLED:
     import graphviz
 
@@ -15,8 +17,9 @@ from .utils import load_breast_cancer
 
 @pytest.fixture(scope="module")
 def breast_cancer_split():
-    return train_test_split(*load_breast_cancer(return_X_y=True),
-                            test_size=0.1, random_state=1)
+    return train_test_split(
+        *load_breast_cancer(return_X_y=True), test_size=0.1, random_state=1
+    )
 
 
 @pytest.fixture(scope="module")
@@ -27,93 +30,107 @@ def train_data(breast_cancer_split):
 
 @pytest.fixture
 def params():
-    return {"objective": "binary",
-            "verbose": -1,
-            "num_leaves": 3}
+    return {"objective": "binary", "verbose": -1, "num_leaves": 3}
 
 
-@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason='matplotlib is not installed')
+@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason="matplotlib is not installed")
 def test_plot_importance(params, breast_cancer_split, train_data):
     X_train, _, y_train, _ = breast_cancer_split
 
     gbm0 = lgb.train(params, train_data, num_boost_round=10)
     ax0 = lgb.plot_importance(gbm0)
     assert isinstance(ax0, matplotlib.axes.Axes)
-    assert ax0.get_title() == 'Feature importance'
-    assert ax0.get_xlabel() == 'Feature importance'
-    assert ax0.get_ylabel() == 'Features'
+    assert ax0.get_title() == "Feature importance"
+    assert ax0.get_xlabel() == "Feature importance"
+    assert ax0.get_ylabel() == "Features"
     assert len(ax0.patches) <= 30
 
     gbm1 = lgb.LGBMClassifier(n_estimators=10, num_leaves=3, silent=True)
     gbm1.fit(X_train, y_train)
 
-    ax1 = lgb.plot_importance(gbm1, color='r', title='t', xlabel='x', ylabel='y')
+    ax1 = lgb.plot_importance(gbm1, color="r", title="t", xlabel="x", ylabel="y")
     assert isinstance(ax1, matplotlib.axes.Axes)
-    assert ax1.get_title() == 't'
-    assert ax1.get_xlabel() == 'x'
-    assert ax1.get_ylabel() == 'y'
+    assert ax1.get_title() == "t"
+    assert ax1.get_xlabel() == "x"
+    assert ax1.get_ylabel() == "y"
     assert len(ax1.patches) <= 30
     for patch in ax1.patches:
-        assert patch.get_facecolor() == (1., 0, 0, 1.)  # red
+        assert patch.get_facecolor() == (1.0, 0, 0, 1.0)  # red
 
-    ax2 = lgb.plot_importance(gbm0, color=['r', 'y', 'g', 'b'],
-                              title=None, xlabel=None, ylabel=None)
+    ax2 = lgb.plot_importance(
+        gbm0, color=["r", "y", "g", "b"], title=None, xlabel=None, ylabel=None
+    )
     assert isinstance(ax2, matplotlib.axes.Axes)
-    assert ax2.get_title() == ''
-    assert ax2.get_xlabel() == ''
-    assert ax2.get_ylabel() == ''
+    assert ax2.get_title() == ""
+    assert ax2.get_xlabel() == ""
+    assert ax2.get_ylabel() == ""
     assert len(ax2.patches) <= 30
-    assert ax2.patches[0].get_facecolor() == (1., 0, 0, 1.)  # r
-    assert ax2.patches[1].get_facecolor() == (.75, .75, 0, 1.)  # y
-    assert ax2.patches[2].get_facecolor() == (0, .5, 0, 1.)  # g
-    assert ax2.patches[3].get_facecolor() == (0, 0, 1., 1.)  # b
+    assert ax2.patches[0].get_facecolor() == (1.0, 0, 0, 1.0)  # r
+    assert ax2.patches[1].get_facecolor() == (0.75, 0.75, 0, 1.0)  # y
+    assert ax2.patches[2].get_facecolor() == (0, 0.5, 0, 1.0)  # g
+    assert ax2.patches[3].get_facecolor() == (0, 0, 1.0, 1.0)  # b
 
 
-@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason='matplotlib is not installed')
+@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason="matplotlib is not installed")
 def test_plot_split_value_histogram(params, breast_cancer_split, train_data):
     X_train, _, y_train, _ = breast_cancer_split
 
     gbm0 = lgb.train(params, train_data, num_boost_round=10)
     ax0 = lgb.plot_split_value_histogram(gbm0, 27)
     assert isinstance(ax0, matplotlib.axes.Axes)
-    assert ax0.get_title() == 'Split value histogram for feature with index 27'
-    assert ax0.get_xlabel() == 'Feature split value'
-    assert ax0.get_ylabel() == 'Count'
+    assert ax0.get_title() == "Split value histogram for feature with index 27"
+    assert ax0.get_xlabel() == "Feature split value"
+    assert ax0.get_ylabel() == "Count"
     assert len(ax0.patches) <= 2
 
     gbm1 = lgb.LGBMClassifier(n_estimators=10, num_leaves=3, silent=True)
     gbm1.fit(X_train, y_train)
 
-    ax1 = lgb.plot_split_value_histogram(gbm1, gbm1.booster_.feature_name()[27], figsize=(10, 5),
-                                         title='Histogram for feature @index/name@ @feature@',
-                                         xlabel='x', ylabel='y', color='r')
+    ax1 = lgb.plot_split_value_histogram(
+        gbm1,
+        gbm1.booster_.feature_name()[27],
+        figsize=(10, 5),
+        title="Histogram for feature @index/name@ @feature@",
+        xlabel="x",
+        ylabel="y",
+        color="r",
+    )
     assert isinstance(ax1, matplotlib.axes.Axes)
-    title = 'Histogram for feature name {}'.format(gbm1.booster_.feature_name()[27])
+    title = "Histogram for feature name {}".format(gbm1.booster_.feature_name()[27])
     assert ax1.get_title() == title
-    assert ax1.get_xlabel() == 'x'
-    assert ax1.get_ylabel() == 'y'
+    assert ax1.get_xlabel() == "x"
+    assert ax1.get_ylabel() == "y"
     assert len(ax1.patches) <= 2
     for patch in ax1.patches:
-        assert patch.get_facecolor() == (1., 0, 0, 1.)  # red
+        assert patch.get_facecolor() == (1.0, 0, 0, 1.0)  # red
 
-    ax2 = lgb.plot_split_value_histogram(gbm0, 27, bins=10, color=['r', 'y', 'g', 'b'],
-                                         title=None, xlabel=None, ylabel=None)
+    ax2 = lgb.plot_split_value_histogram(
+        gbm0,
+        27,
+        bins=10,
+        color=["r", "y", "g", "b"],
+        title=None,
+        xlabel=None,
+        ylabel=None,
+    )
     assert isinstance(ax2, matplotlib.axes.Axes)
-    assert ax2.get_title() == ''
-    assert ax2.get_xlabel() == ''
-    assert ax2.get_ylabel() == ''
+    assert ax2.get_title() == ""
+    assert ax2.get_xlabel() == ""
+    assert ax2.get_ylabel() == ""
     assert len(ax2.patches) == 10
-    assert ax2.patches[0].get_facecolor() == (1., 0, 0, 1.)  # r
-    assert ax2.patches[1].get_facecolor() == (.75, .75, 0, 1.)  # y
-    assert ax2.patches[2].get_facecolor() == (0, .5, 0, 1.)  # g
-    assert ax2.patches[3].get_facecolor() == (0, 0, 1., 1.)  # b
+    assert ax2.patches[0].get_facecolor() == (1.0, 0, 0, 1.0)  # r
+    assert ax2.patches[1].get_facecolor() == (0.75, 0.75, 0, 1.0)  # y
+    assert ax2.patches[2].get_facecolor() == (0, 0.5, 0, 1.0)  # g
+    assert ax2.patches[3].get_facecolor() == (0, 0, 1.0, 1.0)  # b
 
     with pytest.raises(ValueError):
         lgb.plot_split_value_histogram(gbm0, 0)  # was not used in splitting
 
 
-@pytest.mark.skipif(not MATPLOTLIB_INSTALLED or not GRAPHVIZ_INSTALLED,
-                    reason='matplotlib or graphviz is not installed')
+@pytest.mark.skipif(
+    not MATPLOTLIB_INSTALLED or not GRAPHVIZ_INSTALLED,
+    reason="matplotlib or graphviz is not installed",
+)
 def test_plot_tree(breast_cancer_split):
     X_train, _, y_train, _ = breast_cancer_split
     gbm = lgb.LGBMClassifier(n_estimators=10, num_leaves=3, silent=True)
@@ -122,72 +139,84 @@ def test_plot_tree(breast_cancer_split):
     with pytest.raises(IndexError):
         lgb.plot_tree(gbm, tree_index=83)
 
-    ax = lgb.plot_tree(gbm, tree_index=3, figsize=(15, 8), show_info=['split_gain'])
+    ax = lgb.plot_tree(gbm, tree_index=3, figsize=(15, 8), show_info=["split_gain"])
     assert isinstance(ax, matplotlib.axes.Axes)
     w, h = ax.axes.get_figure().get_size_inches()
     assert int(w) == 15
     assert int(h) == 8
 
 
-@pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason='graphviz is not installed')
+@pytest.mark.skipif(not GRAPHVIZ_INSTALLED, reason="graphviz is not installed")
 def test_create_tree_digraph(breast_cancer_split):
     X_train, _, y_train, _ = breast_cancer_split
 
     constraints = [-1, 1] * int(X_train.shape[1] / 2)
-    gbm = lgb.LGBMClassifier(n_estimators=10, num_leaves=3, silent=True, monotone_constraints=constraints)
+    gbm = lgb.LGBMClassifier(
+        n_estimators=10, num_leaves=3, silent=True, monotone_constraints=constraints
+    )
     gbm.fit(X_train, y_train, verbose=False)
 
     with pytest.raises(IndexError):
         lgb.create_tree_digraph(gbm, tree_index=83)
 
-    graph = lgb.create_tree_digraph(gbm, tree_index=3,
-                                    show_info=['split_gain', 'internal_value', 'internal_weight'],
-                                    name='Tree4', node_attr={'color': 'red'})
+    graph = lgb.create_tree_digraph(
+        gbm,
+        tree_index=3,
+        show_info=["split_gain", "internal_value", "internal_weight"],
+        name="Tree4",
+        node_attr={"color": "red"},
+    )
     graph.render(view=False)
     assert isinstance(graph, graphviz.Digraph)
-    assert graph.name == 'Tree4'
-    assert graph.filename == 'Tree4.gv'
+    assert graph.name == "Tree4"
+    assert graph.filename == "Tree4.gv"
     assert len(graph.node_attr) == 1
-    assert graph.node_attr['color'] == 'red'
+    assert graph.node_attr["color"] == "red"
     assert len(graph.graph_attr) == 0
     assert len(graph.edge_attr) == 0
-    graph_body = ''.join(graph.body)
-    assert 'leaf' in graph_body
-    assert 'gain' in graph_body
-    assert 'value' in graph_body
-    assert 'weight' in graph_body
-    assert '#ffdddd' in graph_body
-    assert '#ddffdd' in graph_body
-    assert 'data' not in graph_body
-    assert 'count' not in graph_body
+    graph_body = "".join(graph.body)
+    assert "leaf" in graph_body
+    assert "gain" in graph_body
+    assert "value" in graph_body
+    assert "weight" in graph_body
+    assert "#ffdddd" in graph_body
+    assert "#ddffdd" in graph_body
+    assert "data" not in graph_body
+    assert "count" not in graph_body
 
 
-@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason='matplotlib is not installed')
+@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason="matplotlib is not installed")
 def test_plot_metrics(params, breast_cancer_split, train_data):
     X_train, X_test, y_train, y_test = breast_cancer_split
     test_data = lgb.Dataset(X_test, y_test, reference=train_data)
     params.update({"metric": {"binary_logloss", "binary_error"}})
 
     evals_result0 = {}
-    lgb.train(params, train_data,
-              valid_sets=[train_data, test_data],
-              valid_names=['v1', 'v2'],
-              num_boost_round=10,
-              evals_result=evals_result0,
-              verbose_eval=False)
+    lgb.train(
+        params,
+        train_data,
+        valid_sets=[train_data, test_data],
+        valid_names=["v1", "v2"],
+        num_boost_round=10,
+        evals_result=evals_result0,
+        verbose_eval=False,
+    )
     ax0 = lgb.plot_metric(evals_result0)
     assert isinstance(ax0, matplotlib.axes.Axes)
-    assert ax0.get_title() == 'Metric during training'
-    assert ax0.get_xlabel() == 'Iterations'
-    assert ax0.get_ylabel() in {'binary_logloss', 'binary_error'}
-    ax0 = lgb.plot_metric(evals_result0, metric='binary_error')
-    ax0 = lgb.plot_metric(evals_result0, metric='binary_logloss', dataset_names=['v2'])
+    assert ax0.get_title() == "Metric during training"
+    assert ax0.get_xlabel() == "Iterations"
+    assert ax0.get_ylabel() in {"binary_logloss", "binary_error"}
+    ax0 = lgb.plot_metric(evals_result0, metric="binary_error")
+    ax0 = lgb.plot_metric(evals_result0, metric="binary_logloss", dataset_names=["v2"])
 
     evals_result1 = {}
-    lgb.train(params, train_data,
-              num_boost_round=10,
-              evals_result=evals_result1,
-              verbose_eval=False)
+    lgb.train(
+        params,
+        train_data,
+        num_boost_round=10,
+        evals_result=evals_result1,
+        verbose_eval=False,
+    )
     with pytest.raises(ValueError):
         lgb.plot_metric(evals_result1)
 
@@ -195,6 +224,6 @@ def test_plot_metrics(params, breast_cancer_split, train_data):
     gbm2.fit(X_train, y_train, eval_set=[(X_test, y_test)], verbose=False)
     ax2 = lgb.plot_metric(gbm2, title=None, xlabel=None, ylabel=None)
     assert isinstance(ax2, matplotlib.axes.Axes)
-    assert ax2.get_title() == ''
-    assert ax2.get_xlabel() == ''
-    assert ax2.get_ylabel() == ''
+    assert ax2.get_title() == ""
+    assert ax2.get_xlabel() == ""
+    assert ax2.get_ylabel() == ""

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1,30 +1,42 @@
 # coding: utf-8
 import itertools
-import joblib
 import math
 import os
 
-import lightgbm as lgb
+import joblib
 import numpy as np
 import pytest
 from pkg_resources import parse_version
 from sklearn import __version__ as sk_version
 from sklearn.base import clone
 from sklearn.datasets import load_svmlight_file, make_multilabel_classification
-from sklearn.utils.estimator_checks import check_parameters_default_constructible
 from sklearn.metrics import log_loss, mean_squared_error
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV, train_test_split
-from sklearn.multioutput import (MultiOutputClassifier, ClassifierChain, MultiOutputRegressor,
-                                 RegressorChain)
+from sklearn.multioutput import (
+    ClassifierChain,
+    MultiOutputClassifier,
+    MultiOutputRegressor,
+    RegressorChain,
+)
+from sklearn.utils.estimator_checks import check_parameters_default_constructible
 from sklearn.utils.validation import check_is_fitted
 
-from .utils import load_boston, load_breast_cancer, load_digits, load_iris, load_linnerud
+import lightgbm as lgb
+
+from .utils import (
+    load_boston,
+    load_breast_cancer,
+    load_digits,
+    load_iris,
+    load_linnerud,
+)
 
 sk_version = parse_version(sk_version)
 if sk_version < parse_version("0.23"):
     import warnings
+
     from sklearn.exceptions import SkipTestWarning
-    from sklearn.utils.estimator_checks import _yield_all_checks, SkipTest
+    from sklearn.utils.estimator_checks import SkipTest, _yield_all_checks
 else:
     from sklearn.utils.estimator_checks import parametrize_with_checks
 
@@ -39,7 +51,7 @@ def custom_asymmetric_obj(y_true, y_pred):
 
 
 def objective_ls(y_true, y_pred):
-    grad = (y_pred - y_true)
+    grad = y_pred - y_true
     hess = np.ones(len(y_true))
     return grad, hess
 
@@ -56,15 +68,15 @@ def custom_dummy_obj(y_true, y_pred):
 
 
 def constant_metric(y_true, y_pred):
-    return 'error', 0, False
+    return "error", 0, False
 
 
 def decreasing_metric(y_true, y_pred):
-    return ('decreasing_metric', next(decreasing_generator), False)
+    return ("decreasing_metric", next(decreasing_generator), False)
 
 
 def mse(y_true, y_pred):
-    return 'custom MSE', mean_squared_error(y_true, y_pred), False
+    return "custom MSE", mean_squared_error(y_true, y_pred), False
 
 
 def binary_error(y_true, y_pred):
@@ -81,85 +93,177 @@ def multi_logloss(y_true, y_pred):
 
 def test_binary():
     X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     gbm = lgb.LGBMClassifier(n_estimators=50, silent=True)
-    gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], early_stopping_rounds=5, verbose=False)
+    gbm.fit(
+        X_train,
+        y_train,
+        eval_set=[(X_test, y_test)],
+        early_stopping_rounds=5,
+        verbose=False,
+    )
     ret = log_loss(y_test, gbm.predict_proba(X_test))
     assert ret < 0.12
-    assert gbm.evals_result_['valid_0']['binary_logloss'][gbm.best_iteration_ - 1] == pytest.approx(ret)
+    assert gbm.evals_result_["valid_0"]["binary_logloss"][
+        gbm.best_iteration_ - 1
+    ] == pytest.approx(ret)
 
 
 def test_regression():
     X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     gbm = lgb.LGBMRegressor(n_estimators=50, silent=True)
-    gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], early_stopping_rounds=5, verbose=False)
+    gbm.fit(
+        X_train,
+        y_train,
+        eval_set=[(X_test, y_test)],
+        early_stopping_rounds=5,
+        verbose=False,
+    )
     ret = mean_squared_error(y_test, gbm.predict(X_test))
     assert ret < 7
-    assert gbm.evals_result_['valid_0']['l2'][gbm.best_iteration_ - 1] == pytest.approx(ret)
+    assert gbm.evals_result_["valid_0"]["l2"][gbm.best_iteration_ - 1] == pytest.approx(
+        ret
+    )
 
 
 def test_multiclass():
     X, y = load_digits(n_class=10, return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     gbm = lgb.LGBMClassifier(n_estimators=50, silent=True)
-    gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], early_stopping_rounds=5, verbose=False)
+    gbm.fit(
+        X_train,
+        y_train,
+        eval_set=[(X_test, y_test)],
+        early_stopping_rounds=5,
+        verbose=False,
+    )
     ret = multi_error(y_test, gbm.predict(X_test))
     assert ret < 0.05
     ret = multi_logloss(y_test, gbm.predict_proba(X_test))
     assert ret < 0.16
-    assert gbm.evals_result_['valid_0']['multi_logloss'][gbm.best_iteration_ - 1] == pytest.approx(ret)
+    assert gbm.evals_result_["valid_0"]["multi_logloss"][
+        gbm.best_iteration_ - 1
+    ] == pytest.approx(ret)
 
 
 def test_lambdarank():
-    X_train, y_train = load_svmlight_file(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                                       '../../examples/lambdarank/rank.train'))
-    X_test, y_test = load_svmlight_file(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                                     '../../examples/lambdarank/rank.test'))
-    q_train = np.loadtxt(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                      '../../examples/lambdarank/rank.train.query'))
-    q_test = np.loadtxt(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                     '../../examples/lambdarank/rank.test.query'))
+    X_train, y_train = load_svmlight_file(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../examples/lambdarank/rank.train",
+        )
+    )
+    X_test, y_test = load_svmlight_file(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../examples/lambdarank/rank.test",
+        )
+    )
+    q_train = np.loadtxt(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../examples/lambdarank/rank.train.query",
+        )
+    )
+    q_test = np.loadtxt(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../examples/lambdarank/rank.test.query",
+        )
+    )
     gbm = lgb.LGBMRanker(n_estimators=50)
-    gbm.fit(X_train, y_train, group=q_train, eval_set=[(X_test, y_test)],
-            eval_group=[q_test], eval_at=[1, 3], early_stopping_rounds=10, verbose=False,
-            callbacks=[lgb.reset_parameter(learning_rate=lambda x: max(0.01, 0.1 - 0.01 * x))])
+    gbm.fit(
+        X_train,
+        y_train,
+        group=q_train,
+        eval_set=[(X_test, y_test)],
+        eval_group=[q_test],
+        eval_at=[1, 3],
+        early_stopping_rounds=10,
+        verbose=False,
+        callbacks=[
+            lgb.reset_parameter(learning_rate=lambda x: max(0.01, 0.1 - 0.01 * x))
+        ],
+    )
     assert gbm.best_iteration_ <= 24
-    assert gbm.best_score_['valid_0']['ndcg@1'] > 0.5674
-    assert gbm.best_score_['valid_0']['ndcg@3'] > 0.578
+    assert gbm.best_score_["valid_0"]["ndcg@1"] > 0.5674
+    assert gbm.best_score_["valid_0"]["ndcg@3"] > 0.578
 
 
 def test_xendcg():
     dir_path = os.path.dirname(os.path.realpath(__file__))
-    X_train, y_train = load_svmlight_file(os.path.join(dir_path, '../../examples/xendcg/rank.train'))
-    X_test, y_test = load_svmlight_file(os.path.join(dir_path, '../../examples/xendcg/rank.test'))
-    q_train = np.loadtxt(os.path.join(dir_path, '../../examples/xendcg/rank.train.query'))
-    q_test = np.loadtxt(os.path.join(dir_path, '../../examples/xendcg/rank.test.query'))
-    gbm = lgb.LGBMRanker(n_estimators=50, objective='rank_xendcg', random_state=5, n_jobs=1)
-    gbm.fit(X_train, y_train, group=q_train, eval_set=[(X_test, y_test)],
-            eval_group=[q_test], eval_at=[1, 3], early_stopping_rounds=10, verbose=False,
-            eval_metric='ndcg',
-            callbacks=[lgb.reset_parameter(learning_rate=lambda x: max(0.01, 0.1 - 0.01 * x))])
+    X_train, y_train = load_svmlight_file(
+        os.path.join(dir_path, "../../examples/xendcg/rank.train")
+    )
+    X_test, y_test = load_svmlight_file(
+        os.path.join(dir_path, "../../examples/xendcg/rank.test")
+    )
+    q_train = np.loadtxt(
+        os.path.join(dir_path, "../../examples/xendcg/rank.train.query")
+    )
+    q_test = np.loadtxt(os.path.join(dir_path, "../../examples/xendcg/rank.test.query"))
+    gbm = lgb.LGBMRanker(
+        n_estimators=50, objective="rank_xendcg", random_state=5, n_jobs=1
+    )
+    gbm.fit(
+        X_train,
+        y_train,
+        group=q_train,
+        eval_set=[(X_test, y_test)],
+        eval_group=[q_test],
+        eval_at=[1, 3],
+        early_stopping_rounds=10,
+        verbose=False,
+        eval_metric="ndcg",
+        callbacks=[
+            lgb.reset_parameter(learning_rate=lambda x: max(0.01, 0.1 - 0.01 * x))
+        ],
+    )
     assert gbm.best_iteration_ <= 24
-    assert gbm.best_score_['valid_0']['ndcg@1'] > 0.6211
-    assert gbm.best_score_['valid_0']['ndcg@3'] > 0.6253
+    assert gbm.best_score_["valid_0"]["ndcg@1"] > 0.6211
+    assert gbm.best_score_["valid_0"]["ndcg@3"] > 0.6253
 
 
 def test_regression_with_custom_objective():
     X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     gbm = lgb.LGBMRegressor(n_estimators=50, silent=True, objective=objective_ls)
-    gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], early_stopping_rounds=5, verbose=False)
+    gbm.fit(
+        X_train,
+        y_train,
+        eval_set=[(X_test, y_test)],
+        early_stopping_rounds=5,
+        verbose=False,
+    )
     ret = mean_squared_error(y_test, gbm.predict(X_test))
     assert ret < 7.0
-    assert gbm.evals_result_['valid_0']['l2'][gbm.best_iteration_ - 1] == pytest.approx(ret)
+    assert gbm.evals_result_["valid_0"]["l2"][gbm.best_iteration_ - 1] == pytest.approx(
+        ret
+    )
 
 
 def test_binary_classification_with_custom_objective():
     X, y = load_digits(n_class=2, return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     gbm = lgb.LGBMClassifier(n_estimators=50, silent=True, objective=logregobj)
-    gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], early_stopping_rounds=5, verbose=False)
+    gbm.fit(
+        X_train,
+        y_train,
+        eval_set=[(X_test, y_test)],
+        early_stopping_rounds=5,
+        verbose=False,
+    )
     # prediction result is actually not transformed (is raw) due to custom objective
     y_pred_raw = gbm.predict_proba(X_test)
     assert not np.all(y_pred_raw >= 0)
@@ -170,58 +274,80 @@ def test_binary_classification_with_custom_objective():
 
 def test_dart():
     X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
-    gbm = lgb.LGBMRegressor(boosting_type='dart', n_estimators=50)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
+    gbm = lgb.LGBMRegressor(boosting_type="dart", n_estimators=50)
     gbm.fit(X_train, y_train)
     score = gbm.score(X_test, y_test)
     assert score >= 0.8
-    assert score <= 1.
+    assert score <= 1.0
 
 
 # sklearn <0.23 does not have a stacking classifier and n_features_in_ property
-@pytest.mark.skipif(sk_version < parse_version("0.23"), reason='scikit-learn version is less than 0.23')
+@pytest.mark.skipif(
+    sk_version < parse_version("0.23"), reason="scikit-learn version is less than 0.23"
+)
 def test_stacking_classifier():
     from sklearn.ensemble import StackingClassifier
 
     X, y = load_iris(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-    classifiers = [('gbm1', lgb.LGBMClassifier(n_estimators=3)),
-                   ('gbm2', lgb.LGBMClassifier(n_estimators=3))]
-    clf = StackingClassifier(estimators=classifiers,
-                             final_estimator=lgb.LGBMClassifier(n_estimators=3),
-                             passthrough=True)
+    classifiers = [
+        ("gbm1", lgb.LGBMClassifier(n_estimators=3)),
+        ("gbm2", lgb.LGBMClassifier(n_estimators=3)),
+    ]
+    clf = StackingClassifier(
+        estimators=classifiers,
+        final_estimator=lgb.LGBMClassifier(n_estimators=3),
+        passthrough=True,
+    )
     clf.fit(X_train, y_train)
     score = clf.score(X_test, y_test)
     assert score >= 0.8
-    assert score <= 1.
+    assert score <= 1.0
     assert clf.n_features_in_ == 4  # number of input features
-    assert len(clf.named_estimators_['gbm1'].feature_importances_) == 4
-    assert clf.named_estimators_['gbm1'].n_features_in_ == clf.named_estimators_['gbm2'].n_features_in_
+    assert len(clf.named_estimators_["gbm1"].feature_importances_) == 4
+    assert (
+        clf.named_estimators_["gbm1"].n_features_in_
+        == clf.named_estimators_["gbm2"].n_features_in_
+    )
     assert clf.final_estimator_.n_features_in_ == 10  # number of concatenated features
     assert len(clf.final_estimator_.feature_importances_) == 10
-    assert all(clf.named_estimators_['gbm1'].classes_ == clf.named_estimators_['gbm2'].classes_)
-    assert all(clf.classes_ == clf.named_estimators_['gbm1'].classes_)
+    assert all(
+        clf.named_estimators_["gbm1"].classes_ == clf.named_estimators_["gbm2"].classes_
+    )
+    assert all(clf.classes_ == clf.named_estimators_["gbm1"].classes_)
 
 
 # sklearn <0.23 does not have a stacking regressor and n_features_in_ property
-@pytest.mark.skipif(sk_version < parse_version('0.23'), reason='scikit-learn version is less than 0.23')
+@pytest.mark.skipif(
+    sk_version < parse_version("0.23"), reason="scikit-learn version is less than 0.23"
+)
 def test_stacking_regressor():
     from sklearn.ensemble import StackingRegressor
 
     X, y = load_boston(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-    regressors = [('gbm1', lgb.LGBMRegressor(n_estimators=3)),
-                  ('gbm2', lgb.LGBMRegressor(n_estimators=3))]
-    reg = StackingRegressor(estimators=regressors,
-                            final_estimator=lgb.LGBMRegressor(n_estimators=3),
-                            passthrough=True)
+    regressors = [
+        ("gbm1", lgb.LGBMRegressor(n_estimators=3)),
+        ("gbm2", lgb.LGBMRegressor(n_estimators=3)),
+    ]
+    reg = StackingRegressor(
+        estimators=regressors,
+        final_estimator=lgb.LGBMRegressor(n_estimators=3),
+        passthrough=True,
+    )
     reg.fit(X_train, y_train)
     score = reg.score(X_test, y_test)
     assert score >= 0.2
-    assert score <= 1.
+    assert score <= 1.0
     assert reg.n_features_in_ == 13  # number of input features
-    assert len(reg.named_estimators_['gbm1'].feature_importances_) == 13
-    assert reg.named_estimators_['gbm1'].n_features_in_ == reg.named_estimators_['gbm2'].n_features_in_
+    assert len(reg.named_estimators_["gbm1"].feature_importances_) == 13
+    assert (
+        reg.named_estimators_["gbm1"].n_features_in_
+        == reg.named_estimators_["gbm2"].n_features_in_
+    )
     assert reg.final_estimator_.n_features_in_ == 15  # number of concatenated features
     assert len(reg.final_estimator_.feature_importances_) == 15
 
@@ -229,123 +355,150 @@ def test_stacking_regressor():
 def test_grid_search():
     X, y = load_iris(return_X_y=True)
     y = y.astype(str)  # utilize label encoder at it's max power
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1,
-                                                        random_state=42)
-    X_train, X_val, y_train, y_val = train_test_split(X_train, y_train, test_size=0.1,
-                                                      random_state=42)
-    params = dict(subsample=0.8,
-                  subsample_freq=1)
-    grid_params = dict(boosting_type=['rf', 'gbdt'],
-                       n_estimators=[4, 6],
-                       reg_alpha=[0.01, 0.005])
-    fit_params = dict(verbose=False,
-                      eval_set=[(X_val, y_val)],
-                      eval_metric=constant_metric,
-                      early_stopping_rounds=2)
-    grid = GridSearchCV(estimator=lgb.LGBMClassifier(**params), param_grid=grid_params,
-                        cv=2)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
+    X_train, X_val, y_train, y_val = train_test_split(
+        X_train, y_train, test_size=0.1, random_state=42
+    )
+    params = dict(subsample=0.8, subsample_freq=1)
+    grid_params = dict(
+        boosting_type=["rf", "gbdt"], n_estimators=[4, 6], reg_alpha=[0.01, 0.005]
+    )
+    fit_params = dict(
+        verbose=False,
+        eval_set=[(X_val, y_val)],
+        eval_metric=constant_metric,
+        early_stopping_rounds=2,
+    )
+    grid = GridSearchCV(
+        estimator=lgb.LGBMClassifier(**params), param_grid=grid_params, cv=2
+    )
     grid.fit(X_train, y_train, **fit_params)
     score = grid.score(X_test, y_test)  # utilizes GridSearchCV default refit=True
-    assert grid.best_params_['boosting_type'] in ['rf', 'gbdt']
-    assert grid.best_params_['n_estimators'] in [4, 6]
-    assert grid.best_params_['reg_alpha'] in [0.01, 0.005]
-    assert grid.best_score_ <= 1.
+    assert grid.best_params_["boosting_type"] in ["rf", "gbdt"]
+    assert grid.best_params_["n_estimators"] in [4, 6]
+    assert grid.best_params_["reg_alpha"] in [0.01, 0.005]
+    assert grid.best_score_ <= 1.0
     assert grid.best_estimator_.best_iteration_ == 1
-    assert grid.best_estimator_.best_score_['valid_0']['multi_logloss'] < 0.25
-    assert grid.best_estimator_.best_score_['valid_0']['error'] == 0
+    assert grid.best_estimator_.best_score_["valid_0"]["multi_logloss"] < 0.25
+    assert grid.best_estimator_.best_score_["valid_0"]["error"] == 0
     assert score >= 0.2
-    assert score <= 1.
+    assert score <= 1.0
 
 
 def test_random_search():
     X, y = load_iris(return_X_y=True)
     y = y.astype(str)  # utilize label encoder at it's max power
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1,
-                                                        random_state=42)
-    X_train, X_val, y_train, y_val = train_test_split(X_train, y_train, test_size=0.1,
-                                                      random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
+    X_train, X_val, y_train, y_val = train_test_split(
+        X_train, y_train, test_size=0.1, random_state=42
+    )
     n_iter = 3  # Number of samples
-    params = dict(subsample=0.8,
-                  subsample_freq=1)
-    param_dist = dict(boosting_type=['rf', 'gbdt'],
-                      n_estimators=[np.random.randint(low=3, high=10) for i in range(n_iter)],
-                      reg_alpha=[np.random.uniform(low=0.01, high=0.06) for i in range(n_iter)])
-    fit_params = dict(verbose=False,
-                      eval_set=[(X_val, y_val)],
-                      eval_metric=constant_metric,
-                      early_stopping_rounds=2)
-    rand = RandomizedSearchCV(estimator=lgb.LGBMClassifier(**params),
-                              param_distributions=param_dist, cv=2,
-                              n_iter=n_iter, random_state=42)
+    params = dict(subsample=0.8, subsample_freq=1)
+    param_dist = dict(
+        boosting_type=["rf", "gbdt"],
+        n_estimators=[np.random.randint(low=3, high=10) for i in range(n_iter)],
+        reg_alpha=[np.random.uniform(low=0.01, high=0.06) for i in range(n_iter)],
+    )
+    fit_params = dict(
+        verbose=False,
+        eval_set=[(X_val, y_val)],
+        eval_metric=constant_metric,
+        early_stopping_rounds=2,
+    )
+    rand = RandomizedSearchCV(
+        estimator=lgb.LGBMClassifier(**params),
+        param_distributions=param_dist,
+        cv=2,
+        n_iter=n_iter,
+        random_state=42,
+    )
     rand.fit(X_train, y_train, **fit_params)
     score = rand.score(X_test, y_test)  # utilizes RandomizedSearchCV default refit=True
-    assert rand.best_params_['boosting_type'] in ['rf', 'gbdt']
-    assert rand.best_params_['n_estimators'] in list(range(3, 10))
-    assert rand.best_params_['reg_alpha'] >= 0.01  # Left-closed boundary point
-    assert rand.best_params_['reg_alpha'] <= 0.06  # Right-closed boundary point
-    assert rand.best_score_ <= 1.
-    assert rand.best_estimator_.best_score_['valid_0']['multi_logloss'] < 0.25
-    assert rand.best_estimator_.best_score_['valid_0']['error'] == 0
+    assert rand.best_params_["boosting_type"] in ["rf", "gbdt"]
+    assert rand.best_params_["n_estimators"] in list(range(3, 10))
+    assert rand.best_params_["reg_alpha"] >= 0.01  # Left-closed boundary point
+    assert rand.best_params_["reg_alpha"] <= 0.06  # Right-closed boundary point
+    assert rand.best_score_ <= 1.0
+    assert rand.best_estimator_.best_score_["valid_0"]["multi_logloss"] < 0.25
+    assert rand.best_estimator_.best_score_["valid_0"]["error"] == 0
     assert score >= 0.2
-    assert score <= 1.
+    assert score <= 1.0
 
 
 # sklearn < 0.22 does not have the post fit attribute: classes_
-@pytest.mark.skipif(sk_version < parse_version('0.22'), reason='scikit-learn version is less than 0.22')
+@pytest.mark.skipif(
+    sk_version < parse_version("0.22"), reason="scikit-learn version is less than 0.22"
+)
 def test_multioutput_classifier():
     n_outputs = 3
-    X, y = make_multilabel_classification(n_samples=100, n_features=20,
-                                          n_classes=n_outputs, random_state=0)
+    X, y = make_multilabel_classification(
+        n_samples=100, n_features=20, n_classes=n_outputs, random_state=0
+    )
     y = y.astype(str)  # utilize label encoder at it's max power
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1,
-                                                        random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     clf = MultiOutputClassifier(estimator=lgb.LGBMClassifier(n_estimators=10))
     clf.fit(X_train, y_train)
     score = clf.score(X_test, y_test)
     assert score >= 0.2
-    assert score <= 1.
-    np.testing.assert_array_equal(np.tile(np.unique(y_train), n_outputs),
-                                  np.concatenate(clf.classes_))
+    assert score <= 1.0
+    np.testing.assert_array_equal(
+        np.tile(np.unique(y_train), n_outputs), np.concatenate(clf.classes_)
+    )
     for classifier in clf.estimators_:
         assert isinstance(classifier, lgb.LGBMClassifier)
         assert isinstance(classifier.booster_, lgb.Booster)
 
 
 # sklearn < 0.23 does not have as_frame parameter
-@pytest.mark.skipif(sk_version < parse_version('0.23'), reason='scikit-learn version is less than 0.23')
+@pytest.mark.skipif(
+    sk_version < parse_version("0.23"), reason="scikit-learn version is less than 0.23"
+)
 def test_multioutput_regressor():
     bunch = load_linnerud(as_frame=True)  # returns a Bunch instance
-    X, y = bunch['data'], bunch['target']
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1,
-                                                        random_state=42)
+    X, y = bunch["data"], bunch["target"]
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     reg = MultiOutputRegressor(estimator=lgb.LGBMRegressor(n_estimators=10))
     reg.fit(X_train, y_train)
     y_pred = reg.predict(X_test)
     _, score, _ = mse(y_test, y_pred)
     assert score >= 0.2
-    assert score <= 120.
+    assert score <= 120.0
     for regressor in reg.estimators_:
         assert isinstance(regressor, lgb.LGBMRegressor)
         assert isinstance(regressor.booster_, lgb.Booster)
 
 
 # sklearn < 0.22 does not have the post fit attribute: classes_
-@pytest.mark.skipif(sk_version < parse_version('0.22'), reason='scikit-learn version is less than 0.22')
+@pytest.mark.skipif(
+    sk_version < parse_version("0.22"), reason="scikit-learn version is less than 0.22"
+)
 def test_classifier_chain():
     n_outputs = 3
-    X, y = make_multilabel_classification(n_samples=100, n_features=20,
-                                          n_classes=n_outputs, random_state=0)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1,
-                                                        random_state=42)
+    X, y = make_multilabel_classification(
+        n_samples=100, n_features=20, n_classes=n_outputs, random_state=0
+    )
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     order = [2, 0, 1]
-    clf = ClassifierChain(base_estimator=lgb.LGBMClassifier(n_estimators=10),
-                          order=order, random_state=42)
+    clf = ClassifierChain(
+        base_estimator=lgb.LGBMClassifier(n_estimators=10), order=order, random_state=42
+    )
     clf.fit(X_train, y_train)
     score = clf.score(X_test, y_test)
     assert score >= 0.2
-    assert score <= 1.
-    np.testing.assert_array_equal(np.tile(np.unique(y_train), n_outputs),
-                                  np.concatenate(clf.classes_))
+    assert score <= 1.0
+    np.testing.assert_array_equal(
+        np.tile(np.unique(y_train), n_outputs), np.concatenate(clf.classes_)
+    )
     assert order == clf.order_
     for classifier in clf.estimators_:
         assert isinstance(classifier, lgb.LGBMClassifier)
@@ -353,19 +506,24 @@ def test_classifier_chain():
 
 
 # sklearn < 0.23 does not have as_frame parameter
-@pytest.mark.skipif(sk_version < parse_version('0.23'), reason='scikit-learn version is less than 0.23')
+@pytest.mark.skipif(
+    sk_version < parse_version("0.23"), reason="scikit-learn version is less than 0.23"
+)
 def test_regressor_chain():
     bunch = load_linnerud(as_frame=True)  # returns a Bunch instance
-    X, y = bunch['data'], bunch['target']
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X, y = bunch["data"], bunch["target"]
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     order = [2, 0, 1]
-    reg = RegressorChain(base_estimator=lgb.LGBMRegressor(n_estimators=10), order=order,
-                         random_state=42)
+    reg = RegressorChain(
+        base_estimator=lgb.LGBMRegressor(n_estimators=10), order=order, random_state=42
+    )
     reg.fit(X_train, y_train)
     y_pred = reg.predict(X_test)
     _, score, _ = mse(y_test, y_pred)
     assert score >= 0.2
-    assert score <= 120.
+    assert score <= 120.0
     assert order == reg.order_
     for regressor in reg.estimators_:
         assert isinstance(regressor, lgb.LGBMRegressor)
@@ -392,25 +550,41 @@ def test_clone_and_property():
 
 def test_joblib():
     X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
-    gbm = lgb.LGBMRegressor(n_estimators=10, objective=custom_asymmetric_obj,
-                            silent=True, importance_type='split')
-    gbm.fit(X_train, y_train, eval_set=[(X_train, y_train), (X_test, y_test)],
-            eval_metric=mse, early_stopping_rounds=5, verbose=False,
-            callbacks=[lgb.reset_parameter(learning_rate=list(np.arange(1, 0, -0.1)))])
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
+    gbm = lgb.LGBMRegressor(
+        n_estimators=10,
+        objective=custom_asymmetric_obj,
+        silent=True,
+        importance_type="split",
+    )
+    gbm.fit(
+        X_train,
+        y_train,
+        eval_set=[(X_train, y_train), (X_test, y_test)],
+        eval_metric=mse,
+        early_stopping_rounds=5,
+        verbose=False,
+        callbacks=[lgb.reset_parameter(learning_rate=list(np.arange(1, 0, -0.1)))],
+    )
 
-    joblib.dump(gbm, 'lgb.pkl')  # test model with custom functions
-    gbm_pickle = joblib.load('lgb.pkl')
+    joblib.dump(gbm, "lgb.pkl")  # test model with custom functions
+    gbm_pickle = joblib.load("lgb.pkl")
     assert isinstance(gbm_pickle.booster_, lgb.Booster)
     assert gbm.get_params() == gbm_pickle.get_params()
-    np.testing.assert_array_equal(gbm.feature_importances_, gbm_pickle.feature_importances_)
+    np.testing.assert_array_equal(
+        gbm.feature_importances_, gbm_pickle.feature_importances_
+    )
     assert gbm_pickle.learning_rate == pytest.approx(0.1)
     assert callable(gbm_pickle.objective)
 
     for eval_set in gbm.evals_result_:
         for metric in gbm.evals_result_[eval_set]:
-            np.testing.assert_allclose(gbm.evals_result_[eval_set][metric],
-                                       gbm_pickle.evals_result_[eval_set][metric])
+            np.testing.assert_allclose(
+                gbm.evals_result_[eval_set][metric],
+                gbm_pickle.evals_result_[eval_set][metric],
+            )
     pred_origin = gbm.predict(X_test)
     pred_pickle = gbm_pickle.predict(X_test)
     np.testing.assert_allclose(pred_origin, pred_pickle)
@@ -418,11 +592,17 @@ def test_joblib():
 
 def test_random_state_object():
     X, y = load_iris(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     state1 = np.random.RandomState(123)
     state2 = np.random.RandomState(123)
-    clf1 = lgb.LGBMClassifier(n_estimators=10, subsample=0.5, subsample_freq=1, random_state=state1)
-    clf2 = lgb.LGBMClassifier(n_estimators=10, subsample=0.5, subsample_freq=1, random_state=state2)
+    clf1 = lgb.LGBMClassifier(
+        n_estimators=10, subsample=0.5, subsample_freq=1, random_state=state1
+    )
+    clf2 = lgb.LGBMClassifier(
+        n_estimators=10, subsample=0.5, subsample_freq=1, random_state=state2
+    )
     # Test if random_state is properly stored
     assert clf1.random_state is state1
     assert clf2.random_state is state2
@@ -459,9 +639,9 @@ def test_feature_importances_type():
     data = load_iris(return_X_y=False)
     clf = lgb.LGBMClassifier(n_estimators=10)
     clf.fit(data.data, data.target)
-    clf.set_params(importance_type='split')
+    clf.set_params(importance_type="split")
     importances_split = clf.feature_importances_
-    clf.set_params(importance_type='gain')
+    clf.set_params(importance_type="gain")
     importances_gain = clf.feature_importances_
     # Test that the largest element is NOT the same, the smallest can be the same, i.e. zero
     importance_split_top1 = sorted(importances_split, reverse=True)[0]
@@ -471,39 +651,57 @@ def test_feature_importances_type():
 
 def test_pandas_categorical():
     pd = pytest.importorskip("pandas")
-    np.random.seed(42)  # sometimes there is no difference how cols are treated (cat or not cat)
-    X = pd.DataFrame({"A": np.random.permutation(['a', 'b', 'c', 'd'] * 75),  # str
-                      "B": np.random.permutation([1, 2, 3] * 100),  # int
-                      "C": np.random.permutation([0.1, 0.2, -0.1, -0.1, 0.2] * 60),  # float
-                      "D": np.random.permutation([True, False] * 150),  # bool
-                      "E": pd.Categorical(np.random.permutation(['z', 'y', 'x', 'w', 'v'] * 60),
-                                          ordered=True)})  # str and ordered categorical
+    np.random.seed(
+        42
+    )  # sometimes there is no difference how cols are treated (cat or not cat)
+    X = pd.DataFrame(
+        {
+            "A": np.random.permutation(["a", "b", "c", "d"] * 75),  # str
+            "B": np.random.permutation([1, 2, 3] * 100),  # int
+            "C": np.random.permutation([0.1, 0.2, -0.1, -0.1, 0.2] * 60),  # float
+            "D": np.random.permutation([True, False] * 150),  # bool
+            "E": pd.Categorical(
+                np.random.permutation(["z", "y", "x", "w", "v"] * 60), ordered=True
+            ),
+        }
+    )  # str and ordered categorical
     y = np.random.permutation([0, 1] * 150)
-    X_test = pd.DataFrame({"A": np.random.permutation(['a', 'b', 'e'] * 20),  # unseen category
-                           "B": np.random.permutation([1, 3] * 30),
-                           "C": np.random.permutation([0.1, -0.1, 0.2, 0.2] * 15),
-                           "D": np.random.permutation([True, False] * 30),
-                           "E": pd.Categorical(np.random.permutation(['z', 'y'] * 30),
-                                               ordered=True)})
+    X_test = pd.DataFrame(
+        {
+            "A": np.random.permutation(["a", "b", "e"] * 20),  # unseen category
+            "B": np.random.permutation([1, 3] * 30),
+            "C": np.random.permutation([0.1, -0.1, 0.2, 0.2] * 15),
+            "D": np.random.permutation([True, False] * 30),
+            "E": pd.Categorical(np.random.permutation(["z", "y"] * 30), ordered=True),
+        }
+    )
     np.random.seed()  # reset seed
     cat_cols_actual = ["A", "B", "C", "D"]
     cat_cols_to_store = cat_cols_actual + ["E"]
-    X[cat_cols_actual] = X[cat_cols_actual].astype('category')
-    X_test[cat_cols_actual] = X_test[cat_cols_actual].astype('category')
+    X[cat_cols_actual] = X[cat_cols_actual].astype("category")
+    X_test[cat_cols_actual] = X_test[cat_cols_actual].astype("category")
     cat_values = [X[col].cat.categories.tolist() for col in cat_cols_to_store]
     gbm0 = lgb.sklearn.LGBMClassifier(n_estimators=10).fit(X, y)
     pred0 = gbm0.predict(X_test, raw_score=True)
     pred_prob = gbm0.predict_proba(X_test)[:, 1]
-    gbm1 = lgb.sklearn.LGBMClassifier(n_estimators=10).fit(X, pd.Series(y), categorical_feature=[0])
+    gbm1 = lgb.sklearn.LGBMClassifier(n_estimators=10).fit(
+        X, pd.Series(y), categorical_feature=[0]
+    )
     pred1 = gbm1.predict(X_test, raw_score=True)
-    gbm2 = lgb.sklearn.LGBMClassifier(n_estimators=10).fit(X, y, categorical_feature=['A'])
+    gbm2 = lgb.sklearn.LGBMClassifier(n_estimators=10).fit(
+        X, y, categorical_feature=["A"]
+    )
     pred2 = gbm2.predict(X_test, raw_score=True)
-    gbm3 = lgb.sklearn.LGBMClassifier(n_estimators=10).fit(X, y, categorical_feature=['A', 'B', 'C', 'D'])
+    gbm3 = lgb.sklearn.LGBMClassifier(n_estimators=10).fit(
+        X, y, categorical_feature=["A", "B", "C", "D"]
+    )
     pred3 = gbm3.predict(X_test, raw_score=True)
-    gbm3.booster_.save_model('categorical.model')
-    gbm4 = lgb.Booster(model_file='categorical.model')
+    gbm3.booster_.save_model("categorical.model")
+    gbm4 = lgb.Booster(model_file="categorical.model")
     pred4 = gbm4.predict(X_test)
-    gbm5 = lgb.sklearn.LGBMClassifier(n_estimators=10).fit(X, y, categorical_feature=['A', 'B', 'C', 'D', 'E'])
+    gbm5 = lgb.sklearn.LGBMClassifier(n_estimators=10).fit(
+        X, y, categorical_feature=["A", "B", "C", "D", "E"]
+    )
     pred5 = gbm5.predict(X_test, raw_score=True)
     gbm6 = lgb.sklearn.LGBMClassifier(n_estimators=10).fit(X, y, categorical_feature=[])
     pred6 = gbm6.predict(X_test, raw_score=True)
@@ -515,7 +713,9 @@ def test_pandas_categorical():
     np.testing.assert_allclose(pred0, pred3)
     np.testing.assert_allclose(pred_prob, pred4)
     with pytest.raises(AssertionError):
-        np.testing.assert_allclose(pred0, pred5)  # ordered cat features aren't treated as cat features by default
+        np.testing.assert_allclose(
+            pred0, pred5
+        )  # ordered cat features aren't treated as cat features by default
     with pytest.raises(AssertionError):
         np.testing.assert_allclose(pred0, pred6)
     assert gbm0.booster_.pandas_categorical == cat_values
@@ -533,19 +733,27 @@ def test_pandas_sparse():
         from pandas.arrays import SparseArray
     except ImportError:  # support old versions
         from pandas import SparseArray
-    X = pd.DataFrame({"A": SparseArray(np.random.permutation([0, 1, 2] * 100)),
-                      "B": SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
-                      "C": SparseArray(np.random.permutation([True, False] * 150))})
+    X = pd.DataFrame(
+        {
+            "A": SparseArray(np.random.permutation([0, 1, 2] * 100)),
+            "B": SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
+            "C": SparseArray(np.random.permutation([True, False] * 150)),
+        }
+    )
     y = pd.Series(SparseArray(np.random.permutation([0, 1] * 150)))
-    X_test = pd.DataFrame({"A": SparseArray(np.random.permutation([0, 2] * 30)),
-                           "B": SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
-                           "C": SparseArray(np.random.permutation([True, False] * 30))})
-    if pd.__version__ >= '0.24.0':
+    X_test = pd.DataFrame(
+        {
+            "A": SparseArray(np.random.permutation([0, 2] * 30)),
+            "B": SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
+            "C": SparseArray(np.random.permutation([True, False] * 30)),
+        }
+    )
+    if pd.__version__ >= "0.24.0":
         for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
             assert pd.api.types.is_sparse(dtype)
     gbm = lgb.sklearn.LGBMClassifier(n_estimators=10).fit(X, y)
     pred_sparse = gbm.predict(X_test, raw_score=True)
-    if hasattr(X_test, 'sparse'):
+    if hasattr(X_test, "sparse"):
         pred_dense = gbm.predict(X_test.sparse.to_dense(), raw_score=True)
     else:
         pred_dense = gbm.predict(X_test.to_dense(), raw_score=True)
@@ -555,13 +763,14 @@ def test_pandas_sparse():
 def test_predict():
     # With default params
     iris = load_iris(return_X_y=False)
-    X_train, X_test, y_train, y_test = train_test_split(iris.data, iris.target,
-                                                        test_size=0.2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        iris.data, iris.target, test_size=0.2, random_state=42
+    )
 
-    gbm = lgb.train({'objective': 'multiclass',
-                     'num_class': 3,
-                     'verbose': -1},
-                    lgb.Dataset(X_train, y_train))
+    gbm = lgb.train(
+        {"objective": "multiclass", "num_class": 3, "verbose": -1},
+        lgb.Dataset(X_train, y_train),
+    )
     clf = lgb.LGBMClassifier(verbose=-1).fit(X_train, y_train)
 
     # Tests same probabilities
@@ -591,9 +800,9 @@ def test_predict():
 
     # Tests other parameters for the prediction works
     res_engine = gbm.predict(X_test)
-    res_sklearn_params = clf.predict_proba(X_test,
-                                           pred_early_stop=True,
-                                           pred_early_stop_margin=1.0)
+    res_sklearn_params = clf.predict_proba(
+        X_test, pred_early_stop=True, pred_early_stop_margin=1.0
+    )
     with pytest.raises(AssertionError):
         np.testing.assert_allclose(res_engine, res_sklearn_params)
 
@@ -625,330 +834,382 @@ def test_predict():
 
     # Tests other parameters for the prediction works, starting from iteration 10
     res_engine = gbm.predict(X_test, start_iteration=10)
-    res_sklearn_params = clf.predict_proba(X_test,
-                                           pred_early_stop=True,
-                                           pred_early_stop_margin=1.0, start_iteration=10)
+    res_sklearn_params = clf.predict_proba(
+        X_test, pred_early_stop=True, pred_early_stop_margin=1.0, start_iteration=10
+    )
     with pytest.raises(AssertionError):
         np.testing.assert_allclose(res_engine, res_sklearn_params)
 
 
 def test_evaluate_train_set():
     X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
     gbm = lgb.LGBMRegressor(n_estimators=10, silent=True)
-    gbm.fit(X_train, y_train, eval_set=[(X_train, y_train), (X_test, y_test)], verbose=False)
+    gbm.fit(
+        X_train, y_train, eval_set=[(X_train, y_train), (X_test, y_test)], verbose=False
+    )
     assert len(gbm.evals_result_) == 2
-    assert 'training' in gbm.evals_result_
-    assert len(gbm.evals_result_['training']) == 1
-    assert 'l2' in gbm.evals_result_['training']
-    assert 'valid_1' in gbm.evals_result_
-    assert len(gbm.evals_result_['valid_1']) == 1
-    assert 'l2' in gbm.evals_result_['valid_1']
+    assert "training" in gbm.evals_result_
+    assert len(gbm.evals_result_["training"]) == 1
+    assert "l2" in gbm.evals_result_["training"]
+    assert "valid_1" in gbm.evals_result_
+    assert len(gbm.evals_result_["valid_1"]) == 1
+    assert "l2" in gbm.evals_result_["valid_1"]
 
 
 def test_metrics():
     X, y = load_boston(return_X_y=True)
-    params = {'n_estimators': 2, 'verbose': -1}
-    params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
+    params = {"n_estimators": 2, "verbose": -1}
+    params_fit = {"X": X, "y": y, "eval_set": (X, y), "verbose": False}
 
     # no custom objective, no custom metric
     # default metric
     gbm = lgb.LGBMRegressor(**params).fit(**params_fit)
-    assert len(gbm.evals_result_['training']) == 1
-    assert 'l2' in gbm.evals_result_['training']
+    assert len(gbm.evals_result_["training"]) == 1
+    assert "l2" in gbm.evals_result_["training"]
 
     # non-default metric
-    gbm = lgb.LGBMRegressor(metric='mape', **params).fit(**params_fit)
-    assert len(gbm.evals_result_['training']) == 1
-    assert 'mape' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(metric="mape", **params).fit(**params_fit)
+    assert len(gbm.evals_result_["training"]) == 1
+    assert "mape" in gbm.evals_result_["training"]
 
     # no metric
-    gbm = lgb.LGBMRegressor(metric='None', **params).fit(**params_fit)
+    gbm = lgb.LGBMRegressor(metric="None", **params).fit(**params_fit)
     assert gbm.evals_result_ is None
 
     # non-default metric in eval_metric
-    gbm = lgb.LGBMRegressor(**params).fit(eval_metric='mape', **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'l2' in gbm.evals_result_['training']
-    assert 'mape' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(**params).fit(eval_metric="mape", **params_fit)
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "l2" in gbm.evals_result_["training"]
+    assert "mape" in gbm.evals_result_["training"]
 
     # non-default metric with non-default metric in eval_metric
-    gbm = lgb.LGBMRegressor(metric='gamma', **params).fit(eval_metric='mape', **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'gamma' in gbm.evals_result_['training']
-    assert 'mape' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(metric="gamma", **params).fit(
+        eval_metric="mape", **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "gamma" in gbm.evals_result_["training"]
+    assert "mape" in gbm.evals_result_["training"]
 
     # non-default metric with multiple metrics in eval_metric
-    gbm = lgb.LGBMRegressor(metric='gamma',
-                            **params).fit(eval_metric=['l2', 'mape'], **params_fit)
-    assert len(gbm.evals_result_['training']) == 3
-    assert 'gamma' in gbm.evals_result_['training']
-    assert 'l2' in gbm.evals_result_['training']
-    assert 'mape' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(metric="gamma", **params).fit(
+        eval_metric=["l2", "mape"], **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 3
+    assert "gamma" in gbm.evals_result_["training"]
+    assert "l2" in gbm.evals_result_["training"]
+    assert "mape" in gbm.evals_result_["training"]
 
     # non-default metric with multiple metrics in eval_metric for LGBMClassifier
     X_classification, y_classification = load_breast_cancer(return_X_y=True)
-    params_classification = {'n_estimators': 2, 'verbose': -1,
-                             'objective': 'binary', 'metric': 'binary_logloss'}
-    params_fit_classification = {'X': X_classification, 'y': y_classification,
-                                 'eval_set': (X_classification, y_classification),
-                                 'verbose': False}
-    gbm = lgb.LGBMClassifier(**params_classification).fit(eval_metric=['fair', 'error'],
-                                                          **params_fit_classification)
-    assert len(gbm.evals_result_['training']) == 3
-    assert 'fair' in gbm.evals_result_['training']
-    assert 'binary_error' in gbm.evals_result_['training']
-    assert 'binary_logloss' in gbm.evals_result_['training']
+    params_classification = {
+        "n_estimators": 2,
+        "verbose": -1,
+        "objective": "binary",
+        "metric": "binary_logloss",
+    }
+    params_fit_classification = {
+        "X": X_classification,
+        "y": y_classification,
+        "eval_set": (X_classification, y_classification),
+        "verbose": False,
+    }
+    gbm = lgb.LGBMClassifier(**params_classification).fit(
+        eval_metric=["fair", "error"], **params_fit_classification
+    )
+    assert len(gbm.evals_result_["training"]) == 3
+    assert "fair" in gbm.evals_result_["training"]
+    assert "binary_error" in gbm.evals_result_["training"]
+    assert "binary_logloss" in gbm.evals_result_["training"]
 
     # default metric for non-default objective
-    gbm = lgb.LGBMRegressor(objective='regression_l1', **params).fit(**params_fit)
-    assert len(gbm.evals_result_['training']) == 1
-    assert 'l1' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective="regression_l1", **params).fit(**params_fit)
+    assert len(gbm.evals_result_["training"]) == 1
+    assert "l1" in gbm.evals_result_["training"]
 
     # non-default metric for non-default objective
-    gbm = lgb.LGBMRegressor(objective='regression_l1', metric='mape',
-                            **params).fit(**params_fit)
-    assert len(gbm.evals_result_['training']) == 1
-    assert 'mape' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective="regression_l1", metric="mape", **params).fit(
+        **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 1
+    assert "mape" in gbm.evals_result_["training"]
 
     # no metric
-    gbm = lgb.LGBMRegressor(objective='regression_l1', metric='None',
-                            **params).fit(**params_fit)
+    gbm = lgb.LGBMRegressor(objective="regression_l1", metric="None", **params).fit(
+        **params_fit
+    )
     assert gbm.evals_result_ is None
 
     # non-default metric in eval_metric for non-default objective
-    gbm = lgb.LGBMRegressor(objective='regression_l1',
-                            **params).fit(eval_metric='mape', **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'l1' in gbm.evals_result_['training']
-    assert 'mape' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective="regression_l1", **params).fit(
+        eval_metric="mape", **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "l1" in gbm.evals_result_["training"]
+    assert "mape" in gbm.evals_result_["training"]
 
     # non-default metric with non-default metric in eval_metric for non-default objective
-    gbm = lgb.LGBMRegressor(objective='regression_l1', metric='gamma',
-                            **params).fit(eval_metric='mape', **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'gamma' in gbm.evals_result_['training']
-    assert 'mape' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective="regression_l1", metric="gamma", **params).fit(
+        eval_metric="mape", **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "gamma" in gbm.evals_result_["training"]
+    assert "mape" in gbm.evals_result_["training"]
 
     # non-default metric with multiple metrics in eval_metric for non-default objective
-    gbm = lgb.LGBMRegressor(objective='regression_l1', metric='gamma',
-                            **params).fit(eval_metric=['l2', 'mape'], **params_fit)
-    assert len(gbm.evals_result_['training']) == 3
-    assert 'gamma' in gbm.evals_result_['training']
-    assert 'l2' in gbm.evals_result_['training']
-    assert 'mape' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective="regression_l1", metric="gamma", **params).fit(
+        eval_metric=["l2", "mape"], **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 3
+    assert "gamma" in gbm.evals_result_["training"]
+    assert "l2" in gbm.evals_result_["training"]
+    assert "mape" in gbm.evals_result_["training"]
 
     # custom objective, no custom metric
     # default regression metric for custom objective
     gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, **params).fit(**params_fit)
-    assert len(gbm.evals_result_['training']) == 1
-    assert 'l2' in gbm.evals_result_['training']
+    assert len(gbm.evals_result_["training"]) == 1
+    assert "l2" in gbm.evals_result_["training"]
 
     # non-default regression metric for custom objective
-    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric='mape', **params).fit(**params_fit)
-    assert len(gbm.evals_result_['training']) == 1
-    assert 'mape' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric="mape", **params).fit(
+        **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 1
+    assert "mape" in gbm.evals_result_["training"]
 
     # multiple regression metrics for custom objective
-    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric=['l1', 'gamma'],
-                            **params).fit(**params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'l1' in gbm.evals_result_['training']
-    assert 'gamma' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(
+        objective=custom_dummy_obj, metric=["l1", "gamma"], **params
+    ).fit(**params_fit)
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "l1" in gbm.evals_result_["training"]
+    assert "gamma" in gbm.evals_result_["training"]
 
     # no metric
-    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric='None',
-                            **params).fit(**params_fit)
+    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric="None", **params).fit(
+        **params_fit
+    )
     assert gbm.evals_result_ is None
 
     # default regression metric with non-default metric in eval_metric for custom objective
-    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj,
-                            **params).fit(eval_metric='mape', **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'l2' in gbm.evals_result_['training']
-    assert 'mape' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, **params).fit(
+        eval_metric="mape", **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "l2" in gbm.evals_result_["training"]
+    assert "mape" in gbm.evals_result_["training"]
 
     # non-default regression metric with metric in eval_metric for custom objective
-    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric='mape',
-                            **params).fit(eval_metric='gamma', **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'mape' in gbm.evals_result_['training']
-    assert 'gamma' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric="mape", **params).fit(
+        eval_metric="gamma", **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "mape" in gbm.evals_result_["training"]
+    assert "gamma" in gbm.evals_result_["training"]
 
     # multiple regression metrics with metric in eval_metric for custom objective
-    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric=['l1', 'gamma'],
-                            **params).fit(eval_metric='l2', **params_fit)
-    assert len(gbm.evals_result_['training']) == 3
-    assert 'l1' in gbm.evals_result_['training']
-    assert 'gamma' in gbm.evals_result_['training']
-    assert 'l2' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(
+        objective=custom_dummy_obj, metric=["l1", "gamma"], **params
+    ).fit(eval_metric="l2", **params_fit)
+    assert len(gbm.evals_result_["training"]) == 3
+    assert "l1" in gbm.evals_result_["training"]
+    assert "gamma" in gbm.evals_result_["training"]
+    assert "l2" in gbm.evals_result_["training"]
 
     # multiple regression metrics with multiple metrics in eval_metric for custom objective
-    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric=['l1', 'gamma'],
-                            **params).fit(eval_metric=['l2', 'mape'], **params_fit)
-    assert len(gbm.evals_result_['training']) == 4
-    assert 'l1' in gbm.evals_result_['training']
-    assert 'gamma' in gbm.evals_result_['training']
-    assert 'l2' in gbm.evals_result_['training']
-    assert 'mape' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(
+        objective=custom_dummy_obj, metric=["l1", "gamma"], **params
+    ).fit(eval_metric=["l2", "mape"], **params_fit)
+    assert len(gbm.evals_result_["training"]) == 4
+    assert "l1" in gbm.evals_result_["training"]
+    assert "gamma" in gbm.evals_result_["training"]
+    assert "l2" in gbm.evals_result_["training"]
+    assert "mape" in gbm.evals_result_["training"]
 
     # no custom objective, custom metric
     # default metric with custom metric
     gbm = lgb.LGBMRegressor(**params).fit(eval_metric=constant_metric, **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'l2' in gbm.evals_result_['training']
-    assert 'error' in gbm.evals_result_['training']
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "l2" in gbm.evals_result_["training"]
+    assert "error" in gbm.evals_result_["training"]
 
     # non-default metric with custom metric
-    gbm = lgb.LGBMRegressor(metric='mape',
-                            **params).fit(eval_metric=constant_metric, **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'mape' in gbm.evals_result_['training']
-    assert 'error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(metric="mape", **params).fit(
+        eval_metric=constant_metric, **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "mape" in gbm.evals_result_["training"]
+    assert "error" in gbm.evals_result_["training"]
 
     # multiple metrics with custom metric
-    gbm = lgb.LGBMRegressor(metric=['l1', 'gamma'],
-                            **params).fit(eval_metric=constant_metric, **params_fit)
-    assert len(gbm.evals_result_['training']) == 3
-    assert 'l1' in gbm.evals_result_['training']
-    assert 'gamma' in gbm.evals_result_['training']
-    assert 'error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(metric=["l1", "gamma"], **params).fit(
+        eval_metric=constant_metric, **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 3
+    assert "l1" in gbm.evals_result_["training"]
+    assert "gamma" in gbm.evals_result_["training"]
+    assert "error" in gbm.evals_result_["training"]
 
     # custom metric (disable default metric)
-    gbm = lgb.LGBMRegressor(metric='None',
-                            **params).fit(eval_metric=constant_metric, **params_fit)
-    assert len(gbm.evals_result_['training']) == 1
-    assert 'error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(metric="None", **params).fit(
+        eval_metric=constant_metric, **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 1
+    assert "error" in gbm.evals_result_["training"]
 
     # default metric for non-default objective with custom metric
-    gbm = lgb.LGBMRegressor(objective='regression_l1',
-                            **params).fit(eval_metric=constant_metric, **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'l1' in gbm.evals_result_['training']
-    assert 'error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective="regression_l1", **params).fit(
+        eval_metric=constant_metric, **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "l1" in gbm.evals_result_["training"]
+    assert "error" in gbm.evals_result_["training"]
 
     # non-default metric for non-default objective with custom metric
-    gbm = lgb.LGBMRegressor(objective='regression_l1', metric='mape',
-                            **params).fit(eval_metric=constant_metric, **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'mape' in gbm.evals_result_['training']
-    assert 'error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective="regression_l1", metric="mape", **params).fit(
+        eval_metric=constant_metric, **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "mape" in gbm.evals_result_["training"]
+    assert "error" in gbm.evals_result_["training"]
 
     # multiple metrics for non-default objective with custom metric
-    gbm = lgb.LGBMRegressor(objective='regression_l1', metric=['l1', 'gamma'],
-                            **params).fit(eval_metric=constant_metric, **params_fit)
-    assert len(gbm.evals_result_['training']) == 3
-    assert 'l1' in gbm.evals_result_['training']
-    assert 'gamma' in gbm.evals_result_['training']
-    assert 'error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(
+        objective="regression_l1", metric=["l1", "gamma"], **params
+    ).fit(eval_metric=constant_metric, **params_fit)
+    assert len(gbm.evals_result_["training"]) == 3
+    assert "l1" in gbm.evals_result_["training"]
+    assert "gamma" in gbm.evals_result_["training"]
+    assert "error" in gbm.evals_result_["training"]
 
     # custom metric (disable default metric for non-default objective)
-    gbm = lgb.LGBMRegressor(objective='regression_l1', metric='None',
-                            **params).fit(eval_metric=constant_metric, **params_fit)
-    assert len(gbm.evals_result_['training']) == 1
-    assert 'error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective="regression_l1", metric="None", **params).fit(
+        eval_metric=constant_metric, **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 1
+    assert "error" in gbm.evals_result_["training"]
 
     # custom objective, custom metric
     # custom metric for custom objective
-    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj,
-                            **params).fit(eval_metric=constant_metric, **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, **params).fit(
+        eval_metric=constant_metric, **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "error" in gbm.evals_result_["training"]
 
     # non-default regression metric with custom metric for custom objective
-    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric='mape',
-                            **params).fit(eval_metric=constant_metric, **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'mape' in gbm.evals_result_['training']
-    assert 'error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric="mape", **params).fit(
+        eval_metric=constant_metric, **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "mape" in gbm.evals_result_["training"]
+    assert "error" in gbm.evals_result_["training"]
 
     # multiple regression metrics with custom metric for custom objective
-    gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric=['l2', 'mape'],
-                            **params).fit(eval_metric=constant_metric, **params_fit)
-    assert len(gbm.evals_result_['training']) == 3
-    assert 'l2' in gbm.evals_result_['training']
-    assert 'mape' in gbm.evals_result_['training']
-    assert 'error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMRegressor(
+        objective=custom_dummy_obj, metric=["l2", "mape"], **params
+    ).fit(eval_metric=constant_metric, **params_fit)
+    assert len(gbm.evals_result_["training"]) == 3
+    assert "l2" in gbm.evals_result_["training"]
+    assert "mape" in gbm.evals_result_["training"]
+    assert "error" in gbm.evals_result_["training"]
 
     X, y = load_digits(n_class=3, return_X_y=True)
-    params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
+    params_fit = {"X": X, "y": y, "eval_set": (X, y), "verbose": False}
 
     # default metric and invalid binary metric is replaced with multiclass alternative
-    gbm = lgb.LGBMClassifier(**params).fit(eval_metric='binary_error', **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'multi_logloss' in gbm.evals_result_['training']
-    assert 'multi_error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMClassifier(**params).fit(eval_metric="binary_error", **params_fit)
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "multi_logloss" in gbm.evals_result_["training"]
+    assert "multi_error" in gbm.evals_result_["training"]
 
     # invalid objective is replaced with default multiclass one
     # and invalid binary metric is replaced with multiclass alternative
-    gbm = lgb.LGBMClassifier(objective='invalid_obj',
-                             **params).fit(eval_metric='binary_error', **params_fit)
-    assert gbm.objective_ == 'multiclass'
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'multi_logloss' in gbm.evals_result_['training']
-    assert 'multi_error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMClassifier(objective="invalid_obj", **params).fit(
+        eval_metric="binary_error", **params_fit
+    )
+    assert gbm.objective_ == "multiclass"
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "multi_logloss" in gbm.evals_result_["training"]
+    assert "multi_error" in gbm.evals_result_["training"]
 
     # default metric for non-default multiclass objective
     # and invalid binary metric is replaced with multiclass alternative
-    gbm = lgb.LGBMClassifier(objective='ovr',
-                             **params).fit(eval_metric='binary_error', **params_fit)
-    assert gbm.objective_ == 'ovr'
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'multi_logloss' in gbm.evals_result_['training']
-    assert 'multi_error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMClassifier(objective="ovr", **params).fit(
+        eval_metric="binary_error", **params_fit
+    )
+    assert gbm.objective_ == "ovr"
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "multi_logloss" in gbm.evals_result_["training"]
+    assert "multi_error" in gbm.evals_result_["training"]
 
     X, y = load_digits(n_class=2, return_X_y=True)
-    params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
+    params_fit = {"X": X, "y": y, "eval_set": (X, y), "verbose": False}
 
     # default metric and invalid multiclass metric is replaced with binary alternative
-    gbm = lgb.LGBMClassifier(**params).fit(eval_metric='multi_error', **params_fit)
-    assert len(gbm.evals_result_['training']) == 2
-    assert 'binary_logloss' in gbm.evals_result_['training']
-    assert 'binary_error' in gbm.evals_result_['training']
+    gbm = lgb.LGBMClassifier(**params).fit(eval_metric="multi_error", **params_fit)
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "binary_logloss" in gbm.evals_result_["training"]
+    assert "binary_error" in gbm.evals_result_["training"]
 
     # invalid multiclass metric is replaced with binary alternative for custom objective
-    gbm = lgb.LGBMClassifier(objective=custom_dummy_obj,
-                             **params).fit(eval_metric='multi_logloss', **params_fit)
-    assert len(gbm.evals_result_['training']) == 1
-    assert 'binary_logloss' in gbm.evals_result_['training']
+    gbm = lgb.LGBMClassifier(objective=custom_dummy_obj, **params).fit(
+        eval_metric="multi_logloss", **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 1
+    assert "binary_logloss" in gbm.evals_result_["training"]
 
 
 def test_multiple_eval_metrics():
 
     X, y = load_breast_cancer(return_X_y=True)
 
-    params = {'n_estimators': 2, 'verbose': -1, 'objective': 'binary', 'metric': 'binary_logloss'}
-    params_fit = {'X': X, 'y': y, 'eval_set': (X, y), 'verbose': False}
+    params = {
+        "n_estimators": 2,
+        "verbose": -1,
+        "objective": "binary",
+        "metric": "binary_logloss",
+    }
+    params_fit = {"X": X, "y": y, "eval_set": (X, y), "verbose": False}
 
     # Verify that can receive a list of metrics, only callable
-    gbm = lgb.LGBMClassifier(**params).fit(eval_metric=[constant_metric, decreasing_metric], **params_fit)
-    assert len(gbm.evals_result_['training']) == 3
-    assert 'error' in gbm.evals_result_['training']
-    assert 'decreasing_metric' in gbm.evals_result_['training']
-    assert 'binary_logloss' in gbm.evals_result_['training']
+    gbm = lgb.LGBMClassifier(**params).fit(
+        eval_metric=[constant_metric, decreasing_metric], **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 3
+    assert "error" in gbm.evals_result_["training"]
+    assert "decreasing_metric" in gbm.evals_result_["training"]
+    assert "binary_logloss" in gbm.evals_result_["training"]
 
     # Verify that can receive a list of custom and built-in metrics
-    gbm = lgb.LGBMClassifier(**params).fit(eval_metric=[constant_metric, decreasing_metric, 'fair'], **params_fit)
-    assert len(gbm.evals_result_['training']) == 4
-    assert 'error' in gbm.evals_result_['training']
-    assert 'decreasing_metric' in gbm.evals_result_['training']
-    assert 'binary_logloss' in gbm.evals_result_['training']
-    assert 'fair' in gbm.evals_result_['training']
+    gbm = lgb.LGBMClassifier(**params).fit(
+        eval_metric=[constant_metric, decreasing_metric, "fair"], **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 4
+    assert "error" in gbm.evals_result_["training"]
+    assert "decreasing_metric" in gbm.evals_result_["training"]
+    assert "binary_logloss" in gbm.evals_result_["training"]
+    assert "fair" in gbm.evals_result_["training"]
 
     # Verify that works as expected when eval_metric is empty
     gbm = lgb.LGBMClassifier(**params).fit(eval_metric=[], **params_fit)
-    assert len(gbm.evals_result_['training']) == 1
-    assert 'binary_logloss' in gbm.evals_result_['training']
+    assert len(gbm.evals_result_["training"]) == 1
+    assert "binary_logloss" in gbm.evals_result_["training"]
 
     # Verify that can receive a list of metrics, only built-in
-    gbm = lgb.LGBMClassifier(**params).fit(eval_metric=['fair', 'error'], **params_fit)
-    assert len(gbm.evals_result_['training']) == 3
-    assert 'binary_logloss' in gbm.evals_result_['training']
+    gbm = lgb.LGBMClassifier(**params).fit(eval_metric=["fair", "error"], **params_fit)
+    assert len(gbm.evals_result_["training"]) == 3
+    assert "binary_logloss" in gbm.evals_result_["training"]
 
     # Verify that eval_metric is robust to receiving a list with None
-    gbm = lgb.LGBMClassifier(**params).fit(eval_metric=['fair', 'error', None], **params_fit)
-    assert len(gbm.evals_result_['training']) == 3
-    assert 'binary_logloss' in gbm.evals_result_['training']
+    gbm = lgb.LGBMClassifier(**params).fit(
+        eval_metric=["fair", "error", None], **params_fit
+    )
+    assert len(gbm.evals_result_["training"]) == 3
+    assert "binary_logloss" in gbm.evals_result_["training"]
 
 
 def test_inf_handle():
@@ -957,11 +1218,17 @@ def test_inf_handle():
     X = np.random.randn(nrows, ncols)
     y = np.random.randn(nrows) + np.full(nrows, 1e30)
     weight = np.full(nrows, 1e10)
-    params = {'n_estimators': 20, 'verbose': -1}
-    params_fit = {'X': X, 'y': y, 'sample_weight': weight, 'eval_set': (X, y),
-                  'verbose': False, 'early_stopping_rounds': 5}
+    params = {"n_estimators": 20, "verbose": -1}
+    params_fit = {
+        "X": X,
+        "y": y,
+        "sample_weight": weight,
+        "eval_set": (X, y),
+        "verbose": False,
+        "early_stopping_rounds": 5,
+    }
     gbm = lgb.LGBMRegressor(**params).fit(**params_fit)
-    np.testing.assert_allclose(gbm.evals_result_['training']['l2'], np.inf)
+    np.testing.assert_allclose(gbm.evals_result_["training"]["l2"], np.inf)
 
 
 def test_nan_handle():
@@ -970,17 +1237,24 @@ def test_nan_handle():
     X = np.random.randn(nrows, ncols)
     y = np.random.randn(nrows) + np.full(nrows, 1e30)
     weight = np.zeros(nrows)
-    params = {'n_estimators': 20, 'verbose': -1}
-    params_fit = {'X': X, 'y': y, 'sample_weight': weight, 'eval_set': (X, y),
-                  'verbose': False, 'early_stopping_rounds': 5}
+    params = {"n_estimators": 20, "verbose": -1}
+    params_fit = {
+        "X": X,
+        "y": y,
+        "sample_weight": weight,
+        "eval_set": (X, y),
+        "verbose": False,
+        "early_stopping_rounds": 5,
+    }
     gbm = lgb.LGBMRegressor(**params).fit(**params_fit)
-    np.testing.assert_allclose(gbm.evals_result_['training']['l2'], np.nan)
+    np.testing.assert_allclose(gbm.evals_result_["training"]["l2"], np.nan)
 
 
 def test_first_metric_only():
-
-    def fit_and_check(eval_set_names, metric_names, assumed_iteration, first_metric_only):
-        params['first_metric_only'] = first_metric_only
+    def fit_and_check(
+        eval_set_names, metric_names, assumed_iteration, first_metric_only
+    ):
+        params["first_metric_only"] = first_metric_only
         gbm = lgb.LGBMRegressor(**params).fit(**params_fit)
         assert len(gbm.evals_result_) == len(eval_set_names)
         for eval_set_name in eval_set_names:
@@ -990,145 +1264,209 @@ def test_first_metric_only():
                 assert metric_name in gbm.evals_result_[eval_set_name]
 
                 actual = len(gbm.evals_result_[eval_set_name][metric_name])
-                expected = assumed_iteration + (params_fit['early_stopping_rounds']
-                                                if eval_set_name != 'training'
-                                                and assumed_iteration != gbm.n_estimators else 0)
+                expected = assumed_iteration + (
+                    params_fit["early_stopping_rounds"]
+                    if eval_set_name != "training"
+                    and assumed_iteration != gbm.n_estimators
+                    else 0
+                )
                 assert expected == actual
-                if eval_set_name != 'training':
+                if eval_set_name != "training":
                     assert assumed_iteration == gbm.best_iteration_
                 else:
                     assert gbm.n_estimators == gbm.best_iteration_
 
     X, y = load_boston(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
-    X_test1, X_test2, y_test1, y_test2 = train_test_split(X_test, y_test, test_size=0.5, random_state=72)
-    params = {'n_estimators': 30,
-              'learning_rate': 0.8,
-              'num_leaves': 15,
-              'verbose': -1,
-              'seed': 123}
-    params_fit = {'X': X_train,
-                  'y': y_train,
-                  'early_stopping_rounds': 5,
-                  'verbose': False}
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+    X_test1, X_test2, y_test1, y_test2 = train_test_split(
+        X_test, y_test, test_size=0.5, random_state=72
+    )
+    params = {
+        "n_estimators": 30,
+        "learning_rate": 0.8,
+        "num_leaves": 15,
+        "verbose": -1,
+        "seed": 123,
+    }
+    params_fit = {
+        "X": X_train,
+        "y": y_train,
+        "early_stopping_rounds": 5,
+        "verbose": False,
+    }
 
     iter_valid1_l1 = 3
     iter_valid1_l2 = 18
     iter_valid2_l1 = 11
     iter_valid2_l2 = 7
-    assert len(set([iter_valid1_l1, iter_valid1_l2, iter_valid2_l1, iter_valid2_l2])) == 4
+    assert (
+        len(set([iter_valid1_l1, iter_valid1_l2, iter_valid2_l1, iter_valid2_l2])) == 4
+    )
     iter_min_l1 = min([iter_valid1_l1, iter_valid2_l1])
     iter_min_l2 = min([iter_valid1_l2, iter_valid2_l2])
     iter_min = min([iter_min_l1, iter_min_l2])
     iter_min_valid1 = min([iter_valid1_l1, iter_valid1_l2])
 
     # training data as eval_set
-    params_fit['eval_set'] = (X_train, y_train)
-    fit_and_check(['training'], ['l2'], 30, False)
-    fit_and_check(['training'], ['l2'], 30, True)
+    params_fit["eval_set"] = (X_train, y_train)
+    fit_and_check(["training"], ["l2"], 30, False)
+    fit_and_check(["training"], ["l2"], 30, True)
 
     # feval
-    params['metric'] = 'None'
-    params_fit['eval_metric'] = lambda preds, train_data: [decreasing_metric(preds, train_data),
-                                                           constant_metric(preds, train_data)]
-    params_fit['eval_set'] = (X_test1, y_test1)
-    fit_and_check(['valid_0'], ['decreasing_metric', 'error'], 1, False)
-    fit_and_check(['valid_0'], ['decreasing_metric', 'error'], 30, True)
-    params_fit['eval_metric'] = lambda preds, train_data: [constant_metric(preds, train_data),
-                                                           decreasing_metric(preds, train_data)]
-    fit_and_check(['valid_0'], ['decreasing_metric', 'error'], 1, True)
+    params["metric"] = "None"
+    params_fit["eval_metric"] = lambda preds, train_data: [
+        decreasing_metric(preds, train_data),
+        constant_metric(preds, train_data),
+    ]
+    params_fit["eval_set"] = (X_test1, y_test1)
+    fit_and_check(["valid_0"], ["decreasing_metric", "error"], 1, False)
+    fit_and_check(["valid_0"], ["decreasing_metric", "error"], 30, True)
+    params_fit["eval_metric"] = lambda preds, train_data: [
+        constant_metric(preds, train_data),
+        decreasing_metric(preds, train_data),
+    ]
+    fit_and_check(["valid_0"], ["decreasing_metric", "error"], 1, True)
 
     # single eval_set
-    params.pop('metric')
-    params_fit.pop('eval_metric')
-    fit_and_check(['valid_0'], ['l2'], iter_valid1_l2, False)
-    fit_and_check(['valid_0'], ['l2'], iter_valid1_l2, True)
+    params.pop("metric")
+    params_fit.pop("eval_metric")
+    fit_and_check(["valid_0"], ["l2"], iter_valid1_l2, False)
+    fit_and_check(["valid_0"], ["l2"], iter_valid1_l2, True)
 
-    params_fit['eval_metric'] = "l2"
-    fit_and_check(['valid_0'], ['l2'], iter_valid1_l2, False)
-    fit_and_check(['valid_0'], ['l2'], iter_valid1_l2, True)
+    params_fit["eval_metric"] = "l2"
+    fit_and_check(["valid_0"], ["l2"], iter_valid1_l2, False)
+    fit_and_check(["valid_0"], ["l2"], iter_valid1_l2, True)
 
-    params_fit['eval_metric'] = "l1"
-    fit_and_check(['valid_0'], ['l1', 'l2'], iter_min_valid1, False)
-    fit_and_check(['valid_0'], ['l1', 'l2'], iter_valid1_l1, True)
+    params_fit["eval_metric"] = "l1"
+    fit_and_check(["valid_0"], ["l1", "l2"], iter_min_valid1, False)
+    fit_and_check(["valid_0"], ["l1", "l2"], iter_valid1_l1, True)
 
-    params_fit['eval_metric'] = ["l1", "l2"]
-    fit_and_check(['valid_0'], ['l1', 'l2'], iter_min_valid1, False)
-    fit_and_check(['valid_0'], ['l1', 'l2'], iter_valid1_l1, True)
+    params_fit["eval_metric"] = ["l1", "l2"]
+    fit_and_check(["valid_0"], ["l1", "l2"], iter_min_valid1, False)
+    fit_and_check(["valid_0"], ["l1", "l2"], iter_valid1_l1, True)
 
-    params_fit['eval_metric'] = ["l2", "l1"]
-    fit_and_check(['valid_0'], ['l1', 'l2'], iter_min_valid1, False)
-    fit_and_check(['valid_0'], ['l1', 'l2'], iter_valid1_l2, True)
+    params_fit["eval_metric"] = ["l2", "l1"]
+    fit_and_check(["valid_0"], ["l1", "l2"], iter_min_valid1, False)
+    fit_and_check(["valid_0"], ["l1", "l2"], iter_valid1_l2, True)
 
-    params_fit['eval_metric'] = ["l2", "regression", "mse"]  # test aliases
-    fit_and_check(['valid_0'], ['l2'], iter_valid1_l2, False)
-    fit_and_check(['valid_0'], ['l2'], iter_valid1_l2, True)
+    params_fit["eval_metric"] = ["l2", "regression", "mse"]  # test aliases
+    fit_and_check(["valid_0"], ["l2"], iter_valid1_l2, False)
+    fit_and_check(["valid_0"], ["l2"], iter_valid1_l2, True)
 
     # two eval_set
-    params_fit['eval_set'] = [(X_test1, y_test1), (X_test2, y_test2)]
-    params_fit['eval_metric'] = ["l1", "l2"]
-    fit_and_check(['valid_0', 'valid_1'], ['l1', 'l2'], iter_min_l1, True)
-    params_fit['eval_metric'] = ["l2", "l1"]
-    fit_and_check(['valid_0', 'valid_1'], ['l1', 'l2'], iter_min_l2, True)
+    params_fit["eval_set"] = [(X_test1, y_test1), (X_test2, y_test2)]
+    params_fit["eval_metric"] = ["l1", "l2"]
+    fit_and_check(["valid_0", "valid_1"], ["l1", "l2"], iter_min_l1, True)
+    params_fit["eval_metric"] = ["l2", "l1"]
+    fit_and_check(["valid_0", "valid_1"], ["l1", "l2"], iter_min_l2, True)
 
-    params_fit['eval_set'] = [(X_test2, y_test2), (X_test1, y_test1)]
-    params_fit['eval_metric'] = ["l1", "l2"]
-    fit_and_check(['valid_0', 'valid_1'], ['l1', 'l2'], iter_min, False)
-    fit_and_check(['valid_0', 'valid_1'], ['l1', 'l2'], iter_min_l1, True)
-    params_fit['eval_metric'] = ["l2", "l1"]
-    fit_and_check(['valid_0', 'valid_1'], ['l1', 'l2'], iter_min, False)
-    fit_and_check(['valid_0', 'valid_1'], ['l1', 'l2'], iter_min_l2, True)
+    params_fit["eval_set"] = [(X_test2, y_test2), (X_test1, y_test1)]
+    params_fit["eval_metric"] = ["l1", "l2"]
+    fit_and_check(["valid_0", "valid_1"], ["l1", "l2"], iter_min, False)
+    fit_and_check(["valid_0", "valid_1"], ["l1", "l2"], iter_min_l1, True)
+    params_fit["eval_metric"] = ["l2", "l1"]
+    fit_and_check(["valid_0", "valid_1"], ["l1", "l2"], iter_min, False)
+    fit_and_check(["valid_0", "valid_1"], ["l1", "l2"], iter_min_l2, True)
 
 
 def test_class_weight():
     X, y = load_digits(n_class=10, return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
-    y_train_str = y_train.astype('str')
-    y_test_str = y_test.astype('str')
-    gbm = lgb.LGBMClassifier(n_estimators=10, class_weight='balanced', silent=True)
-    gbm.fit(X_train, y_train,
-            eval_set=[(X_train, y_train), (X_test, y_test), (X_test, y_test),
-                      (X_test, y_test), (X_test, y_test)],
-            eval_class_weight=['balanced', None, 'balanced', {1: 10, 4: 20}, {5: 30, 2: 40}],
-            verbose=False)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+    y_train_str = y_train.astype("str")
+    y_test_str = y_test.astype("str")
+    gbm = lgb.LGBMClassifier(n_estimators=10, class_weight="balanced", silent=True)
+    gbm.fit(
+        X_train,
+        y_train,
+        eval_set=[
+            (X_train, y_train),
+            (X_test, y_test),
+            (X_test, y_test),
+            (X_test, y_test),
+            (X_test, y_test),
+        ],
+        eval_class_weight=[
+            "balanced",
+            None,
+            "balanced",
+            {1: 10, 4: 20},
+            {5: 30, 2: 40},
+        ],
+        verbose=False,
+    )
     for eval_set1, eval_set2 in itertools.combinations(gbm.evals_result_.keys(), 2):
         for metric in gbm.evals_result_[eval_set1]:
-            np.testing.assert_raises(AssertionError,
-                                     np.testing.assert_allclose,
-                                     gbm.evals_result_[eval_set1][metric],
-                                     gbm.evals_result_[eval_set2][metric])
-    gbm_str = lgb.LGBMClassifier(n_estimators=10, class_weight='balanced', silent=True)
-    gbm_str.fit(X_train, y_train_str,
-                eval_set=[(X_train, y_train_str), (X_test, y_test_str),
-                          (X_test, y_test_str), (X_test, y_test_str), (X_test, y_test_str)],
-                eval_class_weight=['balanced', None, 'balanced', {'1': 10, '4': 20}, {'5': 30, '2': 40}],
-                verbose=False)
+            np.testing.assert_raises(
+                AssertionError,
+                np.testing.assert_allclose,
+                gbm.evals_result_[eval_set1][metric],
+                gbm.evals_result_[eval_set2][metric],
+            )
+    gbm_str = lgb.LGBMClassifier(n_estimators=10, class_weight="balanced", silent=True)
+    gbm_str.fit(
+        X_train,
+        y_train_str,
+        eval_set=[
+            (X_train, y_train_str),
+            (X_test, y_test_str),
+            (X_test, y_test_str),
+            (X_test, y_test_str),
+            (X_test, y_test_str),
+        ],
+        eval_class_weight=[
+            "balanced",
+            None,
+            "balanced",
+            {"1": 10, "4": 20},
+            {"5": 30, "2": 40},
+        ],
+        verbose=False,
+    )
     for eval_set1, eval_set2 in itertools.combinations(gbm_str.evals_result_.keys(), 2):
         for metric in gbm_str.evals_result_[eval_set1]:
-            np.testing.assert_raises(AssertionError,
-                                     np.testing.assert_allclose,
-                                     gbm_str.evals_result_[eval_set1][metric],
-                                     gbm_str.evals_result_[eval_set2][metric])
+            np.testing.assert_raises(
+                AssertionError,
+                np.testing.assert_allclose,
+                gbm_str.evals_result_[eval_set1][metric],
+                gbm_str.evals_result_[eval_set2][metric],
+            )
     for eval_set in gbm.evals_result_:
         for metric in gbm.evals_result_[eval_set]:
-            np.testing.assert_allclose(gbm.evals_result_[eval_set][metric],
-                                       gbm_str.evals_result_[eval_set][metric])
+            np.testing.assert_allclose(
+                gbm.evals_result_[eval_set][metric],
+                gbm_str.evals_result_[eval_set][metric],
+            )
 
 
 def test_continue_training_with_model():
     X, y = load_digits(n_class=3, return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
-    init_gbm = lgb.LGBMClassifier(n_estimators=5).fit(X_train, y_train, eval_set=(X_test, y_test),
-                                                      verbose=False)
-    gbm = lgb.LGBMClassifier(n_estimators=5).fit(X_train, y_train, eval_set=(X_test, y_test),
-                                                 verbose=False, init_model=init_gbm)
-    assert len(init_gbm.evals_result_['valid_0']['multi_logloss']) == len(gbm.evals_result_['valid_0']['multi_logloss'])
-    assert len(init_gbm.evals_result_['valid_0']['multi_logloss']) == 5
-    assert gbm.evals_result_['valid_0']['multi_logloss'][-1] < init_gbm.evals_result_['valid_0']['multi_logloss'][-1]
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.1, random_state=42
+    )
+    init_gbm = lgb.LGBMClassifier(n_estimators=5).fit(
+        X_train, y_train, eval_set=(X_test, y_test), verbose=False
+    )
+    gbm = lgb.LGBMClassifier(n_estimators=5).fit(
+        X_train, y_train, eval_set=(X_test, y_test), verbose=False, init_model=init_gbm
+    )
+    assert len(init_gbm.evals_result_["valid_0"]["multi_logloss"]) == len(
+        gbm.evals_result_["valid_0"]["multi_logloss"]
+    )
+    assert len(init_gbm.evals_result_["valid_0"]["multi_logloss"]) == 5
+    assert (
+        gbm.evals_result_["valid_0"]["multi_logloss"][-1]
+        < init_gbm.evals_result_["valid_0"]["multi_logloss"][-1]
+    )
 
 
 # sklearn < 0.22 requires passing "attributes" argument
-@pytest.mark.skipif(sk_version < parse_version('0.22'), reason='scikit-learn version is less than 0.22')
+@pytest.mark.skipif(
+    sk_version < parse_version("0.22"), reason="scikit-learn version is less than 0.22"
+)
 def test_check_is_fitted():
     X, y = load_digits(n_class=2, return_X_y=True)
     est = lgb.LGBMModel(n_estimators=5, objective="binary")
@@ -1153,6 +1491,7 @@ def _tested_estimators():
 
 
 if sk_version < parse_version("0.23"):
+
     def _generate_checks_per_estimator(check_generator, estimators):
         for estimator in estimators:
             name = estimator.__class__.__name__
@@ -1160,7 +1499,8 @@ if sk_version < parse_version("0.23"):
                 yield estimator, check
 
     @pytest.mark.skipif(
-        sk_version < parse_version("0.21"), reason="scikit-learn version is less than 0.21"
+        sk_version < parse_version("0.21"),
+        reason="scikit-learn version is less than 0.21",
     )
     @pytest.mark.parametrize(
         "estimator, check",
@@ -1168,14 +1508,19 @@ if sk_version < parse_version("0.23"):
     )
     def test_sklearn_integration(estimator, check):
         xfail_checks = estimator._get_tags()["_xfail_checks"]
-        check_name = check.__name__ if hasattr(check, "__name__") else check.func.__name__
+        check_name = (
+            check.__name__ if hasattr(check, "__name__") else check.func.__name__
+        )
         if xfail_checks and check_name in xfail_checks:
             warnings.warn(xfail_checks[check_name], SkipTestWarning)
             raise SkipTest
         estimator.set_params(min_child_samples=1, min_data_in_bin=1)
         name = estimator.__class__.__name__
         check(name, estimator)
+
+
 else:
+
     @parametrize_with_checks(list(_tested_estimators()))
     def test_sklearn_integration(estimator, check, request):
         estimator.set_params(min_child_samples=1, min_data_in_bin=1)
@@ -1184,7 +1529,7 @@ else:
 
 @pytest.mark.skipif(
     sk_version >= parse_version("0.24"),
-    reason="Default constructible check included in common check from 0.24"
+    reason="Default constructible check included in common check from 0.24",
 )
 @pytest.mark.parametrize("estimator", list(_tested_estimators()))
 def test_parameters_default_constructible(estimator):

--- a/tests/python_package_test/test_utilities.py
+++ b/tests/python_package_test/test_utilities.py
@@ -2,13 +2,14 @@
 import logging
 
 import numpy as np
+
 import lightgbm as lgb
 
 
 def test_register_logger(tmp_path):
     logger = logging.getLogger("LightGBM")
     logger.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(levelname)s | %(message)s')
+    formatter = logging.Formatter("%(levelname)s | %(message)s")
     log_filename = str(tmp_path / "LightGBM_test_logger.log")
     file_handler = logging.FileHandler(log_filename, mode="w", encoding="utf-8")
     file_handler.setLevel(logging.DEBUG)
@@ -16,24 +17,27 @@ def test_register_logger(tmp_path):
     logger.addHandler(file_handler)
 
     def dummy_metric(_, __):
-        logger.debug('In dummy_metric')
-        return 'dummy_metric', 1, True
+        logger.debug("In dummy_metric")
+        return "dummy_metric", 1, True
 
     lgb.register_logger(logger)
 
-    X = np.array([[1, 2, 3],
-                  [1, 2, 4],
-                  [1, 2, 4],
-                  [1, 2, 3]],
-                 dtype=np.float32)
+    X = np.array([[1, 2, 3], [1, 2, 4], [1, 2, 4], [1, 2, 3]], dtype=np.float32)
     y = np.array([0, 1, 1, 0])
     lgb_data = lgb.Dataset(X, y)
 
     eval_records = {}
-    lgb.train({'objective': 'binary', 'metric': ['auc', 'binary_error']},
-              lgb_data, num_boost_round=10, feval=dummy_metric,
-              valid_sets=[lgb_data], evals_result=eval_records,
-              categorical_feature=[1], early_stopping_rounds=4, verbose_eval=2)
+    lgb.train(
+        {"objective": "binary", "metric": ["auc", "binary_error"]},
+        lgb_data,
+        num_boost_round=10,
+        feval=dummy_metric,
+        valid_sets=[lgb_data],
+        evals_result=eval_records,
+        categorical_feature=[1],
+        early_stopping_rounds=4,
+        verbose_eval=2,
+    )
 
     lgb.plot_metric(eval_records)
 
@@ -84,7 +88,7 @@ WARNING | More than one metric available, picking one to plot.
         "INFO | [LightGBM] [Warning] GPU acceleration is disabled because no non-trivial dense features can be found",
         "INFO | [LightGBM] [Warning] Using sparse features with CUDA is currently not supported.",
         "INFO | [LightGBM] [Warning] CUDA currently requires double precision calculations.",
-        "INFO | [LightGBM] [Info] LightGBM using CUDA trainer with DP float!!"
+        "INFO | [LightGBM] [Info] LightGBM using CUDA trainer with DP float!!",
     ]
     with open(log_filename, "rt", encoding="utf-8") as f:
         actual_log = f.read().strip()

--- a/tests/python_package_test/utils.py
+++ b/tests/python_package_test/utils.py
@@ -31,8 +31,16 @@ def load_linnerud(**kwargs):
     return sklearn.datasets.load_linnerud(**kwargs)
 
 
-def make_ranking(n_samples=100, n_features=20, n_informative=5, gmax=2,
-                 group=None, random_gs=False, avg_gs=10, random_state=0):
+def make_ranking(
+    n_samples=100,
+    n_features=20,
+    n_informative=5,
+    gmax=2,
+    group=None,
+    random_gs=False,
+    avg_gs=10,
+    random_state=0,
+):
     """Generate a learning-to-rank dataset - feature vectors grouped together with
     integer-valued graded relevance scores. Replace this with a sklearn.datasets function
     if ranking objective becomes supported in sklearn.datasets module.
@@ -78,11 +86,13 @@ def make_ranking(n_samples=100, n_features=20, n_informative=5, gmax=2,
     relvalues = range(gmax + 1)
 
     # build y/target and group-id vectors with user-specified group sizes.
-    if group is not None and hasattr(group, '__len__'):
+    if group is not None and hasattr(group, "__len__"):
         n_samples = np.sum(group)
 
         for i, gsize in enumerate(group):
-            y_vec = np.concatenate((y_vec, rnd_generator.choice(relvalues, size=gsize, replace=True)))
+            y_vec = np.concatenate(
+                (y_vec, rnd_generator.choice(relvalues, size=gsize, replace=True))
+            )
             group_id_vec = np.concatenate((group_id_vec, [i] * gsize))
 
     # build y/target and group-id vectors according to n_samples, avg_gs, and random_gs.
@@ -94,7 +104,9 @@ def make_ranking(n_samples=100, n_features=20, n_informative=5, gmax=2,
             if gsize < 1:
                 continue
 
-            y_vec = np.append(y_vec, rnd_generator.choice(relvalues, size=gsize, replace=True))
+            y_vec = np.append(
+                y_vec, rnd_generator.choice(relvalues, size=gsize, replace=True)
+            )
             group_id_vec = np.append(group_id_vec, [gid] * gsize)
             gid += 1
 


### PR DESCRIPTION
A consistent styling and import sorting order improves code readability

This PR just applies two widely used python formatting tools, isort and black, to the python code in lightgbm

https://github.com/PyCQA/isort
https://github.com/psf/black

No code logic should have been changed.
