### PR TITLE
[docs] fix param name typo in comments

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -383,7 +383,7 @@ def _train(
     #
     # This code treates ``_train_part()`` calls as not "pure" because:
     #     1. there is randomness in the training process unless parameters ``seed``
-    #        and ``is_deterministic`` are set
+    #        and ``deterministic`` are set
     #     2. even with those parameters set, the output of one ``_train_part()`` call
     #        relies on global state (it and all the other LightGBM training processes
     #        coordinate with each other)


### PR DESCRIPTION
There is no `is_deterministic` param, only `deterministic`: https://lightgbm.readthedocs.io/en/latest/Parameters.html#deterministic.