### PR TITLE
remove commented-out code in cross-entropy metric source

### DIFF
--- a/src/metric/xentropy_metric.hpp
+++ b/src/metric/xentropy_metric.hpp
@@ -281,12 +281,10 @@ class KullbackLeiblerDivergence : public Metric {
     // evaluate offset term
     presum_label_entropy_ = 0.0f;
     if (weights_ == nullptr) {
-    //  #pragma omp parallel for schedule(static)
       for (data_size_t i = 0; i < num_data; ++i) {
         presum_label_entropy_ += YentLoss(label_[i]);
       }
     } else {
-    //  #pragma omp parallel for schedule(static)
       for (data_size_t i = 0; i < num_data; ++i) {
         presum_label_entropy_ += YentLoss(label_[i]) * weights_[i];
       }


### PR DESCRIPTION
This PR proposes removing removing some commented-out OpenMP pragmas in the cross-entropy source code.

From the blame, it appears this commented-out code was introduced 4 years ago :grinning: 

https://github.com/microsoft/LightGBM/blame/master/src/metric/xentropy_metric.hpp#L284