### PR TITLE
[ci] use GitHub Actions to re-generate R configure

### DIFF
--- a/.github/workflows/r_configure.yml
+++ b/.github/workflows/r_configure.yml
@@ -1,0 +1,38 @@
+name: R generate configure
+
+on:
+  repository_dispatch:
+    types: [gha_run_r_configure]
+
+jobs:
+  r-configure:
+    name: r-configure
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container: "ubuntu:20.04"
+    steps:
+      - name: Install essential software before checkout
+        run: |
+          apt-get update
+          apt-get install --no-install-recommends -y \
+            ca-certificates \
+            git
+      - name: Checkout repository
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 5
+          submodules: true
+          repository: microsoft/LightGBM
+          ref: "refs/heads/${{ fromJSON(github.event.client_payload.pr_branch) }}"
+          token: ${{ secrets.WORKFLOW }}
+          persist-credentials: true
+      - name: Update configure
+        shell: bash
+        run: ./R-package/recreate-configure.sh || exit -1
+      - name: Push changes
+        run: |
+          git config --global user.name "GitHub Actions Bot"
+          git config --global user.email "githubactionsbot@users.noreply.github.com"
+          git add "./R-package/configure"
+          git commit --allow-empty -m "Auto-update configure"
+          git push

--- a/.github/workflows/triggering_comments.yml
+++ b/.github/workflows/triggering_comments.yml
@@ -32,3 +32,11 @@ jobs:
           "${{ github.event.issue.pull_request.url }}" \
           "${{ github.event.comment.id }}" \
           "gha_run_r_solaris"
+
+    - name: Trigger update R configure
+      if: github.event.comment.body == '/gha run r-configure'
+      run: |
+        $GITHUB_WORKSPACE/.ci/trigger_dispatch_run.sh \
+          "${{ github.event.issue.pull_request.url }}" \
+          "${{ github.event.comment.id }}" \
+          "gha_run_r_configure"

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -308,7 +308,7 @@ At build time, `configure` will be run and used to create a file `Makevars`, usi
 
 3. Edit `src/Makevars.in`.
 
-Alternatively, GitHub Actions can re-generate this file for you. On a pull request (only on internal one, not works for ones from forks), create a comment with this phrase:
+Alternatively, GitHub Actions can re-generate this file for you. On a pull request (only on internal one, does not work for ones from forks), create a comment with this phrase:
 
 > /gha run r-configure
 

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -308,6 +308,10 @@ At build time, `configure` will be run and used to create a file `Makevars`, usi
 
 3. Edit `src/Makevars.in`.
 
+Alternatively, GitHub Actions can re-generate this file for you. On a pull request (only on internal one, not works for ones from forks), create a comment with this phrase:
+
+> /gha run r-configure
+
 **Configuring for Windows**
 
 At build time, `configure.win` will be run and used to create a file `Makevars.win`, using `Makevars.win.in` as a template.


### PR DESCRIPTION
Closed #3283.

Refer to https://github.com/microsoft/LightGBM/pull/4117#pullrequestreview-622620015 for the initial discussion.

Refer to https://github.com/StrikerRUS/LightGBM/pull/1 for the usage example.

~Push from a workflow won't trigger our regular workflows:~
> ~For example, if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run even when the repository contains a workflow configured to run when `push` events occur.~
  ~https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token~

~I don't think that this a problem for us, because anyway we need a follow-up commit with reverting back to `~~VERSION~~` in `configure.ac`, right?~