### PR TITLE
[R-package] fix warnings in unit tests

### DIFF
--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -1582,9 +1582,6 @@ test_that("If first_metric_only is TRUE, lgb.cv() decides to stop early based on
     , data = DTRAIN_RANDOM_REGRESSION
     , nfold = nfolds
     , nrounds = nrounds
-    , valids = list(
-      "valid1" = DVALID_RANDOM_REGRESSION
-    )
     , eval = list(
       .increasing_metric
       , .constant_metric
@@ -1641,9 +1638,6 @@ test_that("early stopping works with lgb.cv()", {
     , data = DTRAIN_RANDOM_REGRESSION
     , nfold = nfolds
     , nrounds = nrounds
-    , valids = list(
-      "valid1" = DVALID_RANDOM_REGRESSION
-    )
     , eval = list(
       .constant_metric
       , .increasing_metric
@@ -1841,15 +1835,16 @@ test_that("lgb.train() works with linear learners, bagging, and a Dataset that h
 test_that("lgb.train() works with linear learners and data where a feature has only 1 non-NA value", {
   set.seed(708L)
   .new_dataset <- function() {
-    values <- rep(NA_real_, 100L)
-    values[18L] <- rnorm(1L)
+    values <- c(rnorm(100L), rep(NA_real_, 100L))
+    values[118L] <- rnorm(1L)
     X <- matrix(
       data = values
-      , ncol = 1L
+      , ncol = 2L
     )
     return(lgb.Dataset(
       data = X
-      , label = 2L * X + runif(nrow(X), 0L, 0.1)
+      , label = 2L * X[, 1L] + runif(nrow(X), 0L, 0.1)
+      , feature_pre_filter = FALSE
     ))
   }
 
@@ -1888,7 +1883,7 @@ test_that("lgb.train() works with linear learners when Dataset has categorical f
     , metric = "mse"
     , seed = 0L
     , num_leaves = 2L
-    , categorical_features = 1L
+    , categorical_feature = 1L
   )
 
   dtrain <- .new_dataset()


### PR DESCRIPTION
This PR addresses several (but not all) of the R unit test warnings documented in #4108.

**`Unknown parameter: valids / {memory_address}`**

```text
[LightGBM] [Warning] Unknown parameter: 0x7fb4ee5c84d8>
[LightGBM] [Warning] Unknown parameter: valids
```

These warnings were caused by calls that were passing `valids` to `lgb.cv()`.
`lgb.cv()` does not accept validation data...it creates holdout sets using k-fold cross-validation.

This is an example of something that is currently a warning which would be an error if `...`
was not allowed (https://github.com/microsoft/LightGBM/pull/4202#discussion_r616075433, ~will write up a feature request soon~ https://github.com/microsoft/LightGBM/issues/4226).

**`Unknown parameter: categorical_features`**

```text
[LightGBM] [Warning] Unknown parameter: categorical_features
```

**`There are no meaningful features`**

```text
[LightGBM] [Warning] There are no meaningful features, as all feature values are constant
```

This came from the test `lgb.train() works with linear learners and data where a feature has only 1 non-NA value`. That test should have added an additional feature with enough variability to be usable during training.

### Notes for Reviewers

#4108 was originally opened as a `good first issue` about a month ago, with the hope that an outside contributor would pick it up. Normally I'd leave such an issue for non-maintainers. However, I want to focus on the R package over the next few weeks because of some issues that have been building up about it.

* #4007
* #4034
* #4045
* #4216 (from https://github.com/microsoft/LightGBM/pull/4207#issuecomment-824455972)
* https://github.com/tlverse/sl3/issues/344 & https://github.com/tlverse/sl3/pull/345
* https://github.com/curso-r/treesnip/issues/38

Given that I expect a lot of activity on the R package in the near future, I think it's very important that the R package's unit tests cover the package as reliably as possible.