### PR TITLE
[ci] run 'brew update' in macOS jobs (fixes #4160)

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 if [[ $OS_NAME == "macos" ]]; then
-    brew update-reset && brew update
     if  [[ $COMPILER == "clang" ]]; then
         brew install libomp
         if [[ $AZURE == "true" ]]; then

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 if [[ $OS_NAME == "macos" ]]; then
+    brew update-reset && brew update
     if  [[ $COMPILER == "clang" ]]; then
         brew install libomp
         if [[ $AZURE == "true" ]]; then

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -77,6 +77,7 @@ fi
 
 # Installing R precompiled for Mac OS 10.11 or higher
 if [[ $OS_NAME == "macos" ]]; then
+    brew update-reset && brew update
     if [[ $R_BUILD_TYPE == "cran" ]]; then
         brew install automake
     fi


### PR DESCRIPTION
As documented in #4160, LightGBM's macOS jobs for the R package started failing two days ago, roughly around the same time as the version of `basictex` was updated at https://github.com/Homebrew/homebrew-cask/pull/103001.

I was going to file a bug report with Homebrew, and in that process I was directed to that project's "how to report bugs" guidelines: https://github.com/Homebrew/homebrew-cask#reporting-bugs. That includes the suggestion that you should run `brew update-reset && brew update`. After trying that on my Mac, I was then able to `brew install --cask basictex`.

This PR proposes adding a similar to step to LightGBM's CI. This is similar to how this project uses `sudo apt-get update` to update repository information for the `apt` package manager on Linux jobs.

* `brew update-reset`: "Fetch and reset Homebrew and all tap repositories (or any specified
repository) using git(1) to their latest origin/HEAD."
* `brew update`: "Fetch the newest version of Homebrew and all formulae from GitHub using git(1)
and perform any necessary migrations"

I believe this will fix #4160 and prevent similar disruptions in the future, and that it should add only a few seconds to CI jobs.