### PR TITLE
[swig] add wrapper for LGBM_DatasetGetFeatureNames

### DIFF
--- a/swig/StringArray_API_extensions.i
+++ b/swig/StringArray_API_extensions.i
@@ -104,4 +104,44 @@
 
         return strings.release();
     }
+
+
+    /**
+     * @brief Wraps LGBM_DatasetGetFeatureNames. Has the same limitations as a
+     * LGBM_BoosterGetFeatureNames:
+     *
+     * Allocates a new StringArray. You must free it yourself if it succeeds.
+     * @see StringArrayHandle_free().
+     * In case of failure such resource is freed and nullptr is returned.
+     * Check for that case with null (lightgbmlib) or 0 (lightgbmlibJNI).
+     *
+     * @param handle Booster handle
+     * @return StringArrayHandle with the feature names (or nullptr in case of error)
+     */
+    StringArrayHandle LGBM_DatasetGetFeatureNamesSWIG(BoosterHandle handle)
+    {
+        int num_features;
+        size_t max_feature_name_size;
+        std::unique_ptr<StringArray> strings(nullptr);
+
+        // Retrieve required allocation space:
+        API_OK_OR_NULL(LGBM_DatasetGetFeatureNames(handle,
+                                                   0, &num_features,
+                                                   0, &max_feature_name_size,
+                                                   nullptr));
+        try {
+            strings.reset(new StringArray(num_features, max_feature_name_size));
+        } catch (std::bad_alloc &e) {
+            LGBM_SetLastError("Failure to allocate memory.");
+            return nullptr;
+        }
+
+        API_OK_OR_NULL(LGBM_DatasetGetFeatureNames(handle,
+                                                   num_features, &num_features,
+                                                   max_feature_name_size, &max_feature_name_size,
+                                                   strings->data()));
+
+        return strings.release();
+    }
+
 %}


### PR DESCRIPTION
### TLDR

A SWIG wrapper for a `LGBM_DatasetGetFeatureNames` C API call. There is a similar `LGBM_BoosterGetFeatureNames` already implemented, and this PR just makes it available for another type of handle.

### Purpose
When implementing `LGBM_DatasetGetFeatureNames` call in [lightgbm4j](https://github.com/metarank/lightgbm4j) we found an interesting corner case in the C API, which happens between C <-> JDK:
* we need to preallocate an array of strings for feature names (with a properly-sized per name buffer) to call `LGBM_DatasetGetFeatureNames` method
* it's doable from JVM side, so you can technically call `LGBM_DatasetGetFeatureNames` and call it a day (see the example below).
* but `LGBM_DatasetGetFeatureNames` call writes directly to the char[] buffer of the string, which makes JVM a bit surprised, as
  * Strings are immutable in Java
  * If we want to mutate something coming from the JVM, we need to explicitly signal about our intentions (critical section, so GC will stop reallocating objects)
  * crossing the JVM-C border using JNI causes data copy, even for strings.

My original implementation was copying the approach from `LGBM_BoosterGetFeatureNamesSWIG` but in Java:
```java
    public String[] getFeatureNames() throws LGBMException {
        SWIGTYPE_p_int numFeaturesP = new_intp();
        SWIGTYPE_p_size_t maxFeatureNameSizeP = new_size_tp();
        int result = LGBM_DatasetGetFeatureNames(handle, 0, numFeaturesP, 0, maxFeatureNameSizeP, null);
        if (result < 0) {
            delete_intp(numFeaturesP);
            delete_size_tp(maxFeatureNameSizeP);
            throw new LGBMException(LGBM_GetLastError());
        } else {
            String[] buffer = new String[intp_value(numFeaturesP)];
            for (int i=0; i< buffer.length; i++) {
                buffer[i] = "                                                              "; // nevermind, a temp hack
            }
            int result2 = LGBM_DatasetGetFeatureNames(handle, buffer.length, numFeaturesP, size_tp_value(maxFeatureNameSizeP), maxFeatureNameSizeP, buffer);
            delete_intp(numFeaturesP);
            delete_size_tp(maxFeatureNameSizeP);
            if (result2 < 0) {
                throw new LGBMException(LGBM_GetLastError());
            } else {
                return buffer;
            }
        }

```

LGBM seems to write feature names somewhere (most probably to it's local copy of a preallocated string array), but as it never signaled the intention to mutate it, then these updated feature names are not copied back to the JVM world. So at the end of the `getFeatureNames` call we get the same String[] array we allocated in JVM without any changes coming from LGBM.

### New approach

In this PR we do the same thing as in `LGBM_BoosterGetFeatureNames`:
* create a properly-sized feature names buffer in native code, so we don't need to mess with JVM critical sections and immutable strings,
* fill it with data by calling the C API method
* return it as a String[], which is properly copied to the JVM world.

### Questions

1. Is it OK to have `LGBM_BoosterGetFeatureNames` and `LGBM_DatasetGetFeatureNames` being almost identical? Or should I move all the shared buffer juggling in a separate method?
2. I found no tests for the SWIG interface. For this PR all the testing is done on the `lightgbm4j` side (by compiling the swig wrapper with PR applied and repackaging it inside the jar, and it seems to work fine). Is it OK for a PR to be almost without tests? In general, it should be safe enough as it's not changing current API and just adds a convenient wrapper for the existing code.