### PR TITLE
[python-package] add type hints on Booster.set_network()

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from functools import wraps
 from logging import Logger
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict
+from typing import Any, Dict, List, Set, Union
 
 import numpy as np
 import scipy.sparse
@@ -2336,13 +2336,18 @@ class Booster:
         self.__is_predicted_cur_iter = []
         return self
 
-    def set_network(self, machines: str, local_listen_port: int = 12400,
-                    listen_time_out: int = 120, num_machines: int = 1) -> "Booster":
+    def set_network(
+        self,
+        machines: Union[List[str], Set[str], str],
+        local_listen_port: int = 12400,
+        listen_time_out: int = 120,
+        num_machines: int = 1
+    ) -> "Booster":
         """Set the network configuration.
 
         Parameters
         ----------
-        machines : string
+        machines : list, set or string
             Names of machines.
         local_listen_port : int, optional (default=12400)
             TCP listen port for local machines.
@@ -2356,6 +2361,8 @@ class Booster:
         self : Booster
             Booster with set network.
         """
+        if isinstance(machines, (list, set)):
+            machines = ','.join(machines)
         _safe_call(_LIB.LGBM_NetworkInit(c_str(machines),
                                          ctypes.c_int(local_listen_port),
                                          ctypes.c_int(listen_time_out),

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2336,13 +2336,13 @@ class Booster:
         self.__is_predicted_cur_iter = []
         return self
 
-    def set_network(self, machines, local_listen_port=12400,
-                    listen_time_out=120, num_machines=1):
+    def set_network(self, machines: str, local_listen_port: int = 12400,
+                    listen_time_out: int = 120, num_machines: int = 1) -> "Booster":
         """Set the network configuration.
 
         Parameters
         ----------
-        machines : list, set or string
+        machines : string
             Names of machines.
         local_listen_port : int, optional (default=12400)
             TCP listen port for local machines.


### PR DESCRIPTION
While working on `lightgbm.dask`, I noticed that the docstring for `machines` in `Booster.set_network()` seems to be incorrect.

It says the following:

> machines : list, set or string
    Names of machines.

However, `machines` is passed to `lightgbm.basic.c_str()`, which only accepts strings: https://github.com/microsoft/LightGBM/blob/bcf443b568052eac05cb8b11b17be9926b862f8f/python-package/lightgbm/basic.py#L2359.

If you pass a set or list, you'll get an error like.

> AttributeError: 'set' object has no attribute 'encode'

```python
import lightgbm as lgb
machines = set(["10.1.1.1:12400", "10.1.1.2:12400"])
lgb.basic.c_str(machines)
```

This PR proposes updating that docstring to make it clear that only strings are supported. It also adds type hints on the other arguments in `Booster.set_network()` and a return type hint, as part of #3756.