### PR TITLE
[ci] fix R CMD CHECK note about example timings (fixes #4049)

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -20,6 +20,12 @@ export _R_CHECK_CRAN_INCOMING_REMOTE_=0
 # to catch extreme problems
 export _R_CHECK_PKG_SIZES_THRESHOLD_=60
 
+# don't fail builds for long-running examples unless they're very long
+# See https://github.com/microsoft/LightGBM/issues/4049#issuecomment-793412254.
+if [[ $R_BUILD_TYPE != "cran" ]]; then
+    export _R_CHECK_EXAMPLE_TIMING_THRESHOLD_=30
+fi
+
 # Get details needed for installing R components
 R_MAJOR_VERSION=( ${R_VERSION//./ } )
 if [[ "${R_MAJOR_VERSION}" == "3" ]]; then

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -20,7 +20,7 @@ export _R_CHECK_CRAN_INCOMING_REMOTE_=0
 # to catch extreme problems
 export _R_CHECK_PKG_SIZES_THRESHOLD_=60
 
-# don't fail builds for long-running examples unless they're very long
+# don't fail builds for long-running examples unless they're very long.
 # See https://github.com/microsoft/LightGBM/issues/4049#issuecomment-793412254.
 if [[ $R_BUILD_TYPE != "cran" ]]; then
     export _R_CHECK_EXAMPLE_TIMING_THRESHOLD_=30

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -72,9 +72,9 @@ $env:_R_CHECK_CRAN_INCOMING_REMOTE_ = 0
 # to catch extreme problems
 $env:_R_CHECK_PKG_SIZES_THRESHOLD_ = 60
 
-# don't fail builds for long-running examples unless they're very long
+# don't fail builds for long-running examples unless they're very long.
 # See https://github.com/microsoft/LightGBM/issues/4049#issuecomment-793412254.
-if ($env:R_BUILD_TYPE -eq "cran") {
+if ($env:R_BUILD_TYPE -ne "cran") {
     $env:_R_CHECK_EXAMPLE_TIMING_THRESHOLD_ = 30
 }
 

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -72,6 +72,12 @@ $env:_R_CHECK_CRAN_INCOMING_REMOTE_ = 0
 # to catch extreme problems
 $env:_R_CHECK_PKG_SIZES_THRESHOLD_ = 60
 
+# don't fail builds for long-running examples unless they're very long
+# See https://github.com/microsoft/LightGBM/issues/4049#issuecomment-793412254.
+if ($env:R_BUILD_TYPE -eq "cran") {
+    $env:_R_CHECK_EXAMPLE_TIMING_THRESHOLD_ = 30
+}
+
 if (($env:COMPILER -eq "MINGW") -and ($env:R_BUILD_TYPE -eq "cmake")) {
   $env:CXX = "$env:RTOOLS_MINGW_BIN/g++.exe"
   $env:CC = "$env:RTOOLS_MINGW_BIN/gcc.exe"


### PR DESCRIPTION
This PR attempts to fix #4049. See https://github.com/microsoft/LightGBM/issues/4049#issuecomment-793412254 for a more detailed explanation of this proposal.