### PR TITLE
[ci] Install graphviz system-widely

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -104,8 +104,8 @@ else  # Linux
     fi
     ARCH=$(uname -m)
     if [[ $ARCH != "x86_64" ]] || [[ $TASK == "cuda" ]]; then
-        apt-get update
-        apt-get install --no-install-recommends -y \
+        apt update
+        apt install --no-install-recommends -y \
             graphviz
     else
         sudo apt-get update

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -81,6 +81,7 @@ else  # Linux
         mv $AMDAPPSDK_PATH/lib/x86_64/sdk/* $AMDAPPSDK_PATH/lib/x86_64/
         echo libamdocl64.so > $OPENCL_VENDOR_PATH/amdocl64.icd
     fi
+    ARCH=$(uname -m)
     if [[ $TASK == "cuda" ]]; then
         echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
         apt-get update
@@ -103,12 +104,17 @@ else  # Linux
         apt-get install --no-install-recommends -y \
             cmake
     else
-        sudo apt-get update
-        sudo apt-get install --no-install-recommends -y \
-            graphviz
+        if [[ $ARCH == "x86_64" ]]; then
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends -y \
+                graphviz
+        else
+            apt-get update
+            apt-get install --no-install-recommends -y \
+                graphviz
     fi
     if [[ $SETUP_CONDA != "false" ]]; then
-        ARCH=$(uname -m)
+        
         if [[ $ARCH == "x86_64" ]]; then
             curl -sL -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
         else

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -25,13 +25,10 @@ else  # Linux
         echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
 
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends \
+        sudo apt-get install --no-install-recommends -y \
             software-properties-common
 
-        sudo add-apt-repository -y ppa:git-core/ppa
-        sudo apt-get update
-
-        sudo apt-get install -y --no-install-recommends \
+        sudo apt-get install --no-install-recommends -y \
             apt-utils \
             build-essential \
             ca-certificates \
@@ -64,12 +61,16 @@ else  # Linux
     fi
     if [[ $TASK == "mpi" ]]; then
         sudo apt-get update
-        sudo apt-get install --no-install-recommends -y libopenmpi-dev openmpi-bin
+        sudo apt-get install --no-install-recommends -y \
+            libopenmpi-dev \
+            openmpi-bin
     fi
     if [[ $TASK == "gpu" ]]; then
         sudo add-apt-repository ppa:mhier/libboost-latest -y
         sudo apt-get update
-        sudo apt-get install --no-install-recommends -y libboost1.74-dev ocl-icd-opencl-dev
+        sudo apt-get install --no-install-recommends -y \
+            libboost1.74-dev \
+            ocl-icd-opencl-dev
         cd $BUILD_DIRECTORY  # to avoid permission errors
         curl -sL -o AMD-APP-SDKInstaller.tar.bz2 https://github.com/microsoft/LightGBM/releases/download/v2.0.12/AMD-APP-SDKInstaller-v3.0.130.136-GA-linux64.tar.bz2
         tar -xjf AMD-APP-SDKInstaller.tar.bz2
@@ -84,6 +85,7 @@ else  # Linux
         apt-get update
         apt-get install --no-install-recommends -y \
             curl \
+            graphviz \
             libxau6 \
             libxext6 \
             libxrender1 \
@@ -99,6 +101,10 @@ else  # Linux
         apt-get update
         apt-get install --no-install-recommends -y \
             cmake
+    else
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends -y \
+            graphviz
     fi
     if [[ $SETUP_CONDA != "false" ]]; then
         ARCH=$(uname -m)

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -106,7 +106,7 @@ else  # Linux
     else
         if [[ $ARCH != "x86_64" ]]; then
             yum update -y
-            yum install \
+            yum install -y \
                 graphviz
         else
             sudo apt-get update

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -81,13 +81,11 @@ else  # Linux
         mv $AMDAPPSDK_PATH/lib/x86_64/sdk/* $AMDAPPSDK_PATH/lib/x86_64/
         echo libamdocl64.so > $OPENCL_VENDOR_PATH/amdocl64.icd
     fi
-    ARCH=$(uname -m)
     if [[ $TASK == "cuda" ]]; then
         echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
         apt-get update
         apt-get install --no-install-recommends -y \
             curl \
-            graphviz \
             libxau6 \
             libxext6 \
             libxrender1 \
@@ -103,18 +101,18 @@ else  # Linux
         apt-get update
         apt-get install --no-install-recommends -y \
             cmake
+    fi
+    ARCH=$(uname -m)
+    if [[ $ARCH != "x86_64" ]] || [[ $TASK == "cuda" ]]; then
+        apt-get update
+        apt-get install --no-install-recommends -y \
+            graphviz
     else
-        if [[ $ARCH == "x86_64" ]]; then
-            sudo apt-get update
-            sudo apt-get install --no-install-recommends -y \
-                graphviz
-        else
-            apt-get update
-            apt-get install --no-install-recommends -y \
-                graphviz
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends -y \
+            graphviz
     fi
     if [[ $SETUP_CONDA != "false" ]]; then
-        
         if [[ $ARCH == "x86_64" ]]; then
             curl -sL -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
         else

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -17,6 +17,7 @@ if [[ $OS_NAME == "macos" ]]; then
     if [[ $TASK == "swig" ]]; then
         brew install swig
     fi
+    brew install graphviz
     curl -sL -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
 else  # Linux
     if [[ $IN_UBUNTU_LATEST_CONTAINER == "true" ]]; then

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -81,11 +81,13 @@ else  # Linux
         mv $AMDAPPSDK_PATH/lib/x86_64/sdk/* $AMDAPPSDK_PATH/lib/x86_64/
         echo libamdocl64.so > $OPENCL_VENDOR_PATH/amdocl64.icd
     fi
+    ARCH=$(uname -m)
     if [[ $TASK == "cuda" ]]; then
         echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
         apt-get update
         apt-get install --no-install-recommends -y \
             curl \
+            graphviz \
             libxau6 \
             libxext6 \
             libxrender1 \
@@ -101,16 +103,16 @@ else  # Linux
         apt-get update
         apt-get install --no-install-recommends -y \
             cmake
-    fi
-    ARCH=$(uname -m)
-    if [[ $ARCH != "x86_64" ]] || [[ $TASK == "cuda" ]]; then
-        apt update
-        apt install --no-install-recommends -y \
-            graphviz
     else
-        sudo apt-get update
-        sudo apt-get install --no-install-recommends -y \
-            graphviz
+        if [[ $ARCH != "x86_64" ]]; then
+            yum update -y
+            yum install \
+                graphviz
+        else
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends -y \
+                graphviz
+        fi
     fi
     if [[ $SETUP_CONDA != "false" ]]; then
         if [[ $ARCH == "x86_64" ]]; then

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -104,14 +104,7 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
-
-# graphviz must come from conda-forge to avoid this on some linux distros:
-# https://github.com/conda-forge/graphviz-feedstock/issues/18
-conda install -q -y \
-    -n $CONDA_ENV \
-    -c conda-forge \
-        python-graphviz
+conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest python-graphviz scikit-learn scipy
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     # fix "OMP: Error #15: Initializing libiomp5.dylib, but found libomp.dylib already initialized." (OpenMP library conflict due to conda's MKL)

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -104,7 +104,8 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest python-graphviz scikit-learn scipy
+conda install -q -y -n $CONDA_ENV cloudpickle dask distributed graphviz joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+pip install graphviz  # python-graphviz from Anaconda is not allowed to be installed with Python 3.9
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     # fix "OMP: Error #15: Initializing libiomp5.dylib, but found libomp.dylib already initialized." (OpenMP library conflict due to conda's MKL)

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -104,7 +104,7 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle dask distributed graphviz joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
 pip install graphviz  # python-graphviz from Anaconda is not allowed to be installed with Python 3.9
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then


### PR DESCRIPTION
Fixed #4204.

`graphviz` cannot be installed from the default conda channel with Python 3.9:
```
UnsatisfiableError: The following specifications were found
to be incompatible with the existing python installation in your environment:

Specifications:

  - python-graphviz -> python[version='>=2.7,<2.8.0a0|>=3.5,<3.6.0a0|>=3.8,<3.9.0a0|>=3.7,<3.8.0a0|>=3.6,<3.7.0a0']

Your python: python=3.9

If python is on the left-most side of the chain, that's the version you've asked for.
When python appears to the right, that indicates that the thing on the left is somehow
not available for the python version you are constrained to. Note that conda will not
change your python version to a different minor version unless you explicitly specify
that.

The following specifications were found to be incompatible with each other:

Output in format: Requested package -> Available versions

Package six conflicts for:
scikit-learn -> mkl-service[version='>=2,<3.0a0'] -> six
dask -> bokeh[version='>=1.0.0,!=2.0.0'] -> six[version='>=1.5.2']
distributed -> six
matplotlib -> cycler[version='>=0.10'] -> six[version='>=1.5']
scipy -> mkl-service[version='>=2.3.0,<3.0a0'] -> six
pytest -> more-itertools[version='>=4.0.0'] -> six[version='>=1.0.0,<2.0.0']
pytest -> six[version='>=1.10.0']
pandas -> python-dateutil[version='>=2.7.3'] -> six[version='>=1.5']
numpy -> mkl-service[version='>=2.3.0,<3.0a0'] -> six

Package libcxxabi conflicts for:
scikit-learn -> libcxx[version='>=4.0.1'] -> libcxxabi==4.0.1[build='hcfea43d_1|hebd6815_0']
pandas -> libcxx[version='>=4.0.1'] -> libcxxabi==4.0.1[build='hcfea43d_1|hebd6815_0']
scipy -> libcxx[version='>=4.0.1'] -> libcxxabi==4.0.1[build='hcfea43d_1|hebd6815_0']
matplotlib -> libcxx[version='>=4.0.1'] -> libcxxabi==4.0.1[build='hcfea43d_1|hebd6815_0']

Package pyparsing conflicts for:
pytest -> packaging -> pyparsing[version='>=2.0.2']
matplotlib -> matplotlib-base[version='>=3.3.4,<3.3.5.0a0'] -> pyparsing[version='>=2.0.3,!=2.0.4,!=2.1.2,!=2.1.6']
matplotlib -> pyparsing

Package psutil conflicts for:
distributed -> psutil[version='>=5.0']
dask -> distributed[version='>=2021.4.0'] -> psutil[version='>=5.0']

Package certifi conflicts for:
joblib -> setuptools -> certifi[version='>=2016.09|>=2016.9.26']
matplotlib -> matplotlib-base[version='>=3.3.4,<3.3.5.0a0'] -> certifi[version='>=2016.09|>=2016.9.26|>=2020.06.20']
pytest -> setuptools[version='>=40.0'] -> certifi[version='>=2016.09|>=2016.9.26']
distributed -> setuptools -> certifi[version='>=2016.09|>=2016.9.26']

Package pandas conflicts for:
dask -> bokeh -> pandas
dask -> pandas[version='>=0.19.0|>=0.21.0|>=0.23.0|>=0.25.0']

Package intel-openmp conflicts for:
scipy -> mkl[version='>=2021.2.0,<2022.0a0'] -> intel-openmp=2021
scikit-learn -> mkl[version='>=2019.4,<2020.0a0'] -> intel-openmp
numpy -> mkl[version='>=2021.2.0,<2022.0a0'] -> intel-openmp=2021

Package numpy conflicts for:
dask -> numpy[version='>=1.10|>=1.10.4|>=1.11.0|>=1.13.0|>=1.15.1|>=1.16']
matplotlib -> numpy[version='>=1.14.6,<2.0a0']
matplotlib -> matplotlib-base[version='>=3.3.4,<3.3.5.0a0'] -> numpy[version='>=1.15.4,<2.0a0|>=1.16.6,<2.0a0']
scikit-learn -> numpy[version='>=1.11.3,<2.0a0|>=1.14.6,<2.0a0|>=1.16.6,<2.0a0|>=1.9.3,<2.0a0']
dask -> bokeh[version='>=1.0.0,!=2.0.0'] -> numpy[version='>=1.11.3,<2.0a0|>=1.11.3|>=1.7.1|>=1.19.2,<2.0a0|>=1.16.6,<2.0a0|>=1.15.4,<2.0a0|>=1.14.6,<2.0a0|>=1.13.3,<2.0a0|>=1.12.1,<2.0a0|>=1.9.3,<2.0a0|>=1.9.3,<1.10.0a0|>=1.9']
pandas -> numpy[version='>=1.11.3,<2.0a0|>=1.12.1,<2.0a0|>=1.13.3,<2.0a0|>=1.14.6,<2.0a0|>=1.15.4,<2.0a0|>=1.16.6,<2.0a0|>=1.19.2,<2.0a0|>=1.9.3,<2.0a0|>=1.9.3,<1.10.0a0|>=1.9']
scipy -> numpy[version='>=1.11.3,<2.0a0|>=1.14.6,<2.0a0|>=1.16.6,<2.0a0|>=1.15.1,<2.0a0|>=1.9.3,<2.0a0']
scikit-learn -> scipy -> numpy[version='>=1.15.1,<2.0a0']

Package freetype conflicts for:
matplotlib -> freetype[version='>=2.8,<2.9.0a0|>=2.9.1,<3.0a0']
matplotlib -> matplotlib-base[version='>=3.3.4,<3.3.5.0a0'] -> freetype[version='>=2.10.2,<3.0a0|>=2.10.4,<3.0a0']
python-graphviz -> graphviz -> freetype[version='>=2.8,<2.9.0a0|>=2.9.1,<3.0a0']

Package backports_abc conflicts for:
distributed -> tornado[version='>=5'] -> backports_abc[version='>=0.4']
matplotlib -> tornado -> backports_abc[version='>=0.4']

Package packaging conflicts for:
dask -> bokeh[version='>=1.0.0,!=2.0.0'] -> packaging[version='>=16.8']
pytest -> packaging

Package cloudpickle conflicts for:
distributed -> dask-core[version='>=2020.12.0'] -> cloudpickle[version='>=1.1.1']
dask -> cloudpickle[version='>=0.2.1|>=0.2.2']
distributed -> cloudpickle[version='>=0.2.2|>=1.3.0|>=1.5.0']
dask -> dask-core=2021.4.0 -> cloudpickle[version='>=1.1.1|>=1.5.0|>=1.3.0']

Package setuptools conflicts for:
pytest -> setuptools[version='>=40.0']
python=3.9 -> pip -> setuptools
dask -> distributed[version='>=2021.4.0'] -> setuptools
distributed -> setuptools
matplotlib -> setuptools
joblib -> setuptools
scikit-learn -> joblib[version='>=0.11'] -> setuptools

Package python-dateutil conflicts for:
dask -> bokeh[version='>=1.0.0,!=2.0.0'] -> python-dateutil[version='>=2.1|>=2.7.3|>=2.6.1|>=2.5.*']
matplotlib -> python-dateutil
matplotlib -> matplotlib-base[version='>=3.3.4,<3.3.5.0a0'] -> python-dateutil[version='>=2.1']
pandas -> python-dateutil[version='>=2.5.*|>=2.6.1|>=2.7.3']

Package singledispatch conflicts for:
matplotlib -> tornado -> singledispatch
dask -> distributed[version='>=1.28.0'] -> singledispatch
distributed -> singledispatch
```
so install it via `apt-get`/`yum`/`brew`.

```
sudo add-apt-repository -y ppa:git-core/ppa
```
is not needed in the latest Ubuntu - default git is quite OK.