### PR TITLE
[ci] attach archives with complete source code of the repo to releases

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -288,6 +288,24 @@ jobs:
   pool:
     vmImage: 'ubuntu-latest'
   steps:
+  # Create archives with complete source code included (with git submodules)
+  - task: ArchiveFiles@2
+    displayName: Create zip archive
+    inputs:
+      rootFolderOrFile: $(Build.SourcesDirectory)
+      includeRootFolder: false
+      archiveType: zip
+      archiveFile: '$(Build.ArtifactStagingDirectory)/archives/LightGBM-complete_source_code_zip.zip'
+      replaceExistingArchive: true
+  - task: ArchiveFiles@2
+    displayName: Create tar.gz archive
+    inputs:
+      rootFolderOrFile: $(Build.SourcesDirectory)
+      includeRootFolder: false
+      archiveType: tar
+      tarCompression: gz
+      archiveFile: '$(Build.ArtifactStagingDirectory)/archives/LightGBM-complete_source_code_tar_gz.tar.gz'
+      replaceExistingArchive: true
   # Download all agent packages from all previous phases
   - task: DownloadBuildArtifacts@0
     displayName: Download package assets
@@ -301,10 +319,10 @@ jobs:
     inputs:
       command: pack
       packagesToPack: '$(Build.SourcesDirectory)/.nuget/*.nuspec'
-      packDestination: '$(Build.ArtifactStagingDirectory)'
+      packDestination: '$(Build.ArtifactStagingDirectory)/nuget'
   - task: PublishBuildArtifacts@1
     inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
       artifactName: NuGet
       artifactType: container
   - task: GitHubRelease@0
@@ -319,7 +337,8 @@ jobs:
       title: '$(Build.SourceBranchName)'
       assets: |
         $(Build.SourcesDirectory)/binaries/PackageAssets/*
-        $(Build.ArtifactStagingDirectory)/*.nupkg
+        $(Build.ArtifactStagingDirectory)/nuget/*.nupkg
+        $(Build.ArtifactStagingDirectory)/archives/*
       assetUploadMode: 'delete'
       isDraft: true
       isPreRelease: false

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -291,6 +291,7 @@ jobs:
   # Create archives with complete source code included (with git submodules)
   - task: ArchiveFiles@2
     displayName: Create zip archive
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
     inputs:
       rootFolderOrFile: $(Build.SourcesDirectory)
       includeRootFolder: false
@@ -299,6 +300,7 @@ jobs:
       replaceExistingArchive: true
   - task: ArchiveFiles@2
     displayName: Create tar.gz archive
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
     inputs:
       rootFolderOrFile: $(Build.SourcesDirectory)
       includeRootFolder: false


### PR DESCRIPTION
Refer to https://github.com/microsoft/LightGBM/pull/3872#issuecomment-804087682.

I believe that adding archives with repo source code to artifacts that we produce for each commit in `master` is pointless, so I'm not adding `PublishBuildArtifacts@1` step for archives.