### PR TITLE
[ci] cmake: remove linking to sanitizer library

### DIFF
--- a/cmake/Sanitizer.cmake
+++ b/cmake/Sanitizer.cmake
@@ -6,24 +6,16 @@
 # Add flags
 macro(enable_sanitizer sanitizer)
   if(${sanitizer} MATCHES "address")
-    find_package(ASan REQUIRED)
     set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=address")
-    link_libraries(${ASan_LIBRARY})
 
   elseif(${sanitizer} MATCHES "thread")
-    find_package(TSan REQUIRED)
     set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=thread")
-    link_libraries(${TSan_LIBRARY})
 
   elseif(${sanitizer} MATCHES "leak")
-    find_package(LSan REQUIRED)
     set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=leak")
-    link_libraries(${LSan_LIBRARY})
 
   elseif(${sanitizer} MATCHES "undefined")
-    find_package(UBSan REQUIRED)
     set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=undefined -fno-sanitize-recover=undefined")
-    link_libraries(${UBSan_LIBRARY})
 
   else()
     message(FATAL_ERROR "Santizer ${sanitizer} not supported.")

--- a/cmake/modules/FindASan.cmake
+++ b/cmake/modules/FindASan.cmake
@@ -1,9 +1,0 @@
-set(ASan_LIB_NAME ASan)
-
-find_library(ASan_LIBRARY
-  NAMES libasan.so libasan.so.5 libasan.so.4 libasan.so.3 libasan.so.2 libasan.so.1 libasan.so.0 libasan.so.0.0.0
-  PATHS ${SANITIZER_PATH} /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib ${CMAKE_PREFIX_PATH}/lib)
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(ASan DEFAULT_MSG
-  ASan_LIBRARY)

--- a/cmake/modules/FindLSan.cmake
+++ b/cmake/modules/FindLSan.cmake
@@ -1,9 +1,0 @@
-set(LSan_LIB_NAME lsan)
-
-find_library(LSan_LIBRARY
-  NAMES liblsan.so liblsan.so.0 liblsan.so.0.0.0
-  PATHS ${SANITIZER_PATH} /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib ${CMAKE_PREFIX_PATH}/lib)
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LSan DEFAULT_MSG
-  LSan_LIBRARY)

--- a/cmake/modules/FindTSan.cmake
+++ b/cmake/modules/FindTSan.cmake
@@ -1,9 +1,0 @@
-set(TSan_LIB_NAME tsan)
-
-find_library(TSan_LIBRARY
-  NAMES libtsan.so libtsan.so.0 libtsan.so.0.0.0
-  PATHS ${SANITIZER_PATH} /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib ${CMAKE_PREFIX_PATH}/lib)
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(TSan DEFAULT_MSG
-  TSan_LIBRARY)

--- a/cmake/modules/FindUBSan.cmake
+++ b/cmake/modules/FindUBSan.cmake
@@ -1,9 +1,0 @@
-set(UBSan_LIB_NAME UBSan)
-
-find_library(UBSan_LIBRARY
-  NAMES libubsan.so libubsan.so.1 libubsan.so.0 libubsan.so.0.0.0
-  PATHS ${SANITIZER_PATH} /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib ${CMAKE_PREFIX_PATH}/lib)
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(UBSan DEFAULT_MSG
-  UBSan_LIBRARY)


### PR DESCRIPTION
Adding compiler flag will automatically link to the required libraries.

Besides, clang static links to sanitizer libraries by default. Thus linking to dynamic library must be removed in order to use clang.

For reference:

- [Difference of AddressSanitizer in Clang and GCC](https://github.com/google/sanitizers/wiki/AddressSanitizerClangVsGCC-(5.0-vs-7.1))
- [StackOverflow answer](https://stackoverflow.com/a/40215639/306935) about `-lasan` option has been discouraged. It directs to mailing list answer by ASan developer
- [LeakSanitizer doc](https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer#stand-alone-mode) mentions that standalone mode can work without the slowdown of ASan. This mode will link to "a runtime library containing just the bare necessities required for LeakSanitizer to work". For GCC,
  - when turning on both ASan and LSan, the executable only links with `libasan` without `liblsan`
  - when disabling ASan and enabling LSan, `liblsan` will be linked