### PR TITLE
[python] Migrate to f-strings in python-package/lightgbm/sklearn.py

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -532,9 +532,8 @@ class LGBMModel(_LGBMModelBase):
         """
         for key, value in params.items():
             setattr(self, key, value)
-            under_score = "_"
-            if hasattr(self, f"{under_score} {key}"):
-                setattr(self, f"{under_score} {key}", value)
+            if hasattr(self, f"_{key}"):
+                setattr(self, f"_{key}", value)
             self._other_params[key] = value
         return self
 
@@ -720,7 +719,7 @@ class LGBMModel(_LGBMModelBase):
             X = _LGBMCheckArray(X, accept_sparse=True, force_all_finite=False)
         n_features = X.shape[1]
         if self._n_features != n_features:
-            raise ValueError(f"Number of features of the model must "
+            raise ValueError("Number of features of the model must "
                              f"match the input. Model n_features_ is {self._n_features} and "
                              f"input n_features is {n_features}")
         return self._Booster.predict(X, raw_score=raw_score, start_iteration=start_iteration, num_iteration=num_iteration,
@@ -919,10 +918,9 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
         """Docstring is set after definition, using a template."""
         result = super().predict(X, raw_score, start_iteration, num_iteration, pred_leaf, pred_contrib, **kwargs)
         if callable(self._objective) and not (raw_score or pred_leaf or pred_contrib):
-            new_line = "\n"
-            _log_warning(f"Cannot compute class probabilities or labels "
-                         f"due to the usage of customized objective function.{new_line}"
-                         f"Returning raw scores instead.")
+            _log_warning("Cannot compute class probabilities or labels "
+                         "due to the usage of customized objective function.\n"
+                         "Returning raw scores instead.")
             return result
         elif self._n_classes > 2 or raw_score or pred_leaf or pred_contrib:
             return result
@@ -993,7 +991,7 @@ class LGBMRanker(LGBMModel):
                    + _base_doc[_base_doc.find('eval_init_score :'):])  # type: ignore
     _base_doc = fit.__doc__
     _before_early_stop, _early_stop, _after_early_stop = _base_doc.partition('early_stopping_rounds :')
-    fit.__doc__ = (f"{_before_early_stop}"
-                   f" eval_at : iterable of int, optional (default=(1, 2, 3, 4, 5))\n"
-                   f"{' ':12} The evaluation positions of the specified metric.\n"
-                   f"{' ':8} {_early_stop} {_after_early_stop}")
+    fit.__doc__ = (_before_early_stop
+                   "eval_at : iterable of int, optional (default=(1, 2, 3, 4, 5))\n"
+                   f"{' ':12}The evaluation positions of the specified metric.\n"
+                   f"{' ':8}{_early_stop}{_after_early_stop}")

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -532,8 +532,9 @@ class LGBMModel(_LGBMModelBase):
         """
         for key, value in params.items():
             setattr(self, key, value)
-            if hasattr(self, '_' + key):
-                setattr(self, '_' + key, value)
+            under_score = "_"
+            if hasattr(self, f"{under_score} {key}"):
+                setattr(self, f"{under_score} {key}", value)
             self._other_params[key] = value
         return self
 
@@ -652,7 +653,7 @@ class LGBMModel(_LGBMModelBase):
                 elif isinstance(collection, dict):
                     return collection.get(i, None)
                 else:
-                    raise TypeError('{} should be dict or list'.format(name))
+                    raise TypeError(f"{name} should be dict or list")
 
             if isinstance(eval_set, tuple):
                 eval_set = [eval_set]
@@ -719,9 +720,9 @@ class LGBMModel(_LGBMModelBase):
             X = _LGBMCheckArray(X, accept_sparse=True, force_all_finite=False)
         n_features = X.shape[1]
         if self._n_features != n_features:
-            raise ValueError(f"Number of features of the model must " \
-                             f"match the input. Model n_features_ is {self._n_features} and " \
-                             f"input n_features is {n_features} ")
+            raise ValueError(f"Number of features of the model must "
+                             f"match the input. Model n_features_ is {self._n_features} and "
+                             f"input n_features is {n_features}")
         return self._Booster.predict(X, raw_score=raw_score, start_iteration=start_iteration, num_iteration=num_iteration,
                                      pred_leaf=pred_leaf, pred_contrib=pred_contrib, **kwargs)
 
@@ -919,8 +920,8 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
         result = super().predict(X, raw_score, start_iteration, num_iteration, pred_leaf, pred_contrib, **kwargs)
         if callable(self._objective) and not (raw_score or pred_leaf or pred_contrib):
             new_line = "\n"
-            _log_warning(f"Cannot compute class probabilities or labels " \
-                         f"due to the usage of customized objective function.{new_line}" \
+            _log_warning(f"Cannot compute class probabilities or labels "
+                         f"due to the usage of customized objective function.{new_line}"
                          f"Returning raw scores instead.")
             return result
         elif self._n_classes > 2 or raw_score or pred_leaf or pred_contrib:
@@ -992,7 +993,7 @@ class LGBMRanker(LGBMModel):
                    + _base_doc[_base_doc.find('eval_init_score :'):])  # type: ignore
     _base_doc = fit.__doc__
     _before_early_stop, _early_stop, _after_early_stop = _base_doc.partition('early_stopping_rounds :')
-    fit.__doc__ = (_before_early_stop
-                   + 'eval_at : iterable of int, optional (default=(1, 2, 3, 4, 5))\n'
-                   + ' ' * 12 + 'The evaluation positions of the specified metric.\n'
-                   + ' ' * 8 + _early_stop + _after_early_stop)
+    fit.__doc__ = (f"{_before_early_stop}"
+                   f" eval_at : iterable of int, optional (default=(1, 2, 3, 4, 5))\n"
+                   f"{' ':12} The evaluation positions of the specified metric.\n"
+                   f"{' ':8} {_early_stop} {_after_early_stop}")

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -919,16 +919,10 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
         """Docstring is set after definition, using a template."""
         result = super().predict(X, raw_score, start_iteration, num_iteration, pred_leaf, pred_contrib, **kwargs)
         if callable(self._objective) and not (raw_score or pred_leaf or pred_contrib):
-<<<<<<< HEAD
             new_line = "\n"
             _log_warning(f"Cannot compute class probabilities or labels "
                          f"due to the usage of customized objective function.{new_line}"
                          f"Returning raw scores instead.")
-=======
-            _log_warning("Cannot compute class probabilities or labels "
-                         "due to the usage of customized objective function.\n"
-                         "Returning raw scores instead.")
->>>>>>> 66ea376c13d018ef5eacb9d38e5863491b8cd109
             return result
         elif self._n_classes > 2 or raw_score or pred_leaf or pred_contrib:
             return result

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -991,7 +991,7 @@ class LGBMRanker(LGBMModel):
                    + _base_doc[_base_doc.find('eval_init_score :'):])  # type: ignore
     _base_doc = fit.__doc__
     _before_early_stop, _early_stop, _after_early_stop = _base_doc.partition('early_stopping_rounds :')
-    fit.__doc__ = (_before_early_stop
+    fit.__doc__ = (f"{_before_early_stop}"
                    "eval_at : iterable of int, optional (default=(1, 2, 3, 4, 5))\n"
                    f"{' ':12}The evaluation positions of the specified metric.\n"
                    f"{' ':8}{_early_stop}{_after_early_stop}")

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -76,7 +76,7 @@ class _ObjectiveFunctionWrapper:
         elif argc == 3:
             grad, hess = self.func(labels, preds, dataset.get_group())
         else:
-            raise TypeError("Self-defined objective function should have 2 or 3 arguments, got %d" % argc)
+            raise TypeError(f"Self-defined objective function should have 2 or 3 arguments, got {argc}")
         """weighted for objective"""
         weight = dataset.get_weight()
         if weight is not None:
@@ -171,7 +171,7 @@ class _EvalFunctionWrapper:
         elif argc == 4:
             return self.func(labels, preds, dataset.get_weight(), dataset.get_group())
         else:
-            raise TypeError("Self-defined eval function should have 2, 3 or 4 arguments, got %d" % argc)
+            raise TypeError(f"Self-defined eval function should have 2, 3 or 4 arguments, got {argc}")
 
 
 # documentation templates for LGBMModel methods are shared between the classes in
@@ -719,10 +719,9 @@ class LGBMModel(_LGBMModelBase):
             X = _LGBMCheckArray(X, accept_sparse=True, force_all_finite=False)
         n_features = X.shape[1]
         if self._n_features != n_features:
-            raise ValueError("Number of features of the model must "
-                             "match the input. Model n_features_ is %s and "
-                             "input n_features is %s "
-                             % (self._n_features, n_features))
+            raise ValueError(f"Number of features of the model must " \
+                             f"match the input. Model n_features_ is {self._n_features} and " \
+                             f"input n_features is {n_features} ")
         return self._Booster.predict(X, raw_score=raw_score, start_iteration=start_iteration, num_iteration=num_iteration,
                                      pred_leaf=pred_leaf, pred_contrib=pred_contrib, **kwargs)
 
@@ -919,9 +918,10 @@ class LGBMClassifier(LGBMModel, _LGBMClassifierBase):
         """Docstring is set after definition, using a template."""
         result = super().predict(X, raw_score, start_iteration, num_iteration, pred_leaf, pred_contrib, **kwargs)
         if callable(self._objective) and not (raw_score or pred_leaf or pred_contrib):
-            _log_warning("Cannot compute class probabilities or labels "
-                         "due to the usage of customized objective function.\n"
-                         "Returning raw scores instead.")
+            new_line = "\n"
+            _log_warning(f"Cannot compute class probabilities or labels " \
+                         f"due to the usage of customized objective function.{new_line}" \
+                         f"Returning raw scores instead.")
             return result
         elif self._n_classes > 2 or raw_score or pred_leaf or pred_contrib:
             return result


### PR DESCRIPTION
Switches some string formatting in `sklearn.py` to use f-strings, as part of #4136.