### PR TITLE
show specific error message in TCP accept/send/receive logs

### DIFF
--- a/src/network/socket_wrapper.hpp
+++ b/src/network/socket_wrapper.hpp
@@ -267,7 +267,12 @@ class TcpSocket {
   inline TcpSocket Accept() {
     SOCKET newfd = accept(sockfd_, NULL, NULL);
     if (newfd == INVALID_SOCKET) {
-      Log::Fatal("Socket accept error, code: %d", GetLastError());
+      int err_code = GetLastError();
+#if defined(_WIN32)
+      Log::Fatal("Socket accept error (code: %d)", err_code);
+#else
+      Log::Fatal("Socket accept error, %s (code: %d)", std::strerror(err_code), err_code);
+#endif
     }
     return TcpSocket(newfd);
   }
@@ -275,7 +280,12 @@ class TcpSocket {
   inline int Send(const char *buf_, int len, int flag = 0) {
     int cur_cnt = send(sockfd_, buf_, len, flag);
     if (cur_cnt == SOCKET_ERROR) {
-      Log::Fatal("Socket send error, code: %d", GetLastError());
+      int err_code = GetLastError();
+#if defined(_WIN32)
+      Log::Fatal("Socket send error (code: %d)", err_code);
+#else
+      Log::Fatal("Socket send error, %s (code: %d)", std::strerror(err_code), err_code);
+#endif
     }
     return cur_cnt;
   }
@@ -283,7 +293,12 @@ class TcpSocket {
   inline int Recv(char *buf_, int len, int flags = 0) {
     int cur_cnt = recv(sockfd_, buf_ , len , flags);
     if (cur_cnt == SOCKET_ERROR) {
-      Log::Fatal("Socket recv error, code: %d", GetLastError());
+      int err_code = GetLastError();
+#if defined(_WIN32)
+      Log::Fatal("Socket recv error (code: %d)", err_code);
+#else
+      Log::Fatal("Socket recv error, %s (code: %d)", std::strerror(err_code), err_code);
+#endif
     }
     return cur_cnt;
   }


### PR DESCRIPTION
Today in LightGBM, when `send`, `receive`, or `accept` operations fail in socket-based distributed training, a FATAL-level log message is printed with the integer code for that error.

* Windows codes: https://docs.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2
* non-Windows: https://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html

For example, you might get a message like those that have been showing up in the Dask tests (#4074, #4116)

> lightgbm.basic.LightGBMError: Socket recv error, code: 104

This PR proposes changing those log messages to include the corresponding error text. Using the reproducible example from https://github.com/microsoft/LightGBM/issues/4074#issuecomment-808578600, for example, you can see that after this change the error message I mentioned would become:

> LightGBMError: Socket recv error, Connection reset by peer (code: 104)

![image](https://user-images.githubusercontent.com/7608904/112742964-c9c5a780-8f58-11eb-8804-0dcadb4c9fef.png)

### How this improves `lightgbm`

If training fails with such an error, users who are not experienced C/C++ programmers will likely not know what a code like 104 actually means. For example, it took me some significant effort to figure out what that error meant while reviewing @ffineis 's proposal for adding early stopping in `lightgbm.dask`: https://github.com/microsoft/LightGBM/pull/3952#pullrequestreview-610403805.

I think that including the corresponding error text would help such users in debugging. This is more relevant now than it was in the recent past, since `lightgbm.dask` makes distributed LightGBM training accessible to people who are most comfortable working in Python.

### Notes for reviewers

* I'm only proposing this change for non-Windows systems, since I don't have easy access to a way to test distributed training on Windows, and since the equivalent process of converting error codes to error messages on Windows seems a bit more involved: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessage. If reviewers agree with this PR, I'll write up a feature request for adding similar messages for distributed training on Windows.
* I can't think of a reliable way to simulate the types of connectivity problems that would trigger these messages, so I couldn't come up with automated tests for this change. Maybe such tests could be added in #3841 .
* `@`-ing @imatiach-msft for visibility since I'm guessing this change would also impact MMLSpark.