### PR TITLE
[ci] fix flaky Azure Pipelines jobs

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -44,6 +44,7 @@ else  # Linux
             libicu66 \
             libssl1.1 \
             libunwind8 \
+            libxau6 \
             locales \
             netcat \
             unzip \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -44,7 +44,7 @@ else  # Linux
             libicu66 \
             libssl1.1 \
             libunwind8 \
-            libxau6 \
+            libxau-dev \
             locales \
             netcat \
             unzip \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -83,6 +83,8 @@ else  # Linux
         apt-get update
         apt-get install --no-install-recommends -y \
             curl \
+            libxau-dev \
+            libxrender1 \
             lsb-release \
             software-properties-common
         if [[ $COMPILER == "clang" ]]; then

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -45,6 +45,7 @@ else  # Linux
             libssl1.1 \
             libunwind8 \
             libxau-dev \
+            libxrender1 \
             locales \
             netcat \
             unzip \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -96,15 +96,7 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
-
-# graphviz must come from conda-forge to avoid this on some linux distros:
-# https://github.com/conda-forge/graphviz-feedstock/issues/18
-conda install -q -y \
-    -n $CONDA_ENV \
-    -c conda-forge \
-        python-graphviz \
-        xorg-libxau
+conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest python-graphviz scikit-learn scipy
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     # fix "OMP: Error #15: Initializing libiomp5.dylib, but found libomp.dylib already initialized." (OpenMP library conflict due to conda's MKL)

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -96,7 +96,14 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest python-graphviz scikit-learn scipy
+conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+
+# graphviz must come from conda-forge to avoid this on some linux distros:
+# https://github.com/conda-forge/graphviz-feedstock/issues/18
+conda install -q -y \
+    -n $CONDA_ENV \
+    -c conda-forge \
+        python-graphviz
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     # fix "OMP: Error #15: Initializing libiomp5.dylib, but found libomp.dylib already initialized." (OpenMP library conflict due to conda's MKL)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - master
+    - libxau
   tags:
     include:
     - v*

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - libxau
+    - master
   tags:
     include:
     - v*


### PR DESCRIPTION
Today I had to re-run Azure builds more than 5 times to make it create new release. Also, many current PRs are failing with 
```
Executing transaction: ...working... g_module_open() failed for /home/AzDevOps_azpcontainer/miniconda/envs/test-env/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.so: libXrender.so.1: cannot open shared object file: No such file or directory

g_module_open() failed for /home/AzDevOps_azpcontainer/miniconda/envs/test-env/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.so: libXrender.so.1: cannot open shared object file: No such file or directory
```
For example, #4093, #4092.

I hope system-wide installation of `libxau` along with `libxrender1` will solve the issue.

Refer to https://github.com/conda-forge/graphviz-feedstock/issues/35#issuecomment-786368065:
> So it is possible to get away without installing `libXau` at the OS level ... but for reliable results, you should either install `libXau` at the OS level, or always explicitly install `xorg-libxau`.