### PR TITLE
[ci] refactor graphviz installation workaround

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -96,11 +96,7 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
-
-# graphviz must come from conda-forge to avoid this on some linux distros:
-# https://github.com/conda-forge/graphviz-feedstock/issues/18
-conda install -q -y -n $CONDA_ENV -c conda-forge python-graphviz
+conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest python-graphviz scikit-learn scipy
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     # fix "OMP: Error #15: Initializing libiomp5.dylib, but found libomp.dylib already initialized." (OpenMP library conflict due to conda's MKL)

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -96,7 +96,15 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest python-graphviz scikit-learn scipy
+conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+
+# graphviz must come from conda-forge to avoid this on some linux distros:
+# https://github.com/conda-forge/graphviz-feedstock/issues/18
+conda install -q -y \
+    -n $CONDA_ENV \
+    -c conda-forge \
+        graphviz \
+        python-graphviz
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     # fix "OMP: Error #15: Initializing libiomp5.dylib, but found libomp.dylib already initialized." (OpenMP library conflict due to conda's MKL)

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -100,11 +100,7 @@ conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib
 
 # graphviz must come from conda-forge to avoid this on some linux distros:
 # https://github.com/conda-forge/graphviz-feedstock/issues/18
-conda install -q -y \
-    -n $CONDA_ENV \
-    -c conda-forge \
-        python-graphviz \
-        xorg-libxau
+conda install -q -y -n $CONDA_ENV -c conda-forge python-graphviz
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     # fix "OMP: Error #15: Initializing libiomp5.dylib, but found libomp.dylib already initialized." (OpenMP library conflict due to conda's MKL)


### PR DESCRIPTION
I find listing `graphviz` in installation plan less confusing than `xorg-libxau`.
Without explicitly passed `graphviz` conda installs its old version (!!!) from `default` conda channel. So weird!
```
## Package Plan ##

  environment location: /root/miniconda/envs/test-env

  added / updated specs:
    - python-graphviz


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    ca-certificates-2020.12.5  |       ha878542_0         137 KB  conda-forge
    cairo-1.16.0               |    h18b612c_1001         1.5 MB  conda-forge
    certifi-2020.12.5          |   py37h89c1867_1         143 KB  conda-forge
    fribidi-1.0.10             |       h36c2ea0_0         112 KB  conda-forge
    gettext-0.19.8.1           |    hf34092f_1004         3.6 MB  conda-forge
    glib-2.66.3                |       h58526e2_0         500 KB  conda-forge
    graphite2-1.3.13           |    h58526e2_1001         102 KB  conda-forge
    graphviz-2.40.1            |       h21bd128_2         6.5 MB
    harfbuzz-1.8.8             |       hffaf4a1_0         507 KB
    libffi-3.2.1               |    he1b5a44_1007          47 KB  conda-forge
    libglib-2.66.3             |       hbe7bbb4_0         3.0 MB  conda-forge
    libiconv-1.16              |       h516909a_0         1.4 MB  conda-forge
    openssl-1.1.1h             |       h516909a_0         2.1 MB  conda-forge
    pango-1.42.4               |       h049681c_0         464 KB
    pixman-0.38.0              |    h516909a_1003         594 KB  conda-forge
    python-3.7.8               |h6f2ec95_0_cpython        53.1 MB  conda-forge
    python-graphviz-0.16       |     pyhd3deb0d_1          20 KB  conda-forge
    python_abi-3.7             |          1_cp37m           4 KB  conda-forge
    xorg-kbproto-1.0.7         |    h14c3975_1002          26 KB  conda-forge
    xorg-libice-1.0.10         |       h516909a_0          57 KB  conda-forge
    xorg-libsm-1.2.2           |       h470a237_5          24 KB  conda-forge
    xorg-libx11-1.6.12         |       h516909a_0         917 KB  conda-forge
    xorg-libxext-1.3.4         |       h516909a_0          51 KB  conda-forge
    xorg-libxrender-0.9.10     |    h516909a_1002          31 KB  conda-forge
    xorg-renderproto-0.11.1    |    h14c3975_1002           8 KB  conda-forge
    xorg-xextproto-7.3.0       |    h14c3975_1002          27 KB  conda-forge
    xorg-xproto-7.0.31         |    h14c3975_1007          72 KB  conda-forge
    ------------------------------------------------------------
                                           Total:        74.9 MB

The following NEW packages will be INSTALLED:

  cairo              conda-forge/linux-64::cairo-1.16.0-h18b612c_1001
  fribidi            conda-forge/linux-64::fribidi-1.0.10-h36c2ea0_0
  gettext            conda-forge/linux-64::gettext-0.19.8.1-hf34092f_1004
  graphite2          conda-forge/linux-64::graphite2-1.3.13-h58526e2_1001
  graphviz           pkgs/main/linux-64::graphviz-2.40.1-h21bd128_2
  harfbuzz           pkgs/main/linux-64::harfbuzz-1.8.8-hffaf4a1_0
  libglib            conda-forge/linux-64::libglib-2.66.3-hbe7bbb4_0
  libiconv           conda-forge/linux-64::libiconv-1.16-h516909a_0
  pango              pkgs/main/linux-64::pango-1.42.4-h049681c_0
  pixman             conda-forge/linux-64::pixman-0.38.0-h516909a_1003
  python-graphviz    conda-forge/noarch::python-graphviz-0.16-pyhd3deb0d_1
  python_abi         conda-forge/linux-64::python_abi-3.7-1_cp37m
  xorg-kbproto       conda-forge/linux-64::xorg-kbproto-1.0.7-h14c3975_1002
  xorg-libice        conda-forge/linux-64::xorg-libice-1.0.10-h516909a_0
  xorg-libsm         conda-forge/linux-64::xorg-libsm-1.2.2-h470a237_5
  xorg-libx11        conda-forge/linux-64::xorg-libx11-1.6.12-h516909a_0
  xorg-libxext       conda-forge/linux-64::xorg-libxext-1.3.4-h516909a_0
  xorg-libxrender    conda-forge/linux-64::xorg-libxrender-0.9.10-h516909a_1002
  xorg-renderproto   conda-forge/linux-64::xorg-renderproto-0.11.1-h14c3975_1002
  xorg-xextproto     conda-forge/linux-64::xorg-xextproto-7.3.0-h14c3975_1002
  xorg-xproto        conda-forge/linux-64::xorg-xproto-7.0.31-h14c3975_1007

The following packages will be UPDATED:

  certifi            pkgs/main::certifi-2020.12.5-py37h06a~ --> conda-forge::certifi-2020.12.5-py37h89c1867_1

The following packages will be SUPERSEDED by a higher-priority channel:

  ca-certificates    pkgs/main::ca-certificates-2021.1.19-~ --> conda-forge::ca-certificates-2020.12.5-ha878542_0
  glib                    pkgs/main::glib-2.67.4-h36276a3_1 --> conda-forge::glib-2.66.3-h58526e2_0
  libffi                   pkgs/main::libffi-3.3-he6710b0_2 --> conda-forge::libffi-3.2.1-he1b5a44_1007
  openssl              pkgs/main::openssl-1.1.1j-h27cfd23_0 --> conda-forge::openssl-1.1.1h-h516909a_0
  python                 pkgs/main::python-3.7.9-h7579374_0 --> conda-forge::python-3.7.8-h6f2ec95_0_cpython
```