### PR TITLE
[tests][dask] make find-open-port test more reliable

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -885,27 +885,27 @@ def test_model_and_local_version_are_picklable_whether_or_not_client_set_explici
                     assert_eq(preds_orig_local, preds_loaded_model_local)
 
 
-def test_find_open_port_works():
+def test_find_open_port_works(listen_port):
     worker_ip = '127.0.0.1'
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind((worker_ip, 12400))
+        s.bind((worker_ip, listen_port))
         new_port = lgb.dask._find_open_port(
             worker_ip=worker_ip,
-            local_listen_port=12400,
+            local_listen_port=listen_port,
             ports_to_skip=set()
         )
-        assert new_port >= 12401
+        assert new_port > listen_port
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s_1:
-        s_1.bind((worker_ip, 12400))
+        s_1.bind((worker_ip, listen_port))
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s_2:
-            s_2.bind((worker_ip, 12401))
+            s_2.bind((worker_ip, listen_port + 1))
             new_port = lgb.dask._find_open_port(
                 worker_ip=worker_ip,
-                local_listen_port=12400,
+                local_listen_port=listen_port,
                 ports_to_skip=set()
             )
-            assert new_port >= 12402
+            assert new_port > listen_port + 1
 
 
 def test_warns_and_continues_on_unrecognized_tree_learner(client):

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -894,7 +894,7 @@ def test_find_open_port_works():
             local_listen_port=12400,
             ports_to_skip=set()
         )
-        assert new_port == 12401
+        assert new_port >= 12401
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s_1:
         s_1.bind((worker_ip, 12400))
@@ -905,7 +905,7 @@ def test_find_open_port_works():
                 local_listen_port=12400,
                 ports_to_skip=set()
             )
-            assert new_port == 12402
+            assert new_port >= 12402
 
 
 def test_warns_and_continues_on_unrecognized_tree_learner(client):

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -894,7 +894,7 @@ def test_find_open_port_works(listen_port):
             local_listen_port=listen_port,
             ports_to_skip=set()
         )
-        assert new_port > listen_port
+        assert listen_port < new_port < listen_port + 1000
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s_1:
         s_1.bind((worker_ip, listen_port))
@@ -905,7 +905,7 @@ def test_find_open_port_works(listen_port):
                 local_listen_port=listen_port,
                 ports_to_skip=set()
             )
-            assert new_port > listen_port + 1
+            assert listen_port + 1 < new_port < listen_port + 1000
 
 
 def test_warns_and_continues_on_unrecognized_tree_learner(client):


### PR DESCRIPTION
Working on a proposal to address https://github.com/microsoft/LightGBM/pull/3823#pullrequestreview-582002723, I found that sometimes the "find an open port" test in `test_dask.py` failed with an error.

> assert new_port == 12401
> E assert 12404 == 12401

I think that test is too strict. Right now it checks "if port 12400 is unavailable, `_find_open_port()` returns 12401". If 12401 is busy for some unrelated reason, this test fails.

This PR proposes loosening the condition a bit, to reduce the risk of test failures like that. It isn't important that that method finds 12401 specifically. Just some port that is `>` the port number you passed in.