### PR TITLE
[ci] [R-package] upgrade to R 4.0.4 in CI

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -27,8 +27,8 @@ if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
     export R_LINUX_VERSION="3.6.3-1bionic"
     export R_APT_REPO="bionic-cran35/"
 elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
-    export R_MAC_VERSION=4.0.3
-    export R_LINUX_VERSION="4.0.3-1.1804.0"
+    export R_MAC_VERSION=4.0.4
+    export R_LINUX_VERSION="4.0.4-1.1804.0"
     export R_APT_REPO="bionic-cran40/"
 else
     echo "Unrecognized R version: ${R_VERSION}"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -46,7 +46,7 @@ if ($env:R_MAJOR_VERSION -eq "3") {
   $env:RTOOLS_BIN = "$RTOOLS_INSTALL_PATH\usr\bin"
   $env:RTOOLS_MINGW_BIN = "$RTOOLS_INSTALL_PATH\mingw64\bin"
   $env:RTOOLS_EXE_FILE = "rtools40-x86_64.exe"
-  $env:R_WINDOWS_VERSION = "4.0.3"
+  $env:R_WINDOWS_VERSION = "4.0.4"
 } else {
   Write-Output "[ERROR] Unrecognized R version: $env:R_VERSION"
   Check-Output $false


### PR DESCRIPTION
R Windows CI jobs are currently failing on `master` ([logs](https://github.com/microsoft/LightGBM/runs/2018204127)) and #4027 ([logs](https://github.com/microsoft/LightGBM/pull/4027/checks?check_run_id=2018832067)) with the following:

```text
* checking whether package 'lightgbm' can be installed ... WARNING

Found the following significant warnings:

  Warning: package 'R6' was built under R version 4.0.4

See 'C:/tmp-r-cmd-check/lightgbm.Rcheck/00install.out' for details.

Status: 1 WARNING
```

There has not been a release of `{R6}` since October 2020 (https://cran.r-project.org/web/packages/R6/index.html), but CRAN does create new package binaries when a new version of R is released. R version 4.0.4 was released about two weeks ago: https://twitter.com/pdalgd/status/1361246911378960391, but right now LightGBM's CI uses 4.0.3.

This PR proposes resolving the warning by updating R to 4.0.4.

### Notes for Reviewers

I did look into whether this warning could be disabled in `R CMD CHECK` with an environment variable, and it doesn't look like it.

* https://github.com/wch/r-source/blob/613bdfd0e1d3fc9984142d5da3da448adf2438c7/src/library/base/R/library.R#L321
* https://github.com/wch/r-source/blob/613bdfd0e1d3fc9984142d5da3da448adf2438c7/src/library/base/R/library.R#L119-L122

Linking to #3763