### PR TITLE
Fix tcp_no_deplay setting by using int type

### DIFF
--- a/src/network/socket_wrapper.hpp
+++ b/src/network/socket_wrapper.hpp
@@ -93,7 +93,7 @@ inline int inet_pton(int af, const char *src, void *dst) {
 namespace SocketConfig {
 const int kSocketBufferSize = 100 * 1000;
 const int kMaxReceiveSize = 100 * 1000;
-const bool kNoDelay = true;
+const int kNoDelay = 1;
 }
 
 class TcpSocket {


### PR DESCRIPTION
Issue: set TCP_NODELAY failed in distributed training and it could be found from the warning log. 
![image](https://user-images.githubusercontent.com/6914259/110580515-d0f06580-81a3-11eb-92ad-c479b21ae9fa.png)

The reason is that the type of kNoDelay should be int from https://man7.org/linux/man-pages/man2/getsockopt.2.html and https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-setsockopt
```
int setsockopt(int sockfd, int level, int optname,
                      const void *optval, socklen_t optlen);
```
> Most socket-level options utilize an int argument for optval. 
> To enable a Boolean option, the optval parameter points to a nonzero integer. To disable the option optval points to an integer equal to zero.
 
