### PR TITLE
[ci] set 'pending' commit status for running R Solaris optional workflow

### DIFF
--- a/.github/workflows/r_solaris.yml
+++ b/.github/workflows/r_solaris.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Send init status
         if: ${{ always() }}
         run: |
+          $GITHUB_WORKSPACE/.ci/set_commit_status.sh "${{ github.workflow }}" "pending" "${{ github.event.client_payload.pr_sha }}"
           $GITHUB_WORKSPACE/.ci/append_comment.sh \
             "${{ github.event.client_payload.comment_number }}" \
             "Workflow **${{ github.workflow }}** has been triggered! 🚀\r\n${GITHUB_SERVER_URL}/microsoft/LightGBM/actions/runs/${GITHUB_RUN_ID}"


### PR DESCRIPTION
I forgot to add one line that sets yellow 'pending' status for running R Solaris workflow in #3913.

Similar to R valgrind workflow:
https://github.com/microsoft/LightGBM/blob/15853a7a02621347aa74bdacb97bbbdc80b25cab/.github/workflows/r_valgrind.yml#L31-L37

Noticed that in https://github.com/microsoft/LightGBM/pull/3872#issuecomment-795972470.