### PR TITLE
[R-package] fix typo in linear learner test

### DIFF
--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -1883,7 +1883,7 @@ test_that("lgb.train() works with linear learners when Dataset has categorical f
     , metric = "mse"
     , seed = 0L
     , num_leaves = 2L
-    , categorical_featurs = 1L
+    , categorical_features = 1L
   )
 
   dtrain <- .new_dataset()


### PR DESCRIPTION
This fixes a typo in params on one of the R unit tests, which led to the warning noted in https://github.com/microsoft/LightGBM/issues/4105#issuecomment-806259143

> [LightGBM] [Warning] Unknown parameter: categorical_featurs

That test specifically checks that training a model in R using linear models at the leaves works if you also have categorical features. So this typo might have actually prevented that test from running correctly and covering what it was expected to.

I also looked through the logs from a recent build of the `r-package (windows-2019, MSVC, R 4, cmake)` CI job. Those jobs use `Rscript testthat.R` instead of `R CMD CHECK`, so you can see all of the logs from the tests. For the other warnings that look problematic, I've opened #4108 with the tag `good first issue` so that it might be addressed by other contributors.