### PR TITLE
Migrate to f-strings in .\python-package\lightgbm\sklearn.py

### DIFF
--- a/docs/gcc-Tips.rst
+++ b/docs/gcc-Tips.rst
@@ -32,27 +32,34 @@ Some explanatory pictures:
 .. image:: ./_static/images/gcc-table.png
    :align: center
    :target: ./_static/images/gcc-table.png
+   :alt: picture comparing depth with number of threads with each implementation where red color means bad combination and greener areas mean good combination
 
 .. image:: ./_static/images/gcc-bars.png
    :align: center
    :target: ./_static/images/gcc-bars.png
+   :alt: picture of a simple bar chart against running time
 
 .. image:: ./_static/images/gcc-chart.png
    :align: center
    :target: ./_static/images/gcc-chart.png
+   :alt: this picture is a rendition of first where y-axis is cost and x-axis is number of threads comparing the four algorithms
 
 .. image:: ./_static/images/gcc-comparison-1.png
    :align: center
    :target: ./_static/images/gcc-comparison-1.png
+   :alt: a bar chart comapring Light G.B.M performance versus compilation flags which is maximum at depth 8 with Light G.B.M version 2, flag O 3
 
 .. image:: ./_static/images/gcc-comparison-2.png
    :align: center
    :target: ./_static/images/gcc-comparison-2.png
+   :alt: a bar chart comapring Light G.B.M cumulative performance versus compilation flags which is maximum at depth 8 with Light G.B.M version 2, flag O 3
 
 .. image:: ./_static/images/gcc-meetup-1.png
    :align: center
    :target: ./_static/images/gcc-meetup-1.png
+   :alt: comparison of cumulative speed versus the slowest algorithm at various depths with v-2, O-3 remaining constant almost in all cases
 
 .. image:: ./_static/images/gcc-meetup-2.png
    :align: center
    :target: ./_static/images/gcc-meetup-2.png
+   :alt: comparison of cumulative speed versus the slowest density of each algorithm at various depths with v-2, O-3 remaining constant almost in all cases

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -76,7 +76,7 @@ class _ObjectiveFunctionWrapper:
         elif argc == 3:
             grad, hess = self.func(labels, preds, dataset.get_group())
         else:
-            raise TypeError("Self-defined objective function should have 2 or 3 arguments, got %d" % argc)
+            raise TypeError(f"Self-defined objective function should have 2 or 3 arguments, got {argc}")
         """weighted for objective"""
         weight = dataset.get_weight()
         if weight is not None:
@@ -88,7 +88,7 @@ class _ObjectiveFunctionWrapper:
                 num_data = len(weight)
                 num_class = len(grad) // num_data
                 if num_class * num_data != len(grad):
-                    raise ValueError("Length of grad and hess should equal to num_class * num_data")
+                    raise ValueError(f"Length of grad and hess should equal to {num_class * num_data}")
                 for k in range(num_class):
                     for i in range(num_data):
                         idx = k * num_data + i
@@ -171,7 +171,7 @@ class _EvalFunctionWrapper:
         elif argc == 4:
             return self.func(labels, preds, dataset.get_weight(), dataset.get_group())
         else:
-            raise TypeError("Self-defined eval function should have 2, 3 or 4 arguments, got %d" % argc)
+            raise TypeError(f"Self-defined eval function should have 2, 3 or 4 arguments, got {argc}")
 
 
 # documentation templates for LGBMModel methods are shared between the classes in
@@ -718,11 +718,10 @@ class LGBMModel(_LGBMModelBase):
         if not isinstance(X, (pd_DataFrame, dt_DataTable)):
             X = _LGBMCheckArray(X, accept_sparse=True, force_all_finite=False)
         n_features = X.shape[1]
-        if self._n_features != n_features:
-            raise ValueError("Number of features of the model must "
-                             "match the input. Model n_features_ is %s and "
-                             "input n_features is %s "
-                             % (self._n_features, n_features))
+        if self._n_features != n_features: 
+            raise ValueError(f"Number of features of the model must " \
+                             f"match the input. Model n_features_ is {self._n_features} and " \
+                             f"input n_features is {n_features} ")
         return self._Booster.predict(X, raw_score=raw_score, start_iteration=start_iteration, num_iteration=num_iteration,
                                      pred_leaf=pred_leaf, pred_contrib=pred_contrib, **kwargs)
 
@@ -919,9 +918,10 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
         """Docstring is set after definition, using a template."""
         result = super().predict(X, raw_score, start_iteration, num_iteration, pred_leaf, pred_contrib, **kwargs)
         if callable(self._objective) and not (raw_score or pred_leaf or pred_contrib):
-            _log_warning("Cannot compute class probabilities or labels "
-                         "due to the usage of customized objective function.\n"
-                         "Returning raw scores instead.")
+            new_line = "\n"
+            _log_warning(f"Cannot compute class probabilities or labels " \
+                         f"due to the usage of customized objective function.{new_line}"
+                         f"Returning raw scores instead.")
             return result
         elif self._n_classes > 2 or raw_score or pred_leaf or pred_contrib:
             return result


### PR DESCRIPTION
Related to #4136 

I did not touch the normal strings since the issue quoted:
> Migrate all Python code from old-fashioned format() functions, formatting % operators and simple concatenations (+) to modern f-strings

Please let me know of possible edits.