### PR TITLE
[ci] Restrict breathe version at CI

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -20,7 +20,7 @@ cd $BUILD_DIRECTORY
 
 if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     cd $BUILD_DIRECTORY/docs
-    conda install -q -y -n $CONDA_ENV -c conda-forge "doxygen<1.19" rstcheck
+    conda install -q -y -n $CONDA_ENV -c conda-forge "doxygen<1.9" rstcheck
     pip install --user -r requirements.txt
     # check reStructuredText formatting
     cd $BUILD_DIRECTORY/python-package

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -20,7 +20,7 @@ cd $BUILD_DIRECTORY
 
 if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     cd $BUILD_DIRECTORY/docs
-    conda install -q -y -n $CONDA_ENV -c conda-forge doxygen rstcheck
+    conda install -q -y -n $CONDA_ENV -c conda-forge "doxygen<1.19" rstcheck
     pip install --user -r requirements.txt
     # check reStructuredText formatting
     cd $BUILD_DIRECTORY/python-package

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -20,7 +20,7 @@ cd $BUILD_DIRECTORY
 
 if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     cd $BUILD_DIRECTORY/docs
-    conda install -q -y -n $CONDA_ENV -c conda-forge "doxygen<1.9" rstcheck
+    conda install -q -y -n $CONDA_ENV -c conda-forge doxygen rstcheck
     pip install --user -r requirements.txt
     # check reStructuredText formatting
     cd $BUILD_DIRECTORY/python-package

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 -r requirements_base.txt
-breathe
+breathe<4.29


### PR DESCRIPTION
Recently updated ~Doxygen at `conda-forge`~ results in the following error
```
Warning, treated as error:
/home/runner/work/LightGBM/LightGBM/docs/C-API.rst:2:Unparseable C cross-reference: '[out]'
Invalid C declaration: Expected identifier in nested name. [error at 0]
  [out]
  ^
make: *** [Makefile:20: html] Error 2
```

I guess that this is actually `breathe` issue.

**UPD:** Well, the root cause was updated breathe, not Doxygen.