### PR TITLE
[dask] Fix typo mentioned in 4101

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -422,7 +422,7 @@ def _train(
 
     # Tell each worker to train on the parts that it has locally
     #
-    # This code creates ``_train_part()`` calls as not "pure" because:
+    # This code treats ``_train_part()`` calls as not "pure" because:
     #     1. there is randomness in the training process unless parameters ``seed``
     #        and ``deterministic`` are set
     #     2. even with those parameters set, the output of one ``_train_part()`` call

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -422,7 +422,7 @@ def _train(
 
     # Tell each worker to train on the parts that it has locally
     #
-    # This code treates ``_train_part()`` calls as not "pure" because:
+    # This code creates ``_train_part()`` calls as not "pure" because:
     #     1. there is randomness in the training process unless parameters ``seed``
     #        and ``deterministic`` are set
     #     2. even with those parameters set, the output of one ``_train_part()`` call


### PR DESCRIPTION
Fixes typo in dask _train as mentioned in [this comment](https://github.com/microsoft/LightGBM/pull/4101#discussion_r616275252).