### PR TITLE
fix: Dataset::CreateValid init fields which saves to binary.

### DIFF
--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -727,6 +727,11 @@ void Dataset::CreateValid(const Dataset* dataset) {
   feature_groups_.clear();
   num_features_ = dataset->num_features_;
   num_groups_ = num_features_;
+  max_bin_ = dataset->max_bin_;
+  min_data_in_bin_ = dataset->min_data_in_bin_;
+  bin_construct_sample_cnt_ = dataset->bin_construct_sample_cnt_;
+  use_missing_ = dataset->use_missing_;
+  zero_as_missing_ = dataset->zero_as_missing_;
   feature2group_.clear();
   feature2subfeature_.clear();
   has_raw_ = dataset->has_raw();


### PR DESCRIPTION
These fields are saved to binary file. Currently they are uninitialized and (maybe) not used.

Undefined Behavior Sanitizer will complain about assigning to bool variables (`use_missing_`, `zero_as_missing_`) whose value is not 0 or 1 in `DatasetLoader::LoadFromBinFile`.