### PR TITLE
[dask] make random port search more resilient to random collisions (fixes #4057)

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -170,16 +170,37 @@ def _machines_to_worker_map(machines: str, worker_addresses: List[str]) -> Dict[
     return out
 
 
-def _worker_map_has_duplicates(worker_map: Dict[str, int]) -> bool:
-    """Check if there are any duplicate IP-port pairs in a ``worker_map``."""
+def _possibly_fix_worker_map_duplicates(worker_map: Dict[str, int], client: Client) -> Dict[str, int]:
+    """Fix any duplicate IP-port pairs in a ``worker_map``"""
+    worker_map = deepcopy(worker_map)
+    workers_that_need_new_ports = []
     host_to_port = defaultdict(set)
     for worker, port in worker_map.items():
         host = urlparse(worker).hostname
         if port in host_to_port[host]:
-            return True
+            workers_that_need_new_ports.append(worker)
         else:
             host_to_port[host].add(port)
-    return False
+
+    # if any duplicates were found, search for new ports one by one
+    for worker in workers_that_need_new_ports:
+        _log_info(f"Searching for a LightGBM training port for worker '{worker}'")
+        host = urlparse(worker).hostname
+        retries_remaining = 100
+        while retries_remaining > 0:
+            retries_remaining -= 1
+            new_port = client.submit(
+                _find_random_open_port,
+                workers=[worker],
+                allow_other_workers=False,
+                pure=False
+            ).result()
+            if new_port not in host_to_port[host]:
+                worker_map[worker] = new_port
+                host_to_port[host].add(new_port)
+                break
+
+    return worker_map
 
 
 def _train(
@@ -379,21 +400,18 @@ def _train(
             }
         else:
             _log_info("Finding random open ports for workers")
+            # this approach with client.run() is faster than searching for ports
+            # serially, but can produce duplicates sometimes. Try the fast approach one
+            # time, then pass it through a function that will use a slower but more reliable
+            # approach if duplicates are found.
             worker_address_to_port = client.run(
                 _find_random_open_port,
                 workers=list(worker_addresses)
             )
-            # handle the case where _find_random_open_port() produces duplicates
-            retries_left = 10
-            while _worker_map_has_duplicates(worker_address_to_port) and retries_left > 0:
-                retries_left -= 1
-                _log_warning(
-                    "Searching for random ports generated duplicates. Trying again (will try %i more times after this)." % retries_left
-                )
-                worker_address_to_port = client.run(
-                    _find_random_open_port,
-                    workers=list(worker_addresses)
-                )
+            worker_address_to_port = _possibly_fix_worker_map_duplicates(
+                worker_map=worker_address_to_port,
+                client=client
+            )
 
         machines = ','.join([
             '%s:%d' % (urlparse(worker_address).hostname, port)

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -171,7 +171,7 @@ def _machines_to_worker_map(machines: str, worker_addresses: List[str]) -> Dict[
 
 
 def _worker_map_has_duplicates(worker_map: Dict[str, int]) -> bool:
-    """Check if there are any duplicate IP-port pairs in a ``worker_map``"""
+    """Check if there are any duplicate IP-port pairs in a ``worker_map``."""
     host_to_port = defaultdict(set)
     for worker, port in worker_map.items():
         host = urlparse(worker).hostname

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -200,6 +200,11 @@ def _possibly_fix_worker_map_duplicates(worker_map: Dict[str, int], client: Clie
                 host_to_port[host].add(new_port)
                 break
 
+        if retries_remaining == 0:
+            raise LightGBMError(
+                "Failed to find an open port. Try re-running training or explicitly setting 'machines' or 'local_listen_port'."
+            )
+
     return worker_map
 
 

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -171,7 +171,7 @@ def _machines_to_worker_map(machines: str, worker_addresses: List[str]) -> Dict[
 
 
 def _possibly_fix_worker_map_duplicates(worker_map: Dict[str, int], client: Client) -> Dict[str, int]:
-    """Fix any duplicate IP-port pairs in a ``worker_map``"""
+    """Fix any duplicate IP-port pairs in a ``worker_map``."""
     worker_map = deepcopy(worker_map)
     workers_that_need_new_ports = []
     host_to_port = defaultdict(set)

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -396,15 +396,16 @@ def test_possibly_fix_worker_map(capsys, client):
     assert retry_msg not in capsys.readouterr().out
 
     # should handle worker maps with duplicates
-    map_without_duplicates = {
+    map_with_duplicates = {
         worker_address: 12400
         for i, worker_address in enumerate(worker_addresses)
     }
     patched_map = lgb.dask._possibly_fix_worker_map_duplicates(
         client=client,
-        worker_map=map_without_duplicates
+        worker_map=map_with_duplicates
     )
     assert retry_msg in capsys.readouterr().out
+    assert len(set(patched_map.values())) == len(worker_addresses)
 
 
 def test_training_does_not_fail_on_port_conflicts(client):

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -377,6 +377,27 @@ def test_find_random_open_port(client):
     client.close(timeout=CLIENT_CLOSE_TIMEOUT)
 
 
+def test_worker_map_has_duplicates():
+    map_with_duplicates = worker_map = {
+        'tcp://127.0.0.1:8786': 123,
+        'tcp://127.0.0.1:8788': 123,
+        'tcp://10.1.1.2:15001': 123
+    }
+    assert lgb.dask._worker_map_has_duplicates(map_with_duplicates)
+
+    map_without_duplicates = {
+        'tcp://127.0.0.1:8786': 12405,
+        'tcp://10.1.1.2:15001': 12405
+    }
+    assert lgb.dask._worker_map_has_duplicates(map_without_duplicates) is False
+
+    localcluster_map_without_duplicates = {
+        'tcp://127.0.0.1:708': 12405,
+        'tcp://127.0.0.1:312': 12405,
+    }
+    assert lgb.dask._worker_map_has_duplicates(map_without_duplicates) is False
+
+
 def test_training_does_not_fail_on_port_conflicts(client):
     _, _, _, _, dX, dy, dw, _ = _create_data('binary-classification', output='array')
 


### PR DESCRIPTION
## Changes in this PR

* if using training with "search for random ports" strategy (documented in https://lightgbm.readthedocs.io/en/latest/Parallel-Learning-Guide.html#using-specific-ports), `lightgbm.dask.` will now check for the situation where it found duplicate `IP-port` pairs. If such duplicates are found, `lightgbm.dask` will re-run the random search up to 10 times.

## Background

https://github.com/microsoft/LightGBM/issues/4057 documents a class of error that can fail with distributed training using `lightgbm.dask`. If you do not provide `machines` or `local_listen_port` at training time, LightGBM will randomly search for ports to use on each worker.

To limit the overhead introduced by this random search, a function `_find_random_open_port()` is run once at the same time on every worker, using `distributed.Client.run()` (added in #3823). If you have multiple Dask worker processes on the same physical host (i.e. if you're using `distirbuted.LocalCluster` or `nrprocs > 1`), there is a small but non-zero probability that this setup will choose the same random port for multiple workers on that host. When that happens, LightGBM training will fail with an error like

> Exception: LightGBMError('Socket send error, code: 104',)

Based on https://github.com/microsoft/LightGBM/pull/4112#issuecomment-808166310, I think my original assumptions about how likely such conflicts were (https://github.com/microsoft/LightGBM/issues/4057#issuecomment-794889388) was not correct.

## How this improves `lightgbm`

Removes a source of instability that could cause distributed training with Dask to fail.

Improves the stability of LightGBM's tests, which should reduce maintainer effort needed in re-running failed builds.
