### PR TITLE
[R-package] remove pre-allocated call_state in C++ calls

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -16,11 +16,9 @@ Booster <- R6::R6Class(
       if (!lgb.is.null.handle(x = private$handle)) {
 
         # Freeing up handle
-        call_state <- 0L
         .Call(
           LGBM_BoosterFree_R
           , private$handle
-          , call_state
         )
         private$handle <- NULL
 
@@ -54,13 +52,11 @@ Booster <- R6::R6Class(
           params <- modifyList(params, train_set$get_params())
           params_str <- lgb.params2str(params = params)
           # Store booster handle
-          call_state <- 0L
           .Call(
             LGBM_BoosterCreate_R
             , train_set_handle
             , params_str
             , handle
-            , call_state
           )
 
           # Create private booster information
@@ -73,12 +69,10 @@ Booster <- R6::R6Class(
           if (!is.null(private$init_predictor)) {
 
             # Merge booster
-            call_state <- 0L
             .Call(
               LGBM_BoosterMerge_R
               , handle
               , private$init_predictor$.__enclos_env__$private$handle
-              , call_state
             )
 
           }
@@ -94,12 +88,10 @@ Booster <- R6::R6Class(
           }
 
           # Create booster from model
-          call_state <- 0L
           .Call(
             LGBM_BoosterCreateFromModelfile_R
             , lgb.c_str(x = modelfile)
             , handle
-            , call_state
           )
 
         } else if (!is.null(model_str)) {
@@ -110,12 +102,10 @@ Booster <- R6::R6Class(
           }
 
           # Create booster from model
-          call_state <- 0L
           .Call(
             LGBM_BoosterLoadModelFromString_R
             , lgb.c_str(x = model_str)
             , handle
-            , call_state
           )
 
         } else {
@@ -141,12 +131,10 @@ Booster <- R6::R6Class(
         class(handle) <- "lgb.Booster.handle"
         private$handle <- handle
         private$num_class <- 1L
-        call_state <- 0L
         .Call(
           LGBM_BoosterGetNumClasses_R
           , private$handle
           , private$num_class
-          , call_state
         )
 
       }
@@ -188,12 +176,10 @@ Booster <- R6::R6Class(
       }
 
       # Add validation data to booster
-      call_state <- 0L
       .Call(
         LGBM_BoosterAddValidData_R
         , private$handle
         , data$.__enclos_env__$private$get_handle()
-        , call_state
       )
 
       # Store private information
@@ -216,12 +202,10 @@ Booster <- R6::R6Class(
       params <- modifyList(params, list(...))
       params_str <- lgb.params2str(params = params)
 
-      call_state <- 0L
       .Call(
         LGBM_BoosterResetParameter_R
         , private$handle
         , params_str
-        , call_state
       )
       self$params <- params
 
@@ -252,12 +236,10 @@ Booster <- R6::R6Class(
         }
 
         # Reset training data on booster
-        call_state <- 0L
         .Call(
           LGBM_BoosterResetTrainingData_R
           , private$handle
           , train_set$.__enclos_env__$private$get_handle()
-          , call_state
         )
 
         # Store private train set
@@ -272,11 +254,9 @@ Booster <- R6::R6Class(
           stop("lgb.Booster.update: cannot update due to null objective function")
         }
         # Boost iteration from known objective
-        call_state <- 0L
         .Call(
           LGBM_BoosterUpdateOneIter_R
           , private$handle
-          , call_state
         )
 
       } else {
@@ -299,14 +279,12 @@ Booster <- R6::R6Class(
         }
 
         # Return custom boosting gradient/hessian
-        call_state <- 0L
         .Call(
           LGBM_BoosterUpdateOneIterCustom_R
           , private$handle
           , gpair$grad
           , gpair$hess
           , length(gpair$grad)
-          , call_state
         )
 
       }
@@ -324,11 +302,9 @@ Booster <- R6::R6Class(
     rollback_one_iter = function() {
 
       # Return one iteration behind
-      call_state <- 0L
       .Call(
         LGBM_BoosterRollbackOneIter_R
         , private$handle
-        , call_state
       )
 
       # Loop through each iteration
@@ -344,12 +320,10 @@ Booster <- R6::R6Class(
     current_iter = function() {
 
       cur_iter <- 0L
-      call_state <- 0L
       .Call(
         LGBM_BoosterGetCurrentIteration_R
         , private$handle
         , cur_iter
-        , call_state
       )
       return(cur_iter)
 
@@ -359,12 +333,10 @@ Booster <- R6::R6Class(
     upper_bound = function() {
 
       upper_bound <- 0.0
-      call_state <- 0L
       .Call(
         LGBM_BoosterGetUpperBoundValue_R
         , private$handle
         , upper_bound
-        , call_state
       )
       return(upper_bound)
 
@@ -374,12 +346,10 @@ Booster <- R6::R6Class(
     lower_bound = function() {
 
       lower_bound <- 0.0
-      call_state <- 0L
       .Call(
         LGBM_BoosterGetLowerBoundValue_R
         , private$handle
         , lower_bound
-        , call_state
       )
       return(lower_bound)
 
@@ -477,14 +447,12 @@ Booster <- R6::R6Class(
       }
 
       # Save booster model
-      call_state <- 0L
       .Call(
         LGBM_BoosterSaveModel_R
         , private$handle
         , as.integer(num_iteration)
         , as.integer(feature_importance_type)
         , lgb.c_str(x = filename)
-        , call_state
       )
 
       return(invisible(self))
@@ -504,7 +472,6 @@ Booster <- R6::R6Class(
       buf <- raw(buf_len)
 
       # Call buffer
-      call_state <- 0L
       .Call(
           LGBM_BoosterSaveModelToString_R
           , private$handle
@@ -513,14 +480,12 @@ Booster <- R6::R6Class(
           , buf_len
           , act_len
           , buf
-          , call_state
       )
 
       # Check for buffer content
       if (act_len > buf_len) {
         buf_len <- act_len
         buf <- raw(buf_len)
-        call_state <- 0L
         .Call(
           LGBM_BoosterSaveModelToString_R
           , private$handle
@@ -529,7 +494,6 @@ Booster <- R6::R6Class(
           , buf_len
           , act_len
           , buf
-          , call_state
         )
       }
 
@@ -550,7 +514,6 @@ Booster <- R6::R6Class(
       buf_len <- as.integer(1024L * 1024L)
       act_len <- 0L
       buf <- raw(buf_len)
-      call_state <- 0L
       .Call(
         LGBM_BoosterDumpModel_R
         , private$handle
@@ -559,13 +522,11 @@ Booster <- R6::R6Class(
         , buf_len
         , act_len
         , buf
-        , call_state
       )
 
       if (act_len > buf_len) {
         buf_len <- act_len
         buf <- raw(buf_len)
-        call_state <- 0L
         .Call(
           LGBM_BoosterDumpModel_R
           , private$handle
@@ -574,7 +535,6 @@ Booster <- R6::R6Class(
           , buf_len
           , act_len
           , buf
-          , call_state
         )
       }
 
@@ -674,14 +634,12 @@ Booster <- R6::R6Class(
       if (is.null(private$predict_buffer[[data_name]])) {
 
         # Store predictions
-        call_state <- 0L
         npred <- 0L
         .Call(
           LGBM_BoosterGetNumPredict_R
           , private$handle
           , as.integer(idx - 1L)
           , npred
-          , call_state
         )
         private$predict_buffer[[data_name]] <- numeric(npred)
 
@@ -691,13 +649,11 @@ Booster <- R6::R6Class(
       if (!private$is_predicted_cur_iter[[idx]]) {
 
         # Use buffer
-        call_state <- 0L
         .Call(
           LGBM_BoosterGetPredict_R
           , private$handle
           , as.integer(idx - 1L)
           , private$predict_buffer[[data_name]]
-          , call_state
         )
         private$is_predicted_cur_iter[[idx]] <- TRUE
       }
@@ -715,26 +671,22 @@ Booster <- R6::R6Class(
         buf_len <- as.integer(1024L * 1024L)
         act_len <- 0L
         buf <- raw(buf_len)
-        call_state <- 0L
         .Call(
           LGBM_BoosterGetEvalNames_R
           , private$handle
           , buf_len
           , act_len
           , buf
-          , call_state
         )
         if (act_len > buf_len) {
           buf_len <- act_len
           buf <- raw(buf_len)
-          call_state <- 0L
           .Call(
             LGBM_BoosterGetEvalNames_R
             , private$handle
             , buf_len
             , act_len
             , buf
-            , call_state
           )
         }
         names <- lgb.encode.char(arr = buf, len = act_len)
@@ -778,13 +730,11 @@ Booster <- R6::R6Class(
 
         # Create evaluation values
         tmp_vals <- numeric(length(private$eval_names))
-        call_state <- 0L
         .Call(
           LGBM_BoosterGetEval_R
           , private$handle
           , as.integer(data_idx - 1L)
           , tmp_vals
-          , call_state
         )
 
         # Loop through all evaluation names

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -13,11 +13,9 @@ Dataset <- R6::R6Class(
       if (!lgb.is.null.handle(x = private$handle)) {
 
         # Freeing up handle
-        call_state <- 0L
         .Call(
           LGBM_DatasetFree_R
           , private$handle
-          , call_state
         )
         private$handle <- NULL
 
@@ -202,20 +200,17 @@ Dataset <- R6::R6Class(
         # Are we using a data file?
         if (is.character(private$raw_data)) {
 
-          call_state <- 0L
           .Call(
             LGBM_DatasetCreateFromFile_R
             , lgb.c_str(x = private$raw_data)
             , params_str
             , ref_handle
             , handle
-            , call_state
           )
 
         } else if (is.matrix(private$raw_data)) {
 
           # Are we using a matrix?
-          call_state <- 0L
           .Call(
             LGBM_DatasetCreateFromMat_R
             , private$raw_data
@@ -224,7 +219,6 @@ Dataset <- R6::R6Class(
             , params_str
             , ref_handle
             , handle
-            , call_state
           )
 
         } else if (methods::is(private$raw_data, "dgCMatrix")) {
@@ -232,7 +226,6 @@ Dataset <- R6::R6Class(
             stop("Cannot support large CSC matrix")
           }
           # Are we using a dgCMatrix (sparsed matrix column compressed)
-          call_state <- 0L
           .Call(
             LGBM_DatasetCreateFromCSC_R
             , private$raw_data@p
@@ -244,7 +237,6 @@ Dataset <- R6::R6Class(
             , params_str
             , ref_handle
             , handle
-            , call_state
           )
 
         } else {
@@ -265,7 +257,6 @@ Dataset <- R6::R6Class(
         }
 
         # Construct subset
-        call_state <- 0L
         .Call(
           LGBM_DatasetGetSubset_R
           , ref_handle
@@ -273,7 +264,6 @@ Dataset <- R6::R6Class(
           , length(private$used_indices)
           , params_str
           , handle
-          , call_state
         )
 
       }
@@ -342,19 +332,15 @@ Dataset <- R6::R6Class(
         num_col <- 0L
 
         # Get numeric data and numeric features
-        call_state <- 0L
         .Call(
           LGBM_DatasetGetNumData_R
           , private$handle
           , num_row
-          , call_state
         )
-        call_state <- 0L
         .Call(
           LGBM_DatasetGetNumFeature_R
           , private$handle
           , num_col
-          , call_state
         )
         return(
           c(num_row, num_col)
@@ -388,26 +374,22 @@ Dataset <- R6::R6Class(
         buf_len <- as.integer(1024L * 1024L)
         act_len <- 0L
         buf <- raw(buf_len)
-        call_state <- 0L
         .Call(
           LGBM_DatasetGetFeatureNames_R
           , private$handle
           , buf_len
           , act_len
           , buf
-          , call_state
         )
         if (act_len > buf_len) {
           buf_len <- act_len
           buf <- raw(buf_len)
-          call_state <- 0L
           .Call(
             LGBM_DatasetGetFeatureNames_R
             , private$handle
             , buf_len
             , act_len
             , buf
-            , call_state
           )
         }
         cnames <- lgb.encode.char(arr = buf, len = act_len)
@@ -451,12 +433,10 @@ Dataset <- R6::R6Class(
 
         # Merge names with tab separation
         merged_name <- paste0(as.list(private$colnames), collapse = "\t")
-        call_state <- 0L
         .Call(
           LGBM_DatasetSetFeatureNames_R
           , private$handle
           , lgb.c_str(x = merged_name)
-          , call_state
         )
 
       }
@@ -485,13 +465,11 @@ Dataset <- R6::R6Class(
 
         # Get field size of info
         info_len <- 0L
-        call_state <- 0L
         .Call(
           LGBM_DatasetGetFieldSize_R
           , private$handle
           , lgb.c_str(x = name)
           , info_len
-          , call_state
         )
 
         # Check if info is not empty
@@ -505,13 +483,11 @@ Dataset <- R6::R6Class(
             numeric(info_len) # Numeric
           }
 
-          call_state <- 0L
           .Call(
             LGBM_DatasetGetField_R
             , private$handle
             , lgb.c_str(x = name)
             , ret
-            , call_state
           )
 
           private$info[[name]] <- ret
@@ -548,14 +524,12 @@ Dataset <- R6::R6Class(
 
         if (length(info) > 0L) {
 
-          call_state <- 0L
           .Call(
             LGBM_DatasetSetField_R
             , private$handle
             , lgb.c_str(x = name)
             , info
             , length(info)
-            , call_state
           )
 
           private$version <- private$version + 1L
@@ -600,12 +574,10 @@ Dataset <- R6::R6Class(
         private$params <- modifyList(private$params, params)
       } else {
         tryCatch({
-          call_state <- 0L
           .Call(
             LGBM_DatasetUpdateParamChecking_R
             , lgb.params2str(params = private$params)
             , lgb.params2str(params = params)
-            , call_state
           )
         }, error = function(e) {
           # If updating failed but raw data is not available, raise an error because
@@ -703,12 +675,10 @@ Dataset <- R6::R6Class(
 
       # Store binary data
       self$construct()
-      call_state <- 0L
       .Call(
         LGBM_DatasetSaveBinary_R
         , private$handle
         , lgb.c_str(x = fname)
-        , call_state
       )
       return(invisible(self))
     }

--- a/R-package/R/lgb.Predictor.R
+++ b/R-package/R/lgb.Predictor.R
@@ -14,11 +14,9 @@ Predictor <- R6::R6Class(
       if (private$need_free_handle && !lgb.is.null.handle(x = private$handle)) {
 
         # Freeing up handle
-        call_state <- 0L
         .Call(
           LGBM_BoosterFree_R
           , private$handle
-          , call_state
         )
         private$handle <- NULL
 
@@ -39,12 +37,10 @@ Predictor <- R6::R6Class(
       if (is.character(modelfile)) {
 
         # Create handle on it
-        call_state <- 0L
         .Call(
           LGBM_BoosterCreateFromModelfile_R
           , lgb.c_str(x = modelfile)
           , handle
-          , call_state
         )
         private$need_free_handle <- TRUE
 
@@ -72,12 +68,10 @@ Predictor <- R6::R6Class(
     current_iter = function() {
 
       cur_iter <- 0L
-      call_state <- 0L
       .Call(
         LGBM_BoosterGetCurrentIteration_R
         , private$handle
         , cur_iter
-        , call_state
       )
       return(cur_iter)
 
@@ -112,7 +106,6 @@ Predictor <- R6::R6Class(
         on.exit(unlink(tmp_filename), add = TRUE)
 
         # Predict from temporary file
-        call_state <- 0L
         .Call(
           LGBM_BoosterPredictForFile_R
           , private$handle
@@ -125,7 +118,6 @@ Predictor <- R6::R6Class(
           , as.integer(num_iteration)
           , private$params
           , lgb.c_str(x = tmp_filename)
-          , call_state
         )
 
         # Get predictions from file
@@ -141,7 +133,6 @@ Predictor <- R6::R6Class(
         npred <- 0L
 
         # Check number of predictions to do
-        call_state <- 0L
         .Call(
           LGBM_BoosterCalcNumPredict_R
           , private$handle
@@ -152,7 +143,6 @@ Predictor <- R6::R6Class(
           , as.integer(start_iteration)
           , as.integer(num_iteration)
           , npred
-          , call_state
         )
 
         # Pre-allocate empty vector
@@ -165,7 +155,6 @@ Predictor <- R6::R6Class(
           if (storage.mode(data) != "double") {
             storage.mode(data) <- "double"
           }
-          call_state <- 0L
           .Call(
             LGBM_BoosterPredictForMat_R
             , private$handle
@@ -179,7 +168,6 @@ Predictor <- R6::R6Class(
             , as.integer(num_iteration)
             , private$params
             , preds
-            , call_state
           )
 
         } else if (methods::is(data, "dgCMatrix")) {
@@ -187,7 +175,6 @@ Predictor <- R6::R6Class(
             stop("Cannot support large CSC matrix")
           }
           # Check if data is a dgCMatrix (sparse matrix, column compressed format)
-          call_state <- 0L
           .Call(
             LGBM_BoosterPredictForCSC_R
             , private$handle
@@ -204,7 +191,6 @@ Predictor <- R6::R6Class(
             , as.integer(num_iteration)
             , private$params
             , preds
-            , call_state
           )
 
         } else {

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -28,15 +28,15 @@
 #define R_API_BEGIN() \
   try {
 #define R_API_END() } \
-  catch(std::exception& ex) { R_INT_PTR(call_state)[0] = -1; LGBM_SetLastError(ex.what()); return call_state;} \
-  catch(std::string& ex) { R_INT_PTR(call_state)[0] = -1; LGBM_SetLastError(ex.c_str()); return call_state; } \
-  catch(...) { R_INT_PTR(call_state)[0] = -1; LGBM_SetLastError("unknown exception"); return call_state;} \
-  return call_state;
+  catch(std::exception& ex) { LGBM_SetLastError(ex.what()); return R_NilValue;} \
+  catch(std::string& ex) { LGBM_SetLastError(ex.c_str()); return R_NilValue; } \
+  catch(...) { LGBM_SetLastError("unknown exception"); return R_NilValue;} \
+  return R_NilValue;
 
 #define CHECK_CALL(x) \
   if ((x) != 0) { \
     Rf_error(LGBM_GetLastError()); \
-    return call_state;\
+    return R_NilValue; \
   }
 
 using LightGBM::Common::Join;
@@ -60,11 +60,10 @@ LGBM_SE LGBM_GetLastError_R(LGBM_SE buf_len, LGBM_SE actual_len, LGBM_SE err_msg
   return EncodeChar(err_msg, LGBM_GetLastError(), buf_len, actual_len, std::strlen(LGBM_GetLastError()) + 1);
 }
 
-LGBM_SE LGBM_DatasetCreateFromFile_R(LGBM_SE filename,
+SEXP LGBM_DatasetCreateFromFile_R(LGBM_SE filename,
   LGBM_SE parameters,
   LGBM_SE reference,
-  LGBM_SE out,
-  LGBM_SE call_state) {
+  LGBM_SE out) {
   R_API_BEGIN();
   DatasetHandle handle = nullptr;
   CHECK_CALL(LGBM_DatasetCreateFromFile(R_CHAR_PTR(filename), R_CHAR_PTR(parameters),
@@ -73,7 +72,7 @@ LGBM_SE LGBM_DatasetCreateFromFile_R(LGBM_SE filename,
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetCreateFromCSC_R(LGBM_SE indptr,
+SEXP LGBM_DatasetCreateFromCSC_R(LGBM_SE indptr,
   LGBM_SE indices,
   LGBM_SE data,
   LGBM_SE num_indptr,
@@ -81,8 +80,7 @@ LGBM_SE LGBM_DatasetCreateFromCSC_R(LGBM_SE indptr,
   LGBM_SE num_row,
   LGBM_SE parameters,
   LGBM_SE reference,
-  LGBM_SE out,
-  LGBM_SE call_state) {
+  LGBM_SE out) {
   R_API_BEGIN();
   const int* p_indptr = R_INT_PTR(indptr);
   const int* p_indices = R_INT_PTR(indices);
@@ -99,13 +97,12 @@ LGBM_SE LGBM_DatasetCreateFromCSC_R(LGBM_SE indptr,
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetCreateFromMat_R(LGBM_SE data,
+SEXP LGBM_DatasetCreateFromMat_R(LGBM_SE data,
   LGBM_SE num_row,
   LGBM_SE num_col,
   LGBM_SE parameters,
   LGBM_SE reference,
-  LGBM_SE out,
-  LGBM_SE call_state) {
+  LGBM_SE out) {
   R_API_BEGIN();
   int32_t nrow = static_cast<int32_t>(R_AS_INT(num_row));
   int32_t ncol = static_cast<int32_t>(R_AS_INT(num_col));
@@ -117,12 +114,11 @@ LGBM_SE LGBM_DatasetCreateFromMat_R(LGBM_SE data,
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetGetSubset_R(LGBM_SE handle,
+SEXP LGBM_DatasetGetSubset_R(LGBM_SE handle,
   LGBM_SE used_row_indices,
   LGBM_SE len_used_row_indices,
   LGBM_SE parameters,
-  LGBM_SE out,
-  LGBM_SE call_state) {
+  LGBM_SE out) {
   R_API_BEGIN();
   int len = R_AS_INT(len_used_row_indices);
   std::vector<int> idxvec(len);
@@ -139,9 +135,8 @@ LGBM_SE LGBM_DatasetGetSubset_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetSetFeatureNames_R(LGBM_SE handle,
-  LGBM_SE feature_names,
-  LGBM_SE call_state) {
+SEXP LGBM_DatasetSetFeatureNames_R(LGBM_SE handle,
+  LGBM_SE feature_names) {
   R_API_BEGIN();
   auto vec_names = Split(R_CHAR_PTR(feature_names), '\t');
   std::vector<const char*> vec_sptr;
@@ -154,11 +149,10 @@ LGBM_SE LGBM_DatasetSetFeatureNames_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetGetFeatureNames_R(LGBM_SE handle,
+SEXP LGBM_DatasetGetFeatureNames_R(LGBM_SE handle,
   LGBM_SE buf_len,
   LGBM_SE actual_len,
-  LGBM_SE feature_names,
-  LGBM_SE call_state) {
+  LGBM_SE feature_names) {
   R_API_BEGIN();
   int len = 0;
   CHECK_CALL(LGBM_DatasetGetNumFeature(R_GET_PTR(handle), &len));
@@ -184,17 +178,15 @@ LGBM_SE LGBM_DatasetGetFeatureNames_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetSaveBinary_R(LGBM_SE handle,
-  LGBM_SE filename,
-  LGBM_SE call_state) {
+SEXP LGBM_DatasetSaveBinary_R(LGBM_SE handle,
+  LGBM_SE filename) {
   R_API_BEGIN();
   CHECK_CALL(LGBM_DatasetSaveBinary(R_GET_PTR(handle),
     R_CHAR_PTR(filename)));
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetFree_R(LGBM_SE handle,
-  LGBM_SE call_state) {
+SEXP LGBM_DatasetFree_R(LGBM_SE handle) {
   R_API_BEGIN();
   if (R_GET_PTR(handle) != nullptr) {
     CHECK_CALL(LGBM_DatasetFree(R_GET_PTR(handle)));
@@ -203,11 +195,10 @@ LGBM_SE LGBM_DatasetFree_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetSetField_R(LGBM_SE handle,
+SEXP LGBM_DatasetSetField_R(LGBM_SE handle,
   LGBM_SE field_name,
   LGBM_SE field_data,
-  LGBM_SE num_element,
-  LGBM_SE call_state) {
+  LGBM_SE num_element) {
   R_API_BEGIN();
   int len = static_cast<int>(R_AS_INT(num_element));
   const char* name = R_CHAR_PTR(field_name);
@@ -231,10 +222,9 @@ LGBM_SE LGBM_DatasetSetField_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetGetField_R(LGBM_SE handle,
+SEXP LGBM_DatasetGetField_R(LGBM_SE handle,
   LGBM_SE field_name,
-  LGBM_SE field_data,
-  LGBM_SE call_state) {
+  LGBM_SE field_data) {
   R_API_BEGIN();
   const char* name = R_CHAR_PTR(field_name);
   int out_len = 0;
@@ -265,10 +255,9 @@ LGBM_SE LGBM_DatasetGetField_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetGetFieldSize_R(LGBM_SE handle,
+SEXP LGBM_DatasetGetFieldSize_R(LGBM_SE handle,
   LGBM_SE field_name,
-  LGBM_SE out,
-  LGBM_SE call_state) {
+  LGBM_SE out) {
   R_API_BEGIN();
   const char* name = R_CHAR_PTR(field_name);
   int out_len = 0;
@@ -282,16 +271,14 @@ LGBM_SE LGBM_DatasetGetFieldSize_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetUpdateParamChecking_R(LGBM_SE old_params,
-  LGBM_SE new_params,
-  LGBM_SE call_state) {
+SEXP LGBM_DatasetUpdateParamChecking_R(LGBM_SE old_params,
+  LGBM_SE new_params) {
   R_API_BEGIN();
   CHECK_CALL(LGBM_DatasetUpdateParamChecking(R_CHAR_PTR(old_params), R_CHAR_PTR(new_params)));
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetGetNumData_R(LGBM_SE handle, LGBM_SE out,
-  LGBM_SE call_state) {
+SEXP LGBM_DatasetGetNumData_R(LGBM_SE handle, LGBM_SE out) {
   int nrow;
   R_API_BEGIN();
   CHECK_CALL(LGBM_DatasetGetNumData(R_GET_PTR(handle), &nrow));
@@ -299,9 +286,8 @@ LGBM_SE LGBM_DatasetGetNumData_R(LGBM_SE handle, LGBM_SE out,
   R_API_END();
 }
 
-LGBM_SE LGBM_DatasetGetNumFeature_R(LGBM_SE handle,
-  LGBM_SE out,
-  LGBM_SE call_state) {
+SEXP LGBM_DatasetGetNumFeature_R(LGBM_SE handle,
+  LGBM_SE out) {
   int nfeature;
   R_API_BEGIN();
   CHECK_CALL(LGBM_DatasetGetNumFeature(R_GET_PTR(handle), &nfeature));
@@ -311,8 +297,7 @@ LGBM_SE LGBM_DatasetGetNumFeature_R(LGBM_SE handle,
 
 // --- start Booster interfaces
 
-LGBM_SE LGBM_BoosterFree_R(LGBM_SE handle,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterFree_R(LGBM_SE handle) {
   R_API_BEGIN();
   if (R_GET_PTR(handle) != nullptr) {
     CHECK_CALL(LGBM_BoosterFree(R_GET_PTR(handle)));
@@ -321,10 +306,9 @@ LGBM_SE LGBM_BoosterFree_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterCreate_R(LGBM_SE train_data,
+SEXP LGBM_BoosterCreate_R(LGBM_SE train_data,
   LGBM_SE parameters,
-  LGBM_SE out,
-  LGBM_SE call_state) {
+  LGBM_SE out) {
   R_API_BEGIN();
   BoosterHandle handle = nullptr;
   CHECK_CALL(LGBM_BoosterCreate(R_GET_PTR(train_data), R_CHAR_PTR(parameters), &handle));
@@ -332,9 +316,8 @@ LGBM_SE LGBM_BoosterCreate_R(LGBM_SE train_data,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterCreateFromModelfile_R(LGBM_SE filename,
-  LGBM_SE out,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterCreateFromModelfile_R(LGBM_SE filename,
+  LGBM_SE out) {
   R_API_BEGIN();
   int out_num_iterations = 0;
   BoosterHandle handle = nullptr;
@@ -343,9 +326,8 @@ LGBM_SE LGBM_BoosterCreateFromModelfile_R(LGBM_SE filename,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterLoadModelFromString_R(LGBM_SE model_str,
-  LGBM_SE out,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterLoadModelFromString_R(LGBM_SE model_str,
+  LGBM_SE out) {
   R_API_BEGIN();
   int out_num_iterations = 0;
   BoosterHandle handle = nullptr;
@@ -354,41 +336,36 @@ LGBM_SE LGBM_BoosterLoadModelFromString_R(LGBM_SE model_str,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterMerge_R(LGBM_SE handle,
-  LGBM_SE other_handle,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterMerge_R(LGBM_SE handle,
+  LGBM_SE other_handle) {
   R_API_BEGIN();
   CHECK_CALL(LGBM_BoosterMerge(R_GET_PTR(handle), R_GET_PTR(other_handle)));
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterAddValidData_R(LGBM_SE handle,
-  LGBM_SE valid_data,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterAddValidData_R(LGBM_SE handle,
+  LGBM_SE valid_data) {
   R_API_BEGIN();
   CHECK_CALL(LGBM_BoosterAddValidData(R_GET_PTR(handle), R_GET_PTR(valid_data)));
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterResetTrainingData_R(LGBM_SE handle,
-  LGBM_SE train_data,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterResetTrainingData_R(LGBM_SE handle,
+  LGBM_SE train_data) {
   R_API_BEGIN();
   CHECK_CALL(LGBM_BoosterResetTrainingData(R_GET_PTR(handle), R_GET_PTR(train_data)));
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterResetParameter_R(LGBM_SE handle,
-  LGBM_SE parameters,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterResetParameter_R(LGBM_SE handle,
+  LGBM_SE parameters) {
   R_API_BEGIN();
   CHECK_CALL(LGBM_BoosterResetParameter(R_GET_PTR(handle), R_CHAR_PTR(parameters)));
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterGetNumClasses_R(LGBM_SE handle,
-  LGBM_SE out,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterGetNumClasses_R(LGBM_SE handle,
+  LGBM_SE out) {
   int num_class;
   R_API_BEGIN();
   CHECK_CALL(LGBM_BoosterGetNumClasses(R_GET_PTR(handle), &num_class));
@@ -396,19 +373,17 @@ LGBM_SE LGBM_BoosterGetNumClasses_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterUpdateOneIter_R(LGBM_SE handle,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterUpdateOneIter_R(LGBM_SE handle) {
   int is_finished = 0;
   R_API_BEGIN();
   CHECK_CALL(LGBM_BoosterUpdateOneIter(R_GET_PTR(handle), &is_finished));
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterUpdateOneIterCustom_R(LGBM_SE handle,
+SEXP LGBM_BoosterUpdateOneIterCustom_R(LGBM_SE handle,
   LGBM_SE grad,
   LGBM_SE hess,
-  LGBM_SE len,
-  LGBM_SE call_state) {
+  LGBM_SE len) {
   int is_finished = 0;
   R_API_BEGIN();
   int int_len = R_AS_INT(len);
@@ -422,16 +397,14 @@ LGBM_SE LGBM_BoosterUpdateOneIterCustom_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterRollbackOneIter_R(LGBM_SE handle,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterRollbackOneIter_R(LGBM_SE handle) {
   R_API_BEGIN();
   CHECK_CALL(LGBM_BoosterRollbackOneIter(R_GET_PTR(handle)));
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterGetCurrentIteration_R(LGBM_SE handle,
-  LGBM_SE out,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterGetCurrentIteration_R(LGBM_SE handle,
+  LGBM_SE out) {
   int out_iteration;
   R_API_BEGIN();
   CHECK_CALL(LGBM_BoosterGetCurrentIteration(R_GET_PTR(handle), &out_iteration));
@@ -439,29 +412,26 @@ LGBM_SE LGBM_BoosterGetCurrentIteration_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterGetUpperBoundValue_R(LGBM_SE handle,
-  LGBM_SE out_result,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterGetUpperBoundValue_R(LGBM_SE handle,
+  LGBM_SE out_result) {
   R_API_BEGIN();
   double* ptr_ret = R_REAL_PTR(out_result);
   CHECK_CALL(LGBM_BoosterGetUpperBoundValue(R_GET_PTR(handle), ptr_ret));
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterGetLowerBoundValue_R(LGBM_SE handle,
-  LGBM_SE out_result,
-  LGBM_SE call_state) {
+SEXP LGBM_BoosterGetLowerBoundValue_R(LGBM_SE handle,
+  LGBM_SE out_result) {
   R_API_BEGIN();
   double* ptr_ret = R_REAL_PTR(out_result);
   CHECK_CALL(LGBM_BoosterGetLowerBoundValue(R_GET_PTR(handle), ptr_ret));
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterGetEvalNames_R(LGBM_SE handle,
+SEXP LGBM_BoosterGetEvalNames_R(LGBM_SE handle,
   LGBM_SE buf_len,
   LGBM_SE actual_len,
-  LGBM_SE eval_names,
-  LGBM_SE call_state) {
+  LGBM_SE eval_names) {
   R_API_BEGIN();
   int len;
   CHECK_CALL(LGBM_BoosterGetEvalCounts(R_GET_PTR(handle), &len));
@@ -489,10 +459,9 @@ LGBM_SE LGBM_BoosterGetEvalNames_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterGetEval_R(LGBM_SE handle,
+SEXP LGBM_BoosterGetEval_R(LGBM_SE handle,
   LGBM_SE data_idx,
-  LGBM_SE out_result,
-  LGBM_SE call_state) {
+  LGBM_SE out_result) {
   R_API_BEGIN();
   int len;
   CHECK_CALL(LGBM_BoosterGetEvalCounts(R_GET_PTR(handle), &len));
@@ -503,10 +472,9 @@ LGBM_SE LGBM_BoosterGetEval_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterGetNumPredict_R(LGBM_SE handle,
+SEXP LGBM_BoosterGetNumPredict_R(LGBM_SE handle,
   LGBM_SE data_idx,
-  LGBM_SE out,
-  LGBM_SE call_state) {
+  LGBM_SE out) {
   R_API_BEGIN();
   int64_t len;
   CHECK_CALL(LGBM_BoosterGetNumPredict(R_GET_PTR(handle), R_AS_INT(data_idx), &len));
@@ -514,10 +482,9 @@ LGBM_SE LGBM_BoosterGetNumPredict_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterGetPredict_R(LGBM_SE handle,
+SEXP LGBM_BoosterGetPredict_R(LGBM_SE handle,
   LGBM_SE data_idx,
-  LGBM_SE out_result,
-  LGBM_SE call_state) {
+  LGBM_SE out_result) {
   R_API_BEGIN();
   double* ptr_ret = R_REAL_PTR(out_result);
   int64_t out_len;
@@ -539,7 +506,7 @@ int GetPredictType(LGBM_SE is_rawscore, LGBM_SE is_leafidx, LGBM_SE is_predcontr
   return pred_type;
 }
 
-LGBM_SE LGBM_BoosterPredictForFile_R(LGBM_SE handle,
+SEXP LGBM_BoosterPredictForFile_R(LGBM_SE handle,
   LGBM_SE data_filename,
   LGBM_SE data_has_header,
   LGBM_SE is_rawscore,
@@ -548,8 +515,7 @@ LGBM_SE LGBM_BoosterPredictForFile_R(LGBM_SE handle,
   LGBM_SE start_iteration,
   LGBM_SE num_iteration,
   LGBM_SE parameter,
-  LGBM_SE result_filename,
-  LGBM_SE call_state) {
+  LGBM_SE result_filename) {
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
   CHECK_CALL(LGBM_BoosterPredictForFile(R_GET_PTR(handle), R_CHAR_PTR(data_filename),
@@ -558,15 +524,14 @@ LGBM_SE LGBM_BoosterPredictForFile_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterCalcNumPredict_R(LGBM_SE handle,
+SEXP LGBM_BoosterCalcNumPredict_R(LGBM_SE handle,
   LGBM_SE num_row,
   LGBM_SE is_rawscore,
   LGBM_SE is_leafidx,
   LGBM_SE is_predcontrib,
   LGBM_SE start_iteration,
   LGBM_SE num_iteration,
-  LGBM_SE out_len,
-  LGBM_SE call_state) {
+  LGBM_SE out_len) {
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
   int64_t len = 0;
@@ -576,7 +541,7 @@ LGBM_SE LGBM_BoosterCalcNumPredict_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterPredictForCSC_R(LGBM_SE handle,
+SEXP LGBM_BoosterPredictForCSC_R(LGBM_SE handle,
   LGBM_SE indptr,
   LGBM_SE indices,
   LGBM_SE data,
@@ -589,8 +554,7 @@ LGBM_SE LGBM_BoosterPredictForCSC_R(LGBM_SE handle,
   LGBM_SE start_iteration,
   LGBM_SE num_iteration,
   LGBM_SE parameter,
-  LGBM_SE out_result,
-  LGBM_SE call_state) {
+  LGBM_SE out_result) {
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
 
@@ -610,7 +574,7 @@ LGBM_SE LGBM_BoosterPredictForCSC_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterPredictForMat_R(LGBM_SE handle,
+SEXP LGBM_BoosterPredictForMat_R(LGBM_SE handle,
   LGBM_SE data,
   LGBM_SE num_row,
   LGBM_SE num_col,
@@ -620,8 +584,7 @@ LGBM_SE LGBM_BoosterPredictForMat_R(LGBM_SE handle,
   LGBM_SE start_iteration,
   LGBM_SE num_iteration,
   LGBM_SE parameter,
-  LGBM_SE out_result,
-  LGBM_SE call_state) {
+  LGBM_SE out_result) {
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
 
@@ -638,23 +601,21 @@ LGBM_SE LGBM_BoosterPredictForMat_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterSaveModel_R(LGBM_SE handle,
+SEXP LGBM_BoosterSaveModel_R(LGBM_SE handle,
   LGBM_SE num_iteration,
   LGBM_SE feature_importance_type,
-  LGBM_SE filename,
-  LGBM_SE call_state) {
+  LGBM_SE filename) {
   R_API_BEGIN();
   CHECK_CALL(LGBM_BoosterSaveModel(R_GET_PTR(handle), 0, R_AS_INT(num_iteration), R_AS_INT(feature_importance_type), R_CHAR_PTR(filename)));
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterSaveModelToString_R(LGBM_SE handle,
+SEXP LGBM_BoosterSaveModelToString_R(LGBM_SE handle,
   LGBM_SE num_iteration,
   LGBM_SE feature_importance_type,
   LGBM_SE buffer_len,
   LGBM_SE actual_len,
-  LGBM_SE out_str,
-  LGBM_SE call_state) {
+  LGBM_SE out_str) {
   R_API_BEGIN();
   int64_t out_len = 0;
   std::vector<char> inner_char_buf(R_AS_INT(buffer_len));
@@ -663,13 +624,12 @@ LGBM_SE LGBM_BoosterSaveModelToString_R(LGBM_SE handle,
   R_API_END();
 }
 
-LGBM_SE LGBM_BoosterDumpModel_R(LGBM_SE handle,
+SEXP LGBM_BoosterDumpModel_R(LGBM_SE handle,
   LGBM_SE num_iteration,
   LGBM_SE feature_importance_type,
   LGBM_SE buffer_len,
   LGBM_SE actual_len,
-  LGBM_SE out_str,
-  LGBM_SE call_state) {
+  LGBM_SE out_str) {
   R_API_BEGIN();
   int64_t out_len = 0;
   std::vector<char> inner_char_buf(R_AS_INT(buffer_len));
@@ -681,46 +641,46 @@ LGBM_SE LGBM_BoosterDumpModel_R(LGBM_SE handle,
 // .Call() calls
 static const R_CallMethodDef CallEntries[] = {
   {"LGBM_GetLastError_R"              , (DL_FUNC) &LGBM_GetLastError_R              , 3},
-  {"LGBM_DatasetCreateFromFile_R"     , (DL_FUNC) &LGBM_DatasetCreateFromFile_R     , 5},
-  {"LGBM_DatasetCreateFromCSC_R"      , (DL_FUNC) &LGBM_DatasetCreateFromCSC_R      , 10},
-  {"LGBM_DatasetCreateFromMat_R"      , (DL_FUNC) &LGBM_DatasetCreateFromMat_R      , 7},
-  {"LGBM_DatasetGetSubset_R"          , (DL_FUNC) &LGBM_DatasetGetSubset_R          , 6},
-  {"LGBM_DatasetSetFeatureNames_R"    , (DL_FUNC) &LGBM_DatasetSetFeatureNames_R    , 3},
-  {"LGBM_DatasetGetFeatureNames_R"    , (DL_FUNC) &LGBM_DatasetGetFeatureNames_R    , 5},
-  {"LGBM_DatasetSaveBinary_R"         , (DL_FUNC) &LGBM_DatasetSaveBinary_R         , 3},
-  {"LGBM_DatasetFree_R"               , (DL_FUNC) &LGBM_DatasetFree_R               , 2},
-  {"LGBM_DatasetSetField_R"           , (DL_FUNC) &LGBM_DatasetSetField_R           , 5},
-  {"LGBM_DatasetGetFieldSize_R"       , (DL_FUNC) &LGBM_DatasetGetFieldSize_R       , 4},
-  {"LGBM_DatasetGetField_R"           , (DL_FUNC) &LGBM_DatasetGetField_R           , 4},
-  {"LGBM_DatasetUpdateParamChecking_R", (DL_FUNC) &LGBM_DatasetUpdateParamChecking_R, 3},
-  {"LGBM_DatasetGetNumData_R"         , (DL_FUNC) &LGBM_DatasetGetNumData_R         , 3},
-  {"LGBM_DatasetGetNumFeature_R"      , (DL_FUNC) &LGBM_DatasetGetNumFeature_R      , 3},
-  {"LGBM_BoosterCreate_R"             , (DL_FUNC) &LGBM_BoosterCreate_R             , 4},
-  {"LGBM_BoosterFree_R"               , (DL_FUNC) &LGBM_BoosterFree_R               , 2},
-  {"LGBM_BoosterCreateFromModelfile_R", (DL_FUNC) &LGBM_BoosterCreateFromModelfile_R, 3},
-  {"LGBM_BoosterLoadModelFromString_R", (DL_FUNC) &LGBM_BoosterLoadModelFromString_R, 3},
-  {"LGBM_BoosterMerge_R"              , (DL_FUNC) &LGBM_BoosterMerge_R              , 3},
-  {"LGBM_BoosterAddValidData_R"       , (DL_FUNC) &LGBM_BoosterAddValidData_R       , 3},
-  {"LGBM_BoosterResetTrainingData_R"  , (DL_FUNC) &LGBM_BoosterResetTrainingData_R  , 3},
-  {"LGBM_BoosterResetParameter_R"     , (DL_FUNC) &LGBM_BoosterResetParameter_R     , 3},
-  {"LGBM_BoosterGetNumClasses_R"      , (DL_FUNC) &LGBM_BoosterGetNumClasses_R      , 3},
-  {"LGBM_BoosterUpdateOneIter_R"      , (DL_FUNC) &LGBM_BoosterUpdateOneIter_R      , 2},
-  {"LGBM_BoosterUpdateOneIterCustom_R", (DL_FUNC) &LGBM_BoosterUpdateOneIterCustom_R, 5},
-  {"LGBM_BoosterRollbackOneIter_R"    , (DL_FUNC) &LGBM_BoosterRollbackOneIter_R    , 2},
-  {"LGBM_BoosterGetCurrentIteration_R", (DL_FUNC) &LGBM_BoosterGetCurrentIteration_R, 3},
-  {"LGBM_BoosterGetUpperBoundValue_R" , (DL_FUNC) &LGBM_BoosterGetUpperBoundValue_R , 3},
-  {"LGBM_BoosterGetLowerBoundValue_R" , (DL_FUNC) &LGBM_BoosterGetLowerBoundValue_R , 3},
-  {"LGBM_BoosterGetEvalNames_R"       , (DL_FUNC) &LGBM_BoosterGetEvalNames_R       , 5},
-  {"LGBM_BoosterGetEval_R"            , (DL_FUNC) &LGBM_BoosterGetEval_R            , 4},
-  {"LGBM_BoosterGetNumPredict_R"      , (DL_FUNC) &LGBM_BoosterGetNumPredict_R      , 4},
-  {"LGBM_BoosterGetPredict_R"         , (DL_FUNC) &LGBM_BoosterGetPredict_R         , 4},
-  {"LGBM_BoosterPredictForFile_R"     , (DL_FUNC) &LGBM_BoosterPredictForFile_R     , 11},
-  {"LGBM_BoosterCalcNumPredict_R"     , (DL_FUNC) &LGBM_BoosterCalcNumPredict_R     , 9},
-  {"LGBM_BoosterPredictForCSC_R"      , (DL_FUNC) &LGBM_BoosterPredictForCSC_R      , 15},
-  {"LGBM_BoosterPredictForMat_R"      , (DL_FUNC) &LGBM_BoosterPredictForMat_R      , 12},
-  {"LGBM_BoosterSaveModel_R"          , (DL_FUNC) &LGBM_BoosterSaveModel_R          , 5},
-  {"LGBM_BoosterSaveModelToString_R"  , (DL_FUNC) &LGBM_BoosterSaveModelToString_R  , 7},
-  {"LGBM_BoosterDumpModel_R"          , (DL_FUNC) &LGBM_BoosterDumpModel_R          , 7},
+  {"LGBM_DatasetCreateFromFile_R"     , (DL_FUNC) &LGBM_DatasetCreateFromFile_R     , 4},
+  {"LGBM_DatasetCreateFromCSC_R"      , (DL_FUNC) &LGBM_DatasetCreateFromCSC_R      , 9},
+  {"LGBM_DatasetCreateFromMat_R"      , (DL_FUNC) &LGBM_DatasetCreateFromMat_R      , 6},
+  {"LGBM_DatasetGetSubset_R"          , (DL_FUNC) &LGBM_DatasetGetSubset_R          , 5},
+  {"LGBM_DatasetSetFeatureNames_R"    , (DL_FUNC) &LGBM_DatasetSetFeatureNames_R    , 2},
+  {"LGBM_DatasetGetFeatureNames_R"    , (DL_FUNC) &LGBM_DatasetGetFeatureNames_R    , 4},
+  {"LGBM_DatasetSaveBinary_R"         , (DL_FUNC) &LGBM_DatasetSaveBinary_R         , 2},
+  {"LGBM_DatasetFree_R"               , (DL_FUNC) &LGBM_DatasetFree_R               , 1},
+  {"LGBM_DatasetSetField_R"           , (DL_FUNC) &LGBM_DatasetSetField_R           , 4},
+  {"LGBM_DatasetGetFieldSize_R"       , (DL_FUNC) &LGBM_DatasetGetFieldSize_R       , 3},
+  {"LGBM_DatasetGetField_R"           , (DL_FUNC) &LGBM_DatasetGetField_R           , 3},
+  {"LGBM_DatasetUpdateParamChecking_R", (DL_FUNC) &LGBM_DatasetUpdateParamChecking_R, 2},
+  {"LGBM_DatasetGetNumData_R"         , (DL_FUNC) &LGBM_DatasetGetNumData_R         , 2},
+  {"LGBM_DatasetGetNumFeature_R"      , (DL_FUNC) &LGBM_DatasetGetNumFeature_R      , 2},
+  {"LGBM_BoosterCreate_R"             , (DL_FUNC) &LGBM_BoosterCreate_R             , 3},
+  {"LGBM_BoosterFree_R"               , (DL_FUNC) &LGBM_BoosterFree_R               , 1},
+  {"LGBM_BoosterCreateFromModelfile_R", (DL_FUNC) &LGBM_BoosterCreateFromModelfile_R, 2},
+  {"LGBM_BoosterLoadModelFromString_R", (DL_FUNC) &LGBM_BoosterLoadModelFromString_R, 2},
+  {"LGBM_BoosterMerge_R"              , (DL_FUNC) &LGBM_BoosterMerge_R              , 2},
+  {"LGBM_BoosterAddValidData_R"       , (DL_FUNC) &LGBM_BoosterAddValidData_R       , 2},
+  {"LGBM_BoosterResetTrainingData_R"  , (DL_FUNC) &LGBM_BoosterResetTrainingData_R  , 2},
+  {"LGBM_BoosterResetParameter_R"     , (DL_FUNC) &LGBM_BoosterResetParameter_R     , 2},
+  {"LGBM_BoosterGetNumClasses_R"      , (DL_FUNC) &LGBM_BoosterGetNumClasses_R      , 2},
+  {"LGBM_BoosterUpdateOneIter_R"      , (DL_FUNC) &LGBM_BoosterUpdateOneIter_R      , 1},
+  {"LGBM_BoosterUpdateOneIterCustom_R", (DL_FUNC) &LGBM_BoosterUpdateOneIterCustom_R, 4},
+  {"LGBM_BoosterRollbackOneIter_R"    , (DL_FUNC) &LGBM_BoosterRollbackOneIter_R    , 1},
+  {"LGBM_BoosterGetCurrentIteration_R", (DL_FUNC) &LGBM_BoosterGetCurrentIteration_R, 2},
+  {"LGBM_BoosterGetUpperBoundValue_R" , (DL_FUNC) &LGBM_BoosterGetUpperBoundValue_R , 2},
+  {"LGBM_BoosterGetLowerBoundValue_R" , (DL_FUNC) &LGBM_BoosterGetLowerBoundValue_R , 2},
+  {"LGBM_BoosterGetEvalNames_R"       , (DL_FUNC) &LGBM_BoosterGetEvalNames_R       , 4},
+  {"LGBM_BoosterGetEval_R"            , (DL_FUNC) &LGBM_BoosterGetEval_R            , 3},
+  {"LGBM_BoosterGetNumPredict_R"      , (DL_FUNC) &LGBM_BoosterGetNumPredict_R      , 3},
+  {"LGBM_BoosterGetPredict_R"         , (DL_FUNC) &LGBM_BoosterGetPredict_R         , 3},
+  {"LGBM_BoosterPredictForFile_R"     , (DL_FUNC) &LGBM_BoosterPredictForFile_R     , 10},
+  {"LGBM_BoosterCalcNumPredict_R"     , (DL_FUNC) &LGBM_BoosterCalcNumPredict_R     , 8},
+  {"LGBM_BoosterPredictForCSC_R"      , (DL_FUNC) &LGBM_BoosterPredictForCSC_R      , 14},
+  {"LGBM_BoosterPredictForMat_R"      , (DL_FUNC) &LGBM_BoosterPredictForMat_R      , 11},
+  {"LGBM_BoosterSaveModel_R"          , (DL_FUNC) &LGBM_BoosterSaveModel_R          , 4},
+  {"LGBM_BoosterSaveModelToString_R"  , (DL_FUNC) &LGBM_BoosterSaveModelToString_R  , 6},
+  {"LGBM_BoosterDumpModel_R"          , (DL_FUNC) &LGBM_BoosterDumpModel_R          , 6},
   {NULL, NULL, 0}
 };
 

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -31,12 +31,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_GetLastError_R(
 * \param out created dataset
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromFile_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromFile_R(
   LGBM_SE filename,
   LGBM_SE parameters,
   LGBM_SE reference,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 /*!
@@ -52,7 +51,7 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromFile_R(
 * \param out created dataset
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromCSC_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromCSC_R(
   LGBM_SE indptr,
   LGBM_SE indices,
   LGBM_SE data,
@@ -61,8 +60,7 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromCSC_R(
   LGBM_SE num_row,
   LGBM_SE parameters,
   LGBM_SE reference,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 /*!
@@ -75,14 +73,13 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromCSC_R(
 * \param out created dataset
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromMat_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromMat_R(
   LGBM_SE data,
   LGBM_SE nrow,
   LGBM_SE ncol,
   LGBM_SE parameters,
   LGBM_SE reference,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 /*!
@@ -94,13 +91,12 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetCreateFromMat_R(
 * \param out created dataset
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetSubset_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetSubset_R(
   LGBM_SE handle,
   LGBM_SE used_row_indices,
   LGBM_SE len_used_row_indices,
   LGBM_SE parameters,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 /*!
@@ -109,10 +105,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetSubset_R(
 * \param feature_names feature names
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSetFeatureNames_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetFeatureNames_R(
   LGBM_SE handle,
-  LGBM_SE feature_names,
-  LGBM_SE call_state
+  LGBM_SE feature_names
 );
 
 /*!
@@ -121,12 +116,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSetFeatureNames_R(
 * \param feature_names feature names
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetFeatureNames_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetFeatureNames_R(
   LGBM_SE handle,
   LGBM_SE buf_len,
   LGBM_SE actual_len,
-  LGBM_SE feature_names,
-  LGBM_SE call_state
+  LGBM_SE feature_names
 );
 
 /*!
@@ -135,10 +129,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetFeatureNames_R(
 * \param filename file name
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSaveBinary_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSaveBinary_R(
   LGBM_SE handle,
-  LGBM_SE filename,
-  LGBM_SE call_state
+  LGBM_SE filename
 );
 
 /*!
@@ -146,9 +139,8 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSaveBinary_R(
 * \param handle an instance of dataset
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetFree_R(
-  LGBM_SE handle,
-  LGBM_SE call_state
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetFree_R(
+  LGBM_SE handle
 );
 
 /*!
@@ -161,12 +153,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetFree_R(
 * \param num_element number of element in field_data
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSetField_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetField_R(
   LGBM_SE handle,
   LGBM_SE field_name,
   LGBM_SE field_data,
-  LGBM_SE num_element,
-  LGBM_SE call_state
+  LGBM_SE num_element
 );
 
 /*!
@@ -176,11 +167,10 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetSetField_R(
 * \param out size of info vector from dataset
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetFieldSize_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetFieldSize_R(
   LGBM_SE handle,
   LGBM_SE field_name,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 /*!
@@ -190,11 +180,10 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetFieldSize_R(
 * \param field_data pointer to vector
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetField_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetField_R(
   LGBM_SE handle,
   LGBM_SE field_name,
-  LGBM_SE field_data,
-  LGBM_SE call_state
+  LGBM_SE field_data
 );
 
 /*!
@@ -203,10 +192,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetField_R(
  * \param new_params New dataset parameters
  * \return 0 when succeed, -1 when failure happens
  */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetUpdateParamChecking_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetUpdateParamChecking_R(
   LGBM_SE old_params,
-  LGBM_SE new_params,
-  LGBM_SE call_state
+  LGBM_SE new_params
 );
 
 /*!
@@ -215,10 +203,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetUpdateParamChecking_R(
 * \param out The address to hold number of data
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetNumData_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetNumData_R(
   LGBM_SE handle,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 /*!
@@ -227,10 +214,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetNumData_R(
 * \param out The output of number of features
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetNumFeature_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetNumFeature_R(
   LGBM_SE handle,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 // --- start Booster interfaces
@@ -242,11 +228,10 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_DatasetGetNumFeature_R(
 * \param out handle of created Booster
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCreate_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterCreate_R(
   LGBM_SE train_data,
   LGBM_SE parameters,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 /*!
@@ -254,9 +239,8 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCreate_R(
 * \param handle handle to be freed
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterFree_R(
-  LGBM_SE handle,
-  LGBM_SE call_state
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterFree_R(
+  LGBM_SE handle
 );
 
 /*!
@@ -265,10 +249,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterFree_R(
 * \param out handle of created Booster
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCreateFromModelfile_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterCreateFromModelfile_R(
   LGBM_SE filename,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 /*!
@@ -277,10 +260,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCreateFromModelfile_R(
 * \param out handle of created Booster
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterLoadModelFromString_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterLoadModelFromString_R(
   LGBM_SE model_str,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 /*!
@@ -289,10 +271,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterLoadModelFromString_R(
 * \param other_handle
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterMerge_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterMerge_R(
   LGBM_SE handle,
-  LGBM_SE other_handle,
-  LGBM_SE call_state
+  LGBM_SE other_handle
 );
 
 /*!
@@ -301,10 +282,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterMerge_R(
 * \param valid_data validation data set
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterAddValidData_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterAddValidData_R(
   LGBM_SE handle,
-  LGBM_SE valid_data,
-  LGBM_SE call_state
+  LGBM_SE valid_data
 );
 
 /*!
@@ -313,10 +293,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterAddValidData_R(
 * \param train_data training data set
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterResetTrainingData_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterResetTrainingData_R(
   LGBM_SE handle,
-  LGBM_SE train_data,
-  LGBM_SE call_state
+  LGBM_SE train_data
 );
 
 /*!
@@ -325,10 +304,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterResetTrainingData_R(
 * \param parameters format: 'key1=value1 key2=value2'
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterResetParameter_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterResetParameter_R(
   LGBM_SE handle,
-  LGBM_SE parameters,
-  LGBM_SE call_state
+  LGBM_SE parameters
 );
 
 /*!
@@ -337,10 +315,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterResetParameter_R(
 * \param out number of classes
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetNumClasses_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetNumClasses_R(
   LGBM_SE handle,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 /*!
@@ -348,9 +325,8 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetNumClasses_R(
 * \param handle handle
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterUpdateOneIter_R(
-  LGBM_SE handle,
-  LGBM_SE call_state
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterUpdateOneIter_R(
+  LGBM_SE handle
 );
 
 /*!
@@ -362,12 +338,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterUpdateOneIter_R(
 * \param len length of grad/hess
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterUpdateOneIterCustom_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterUpdateOneIterCustom_R(
   LGBM_SE handle,
   LGBM_SE grad,
   LGBM_SE hess,
-  LGBM_SE len,
-  LGBM_SE call_state
+  LGBM_SE len
 );
 
 /*!
@@ -375,9 +350,8 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterUpdateOneIterCustom_R(
 * \param handle handle
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterRollbackOneIter_R(
-  LGBM_SE handle,
-  LGBM_SE call_state
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterRollbackOneIter_R(
+  LGBM_SE handle
 );
 
 /*!
@@ -385,10 +359,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterRollbackOneIter_R(
 * \param out iteration of boosting rounds
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetCurrentIteration_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetCurrentIteration_R(
   LGBM_SE handle,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 /*!
@@ -397,10 +370,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetCurrentIteration_R(
 * \param[out] out_results Result pointing to max value
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetUpperBoundValue_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetUpperBoundValue_R(
     LGBM_SE handle,
-    LGBM_SE out_result,
-    LGBM_SE call_state
+    LGBM_SE out_result
 );
 
 /*!
@@ -409,10 +381,9 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetUpperBoundValue_R(
 * \param[out] out_results Result pointing to min value
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetLowerBoundValue_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetLowerBoundValue_R(
     LGBM_SE handle,
-    LGBM_SE out_result,
-    LGBM_SE call_state
+    LGBM_SE out_result
 );
 
 /*!
@@ -420,12 +391,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetLowerBoundValue_R(
 * \param eval_names eval names
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetEvalNames_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEvalNames_R(
   LGBM_SE handle,
   LGBM_SE buf_len,
   LGBM_SE actual_len,
-  LGBM_SE eval_names,
-  LGBM_SE call_state
+  LGBM_SE eval_names
 );
 
 /*!
@@ -435,11 +405,10 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetEvalNames_R(
 * \param out_result float array contains result
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetEval_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEval_R(
   LGBM_SE handle,
   LGBM_SE data_idx,
-  LGBM_SE out_result,
-  LGBM_SE call_state
+  LGBM_SE out_result
 );
 
 /*!
@@ -449,11 +418,10 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetEval_R(
 * \param out size of predict
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetNumPredict_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetNumPredict_R(
   LGBM_SE handle,
   LGBM_SE data_idx,
-  LGBM_SE out,
-  LGBM_SE call_state
+  LGBM_SE out
 );
 
 /*!
@@ -464,11 +432,10 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetNumPredict_R(
 * \param out_result, used to store predict result, should pre-allocate memory
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetPredict_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetPredict_R(
   LGBM_SE handle,
   LGBM_SE data_idx,
-  LGBM_SE out_result,
-  LGBM_SE call_state
+  LGBM_SE out_result
 );
 
 /*!
@@ -482,7 +449,7 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterGetPredict_R(
 * \return 0 when succeed, -1 when failure happens
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForFile_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForFile_R(
   LGBM_SE handle,
   LGBM_SE data_filename,
   LGBM_SE data_has_header,
@@ -492,8 +459,7 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForFile_R(
   LGBM_SE start_iteration,
   LGBM_SE num_iteration,
   LGBM_SE parameter,
-  LGBM_SE result_filename,
-  LGBM_SE call_state
+  LGBM_SE result_filename
 );
 
 /*!
@@ -506,7 +472,7 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForFile_R(
 * \param out_len length of prediction
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCalcNumPredict_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterCalcNumPredict_R(
   LGBM_SE handle,
   LGBM_SE num_row,
   LGBM_SE is_rawscore,
@@ -514,8 +480,7 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCalcNumPredict_R(
   LGBM_SE is_predcontrib,
   LGBM_SE start_iteration,
   LGBM_SE num_iteration,
-  LGBM_SE out_len,
-  LGBM_SE call_state
+  LGBM_SE out_len
 );
 
 /*!
@@ -536,7 +501,7 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterCalcNumPredict_R(
 * \param out prediction result
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForCSC_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForCSC_R(
   LGBM_SE handle,
   LGBM_SE indptr,
   LGBM_SE indices,
@@ -550,8 +515,7 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForCSC_R(
   LGBM_SE start_iteration,
   LGBM_SE num_iteration,
   LGBM_SE parameter,
-  LGBM_SE out_result,
-  LGBM_SE call_state
+  LGBM_SE out_result
 );
 
 /*!
@@ -569,7 +533,7 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForCSC_R(
 * \param out prediction result
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForMat_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForMat_R(
   LGBM_SE handle,
   LGBM_SE data,
   LGBM_SE nrow,
@@ -580,8 +544,7 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForMat_R(
   LGBM_SE start_iteration,
   LGBM_SE num_iteration,
   LGBM_SE parameter,
-  LGBM_SE out_result,
-  LGBM_SE call_state
+  LGBM_SE out_result
 );
 
 /*!
@@ -591,12 +554,11 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterPredictForMat_R(
 * \param filename file name
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterSaveModel_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModel_R(
   LGBM_SE handle,
   LGBM_SE num_iteration,
   LGBM_SE feature_importance_type,
-  LGBM_SE filename,
-  LGBM_SE call_state
+  LGBM_SE filename
 );
 
 /*!
@@ -606,14 +568,13 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterSaveModel_R(
 * \param out_str string of model
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterSaveModelToString_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModelToString_R(
   LGBM_SE handle,
   LGBM_SE num_iteration,
   LGBM_SE feature_importance_type,
   LGBM_SE buffer_len,
   LGBM_SE actual_len,
-  LGBM_SE out_str,
-  LGBM_SE call_state
+  LGBM_SE out_str
 );
 
 /*!
@@ -623,14 +584,13 @@ LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterSaveModelToString_R(
 * \param out_str json format string of model
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT LGBM_SE LGBM_BoosterDumpModel_R(
+LIGHTGBM_C_EXPORT SEXP LGBM_BoosterDumpModel_R(
   LGBM_SE handle,
   LGBM_SE num_iteration,
   LGBM_SE feature_importance_type,
   LGBM_SE buffer_len,
   LGBM_SE actual_len,
-  LGBM_SE out_str,
-  LGBM_SE call_state
+  LGBM_SE out_str
 );
 
 #endif  // LIGHTGBM_R_H_

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -75,7 +75,6 @@ test_that("lgb.Dataset: Dataset should be able to construct from matrix and retu
   rawData <- matrix(runif(1000L), ncol = 10L)
   handle <- lgb.null.handle()
   ref_handle <- NULL
-  call_state <- 0L
   .Call(
     LGBM_DatasetCreateFromMat_R
     , rawData
@@ -84,11 +83,9 @@ test_that("lgb.Dataset: Dataset should be able to construct from matrix and retu
     , lightgbm:::lgb.params2str(params = list())
     , ref_handle
     , handle
-    , call_state
   )
   expect_false(is.na(handle))
-  call_state <- 0L
-  .Call(LGBM_DatasetFree_R, handle, call_state)
+  .Call(LGBM_DatasetFree_R, handle)
   handle <- NULL
 })
 

--- a/build_r.R
+++ b/build_r.R
@@ -391,6 +391,11 @@ c_api_contents <- gsub(
   , replacement = ""
   , x = c_api_contents
 )
+c_api_contents <- gsub(
+  pattern = "LIGHTGBM_C_EXPORT SEXP "
+  , replacement = ""
+  , x = c_api_contents
+)
 c_api_symbols <- gsub(
   pattern = "\\("
   , replacement = ""


### PR DESCRIPTION
This is another step towards #3016.

As of #4155 and #4163, the R package use `.Call()` to call routines from the C++ library. Currently, an integer called `call_state` is initialized on the R side before each such call, its value is manipulated during the call, and its value is returned by each call. Initializing this integer and passing it around is unnecessary, because nothing is done with it on the R side after the call completes. All uses of `.Call()` in the R package (except in calls to `LGBM_GetLastError_R`) modify their inputs by reference and do not return anything.

This PR proposes simplifying the R package and removing unnecessary memory usage and computation by removing the `call_state` concept. Instead, the functions defined in https://github.com/microsoft/LightGBM/blob/b27dcfa48f76e77c9e5033dcdefc1f3a76d99c8b/R-package/src/lightgbm_R.h are converted to return a `SEXP` (R's built-in type for passing data between R and C). This is initialized on the C++ side.

### Notes for Reviewers

If you want to learn more about the R `SEXP` object, see https://cran.r-project.org/doc/manuals/r-release/R-ints.html#SEXPs.