### PR TITLE
Update test_chunked_array to please cpplint

### DIFF
--- a/tests/cpp_test/test_chunked_array.cpp
+++ b/tests/cpp_test/test_chunked_array.cpp
@@ -39,9 +39,9 @@ class ChunkedArrayTest : public testing::Test {
   void SetUp() override {
   }
 
-  void add_items_to_array(const std::vector<int> &vec, ChunkedArray<int> &ca) {
+  void add_items_to_array(const std::vector<int> &vec, ChunkedArray<int> *ca) {
     for (auto v : vec) {
-      ca.add(v);
+      ca->add(v);
     }
   }
 
@@ -125,7 +125,7 @@ TEST_F(ChunkedArrayTest, getAddCount) {
 */
 TEST_F(ChunkedArrayTest, coalesceTo) {
   std::vector<int> out(REF_VEC.size());
-  add_items_to_array(REF_VEC, ca_);
+  add_items_to_array(REF_VEC, &ca_);
 
   ca_.coalesce_to(out.data());
 
@@ -137,13 +137,13 @@ TEST_F(ChunkedArrayTest, coalesceTo) {
 */
 TEST_F(ChunkedArrayTest, clear) {
   const std::vector<int> ref_vec2 = {1, 2, 5, -1};
-  add_items_to_array(REF_VEC, ca_);
+  add_items_to_array(REF_VEC, &ca_);
   // Start with some content:
   ASSERT_TRUE(coalesced_output_equals_vec(ca_, REF_VEC));
 
   // Clear & re-use:
   ca_.clear();
-  add_items_to_array(ref_vec2, ca_);
+  add_items_to_array(ref_vec2, &ca_);
 
   // Output should match new content:
   ASSERT_TRUE(coalesced_output_equals_vec(ca_, ref_vec2));
@@ -163,7 +163,7 @@ TEST_F(ChunkedArrayTest, doubleFreeSafe) {
   Ensure size computations in the getters are correct.
 */
 TEST_F(ChunkedArrayTest, totalArraySizeMatchesLastChunkAddCount) {
-  add_items_to_array(REF_VEC, ca_);
+  add_items_to_array(REF_VEC, &ca_);
 
   const size_t first_chunks_add_count = (ca_.get_chunks_count() - 1) * ca_.get_chunk_size();
   const size_t last_chunk_add_count = ca_.get_last_chunk_add_count();
@@ -183,7 +183,7 @@ TEST_F(ChunkedArrayTest, totalArraySizeMatchesLastChunkAddCount) {
   This would occur if there was an improper data layout with the chunks.
 */
 TEST_F(ChunkedArrayTest, dataLayoutTestThroughGetitem) {
-  add_items_to_array(REF_VEC, ca_);
+  add_items_to_array(REF_VEC, &ca_);
 
   for (size_t i = 0, chunk = 0, in_chunk_idx = 0; i < REF_VEC.size(); ++i) {
     int value = ca_.getitem(chunk, in_chunk_idx, -1);  // -1 works as sentinel value (bad layout found)
@@ -207,7 +207,7 @@ TEST_F(ChunkedArrayTest, dataLayoutTestThroughGetitem) {
   We also gradually add more chunks to the ChunkedArray and re-run more trials
   to ensure the valid/invalid addresses are updated.
 
-  With each valid update we add to a "memory" vector the history of all the insertions.
+  With each valid update we add to a "memory" vector the latest inserted values.
   This is used at the end to ensure all values were stored properly, including after
   value overrides.
 */
@@ -216,8 +216,9 @@ TEST_F(ChunkedArrayTest, testDataLayoutWithAdvancedInsertionAPI) {
   const size_t MAX_IN_CHUNK_SEARCH_IDX = 2 * CHUNK_SIZE;
   // Number of trials for each new ChunkedArray configuration. Pass 100 times over the search space:
   const size_t N_TRIALS = MAX_CHUNKS_SEARCH * MAX_IN_CHUNK_SEARCH_IDX * 100;
-  std::vector<int> overriden_trials_values(MAX_CHUNKS_SEARCH * CHUNK_SIZE);
-  std::vector<bool> overriden_trials_mask(MAX_CHUNKS_SEARCH * CHUNK_SIZE, false);
+  const int INVALID = -1;  // A negative value signaling the requested value lives in an invalid address.
+  const int UNITIALIZED = -99;  // A negative value to signal this was never updated.
+  std::vector<int> overriden_trials_values(MAX_CHUNKS_SEARCH * CHUNK_SIZE, UNITIALIZED);
 
   // Each outer loop iteration changes the test by adding +1 chunk. We start with 1 chunk only:
   for (size_t chunks = 1; chunks < MAX_CHUNKS_SEARCH; ++chunks) {
@@ -237,11 +238,10 @@ TEST_F(ChunkedArrayTest, testDataLayoutWithAdvancedInsertionAPI) {
       // If at valid address, check that the stored value is correct & remember it for the future:
       if (valid_address) {
         // Check the just-stored value with getitem():
-        EXPECT_EQ(ca_.getitem(trial_chunk, trial_in_chunk_idx, -1), trial_value);  // -1 is the sentinel value.
+        EXPECT_EQ(ca_.getitem(trial_chunk, trial_in_chunk_idx, INVALID), trial_value);
 
         // Also store the just-stored value for future tracking:
         overriden_trials_values[trial_chunk * CHUNK_SIZE + trial_in_chunk_idx] = trial_value;
-        overriden_trials_mask[trial_chunk * CHUNK_SIZE + trial_in_chunk_idx] = true;
       }
     }
 
@@ -249,11 +249,11 @@ TEST_F(ChunkedArrayTest, testDataLayoutWithAdvancedInsertionAPI) {
   }
 
   // Final check: ensure even with overrides, all valid insertions store the latest value at that address:
-  std::vector<int> coalesced_out(MAX_CHUNKS_SEARCH * CHUNK_SIZE, -1);
+  std::vector<int> coalesced_out(MAX_CHUNKS_SEARCH * CHUNK_SIZE, UNITIALIZED);
   ca_.coalesce_to(coalesced_out.data(), true);  // Export all valid addresses.
-  for (size_t i = 0; i < overriden_trials_mask.size(); ++i) {
-    if (overriden_trials_mask[i]) {
-      EXPECT_EQ(ca_.getitem(i / CHUNK_SIZE, i % CHUNK_SIZE, -1), overriden_trials_values[i]);
+  for (size_t i = 0; i < overriden_trials_values.size(); ++i) {
+    if (overriden_trials_values[i] != UNITIALIZED) {
+      EXPECT_EQ(ca_.getitem(i / CHUNK_SIZE, i % CHUNK_SIZE, INVALID), overriden_trials_values[i]);
       EXPECT_EQ(coalesced_out[i], overriden_trials_values[i]);
     }
   }

--- a/tests/cpp_test/test_chunked_array.cpp
+++ b/tests/cpp_test/test_chunked_array.cpp
@@ -253,6 +253,7 @@ TEST_F(ChunkedArrayTest, testDataLayoutWithAdvancedInsertionAPI) {
   ca_.coalesce_to(coalesced_out.data(), true);  // Export all valid addresses.
   for (size_t i = 0; i < ref_values.size(); ++i) {
     if (ref_values[i] != UNITIALIZED) {
+      // Test in 2 ways that the values are correctly laid out in memory:
       EXPECT_EQ(ca_.getitem(i / CHUNK_SIZE, i % CHUNK_SIZE, INVALID), ref_values[i]);
       EXPECT_EQ(coalesced_out[i], ref_values[i]);
     }


### PR DESCRIPTION
This should fix the remaining cpplint issues in test_chunked_array.

This also cleans up a bit the last test.

Requested by @StrikerRUS in https://github.com/microsoft/LightGBM/pull/4092.