### PR TITLE
[docs] remove macOS installation method with Homebrew formula 

### DIFF
--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -117,22 +117,12 @@ Also, you may want to read `gcc Tips <./gcc-Tips.rst>`__.
 macOS
 ~~~~~
 
-On macOS LightGBM can be installed using **Homebrew**, or can be built using **CMake** and **Apple Clang** or **gcc**.
+On macOS LightGBM can be built using **CMake** and **Apple Clang** or **gcc**.
 
 Apple Clang
 ^^^^^^^^^^^
 
 Only **Apple Clang** version 8.1 or higher is supported.
-
-Install Using ``Homebrew``
-**************************
-
-.. code::
-
-  brew install lightgbm
-
-Build from GitHub
-*****************
 
 1. Install `CMake`_ (3.16 or higher):
 


### PR DESCRIPTION
This reverts commit f2632a6e1eb1088ea3f462724e61d70f7131c784.

Refer to https://github.com/microsoft/LightGBM/pull/3872#issuecomment-806252148.

Hope this is temporarily.

But right now our installation guide suggests to install outdated version of LightGBM via Homebrew.