### PR TITLE
[dask] [ci] fix flaky network-setup test

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1024,6 +1024,8 @@ def test_network_params_not_required_but_respected_if_given(client, task, output
     if task == 'ranking' and output == 'scipy_csr_matrix':
         pytest.skip('LGBMRanker is not currently tested on sparse matrices')
 
+    client.wait_for_workers(2)
+
     if task == 'ranking':
         _, _, _, _, dX, dy, _, dg = _create_ranking_data(
             output=output,


### PR DESCRIPTION
This PR attempts to fix the occasional failure in the Dask tests mentioned in https://github.com/microsoft/LightGBM/pull/4068#issuecomment-798972634. One of the test cases in `test_dask.py` explicitly requires that at least two workers join the cluster and have pieces of the training data.

This PR tries to prevent that error by using [`Client.wait_for_workers(2)`](https://distributed.dask.org/en/latest/api.html#distributed.Client.wait_for_workers). That call will block until at least 2 workers are up and have joined the cluster, which should prevent errors caused by one worker process being a little slow to start sometimes.

It's difficult to reliably test that this PR would fix the problem mentioned in https://github.com/microsoft/LightGBM/pull/4068#issuecomment-798972634, since it happens so rarely and randomly. I tried running the test in question 11 times on `master` and 11 times after this change (locally on my Mac) and it passed every time.