### PR TITLE
[ci] [python-package] remove unused import in tests

### DIFF
--- a/tests/python_package_test/test_dual.py
+++ b/tests/python_package_test/test_dual.py
@@ -3,7 +3,6 @@
 
 import os
 
-import numpy as np
 import pytest
 from sklearn.metrics import log_loss
 


### PR DESCRIPTION
This PR removes an unused import in tests, found with `flake8 --ignore=E501,W503 tests/`:

```text
tests/python_package_test/test_dual.py:6:1: F401 'numpy as np' imported but unused
```