### PR TITLE
[ci] prefer older binary to new source for R packages on Mac builds (fixes #4008)

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -103,7 +103,7 @@ packages="c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat')"
 if [[ $OS_NAME == "macos" ]]; then
     packages+=", type = 'both'"
 fi
-Rscript --vanilla -e "options(install.packages.compile.from.source = 'both'); install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
+Rscript --vanilla -e "options(install.packages.compile.from.source = 'never'); install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
 
 cd ${BUILD_DIRECTORY}
 

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -100,10 +100,12 @@ fi
 # Manually install Depends and Imports libraries + 'testthat'
 # to avoid a CI-time dependency on devtools (for devtools::install_deps())
 packages="c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat')"
+compile_from_source="both"
 if [[ $OS_NAME == "macos" ]]; then
     packages+=", type = 'binary'"
+    compile_from_source="never"
 fi
-Rscript --vanilla -e "options(install.packages.compile.from.source = 'never'); install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
+Rscript --vanilla -e "options(install.packages.compile.from.source = '${compile_from_source}'); install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
 
 cd ${BUILD_DIRECTORY}
 

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -101,7 +101,7 @@ fi
 # to avoid a CI-time dependency on devtools (for devtools::install_deps())
 packages="c('data.table', 'jsonlite', 'Matrix', 'R6', 'testthat')"
 if [[ $OS_NAME == "macos" ]]; then
-    packages+=", type = 'both'"
+    packages+=", type = 'binary'"
 fi
 Rscript --vanilla -e "options(install.packages.compile.from.source = 'never'); install.packages(${packages}, repos = '${CRAN_MIRROR}', lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'))" || exit -1
 


### PR DESCRIPTION
This PR proposes a fix to #4008. The root cause for that issues is that `{data.table}` recently did a release, but binaries are not available from CRAN yet for it. As a result, the newest version is being compiled from source in CI, and that compilation is failing.

This PR proposes changing the strategy for installing dependencies to "install the newest binary" instead, so that such temporary situations won't disrupt CI and slow development on the entire project in the future.

This reverts the change made in https://github.com/microsoft/LightGBM/pull/3876. Since R package builds have to pass for any LightGBM PRs to be merged, I think we should prefer minimizing disruptions even if it means that it takes an extra day or two for our CI to start using the newest version of a dependency.

## How I tested this

I tested on my Mac. I could reproduce the original problem and confirm this fixes it.

**source install**

![image](https://user-images.githubusercontent.com/7608904/108639543-b5beef80-745a-11eb-9411-f55b9890cd6f.png)

**binary install**

![image](https://user-images.githubusercontent.com/7608904/108639570-e7d05180-745a-11eb-9ff0-8f0ed5f1adc9.png)

### References

Based on the advice in https://community.rstudio.com/t/prefer-install-packages-from-binaries-in-windows/50760.

