### PR TITLE
[ci][python] run isort in CI linting job

### DIFF
--- a/.ci/get_workflow_status.py
+++ b/.ci/get_workflow_status.py
@@ -10,6 +10,7 @@ import json
 from os import environ
 from sys import argv, exit
 from time import sleep
+
 try:
     from urllib import request
 except ImportError:

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -20,8 +20,8 @@ cd $BUILD_DIRECTORY
 
 if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     cd $BUILD_DIRECTORY/docs
-    conda install -q -y -n $CONDA_ENV -c conda-forge doxygen
-    pip install --user -r requirements.txt rstcheck
+    conda install -q -y -n $CONDA_ENV -c conda-forge doxygen rstcheck
+    pip install --user -r requirements.txt
     # check reStructuredText formatting
     cd $BUILD_DIRECTORY/python-package
     rstcheck --report warning `find . -type f -name "*.rst"` || exit -1
@@ -46,6 +46,8 @@ fi
 
 if [[ $TASK == "lint" ]]; then
     conda install -q -y -n $CONDA_ENV \
+        isort \
+        mypy \
         pycodestyle \
         pydocstyle \
         r-stringi  # stringi needs to be installed separate from r-lintr to avoid issues like 'unable to load shared object stringi.so'
@@ -55,10 +57,11 @@ if [[ $TASK == "lint" ]]; then
             libxml2 \
             "r-xfun>=0.19" \
             "r-lintr>=2.0"
-    pip install --user cpplint mypy
+    pip install --user cpplint
     echo "Linting Python code"
     pycodestyle --ignore=E501,W503 --exclude=./.nuget,./external_libs . || exit -1
     pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^external_libs|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1
+    isort . --check-only || exit -1
     mypy --ignore-missing-imports python-package/ || true
     echo "Linting R code"
     Rscript ${BUILD_DIRECTORY}/.ci/lint_r_code.R ${BUILD_DIRECTORY} || exit -1

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -46,8 +46,6 @@ fi
 
 if [[ $TASK == "lint" ]]; then
     conda install -q -y -n $CONDA_ENV \
-        isort \
-        mypy \
         pycodestyle \
         pydocstyle \
         r-stringi  # stringi needs to be installed separate from r-lintr to avoid issues like 'unable to load shared object stringi.so'
@@ -57,7 +55,7 @@ if [[ $TASK == "lint" ]]; then
             libxml2 \
             "r-xfun>=0.19" \
             "r-lintr>=2.0"
-    pip install --user cpplint
+    pip install --user cpplint isort mypy
     echo "Linting Python code"
     pycodestyle --ignore=E501,W503 --exclude=./.nuget,./external_libs . || exit -1
     pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^external_libs|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ indent_size = 2
 
 [*.{py,sh,js}]
 indent_size = 4
+line_length = 120
+skip = external_libs
+known_first_party = lightgbm
 
 # Placeholder files
 [{*.gitkeep,__init__.py}]

--- a/.nuget/create_nuget.py
+++ b/.nuget/create_nuget.py
@@ -3,9 +3,7 @@
 import datetime
 import os
 import sys
-
 from distutils.file_util import copy_file
-
 
 if __name__ == "__main__":
     source = sys.argv[1]

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -6,8 +6,7 @@ Contributors: https://github.com/microsoft/LightGBM/graphs/contributors.
 import os
 
 from .basic import Booster, Dataset, register_logger
-from .callback import (early_stopping, print_evaluation, record_evaluation,
-                       reset_parameter)
+from .callback import early_stopping, print_evaluation, record_evaluation, reset_parameter
 from .engine import CVBooster, cv, train
 
 try:
@@ -15,8 +14,7 @@ try:
 except ImportError:
     pass
 try:
-    from .plotting import (create_tree_digraph, plot_importance, plot_metric,
-                           plot_split_value_histogram, plot_tree)
+    from .plotting import create_tree_digraph, plot_importance, plot_metric, plot_split_value_histogram, plot_tree
 except ImportError:
     pass
 try:

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -14,8 +14,7 @@ from typing import Any, Dict
 import numpy as np
 import scipy.sparse
 
-from .compat import (PANDAS_INSTALLED, concat, dt_DataTable, is_dtype_sparse,
-                     pd_DataFrame, pd_Series)
+from .compat import PANDAS_INSTALLED, concat, dt_DataTable, is_dtype_sparse, pd_DataFrame, pd_Series
 from .libpath import find_lib_path
 
 

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -61,8 +61,7 @@ try:
     from sklearn.preprocessing import LabelEncoder
     from sklearn.utils.class_weight import compute_sample_weight
     from sklearn.utils.multiclass import check_classification_targets
-    from sklearn.utils.validation import (assert_all_finite, check_array,
-                                          check_X_y)
+    from sklearn.utils.validation import assert_all_finite, check_array, check_X_y
     try:
         from sklearn.exceptions import NotFittedError
         from sklearn.model_selection import GroupKFold, StratifiedKFold

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -9,20 +9,17 @@ It is based on dask-lightgbm, which was based on dask-xgboost.
 import socket
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, Callable, Dict, Iterable, List, Optional, Type, Union, Set
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Type, Union
 from urllib.parse import urlparse
 
 import numpy as np
 import scipy.sparse as ss
 
-from .basic import (_LIB, LightGBMError, _choose_param_value, _ConfigAliases,
-                    _log_warning, _safe_call)
-from .compat import (DASK_INSTALLED, PANDAS_INSTALLED, SKLEARN_INSTALLED,
-                     Client, LGBMNotFittedError, concat, dask_Array,
-                     dask_DataFrame, dask_Series, default_client, delayed,
-                     get_worker, pd_DataFrame, pd_Series, wait)
-from .sklearn import (LGBMClassifier, LGBMModel, LGBMRanker, LGBMRegressor,
-                      _lgbmmodel_doc_fit, _lgbmmodel_doc_predict)
+from .basic import _LIB, LightGBMError, _choose_param_value, _ConfigAliases, _log_warning, _safe_call
+from .compat import (DASK_INSTALLED, PANDAS_INSTALLED, SKLEARN_INSTALLED, Client, LGBMNotFittedError, concat,
+                     dask_Array, dask_DataFrame, dask_Series, default_client, delayed, get_worker, pd_DataFrame,
+                     pd_Series, wait)
+from .sklearn import LGBMClassifier, LGBMModel, LGBMRanker, LGBMRegressor, _lgbmmodel_doc_fit, _lgbmmodel_doc_predict
 
 _DaskCollection = Union[dask_Array, dask_DataFrame, dask_Series]
 _DaskMatrixLike = Union[dask_Array, dask_DataFrame]

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -7,8 +7,7 @@ from operator import attrgetter
 import numpy as np
 
 from . import callback
-from .basic import (Booster, Dataset, LightGBMError, _ConfigAliases,
-                    _InnerPredictor, _log_warning)
+from .basic import Booster, Dataset, LightGBMError, _ConfigAliases, _InnerPredictor, _log_warning
 from .compat import SKLEARN_INSTALLED, _LGBMGroupKFold, _LGBMStratifiedKFold
 
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -5,14 +5,10 @@ from inspect import signature
 
 import numpy as np
 
-from .basic import (Dataset, LightGBMError, _choose_param_value,
-                    _ConfigAliases, _log_warning)
-from .compat import (SKLEARN_INSTALLED, LGBMNotFittedError,
-                     _LGBMAssertAllFinite, _LGBMCheckArray,
-                     _LGBMCheckClassificationTargets, _LGBMCheckSampleWeight,
-                     _LGBMCheckXY, _LGBMClassifierBase,
-                     _LGBMComputeSampleWeight, _LGBMLabelEncoder,
-                     _LGBMModelBase, _LGBMRegressorBase, dt_DataTable,
+from .basic import Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _log_warning
+from .compat import (SKLEARN_INSTALLED, LGBMNotFittedError, _LGBMAssertAllFinite, _LGBMCheckArray,
+                     _LGBMCheckClassificationTargets, _LGBMCheckSampleWeight, _LGBMCheckXY, _LGBMClassifierBase,
+                     _LGBMComputeSampleWeight, _LGBMLabelEncoder, _LGBMModelBase, _LGBMRegressorBase, dt_DataTable,
                      pd_DataFrame)
 from .engine import train
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -11,11 +11,8 @@ import psutil
 import pytest
 from scipy.sparse import csr_matrix, isspmatrix_csc, isspmatrix_csr
 from sklearn.datasets import load_svmlight_file, make_multilabel_classification
-from sklearn.metrics import (average_precision_score, log_loss,
-                             mean_absolute_error, mean_squared_error,
-                             roc_auc_score)
-from sklearn.model_selection import (GroupKFold, TimeSeriesSplit,
-                                     train_test_split)
+from sklearn.metrics import average_precision_score, log_loss, mean_absolute_error, mean_squared_error, roc_auc_score
+from sklearn.model_selection import GroupKFold, TimeSeriesSplit, train_test_split
 
 import lightgbm as lgb
 

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1,30 +1,31 @@
 # coding: utf-8
 import itertools
-import joblib
 import math
 import os
 
-import lightgbm as lgb
+import joblib
 import numpy as np
 import pytest
 from pkg_resources import parse_version
 from sklearn import __version__ as sk_version
 from sklearn.base import clone
 from sklearn.datasets import load_svmlight_file, make_multilabel_classification
-from sklearn.utils.estimator_checks import check_parameters_default_constructible
 from sklearn.metrics import log_loss, mean_squared_error
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV, train_test_split
-from sklearn.multioutput import (MultiOutputClassifier, ClassifierChain, MultiOutputRegressor,
-                                 RegressorChain)
+from sklearn.multioutput import ClassifierChain, MultiOutputClassifier, MultiOutputRegressor, RegressorChain
+from sklearn.utils.estimator_checks import check_parameters_default_constructible
 from sklearn.utils.validation import check_is_fitted
+
+import lightgbm as lgb
 
 from .utils import load_boston, load_breast_cancer, load_digits, load_iris, load_linnerud
 
 sk_version = parse_version(sk_version)
 if sk_version < parse_version("0.23"):
     import warnings
+
     from sklearn.exceptions import SkipTestWarning
-    from sklearn.utils.estimator_checks import _yield_all_checks, SkipTest
+    from sklearn.utils.estimator_checks import SkipTest, _yield_all_checks
 else:
     from sklearn.utils.estimator_checks import parametrize_with_checks
 


### PR DESCRIPTION
Fixed #3958.
Closed #3983.

Some files have `isort`-related diff although `isort` has been already applied due to new `120` length limit in config file.

Also prefer installation from conda to pip for `rstcheck`. `mypy`, `isort` and `pycodestyle` have conflicts when installing from `conda` altogether.