### PR TITLE
[ci] Added curl library to the installed packages list inside dockerfile-python installation

### DIFF
--- a/docker/dockerfile-python
+++ b/docker/dockerfile-python
@@ -10,6 +10,7 @@ RUN apt-get update && \
         build-essential \
         gcc \
         g++ \
+        curl \
         git && \
     # python environment
     curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o conda.sh && \


### PR DESCRIPTION
While trying to run LightGBM via the Dockerfile (dockerfile-python) there was a below issue saying 'curl not found' while trying to run the curl command, as curl lib was not added as part of the installation package lists. So I have added the curl lib as part of the docker installation.

```/bin/sh: 1: curl: not found```

```The command '/bin/sh -c apt-get update &&     apt-get install -y --no-install-recommends         ca-certificates         cmake         build-essential         gcc         g++         git &&     curl -sL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o conda.sh &&     /bin/bash conda.sh -f -b -p $CONDA_DIR &&     export PATH="$CONDA_DIR/bin:$PATH" &&     conda config --set always_yes yes --set changeps1 no &&     conda install -q -y numpy scipy scikit-learn pandas &&     git clone --recursive --branch stable --depth 1 https://github.com/Microsoft/LightGBM &&     cd LightGBM/python-package && python setup.py install &&     apt-get autoremove -y && apt-get clean &&     conda clean -a -y &&     rm -rf /usr/local/src/*' returned a non-zero code: 127```