### PR TITLE
update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,8 @@ tests/data/    @guolinke @chivee @btrotta @shiyu1994
 windows/    @guolinke @chivee @btrotta @StrikerRUS @shiyu1994
 
 # R code
+build_r.R    @jameslamb @StrikerRUS
+build-cran-package.sh    @jameslamb @StrikerRUS
 R-package/    @Laurae2 @jameslamb
 
 # Python code

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 # offer a reasonable automatic best-guess
 
 # catch-all rule (this only gets matched if no rules below match)
-*    @guolinke @StrikerRUS @jameslamb @Laurae2
+*    @guolinke @StrikerRUS @jameslamb @shiyu1994
 
 # other catch-alls that will get matched if specific rules below are not matched
 *.R    @Laurae2 @jameslamb
@@ -28,7 +28,7 @@ windows/    @guolinke @chivee @btrotta @StrikerRUS @shiyu1994
 R-package/    @Laurae2 @jameslamb
 
 # Python code
-python-package/    @StrikerRUS @chivee @wxchan @henry0312 @shiyu1994
+python-package/    @StrikerRUS @chivee @wxchan @henry0312 @shiyu1994 @jameslamb
 
 # Dask integration
 python-package/lightgbm/dask.py    @jameslamb
@@ -38,11 +38,11 @@ tests/python_package_test/test_dask.py    @jameslamb
 helpers/    @StrikerRUS @guolinke
 
 # CI administrative stuff
-.ci/    @StrikerRUS @Laurae2 @jameslamb
-docs/    @StrikerRUS @Laurae2 @jameslamb
+.ci/    @StrikerRUS @jameslamb
+docs/    @StrikerRUS @jameslamb
 examples/     @StrikerRUS @jameslamb @guolinke
-*.yml    @StrikerRUS @Laurae2 @jameslamb
-.vsts-ci.yml    @Laurae2
+*.yml    @StrikerRUS @jameslamb
+.vsts-ci.yml    @StrikerRUS @jameslamb
 
 # docker setup
 docker/    @StrikerRUS @jameslamb


### PR DESCRIPTION
This PR proposes some changes to CODEOWNERS based on my experience of the last year with reviews in this project. My hope is that this change will reduce the number of times that we have to manually add reviewers, and will reduce notifications for other maintainers who don't need to be on some PRs.

For example, I have no idea why we had the rule "only @Laurae2 is added by default if `.vsts-ci.yml` is touched" haha.

