### PR TITLE
[docs] fix broken MS MPI link in Installation Guide

### DIFF
--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -899,7 +899,7 @@ gcc
 
 .. _RDMA: https://en.wikipedia.org/wiki/Remote_direct_memory_access
 
-.. _MS MPI: https://www.microsoft.com/en-us/download/details.aspx?id=100593
+.. _MS MPI: https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi-release-notes
 
 .. _Open MPI: https://www.open-mpi.org/
 


### PR DESCRIPTION
The "Link Checks" job is currently failing with the following error.

```text
URL        `https://www.microsoft.com/en-us/download/details.aspx?id=100593'
Name       `MS MPI'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/Installation-Guide.html, line 596, col 28
Real URL   https://www.microsoft.com/en-us/download/404Error.aspx
Check time 1.069 seconds
Size       92.45KB
Info       Redirected to
           `https://www.microsoft.com/en-us/download/404Error.aspx'.
Result     Error: 404 Not Found
```

Most recent build was 10 hours ago: https://github.com/microsoft/LightGBM/actions/runs/782291613

I see that broken download links have also been reported in the MS MPI repo: https://github.com/microsoft/Microsoft-MPI/issues/54

This PR proposes linking to [the official release notes for MS MPI](https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi-release-notes) instead of to aa specific download in the Microsoft Download center. That should fix the failing build and I think it's a better link anyway because users can read release notes AND get downloads there.