### PR TITLE
[R-package] Convert LGBM_GetLastError_R to use R built-in types

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -28,32 +28,12 @@ lgb.encode.char <- function(arr, len) {
 # [description] Raise an error. Before raising that error, check for any error message
 #               stored in a buffer on the C++ side.
 lgb.last_error <- function() {
-  # Perform text error buffering
-  buf_len <- 200L
-  act_len <- 0L
-  err_msg <- raw(buf_len)
   err_msg <- .Call(
     "LGBM_GetLastError_R"
-    , buf_len
-    , act_len
-    , err_msg
     , PACKAGE = "lib_lightgbm"
   )
 
-  # Check error buffer
-  if (act_len > buf_len) {
-    buf_len <- act_len
-    err_msg <- raw(buf_len)
-    err_msg <- .Call(
-      "LGBM_GetLastError_R"
-      , buf_len
-      , act_len
-      , err_msg
-      , PACKAGE = "lib_lightgbm"
-    )
-  }
-
-  stop("api error: ", lgb.encode.char(arr = err_msg, len = act_len))
+  stop(paste0("api error: ", err_msg))
 
   return(invisible(NULL))
 

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -25,7 +25,7 @@ lgb.encode.char <- function(arr, len) {
   return(rawToChar(arr[seq_len(len)]))
 }
 
-# [description] Get the moost recent error stored on the C++ side and raise it
+# [description] Get the most recent error stored on the C++ side and raise it
 #               as an R error.
 lgb.last_error <- function() {
   err_msg <- .Call(

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -25,18 +25,15 @@ lgb.encode.char <- function(arr, len) {
   return(rawToChar(arr[seq_len(len)]))
 }
 
-# [description] Raise an error. Before raising that error, check for any error message
-#               stored in a buffer on the C++ side.
+# [description] Get the moost recent error stored on the C++ side and raise it
+#               as an R error.
 lgb.last_error <- function() {
   err_msg <- .Call(
     "LGBM_GetLastError_R"
     , PACKAGE = "lib_lightgbm"
   )
-
   stop(paste0("api error: ", err_msg))
-
   return(invisible(NULL))
-
 }
 
 lgb.call <- function(fun_name, ret, ...) {

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -32,7 +32,7 @@ lgb.last_error <- function() {
     "LGBM_GetLastError_R"
     , PACKAGE = "lib_lightgbm"
   )
-  stop(paste0("api error: ", err_msg))
+  stop("api error: ", err_msg)
   return(invisible(NULL))
 }
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -56,8 +56,12 @@ LGBM_SE EncodeChar(LGBM_SE dest, const char* src, LGBM_SE buf_len, LGBM_SE actua
   return dest;
 }
 
-LGBM_SE LGBM_GetLastError_R(LGBM_SE buf_len, LGBM_SE actual_len, LGBM_SE err_msg) {
-  return EncodeChar(err_msg, LGBM_GetLastError(), buf_len, actual_len, std::strlen(LGBM_GetLastError()) + 1);
+SEXP LGBM_GetLastError_R() {
+  SEXP out;
+  out = PROTECT(Rf_allocVector(STRSXP, 1));
+  SET_STRING_ELT(out, 0, Rf_mkChar(LGBM_GetLastError()));
+  UNPROTECT(1);
+  return out;
 }
 
 LGBM_SE LGBM_DatasetCreateFromFile_R(LGBM_SE filename,

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -684,7 +684,7 @@ LGBM_SE LGBM_BoosterDumpModel_R(LGBM_SE handle,
 
 // .Call() calls
 static const R_CallMethodDef CallEntries[] = {
-  {"LGBM_GetLastError_R"              , (DL_FUNC) &LGBM_GetLastError_R              , 3},
+  {"LGBM_GetLastError_R"              , (DL_FUNC) &LGBM_GetLastError_R              , 0},
   {"LGBM_DatasetCreateFromFile_R"     , (DL_FUNC) &LGBM_DatasetCreateFromFile_R     , 5},
   {"LGBM_DatasetCreateFromCSC_R"      , (DL_FUNC) &LGBM_DatasetCreateFromCSC_R      , 10},
   {"LGBM_DatasetCreateFromMat_R"      , (DL_FUNC) &LGBM_DatasetCreateFromMat_R      , 7},

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -15,11 +15,7 @@
 * \return err_msg error information
 * \return error information
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_GetLastError_R(
-    LGBM_SE buf_len,
-    LGBM_SE actual_len,
-    LGBM_SE err_msg
-);
+LIGHTGBM_C_EXPORT SEXP LGBM_GetLastError_R();
 
 // --- start Dataset interface
 

--- a/build_r.R
+++ b/build_r.R
@@ -391,8 +391,13 @@ c_api_contents <- gsub(
   , replacement = ""
   , x = c_api_contents
 )
+c_api_contents <- gsub(
+  pattern = "LIGHTGBM_C_EXPORT SEXP "
+  , replacement = ""
+  , x = c_api_contents
+)
 c_api_symbols <- gsub(
-  pattern = "\\("
+  pattern = "\\(.*"
   , replacement = ""
   , x = c_api_contents
 )


### PR DESCRIPTION
This is a small step towards #3016. This PR proposes converting `LGBM_GetLastError_R` (and the R function that calls it, `lgb.last_error()`) to use R's built-in types instead of the custom type defined in https://github.com/microsoft/LightGBM/blob/91f72e2a8c8b1e5433d30d3891923b3a067402a6/R-package/src/R_object_helper.h.

### Notes for Reviewers

~This PR is not dependent on #4155.~ #4155 has been merged to `master` and this PR has been updated with it.

You can see the following to learn about the `SEXP`type.

* usage:
    - https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Handling-R-objects-in-C
    - https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Garbage-Collection
    - https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Allocating-storage
    - https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Handling-character-data
* low-level details:
    - https://cran.r-project.org/doc/manuals/r-release/R-ints.html#SEXPs