### PR TITLE
[ci] add CMake + R 3.6 test back (fixes #3469)

### DIFF
--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -31,9 +31,9 @@ function Run-R-Code-Redirect-Stderr {
 # Remove all items matching some pattern from PATH environment variable
 function Remove-From-Path {
   param(
-    [string]$item_to_remove
+    [string]$pattern_to_remove
   )
-  $env:PATH = ($env:PATH.Split(';') | Where-Object { $_ -notmatch "$item_to_remove" }) -join ';'
+  $env:PATH = ($env:PATH.Split(';') | Where-Object { $_ -notmatch "$pattern_to_remove" }) -join ';'
 }
 
 # remove some details that exist in the GitHub Actions images which might

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -28,6 +28,24 @@ function Run-R-Code-Redirect-Stderr {
   Rscript --vanilla -e $decorated_code
 }
 
+# Remove all items matching some pattern from PATH environment variable
+function Remove-From-Path {
+  param(
+    [string]$item_to_remove
+  )
+  $env:path = ($env:path.Split(';') | Where-Object { $_ -notmatch "$item_to_remove" }) -join ';'
+}
+
+# remove some details that exist in the GitHub Actions images which might
+# cause conflicts with R and other components installed by this script
+$env:RTOOLS40_HOME = ""
+Remove-From-Path ".*chocolatey.*"
+Remove-From-Path ".*Chocolatey.*"
+Remove-From-Path ".*Git.*mingw64.*"
+Remove-From-Path ".*msys64.*"
+Remove-From-Path ".*rtools40.*"
+Remove-From-Path ".*Strawberry.*"
+
 # Get details needed for installing R components
 #
 # NOTES:
@@ -94,6 +112,10 @@ Write-Output "Done installing R"
 Write-Output "Installing Rtools"
 ./Rtools.exe /VERYSILENT /SUPPRESSMSGBOXES /DIR=$RTOOLS_INSTALL_PATH ; Check-Output $?
 Write-Output "Done installing Rtools"
+
+# wait for all Rtools files to be written
+Write-Output "Sleeping to allow Rtools install to finish"
+Start-Sleep -Seconds 60
 
 Write-Output "Installing dependencies"
 $packages = "c('data.table', 'jsonlite', 'Matrix', 'processx', 'R6', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -46,6 +46,8 @@ Remove-From-Path ".*msys64.*"
 Remove-From-Path ".*rtools40.*"
 Remove-From-Path ".*Strawberry.*"
 
+Remove-Item C:\rtools40 -Force -Recurse -ErrorAction Ignore
+
 # Get details needed for installing R components
 #
 # NOTES:
@@ -110,12 +112,8 @@ Start-Process -FilePath R-win.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT 
 Write-Output "Done installing R"
 
 Write-Output "Installing Rtools"
-./Rtools.exe /VERYSILENT /SUPPRESSMSGBOXES /DIR=$RTOOLS_INSTALL_PATH ; Check-Output $?
+Start-Process -FilePath Rtools.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /DIR=$RTOOLS_INSTALL_PATH" ; Check-Output $?
 Write-Output "Done installing Rtools"
-
-# wait for all Rtools files to be written
-Write-Output "Sleeping to allow Rtools install to finish"
-Start-Sleep -Seconds 60
 
 Write-Output "Installing dependencies"
 $packages = "c('data.table', 'jsonlite', 'Matrix', 'processx', 'R6', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -33,7 +33,7 @@ function Remove-From-Path {
   param(
     [string]$item_to_remove
   )
-  $env:path = ($env:path.Split(';') | Where-Object { $_ -notmatch "$item_to_remove" }) -join ';'
+  $env:PATH = ($env:PATH.Split(';') | Where-Object { $_ -notmatch "$item_to_remove" }) -join ';'
 }
 
 # remove some details that exist in the GitHub Actions images which might

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -63,6 +63,12 @@ jobs:
           - os: windows-latest
             task: r-package
             compiler: MINGW
+            toolchain: MINGW
+            r_version: 3.6
+            build_type: cmake
+          - os: windows-latest
+            task: r-package
+            compiler: MINGW
             toolchain: MSYS
             r_version: 4.0
             build_type: cmake


### PR DESCRIPTION
I *think* this PR fixes https://github.com/microsoft/LightGBM/issues/3469 😬 

## My theory

Using https://github.com/nelsonjchen/reverse-rdp-windows-github-actions, (mentioned in https://github.com/microsoft/LightGBM/issues/3469#issuecomment-785538447), I RDP'd into a GitHub Actions runner running the `windows-latest` image and try some experiments. I discovered something confusing and scary that I think could be the root cause of CI instability mentioned in #3469.

I manually copied the content of [test_r_package_windows.ps1](https://github.com/microsoft/LightGBM/blob/3a5e3c001f7a571eec375d021d12ccd37353a60c/.ci/test_r_package_windows.ps1) into a Powershell shell running in that runner, a few lines at a time.

Immediately after installing Rtools, the directory `C:\Rtools` was visible in Windows Explorer but `C:\Rtools\mingw_64` didn't exist yet! Even though, in powershell, the command had exited successfully and returned control to the shell.

![image](https://user-images.githubusercontent.com/7608904/110277214-6e784900-7f9a-11eb-85f0-82fd25a1b562.png)

After around 20 seconds, the `mingw_64` directory finally popped up.

![image](https://user-images.githubusercontent.com/7608904/110277285-894abd80-7f9a-11eb-84e4-519227df27f4.png)

And when I say "it popped up", I don't think that's just the effect of buffering or a delay in showing the files. I hit "refresh" in Windows Explorer several times and did not see mingw_64 show up until after 20 seconds or so had passed. So I think the install returned control to powershell before all the files were actually written, somehow 😱 .

This type of problem could explain what we've seen in #3469, where the R 3.6 + CMake job fails but not always. Recall that the failures look like this:

```text
  The C compiler

    "C:/Rtools/mingw_64/bin/gcc.exe"

  is not able to compile a simple test program.

...

    C:/Rtools/mingw_64/bin/../lib/gcc/x86_64-w64-mingw32/4.9.3/../../../../x86_64-w64-mingw32/bin/ld.exe: cannot find -lshell32
```

It makes sense to me that that could happen if all of the contents of `C:\Rtools\mingw_64` (which include a lot of things used by `ld.exe`) aren't available yet when CMake tries to compile LightGBM!

## Proposed Changes

* just sleeping for 1 minute after installing Rtools
* removing possibly-conflicting files pre-installed by GitHub from PATH (https://github.com/microsoft/LightGBM/issues/3469#issuecomment-785538447)

I know fixing a problem by just introducing a sleep isn't ideal, but I think it would be difficult to figure out the full list of files needed by `ld.exe` when compiling LightGBM. I found that with this fix, I got two consecutive runs of the R 3.6 + CMake + Windows job (5  builds on each run) to complete successfully on my fork.

![image](https://user-images.githubusercontent.com/7608904/110281641-ba2ef080-7fa2-11eb-8606-422f73de649a.png)

* https://github.com/jameslamb/LightGBM/actions/runs/631289073
* https://github.com/jameslamb/LightGBM/actions/runs/631256411

