### PR TITLE
[dask] use more specific method names on _DaskLGBMModel

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -465,7 +465,7 @@ class _DaskLGBMModel:
 
         return _get_dask_client(client=self.client)
 
-    def _lgb_getstate(self) -> Dict[Any, Any]:
+    def _lgb_dask_getstate(self) -> Dict[Any, Any]:
         """Remove un-picklable attributes before serialization."""
         client = self.__dict__.pop("client", None)
         self._other_params.pop("client", None)
@@ -474,7 +474,7 @@ class _DaskLGBMModel:
         self.client = client
         return out
 
-    def _fit(
+    def _lgb_dask_fit(
         self,
         model_factory: Type[LGBMModel],
         X: _DaskMatrixLike,
@@ -501,20 +501,20 @@ class _DaskLGBMModel:
         )
 
         self.set_params(**model.get_params())
-        self._copy_extra_params(model, self)
+        self._lgb_dask_copy_extra_params(model, self)
 
         return self
 
-    def _to_local(self, model_factory: Type[LGBMModel]) -> LGBMModel:
+    def _lgb_dask_to_local(self, model_factory: Type[LGBMModel]) -> LGBMModel:
         params = self.get_params()
         params.pop("client", None)
         model = model_factory(**params)
-        self._copy_extra_params(self, model)
+        self._lgb_dask_copy_extra_params(self, model)
         model._other_params.pop("client", None)
         return model
 
     @staticmethod
-    def _copy_extra_params(source: Union["_DaskLGBMModel", LGBMModel], dest: Union["_DaskLGBMModel", LGBMModel]) -> None:
+    def _lgb_dask_copy_extra_params(source: Union["_DaskLGBMModel", LGBMModel], dest: Union["_DaskLGBMModel", LGBMModel]) -> None:
         params = source.get_params()
         attributes = source.__dict__
         extra_param_names = set(attributes.keys()).difference(params.keys())
@@ -590,7 +590,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
     __init__.__doc__ = _base_doc[:_base_doc.find('Note\n')]
 
     def __getstate__(self) -> Dict[Any, Any]:
-        return self._lgb_getstate()
+        return self._lgb_dask_getstate()
 
     def fit(
         self,
@@ -600,7 +600,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
         **kwargs: Any
     ) -> "DaskLGBMClassifier":
         """Docstring is inherited from the lightgbm.LGBMClassifier.fit."""
-        return self._fit(
+        return self._lgb_dask_fit(
             model_factory=LGBMClassifier,
             X=X,
             y=y,
@@ -670,7 +670,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
         model : lightgbm.LGBMClassifier
             Local underlying model.
         """
-        return self._to_local(LGBMClassifier)
+        return self._lgb_dask_to_local(LGBMClassifier)
 
 
 class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
@@ -741,7 +741,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
     __init__.__doc__ = _base_doc[:_base_doc.find('Note\n')]
 
     def __getstate__(self) -> Dict[Any, Any]:
-        return self._lgb_getstate()
+        return self._lgb_dask_getstate()
 
     def fit(
         self,
@@ -751,7 +751,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         **kwargs: Any
     ) -> "DaskLGBMRegressor":
         """Docstring is inherited from the lightgbm.LGBMRegressor.fit."""
-        return self._fit(
+        return self._lgb_dask_fit(
             model_factory=LGBMRegressor,
             X=X,
             y=y,
@@ -802,7 +802,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         model : lightgbm.LGBMRegressor
             Local underlying model.
         """
-        return self._to_local(LGBMRegressor)
+        return self._lgb_dask_to_local(LGBMRegressor)
 
 
 class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
@@ -873,7 +873,7 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
     __init__.__doc__ = _base_doc[:_base_doc.find('Note\n')]
 
     def __getstate__(self) -> Dict[Any, Any]:
-        return self._lgb_getstate()
+        return self._lgb_dask_getstate()
 
     def fit(
         self,
@@ -888,7 +888,7 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
         if init_score is not None:
             raise RuntimeError('init_score is not currently supported in lightgbm.dask')
 
-        return self._fit(
+        return self._lgb_dask_fit(
             model_factory=LGBMRanker,
             X=X,
             y=y,
@@ -939,4 +939,4 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
         model : lightgbm.LGBMRanker
             Local underlying model.
         """
-        return self._to_local(LGBMRanker)
+        return self._lgb_dask_to_local(LGBMRanker)


### PR DESCRIPTION
The Dask sklearn estimators in `lightgbm.dask` inherit from both their `lightgbm.sklearn` equivalent and a mixin called `_DaskLGBMModel`.

https://github.com/microsoft/LightGBM/blob/7880b79fde36873b95839c0029ea9d649397da51/python-package/lightgbm/dask.py#L525

Those equivalents from `lightgbm.sklearn` inherit from a mix of LightGBM internal classes and some mixins brought in from `sklearn`.

```python
from lightgbm.sklearn import DaskLGBMClassifier
for c in DaskLGBMClassifier.__mro__:
    print(c)

# <class 'lightgbm.dask.DaskLGBMClassifier'>
# <class 'lightgbm.sklearn.LGBMClassifier'>
# <class 'lightgbm.sklearn.LGBMModel'>
# <class 'sklearn.base.BaseEstimator'>
# <class 'sklearn.base.ClassifierMixin'>
# <class 'lightgbm.dask._DaskLGBMModel'>
# <class 'object'>
```

Since `LGBMClassifier` is the first parent class in the method resolution order ("MRO") for `DaskLGBMClassifier`, if it or any of the parent classes from `sklearn` introduce a method that conflicts with one of the method names in `_DaskLGBMModel`, the `_DaskLGBMModel` method won't be used, which could break `DaskLGBMClassifier`.

To protect against this happening, this PR proposes changing the method names on `_DaskLGBMModel` to names that are less likely to conflict with `sklearn` in the future. For example, it proposes changing `_fit()` to `_lgb_dask_fit()`, so that if an `sklearn.base.BaseEstimator._fit()` is introduced in some future version of `sklearn`, `DaskLGBMClassifier` will still use the correct method.

All of the methods changed here are internal, so this should not have any user-facing impact.

### Notes for reviewers

I also considered the pattern below for absolute certainty:

```python
class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel)
    def fit(self, ...):
        _DaskLGBMModel._fit(self, ...)
```

But I don't understand the full implications of doing that, so I decided against it.