### PR TITLE
[ci] run Dask examples on CI

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -224,7 +224,7 @@ import matplotlib\
 matplotlib.use\(\"Agg\"\)\
 ' plot_example.py  # prevent interactive window mode
     sed -i'.bak' 's/graph.render(view=True)/graph.render(view=False)/' plot_example.py
-    for f in *.py; do python $f || exit -1; done  # run all examples
+    for f in *.py **/*.py; do python $f || exit -1; done  # run all examples
     cd $BUILD_DIRECTORY/examples/python-guide/notebooks
     conda install -q -y -n $CONDA_ENV ipywidgets notebook
     jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb || exit -1  # run all notebooks

--- a/docs/Parallel-Learning-Guide.rst
+++ b/docs/Parallel-Learning-Guide.rst
@@ -65,7 +65,7 @@ LightGBM's Python package supports distributed learning via `Dask`_. This integr
 Dask Examples
 '''''''''''''
 
-For sample code using ``lightgbm.dask``, see `these Dask examples`_ .
+For sample code using ``lightgbm.dask``, see `these Dask examples`_.
 
 Training with Dask
 ''''''''''''''''''
@@ -121,9 +121,9 @@ While setting up for training, ``lightgbm`` will concatenate all of the partitio
 
 When setting up data partitioning for LightGBM training with Dask, try to follow these suggestions:
 
-* ensure that each worker in the cluster has some of the training data
-* try to give each worker roughly the same amount of data, especially if your dataset is small
-* if you plan to train multiple models (for example, to tune hyperparameters) on the same data, use ``client.persist()`` before training to materialize the data one time
+* ensure that each worker in the cluster has some of the training data;
+* try to give each worker roughly the same amount of data, especially if your dataset is small;
+* if you plan to train multiple models (for example, to tune hyperparameters) on the same data, use ``client.persist()`` before training to materialize the data one time.
 
 Using a Specific Dask Client
 ****************************
@@ -195,9 +195,9 @@ If you are running multiple Dask worker processes on physical host in the cluste
 
   Providing ``machines`` gives you complete control over the networking details of training, but it also makes the training process fragile. Training will fail if you use ``machines`` and any of the following are true:
 
-  * any of the ports mentioned in ``machines`` are not open when training begins
-  * some partitions of the training data are held by machines that that are not present in ``machines``
-  * some machines mentioned in ``machines`` do not hold any of the training data
+  * any of the ports mentioned in ``machines`` are not open when training begins;
+  * some partitions of the training data are held by machines that that are not present in ``machines``;
+  * some machines mentioned in ``machines`` do not hold any of the training data.
 
 **Option 2: specify one port to use on every worker**
 
@@ -223,8 +223,8 @@ You could edit your firewall rules to allow communication between any of the wor
 
   Providing ``local_listen_port`` is slightly less fragile than ``machines`` because LightGBM will automatically figure out which workers have pieces of the training data. However, using this method, training can fail if any of the following are true:
 
-  * the port ``local_listen_port`` is not open on any of the worker hosts
-  * any machine has multiple Dask worker processes running on it
+  * the port ``local_listen_port`` is not open on any of the worker hosts;
+  * any machine has multiple Dask worker processes running on it.
 
 Prediction with Dask
 ''''''''''''''''''''
@@ -335,10 +335,10 @@ The lowest-level model object in LightGBM is the ``lightgbm.Booster``. After tra
 
 From the point forward, you can use any of the following methods to save the Booster:
 
-* serialize with ``cloudpickle``, ``joblib``, or ``pickle``
-* ``bst.dump_model()``: dump the model to a dictionary which could be written out as JSON
-* ``bst.model_to_string()``: dump the model to a string in memory
-* ``bst.save_model()``: write the output of ``bst.model_to_string()`` to a text file
+* serialize with ``cloudpickle``, ``joblib``, or ``pickle``;
+* ``bst.dump_model()``: dump the model to a dictionary which could be written out as JSON;
+* ``bst.model_to_string()``: dump the model to a string in memory;
+* ``bst.save_model()``: write the output of ``bst.model_to_string()`` to a text file.
 
 Kubeflow
 ^^^^^^^^

--- a/docs/Parallel-Learning-Guide.rst
+++ b/docs/Parallel-Learning-Guide.rst
@@ -62,6 +62,10 @@ Dask
 
 LightGBM's Python package supports distributed learning via `Dask`_. This integration is maintained by LightGBM's maintainers.
 
+.. warning::
+
+    Dask integration is only tested on Linux.
+
 Dask Examples
 '''''''''''''
 
@@ -121,9 +125,9 @@ While setting up for training, ``lightgbm`` will concatenate all of the partitio
 
 When setting up data partitioning for LightGBM training with Dask, try to follow these suggestions:
 
-* ensure that each worker in the cluster has some of the training data;
-* try to give each worker roughly the same amount of data, especially if your dataset is small;
-* if you plan to train multiple models (for example, to tune hyperparameters) on the same data, use ``client.persist()`` before training to materialize the data one time.
+* ensure that each worker in the cluster has some of the training data
+* try to give each worker roughly the same amount of data, especially if your dataset is small
+* if you plan to train multiple models (for example, to tune hyperparameters) on the same data, use ``client.persist()`` before training to materialize the data one time
 
 Using a Specific Dask Client
 ****************************
@@ -195,9 +199,9 @@ If you are running multiple Dask worker processes on physical host in the cluste
 
   Providing ``machines`` gives you complete control over the networking details of training, but it also makes the training process fragile. Training will fail if you use ``machines`` and any of the following are true:
 
-  * any of the ports mentioned in ``machines`` are not open when training begins;
-  * some partitions of the training data are held by machines that that are not present in ``machines``;
-  * some machines mentioned in ``machines`` do not hold any of the training data.
+  * any of the ports mentioned in ``machines`` are not open when training begins
+  * some partitions of the training data are held by machines that that are not present in ``machines``
+  * some machines mentioned in ``machines`` do not hold any of the training data
 
 **Option 2: specify one port to use on every worker**
 
@@ -223,8 +227,8 @@ You could edit your firewall rules to allow communication between any of the wor
 
   Providing ``local_listen_port`` is slightly less fragile than ``machines`` because LightGBM will automatically figure out which workers have pieces of the training data. However, using this method, training can fail if any of the following are true:
 
-  * the port ``local_listen_port`` is not open on any of the worker hosts;
-  * any machine has multiple Dask worker processes running on it.
+  * the port ``local_listen_port`` is not open on any of the worker hosts
+  * any machine has multiple Dask worker processes running on it
 
 Prediction with Dask
 ''''''''''''''''''''
@@ -335,10 +339,10 @@ The lowest-level model object in LightGBM is the ``lightgbm.Booster``. After tra
 
 From the point forward, you can use any of the following methods to save the Booster:
 
-* serialize with ``cloudpickle``, ``joblib``, or ``pickle``;
-* ``bst.dump_model()``: dump the model to a dictionary which could be written out as JSON;
-* ``bst.model_to_string()``: dump the model to a string in memory;
-* ``bst.save_model()``: write the output of ``bst.model_to_string()`` to a text file.
+* serialize with ``cloudpickle``, ``joblib``, or ``pickle``
+* ``bst.dump_model()``: dump the model to a dictionary which could be written out as JSON
+* ``bst.model_to_string()``: dump the model to a string in memory
+* ``bst.save_model()``: write the output of ``bst.model_to_string()`` to a text file
 
 Kubeflow
 ^^^^^^^^

--- a/examples/python-guide/dask/binary-classification.py
+++ b/examples/python-guide/dask/binary-classification.py
@@ -1,5 +1,3 @@
-import sys
-
 import dask.array as da
 from distributed import Client, LocalCluster
 from sklearn.datasets import make_blobs
@@ -7,10 +5,6 @@ from sklearn.datasets import make_blobs
 import lightgbm as lgb
 
 if __name__ == "__main__":
-    if not sys.platform.startswith('linux'):
-        print('lightgbm.dask is currently supported in Linux environments')
-        sys.exit(0)
-
     print("loading data")
 
     X, y = make_blobs(n_samples=1000, n_features=50, centers=2)

--- a/examples/python-guide/dask/binary-classification.py
+++ b/examples/python-guide/dask/binary-classification.py
@@ -1,3 +1,5 @@
+import sys
+
 import dask.array as da
 from distributed import Client, LocalCluster
 from sklearn.datasets import make_blobs
@@ -5,6 +7,9 @@ from sklearn.datasets import make_blobs
 import lightgbm as lgb
 
 if __name__ == "__main__":
+    if not sys.platform.startswith('linux'):
+        print('lightgbm.dask is currently supported in Linux environments')
+        sys.exit(0)
 
     print("loading data")
 

--- a/examples/python-guide/dask/multiclass-classification.py
+++ b/examples/python-guide/dask/multiclass-classification.py
@@ -1,5 +1,3 @@
-import sys
-
 import dask.array as da
 from distributed import Client, LocalCluster
 from sklearn.datasets import make_blobs
@@ -7,10 +5,6 @@ from sklearn.datasets import make_blobs
 import lightgbm as lgb
 
 if __name__ == "__main__":
-    if not sys.platform.startswith('linux'):
-        print('lightgbm.dask is currently supported in Linux environments')
-        sys.exit(0)
-
     print("loading data")
 
     X, y = make_blobs(n_samples=1000, n_features=50, centers=3)

--- a/examples/python-guide/dask/multiclass-classification.py
+++ b/examples/python-guide/dask/multiclass-classification.py
@@ -1,3 +1,5 @@
+import sys
+
 import dask.array as da
 from distributed import Client, LocalCluster
 from sklearn.datasets import make_blobs
@@ -5,6 +7,9 @@ from sklearn.datasets import make_blobs
 import lightgbm as lgb
 
 if __name__ == "__main__":
+    if not sys.platform.startswith('linux'):
+        print('lightgbm.dask is currently supported in Linux environments')
+        sys.exit(0)
 
     print("loading data")
 

--- a/examples/python-guide/dask/prediction.py
+++ b/examples/python-guide/dask/prediction.py
@@ -1,5 +1,3 @@
-import sys
-
 import dask.array as da
 from distributed import Client, LocalCluster
 from sklearn.datasets import make_regression
@@ -8,10 +6,6 @@ from sklearn.metrics import mean_squared_error
 import lightgbm as lgb
 
 if __name__ == "__main__":
-    if not sys.platform.startswith('linux'):
-        print('lightgbm.dask is currently supported in Linux environments')
-        sys.exit(0)
-
     print("loading data")
 
     X, y = make_regression(n_samples=1000, n_features=50)

--- a/examples/python-guide/dask/prediction.py
+++ b/examples/python-guide/dask/prediction.py
@@ -1,3 +1,5 @@
+import sys
+
 import dask.array as da
 from distributed import Client, LocalCluster
 from sklearn.datasets import make_regression
@@ -6,6 +8,9 @@ from sklearn.metrics import mean_squared_error
 import lightgbm as lgb
 
 if __name__ == "__main__":
+    if not sys.platform.startswith('linux'):
+        print('lightgbm.dask is currently supported in Linux environments')
+        sys.exit(0)
 
     print("loading data")
 

--- a/examples/python-guide/dask/ranking.py
+++ b/examples/python-guide/dask/ranking.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 import dask.array as da
 import numpy as np
 from distributed import Client, LocalCluster
@@ -6,11 +9,16 @@ from sklearn.datasets import load_svmlight_file
 import lightgbm as lgb
 
 if __name__ == "__main__":
+    if not sys.platform.startswith('linux'):
+        print('lightgbm.dask is currently supported in Linux environments')
+        sys.exit(0)
 
     print("loading data")
 
-    X, y = load_svmlight_file("../lambdarank/rank.train")
-    group = np.loadtxt("../lambdarank/rank.train.query")
+    X, y = load_svmlight_file(os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                           '../../lambdarank/rank.train'))
+    group = np.loadtxt(os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                    '../../lambdarank/rank.train.query'))
 
     print("initializing a Dask cluster")
 

--- a/examples/python-guide/dask/ranking.py
+++ b/examples/python-guide/dask/ranking.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import dask.array as da
 import numpy as np
@@ -9,10 +8,6 @@ from sklearn.datasets import load_svmlight_file
 import lightgbm as lgb
 
 if __name__ == "__main__":
-    if not sys.platform.startswith('linux'):
-        print('lightgbm.dask is currently supported in Linux environments')
-        sys.exit(0)
-
     print("loading data")
 
     X, y = load_svmlight_file(os.path.join(os.path.dirname(os.path.realpath(__file__)),

--- a/examples/python-guide/dask/regression.py
+++ b/examples/python-guide/dask/regression.py
@@ -1,5 +1,3 @@
-import sys
-
 import dask.array as da
 from distributed import Client, LocalCluster
 from sklearn.datasets import make_regression
@@ -7,10 +5,6 @@ from sklearn.datasets import make_regression
 import lightgbm as lgb
 
 if __name__ == "__main__":
-    if not sys.platform.startswith('linux'):
-        print('lightgbm.dask is currently supported in Linux environments')
-        sys.exit(0)
-
     print("loading data")
 
     X, y = make_regression(n_samples=1000, n_features=50)

--- a/examples/python-guide/dask/regression.py
+++ b/examples/python-guide/dask/regression.py
@@ -1,3 +1,5 @@
+import sys
+
 import dask.array as da
 from distributed import Client, LocalCluster
 from sklearn.datasets import make_regression
@@ -5,6 +7,9 @@ from sklearn.datasets import make_regression
 import lightgbm as lgb
 
 if __name__ == "__main__":
+    if not sys.platform.startswith('linux'):
+        print('lightgbm.dask is currently supported in Linux environments')
+        sys.exit(0)
 
     print("loading data")
 

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -204,6 +204,10 @@ You can use ``python setup.py bdist_wheel`` instead of ``python setup.py install
 Install Dask-package
 ''''''''''''''''''''
 
+.. warning::
+
+    Dask-package is only tested on Linux.
+
 To install all additional dependencies required for Dask-package, you can append ``[dask]`` to LightGBM package name:
 
 .. code:: sh


### PR DESCRIPTION
Dask examples are placed in the [`python-guide/dask`](https://github.com/microsoft/LightGBM/tree/master/examples/python-guide/dask) subdirectory.

Also this PR adds some punctuation to Dask guide.