### PR TITLE
[DOCS] Update docs to note that pred_contrib is not available for linear trees

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -863,7 +863,7 @@ Predict Parameters
 
    -  **Note**: unlike the shap package, with ``predict_contrib`` we return a matrix with an extra column, where the last column is the expected value
 
-   -  **Note**: this feature is not implemented for linear trees, and the output will not be correct
+   -  **Note**: this feature is not implemented for linear trees
 
 -  ``predict_disable_shape_check`` :raw-html:`<a id="predict_disable_shape_check" title="Permalink to this parameter" href="#predict_disable_shape_check">&#x1F517;&#xFE0E;</a>`, default = ``false``, type = bool
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -863,6 +863,8 @@ Predict Parameters
 
    -  **Note**: unlike the shap package, with ``predict_contrib`` we return a matrix with an extra column, where the last column is the expected value
 
+   -  **Note**: this feature is not implemented for linear trees, and the output will not be correct
+
 -  ``predict_disable_shape_check`` :raw-html:`<a id="predict_disable_shape_check" title="Permalink to this parameter" href="#predict_disable_shape_check">&#x1F517;&#xFE0E;</a>`, default = ``false``, type = bool
 
    -  used only in ``prediction`` task

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -747,7 +747,7 @@ struct Config {
   // desc = produces ``#features + 1`` values where the last value is the expected value of the model output over the training data
   // desc = **Note**: if you want to get more explanation for your model's predictions using SHAP values like SHAP interaction values, you can install `shap package <https://github.com/slundberg/shap>`__
   // desc = **Note**: unlike the shap package, with ``predict_contrib`` we return a matrix with an extra column, where the last column is the expected value
-  // desc = **Note**: this feature is not implemented for linear trees, and the output will not be correct
+  // desc = **Note**: this feature is not implemented for linear trees
   bool predict_contrib = false;
 
   // [no-save]

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -747,6 +747,7 @@ struct Config {
   // desc = produces ``#features + 1`` values where the last value is the expected value of the model output over the training data
   // desc = **Note**: if you want to get more explanation for your model's predictions using SHAP values like SHAP interaction values, you can install `shap package <https://github.com/slundberg/shap>`__
   // desc = **Note**: unlike the shap package, with ``predict_contrib`` we return a matrix with an extra column, where the last column is the expected value
+  // desc = **Note**: this feature is not implemented for linear trees, and the output will not be correct
   bool predict_contrib = false;
 
   // [no-save]

--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -85,6 +85,10 @@ class Predictor {
         }
       };
     } else if (predict_contrib) {
+      if (boosting_->IsLinear()) {
+        Log::Warning("Predicting SHAP feature contributions is not implemented for linear trees. "
+          "Results will be incorrect.");
+      }
       predict_fun_ = [=](const std::vector<std::pair<int, double>>& features,
                          double* output) {
         int tid = omp_get_thread_num();

--- a/src/application/predictor.hpp
+++ b/src/application/predictor.hpp
@@ -86,8 +86,7 @@ class Predictor {
       };
     } else if (predict_contrib) {
       if (boosting_->IsLinear()) {
-        Log::Warning("Predicting SHAP feature contributions is not implemented for linear trees. "
-          "Results will be incorrect.");
+        Log::Fatal("Predicting SHAP feature contributions is not implemented for linear trees.");
       }
       predict_fun_ = [=](const std::vector<std::pair<int, double>>& features,
                          double* output) {


### PR DESCRIPTION
As noted in #4002, `pred_contrib` does not work for linear trees. 