### PR TITLE
clarify DEBUG-level log about tree depth

### DIFF
--- a/docs/GPU-Targets.rst
+++ b/docs/GPU-Targets.rst
@@ -104,10 +104,10 @@ Example of using GPU (``gpu_platform_id = 0`` and ``gpu_device_id = 0`` in our s
     [LightGBM] [Info] Size of histogram bin entry: 12
     [LightGBM] [Info] 40 dense feature groups (0.12 MB) transferred to GPU in 0.004211 secs. 76 sparse feature groups.
     [LightGBM] [Info] No further splits with positive gain, best gain: -inf
-    [LightGBM] [Info] Trained a tree with leaves=16 and max_depth=8
+    [LightGBM] [Info] Trained a tree with leaves=16 and depth=8
     [1]:    test's rmse:1.10643e-17 
     [LightGBM] [Info] No further splits with positive gain, best gain: -inf
-    [LightGBM] [Info] Trained a tree with leaves=7 and max_depth=5
+    [LightGBM] [Info] Trained a tree with leaves=7 and depth=5
     [2]:    test's rmse:0
 
 Running on OpenCL CPU backend devices is in generally slow, and we observe crashes on some Windows and macOS systems. Make sure you check the ``Using GPU Device`` line in the log and it is not using a CPU. The above log shows that we are using ``Oland`` GPU from AMD and not CPU.
@@ -142,10 +142,10 @@ Example of using CPU (``gpu_platform_id = 0``, ``gpu_device_id = 1``). The GPU d
     [LightGBM] [Info] Size of histogram bin entry: 12
     [LightGBM] [Info] 40 dense feature groups (0.12 MB) transferred to GPU in 0.004540 secs. 76 sparse feature groups.
     [LightGBM] [Info] No further splits with positive gain, best gain: -inf
-    [LightGBM] [Info] Trained a tree with leaves=16 and max_depth=8
+    [LightGBM] [Info] Trained a tree with leaves=16 and depth=8
     [1]:    test's rmse:1.10643e-17 
     [LightGBM] [Info] No further splits with positive gain, best gain: -inf
-    [LightGBM] [Info] Trained a tree with leaves=7 and max_depth=5
+    [LightGBM] [Info] Trained a tree with leaves=7 and depth=5
     [2]:    test's rmse:0
     
 

--- a/src/treelearner/linear_tree_learner.cpp
+++ b/src/treelearner/linear_tree_learner.cpp
@@ -125,7 +125,7 @@ Tree* LinearTreeLearner::Train(const score_t* gradients, const score_t *hessians
     CalculateLinear<false>(tree_ptr, false, gradients_, hessians_, is_first_tree);
   }
 
-  Log::Debug("Trained a tree with leaves = %d and max_depth = %d", tree->num_leaves(), cur_depth);
+  Log::Debug("Trained a tree with leaves = %d and depth = %d", tree->num_leaves(), cur_depth);
   return tree.release();
 }
 

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -204,7 +204,7 @@ Tree* SerialTreeLearner::Train(const score_t* gradients, const score_t *hessians
     cur_depth = std::max(cur_depth, tree->leaf_depth(left_leaf));
   }
 
-  Log::Debug("Trained a tree with leaves = %d and max_depth = %d", tree->num_leaves(), cur_depth);
+  Log::Debug("Trained a tree with leaves = %d and depth = %d", tree->num_leaves(), cur_depth);
   return tree.release();
 }
 


### PR DESCRIPTION
`*TreeLearner::Train()` methods have a DEBUG-level log like this:

```text
[LightGBM] [Debug] Trained a tree with leaves = 31 and max_depth = 6
[LightGBM] [Debug] Trained a tree with leaves = 31 and max_depth = 7
[LightGBM] [Debug] Trained a tree with leaves = 31 and max_depth = 8
[LightGBM] [Debug] Trained a tree with leaves = 31 and max_depth = 8
[LightGBM] [Debug] Trained a tree with leaves = 31 and max_depth = 7
[LightGBM] [Debug] Trained a tree with leaves = 31 and max_depth = 9
[LightGBM] [Debug] Trained a tree with leaves = 31 and max_depth = 8
[LightGBM] [Debug] Trained a tree with leaves = 31 and max_depth = 9
[LightGBM] [Debug] Trained a tree with leaves = 31 and max_depth = 7
[LightGBM] [Debug] Trained a tree with leaves = 31 and max_depth = 9
```

This message is saying "ok, this tree is complete. It has `n` leaves and depth `d`". I think it's confusing to refer to the depth of that tree as `max_depth`, since that is also the name of a LightGBM parameter (https://lightgbm.readthedocs.io/en/latest/Parameters.html#max_depth). When I first saw logs like this, I thought "wait, why is LightGBM changing the `max_depth` parameter at each training iteration?".

This PR proposes changing that language to "depth" to avoid such confusion.

Linking to https://github.com/microsoft/LightGBM/issues/4026#issuecomment-808820872.