### PR TITLE
[dask] remove unused imports from typing

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -9,7 +9,7 @@ It is based on dask-lightgbm, which was based on dask-xgboost.
 import socket
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 from urllib.parse import urlparse
 
 import numpy as np


### PR DESCRIPTION
This PR removes two unused imports from `typing`  in the Dask module. I think the need for them was removed in recent refactorings.

Caught these by looking at `pylint python-package/`.