### PR TITLE
[ci] prevent getting incompatible dask and distributed versions

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -103,7 +103,7 @@ conda install -q -y -n $CONDA_ENV cloudpickle joblib matplotlib numpy pandas psu
 #
 # dask and distributed must come from conda-forge because they need to be kept
 # in sync and conda-forge packages are updated more quickly (automatically based
-# on pushes to PyPi)
+# on pushes to PyPI)
 conda install -q -y \
     -n $CONDA_ENV \
     -c conda-forge \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -96,13 +96,19 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+conda install -q -y -n $CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
 
 # graphviz must come from conda-forge to avoid this on some linux distros:
 # https://github.com/conda-forge/graphviz-feedstock/issues/18
+#
+# dask and distributed must come from conda-forge because they need to be kept
+# in sync and conda-forge packages are updated more quickly (automatically based
+# on pushes to PyPi)
 conda install -q -y \
     -n $CONDA_ENV \
     -c conda-forge \
+        'dask>=2021.3.0' \
+        'distributed>=2021.3.0' \
         python-graphviz \
         xorg-libxau
 


### PR DESCRIPTION
Python CI jobs in several pull requests are failing right now. For example, see https://github.com/microsoft/LightGBM/pull/4048#issuecomment-79328858 and https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=9396&view=logs&j=c28dceab-947a-5848-c21f-eef3695e5f11&t=fa158246-17e2-53d4-5936-86070edbaacf .

All of the Dask tests are failing with an error like this

> E AttributeError: 'HighLevelGraph' object has no attribute 'dask_distributed_pack'

This error occurs when you try to use `dask` 2021.2.0 with `distributed` 2021.3.0. For more documentation on that, see https://github.com/dask/dask/issues/7331.

Specifically, LightGBM's CI is hitting this error because it installs `dask` and `distributed` from the default anaconda channel, which is updated more slowly than `conda-forge`.

I see the following in the logs from one of the failed jobs.

```text
The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    ...
    dask-2021.2.0              |     pyhd3eb1b0_0           5 KB
    dask-core-2021.2.0         |     pyhd3eb1b0_0         643 KB
    ...
    distributed-2021.3.0       |   py39h06a4308_0         1.0 MB
```

This PR proposes installing `dask` and `distributed` from conda-forge, and putting an explicit version floor of 2021.3.0 on those libraries.