### PR TITLE
[R-package] Make returned feature importances from lgb.importance() visible by default

### DIFF
--- a/R-package/R/lgb.importance.R
+++ b/R-package/R/lgb.importance.R
@@ -75,6 +75,7 @@ lgb.importance <- function(model, percentage = TRUE) {
     )]
   }
 
-  return(withVisible(tree_imp_dt)$value)
+  # adding an empty [] to ensure the table is printed the first time print.data.table() is called
+  return(tree_imp_dt[])
 
 }

--- a/R-package/R/lgb.importance.R
+++ b/R-package/R/lgb.importance.R
@@ -75,6 +75,6 @@ lgb.importance <- function(model, percentage = TRUE) {
     )]
   }
 
-  return(tree_imp_dt)
+  return(withVisible(tree_imp_dt)$value)
 
 }


### PR DESCRIPTION
Feature importances are returned as invisible. I don't get why would anyone want them invisible. This PR fixes it.