### PR TITLE
[ci] ignore untitle Jupyter notebooks in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,6 +354,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+Untitled*.ipynb
 
 # pyenv
 .python-version


### PR DESCRIPTION
While developing on the python package, I regularly run `jupyter lab` and create a new notebook for testing. This results in leaving behind files with names like `Untitled.ipynb`, `Untitled2.ipynb`, etc. Those names are the default notebook names created by Jupyter ( https://github.com/jupyter/notebook/blob/bc28d6123117c3c733697e27e9d4bd71d7f0c46b/notebook/services/contents/manager.py#L74), so anyone doing something similar might create such files.

This PR proposes adding a rule to `.gitignore` to prevent such notebooks from being checked into source control here.