### PR TITLE
[dask] raise more informative error for duplicates in 'machines' (fixes #4057)

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -153,6 +153,10 @@ def _machines_to_worker_map(machines: str, worker_addresses: List[str]) -> Dict[
         Dictionary where keys are work addresses in the form expected by Dask and values are a port for LightGBM to use.
     """
     machine_addresses = machines.split(",")
+
+    if len(set(machine_addresses)) != len(machine_addresses):
+        raise ValueError(f"Found duplicates in 'machines' ({machines}). Each entry in 'machines' must be a unique IP-port combination.")
+
     machine_to_port = defaultdict(set)
     for address in machine_addresses:
         host, port = address.split(":")

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1057,7 +1057,11 @@ def test_network_params_not_required_but_respected_if_given(client, task, output
 
     # model 2 - machines given
     n_workers = len(client.scheduler_info()['workers'])
-    open_ports = [lgb.dask._find_random_open_port() for _ in range(n_workers)]
+    while True:
+        open_ports = [lgb.dask._find_random_open_port() for _ in range(n_workers)]
+        if len(set(open_ports)) == len(open_ports):
+            break
+
     dask_model2 = dask_model_factory(
         n_estimators=5,
         num_leaves=5,

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -14,8 +14,8 @@ import pytest
 
 import lightgbm as lgb
 
-# if not platform.startswith('linux'):
-#     pytest.skip('lightgbm.dask is currently supported in Linux environments', allow_module_level=True)
+if not platform.startswith('linux'):
+    pytest.skip('lightgbm.dask is currently supported in Linux environments', allow_module_level=True)
 if not lgb.compat.DASK_INSTALLED:
     pytest.skip('Dask is not installed', allow_module_level=True)
 

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1057,11 +1057,7 @@ def test_network_params_not_required_but_respected_if_given(client, task, output
 
     # model 2 - machines given
     n_workers = len(client.scheduler_info()['workers'])
-    while True:
-        open_ports = [lgb.dask._find_random_open_port() for _ in range(n_workers)]
-        if len(set(open_ports)) == len(open_ports):
-            break
-
+    open_ports = [lgb.dask._find_random_open_port() for _ in range(n_workers)]
     dask_model2 = dask_model_factory(
         n_estimators=5,
         num_leaves=5,


### PR DESCRIPTION
As of #3994 , it's possible to give the estimators in `lightgbm.dask` an exact set of worker IPs + ports to use for distributed training. This is done by providing a parameter `machines`, a string with a comma-delimited list like `ip1:port1,ip2:port2`.

If you accidentally include duplicates in this list, the error you get today is not very informative:

>  KeyError: 'pop from an empty set'

This PR proposes catching this case and throwing a more informative error.

## Notes for Reviewers

In this case, "duplicates" refers to duplicate `ip-port` pairs. It is possible and very common to run multiple Dask workers on one physical machine. In those cases, it's `machines` might look like this

```text
ip1:12400
ip1:12405
ip1:12475
```

In #4057, I mentioned that it was probably possible to even further reduce the risk of the type of job failure that cause #4057. This could be done with something like this: https://github.com/microsoft/LightGBM/pull/4059/commits/9442bdf00f193a19a923dc0deb46b7822cb6f601.

However, after thinking about it, I now think we shouldn't do that. If a change results in this error happening a lot more frequently than I expect it to (1 in ever 4 billion runs), then we should see CI failing more frequently. I think it's desirable for that to happen so we know something is wrong.