### PR TITLE
[ci] fix flaky Azure Pipelines jobs (2)

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -44,7 +44,8 @@ else  # Linux
             libicu66 \
             libssl1.1 \
             libunwind8 \
-            libxau-dev \
+            libxau6 \
+            libxext6 \
             libxrender1 \
             locales \
             netcat \
@@ -83,7 +84,8 @@ else  # Linux
         apt-get update
         apt-get install --no-install-recommends -y \
             curl \
-            libxau-dev \
+            libxau6 \
+            libxext6 \
             libxrender1 \
             lsb-release \
             software-properties-common


### PR DESCRIPTION
Continuation of #4095.

Now we get 

```
Executing transaction: ...working... g_module_open() failed for /home/AzDevOps_azpcontainer/miniconda/envs/test-env/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.so: libXext.so.6: cannot open shared object file: No such file or directory

g_module_open() failed for /home/AzDevOps_azpcontainer/miniconda/envs/test-env/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.so: libXext.so.6: cannot open shared object file: No such file or directory
```

randomly.

Also, I think our Azure agents are unhealthy because I see some weird errors: failures to clone the repo, Dask test hangs for 1h and aborted, failures during `apt-get install ...`, etc.