### PR TITLE
Set `is_linear_` to false when it is absent from the model file

### DIFF
--- a/src/io/tree.cpp
+++ b/src/io/tree.cpp
@@ -698,6 +698,8 @@ Tree::Tree(const char* str, size_t* used_len) {
     int is_linear_int;
     Common::Atoi(key_vals["is_linear"].c_str(), &is_linear_int);
     is_linear_ = static_cast<bool>(is_linear_int);
+  } else {
+    is_linear_ = false;
   }
 
   if ((num_leaves_ <= 1) && !is_linear_) {


### PR DESCRIPTION
This is to fix #3778. When loading booster from a model file produced by old version of LightGBM without linear tree option, we should set `is_linear_` of a tree to `false`, to avoid uninitialized `is_linear_` value, which can cause undefined behavior.