### PR TITLE
[dask] run one training task on each worker

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -391,6 +391,8 @@ def _train(
             num_machines=num_machines,
             time_out=params.get('time_out', 120),
             return_model=(worker == master_worker),
+            workers=[worker],
+            allow_other_workers=False,
             **kwargs
         )
         for worker, list_of_parts in worker_map.items()

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -380,6 +380,13 @@ def _train(
     num_machines = len(worker_address_to_port)
 
     # Tell each worker to train on the parts that it has locally
+    #
+    # This code treates _train_part()` calls as not "pure" because:
+    #     1. there is randomness in the training process unless parameters ``seed``
+    #        and ``is_deterministic`` are set
+    #     2. even with those parameters set, the output of one ``_train_part()`` call
+    #        relies on global state (it and all the other LightGBM training processes
+    #        coordinate with each other)
     futures_classifiers = [
         client.submit(
             _train_part,
@@ -393,6 +400,7 @@ def _train(
             return_model=(worker == master_worker),
             workers=[worker],
             allow_other_workers=False,
+            pure=False,
             **kwargs
         )
         for worker, list_of_parts in worker_map.items()

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -381,7 +381,7 @@ def _train(
 
     # Tell each worker to train on the parts that it has locally
     #
-    # This code treates _train_part()` calls as not "pure" because:
+    # This code treates ``_train_part()`` calls as not "pure" because:
     #     1. there is randomness in the training process unless parameters ``seed``
     #        and ``is_deterministic`` are set
     #     2. even with those parameters set, the output of one ``_train_part()`` call


### PR DESCRIPTION
This PR resolves a critical source of instability in `lightgbm.dask`, which I think might be the cause of some of the issues we have observed sporadically in tests (#4057, #4074, #4099).

## Changes in this PR

* specifies arguments in `lightgbm.dask`'s use of [`distributed.Client.submit()`](https://distributed.dask.org/en/latest/api.html#distributed.Client.submit) to more tightly control how Dask schedules LightGBM training tasks

## How this improves `lightgbm`

I believe this PR will fix a critical source of instability that can cause training to fail (either throwing an error or hanging indefinitely) if multiple training tasks are accidentally scheduled onto the same worker. I think that the risk of this issue increases as you have more workers in the Dask cluster and as there is more other work going on in the cluster alongside LightGBM training.

This PR should also improve the stability of LightGBM's Dask unit tests.

## Overview

In distributed LightGBM training, users create `n` workers, each of which runs LightGBM training on a local chunk of the full training data. Estimators in `lightgbm.dask` expect training data to be given in [Dask collections](https://docs.dask.org/en/latest/delayed-collections.html). Those estimators look at which Dask workers hold each partition of the training data, and run one LightGBM training process per worker.

The logic for scheduling those training processes out onto Dask workers is currently incorrect.

https://github.com/microsoft/LightGBM/blob/9cab93a9f3c0b46301a2cd11631223f4ab1daf16/python-package/lightgbm/dask.py#L383-L397

The current code follows this pseudocode, which is like

> **"given `n` workers with data, run `n` training processes on the cluster"**

```python
for work in workers:
    client.submit(
        _train_part
    )
```

However, the desired behavior is slightly different. It should be

> **"given `n` workers with data, run exactly 1 training process on each worker"**

```python
for work in workers:
    client.submit(
        _train_part,
        workers=worker
    )
```

This more specific definition is important. If the training data are split across two workers (for example) and LightGBM sets `machines` to a list with those two workers, but then two `_train_part()` tasks are scheduled on the same worker, training will fail.

* if both scheduled onto the worker that is `rank 0`, the worker will be killed and restarted.
    - > distributed.nanny - INFO - Worker process 23623 was killed by signal 11
* if both scheduled onto a worker that is not `rank 0`, I saw that LightGBM just hangs indefinitely. If you have task-level timeouts set in Dask, Dask might eventually kill that process. Either way, training will not succeed.

Per [the Dask docs](https://distributed.dask.org/en/latest/api.html#distributed.Client.submit), the following parameters should be used in `lightgbm.dask` to achieve tight control over where tasks run.

* `workers`: specify EXACTLY which worker(s) the task being submitted can run on
* `allow_other_workers` (default: ~True~ False): indicate whether it is ok to run the task on other workers not mentioned in `workers`
* `pure` (default: True): whether or not the function is a "pure function", which [according to Wikipedia](https://en.wikipedia.org/wiki/Pure_function), means that it always returns the same outputs given the same inputs, does not modify any global state (including the file system), and does not have side effects on output streams

## More Background

The bug fixed by this PR is a general class of problem in `lightgbm.dask` that we should be aware of. By default, Dask assumes that tasks can be scheduled onto any worker, and even that t[hey can be "stolen" from one worker by another](https://distributed.dask.org/en/latest/work-stealing.html)).

These default assumptions don't hold for distributed training of LightGBM or XGBoost.

## Notes for Reviewers

I checked the blame in `dask/distributed`, and it looks like the three keyword arguments to `client.submit()` that I'm specifying here have been a part of the client for at least 3 years. So I don't think they cause any compatibility issues we need to worry about.

https://github.com/dask/distributed/blame/1b32bd30201ef6ced5029180143d2c37b393b586/distributed/client.py#L1234-L1240