### PR TITLE
[R-package] use R standard routine to access read-only ints passed to C++

### DIFF
--- a/R-package/src/R_object_helper.h
+++ b/R-package/src/R_object_helper.h
@@ -106,8 +106,6 @@ typedef union { VECTOR_SER s; double align; } SEXPREC_ALIGN;
 
 #define R_REAL_PTR(x)  (reinterpret_cast<double*> DATAPTR(x))
 
-#define R_AS_INT(x)    (*(reinterpret_cast<int*> DATAPTR(x)))
-
 #define R_IS_NULL(x)   ((*reinterpret_cast<LGBM_SE>(x)).sxpinfo.type == 0)
 
 // 64bit pointer

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -622,8 +622,9 @@ SEXP LGBM_BoosterSaveModelToString_R(LGBM_SE handle,
   LGBM_SE out_str) {
   R_API_BEGIN();
   int64_t out_len = 0;
-  std::vector<char> inner_char_buf(Rf_asInteger(buffer_len));
-  CHECK_CALL(LGBM_BoosterSaveModelToString(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), Rf_asInteger(buffer_len), &out_len, inner_char_buf.data()));
+  int64_t buf_len = static_cast<int64_t>(Rf_asInteger(buffer_len));
+  std::vector<char> inner_char_buf(buf_len);
+  CHECK_CALL(LGBM_BoosterSaveModelToString(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
   EncodeChar(out_str, inner_char_buf.data(), buffer_len, actual_len, static_cast<size_t>(out_len));
   R_API_END();
 }
@@ -636,8 +637,9 @@ SEXP LGBM_BoosterDumpModel_R(LGBM_SE handle,
   LGBM_SE out_str) {
   R_API_BEGIN();
   int64_t out_len = 0;
-  std::vector<char> inner_char_buf(Rf_asInteger(buffer_len));
-  CHECK_CALL(LGBM_BoosterDumpModel(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), Rf_asInteger(buffer_len), &out_len, inner_char_buf.data()));
+  int64_t buf_len = static_cast<int64_t>(Rf_asInteger(buffer_len));
+  std::vector<char> inner_char_buf(buf_len);
+  CHECK_CALL(LGBM_BoosterDumpModel(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
   EncodeChar(out_str, inner_char_buf.data(), buffer_len, actual_len, static_cast<size_t>(out_len));
   R_API_END();
 }

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -43,7 +43,7 @@ using LightGBM::Common::Join;
 using LightGBM::Common::Split;
 using LightGBM::Log;
 
-LGBM_SE EncodeChar(LGBM_SE dest, const char* src, LGBM_SE buf_len, LGBM_SE actual_len, size_t str_len) {
+LGBM_SE EncodeChar(LGBM_SE dest, const char* src, SEXP buf_len, LGBM_SE actual_len, size_t str_len) {
   if (str_len > INT32_MAX) {
     Log::Fatal("Don't support large string in R-package");
   }
@@ -56,7 +56,7 @@ LGBM_SE EncodeChar(LGBM_SE dest, const char* src, LGBM_SE buf_len, LGBM_SE actua
   return dest;
 }
 
-LGBM_SE LGBM_GetLastError_R(LGBM_SE buf_len, LGBM_SE actual_len, LGBM_SE err_msg) {
+LGBM_SE LGBM_GetLastError_R(SEXP buf_len, LGBM_SE actual_len, LGBM_SE err_msg) {
   return EncodeChar(err_msg, LGBM_GetLastError(), buf_len, actual_len, std::strlen(LGBM_GetLastError()) + 1);
 }
 
@@ -150,7 +150,7 @@ SEXP LGBM_DatasetSetFeatureNames_R(LGBM_SE handle,
 }
 
 SEXP LGBM_DatasetGetFeatureNames_R(LGBM_SE handle,
-  LGBM_SE buf_len,
+  SEXP buf_len,
   LGBM_SE actual_len,
   LGBM_SE feature_names) {
   R_API_BEGIN();
@@ -429,7 +429,7 @@ SEXP LGBM_BoosterGetLowerBoundValue_R(LGBM_SE handle,
 }
 
 SEXP LGBM_BoosterGetEvalNames_R(LGBM_SE handle,
-  LGBM_SE buf_len,
+  SEXP buf_len,
   LGBM_SE actual_len,
   LGBM_SE eval_names) {
   R_API_BEGIN();
@@ -492,7 +492,6 @@ SEXP LGBM_BoosterGetPredict_R(LGBM_SE handle,
   R_API_END();
 }
 
-// https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Some-convenience-functions
 int GetPredictType(SEXP is_rawscore, SEXP is_leafidx, SEXP is_predcontrib) {
   int pred_type = C_API_PREDICT_NORMAL;
   if (Rf_asInteger(is_rawscore)) {

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -16,7 +16,7 @@
 * \return error information
 */
 LIGHTGBM_C_EXPORT LGBM_SE LGBM_GetLastError_R(
-    LGBM_SE buf_len,
+    SEXP buf_len,
     LGBM_SE actual_len,
     LGBM_SE err_msg
 );
@@ -118,7 +118,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetFeatureNames_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetFeatureNames_R(
   LGBM_SE handle,
-  LGBM_SE buf_len,
+  SEXP buf_len,
   LGBM_SE actual_len,
   LGBM_SE feature_names
 );
@@ -393,7 +393,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetLowerBoundValue_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEvalNames_R(
   LGBM_SE handle,
-  LGBM_SE buf_len,
+  SEXP buf_len,
   LGBM_SE actual_len,
   LGBM_SE eval_names
 );

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -43,7 +43,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromFile_R(
 * \param indptr pointer to row headers
 * \param indices findex
 * \param data fvalue
-* \param nindptr number of cols in the matrix + 1
+* \param num_indptr number of cols in the matrix + 1
 * \param nelem number of nonzero elements in the matrix
 * \param num_row number of rows
 * \param parameters additional parameters
@@ -55,9 +55,9 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromCSC_R(
   LGBM_SE indptr,
   LGBM_SE indices,
   LGBM_SE data,
-  LGBM_SE nindptr,
-  LGBM_SE nelem,
-  LGBM_SE num_row,
+  SEXP num_indptr,
+  SEXP nelem,
+  SEXP num_row,
   LGBM_SE parameters,
   LGBM_SE reference,
   LGBM_SE out
@@ -66,8 +66,8 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromCSC_R(
 /*!
 * \brief create dataset from dense matrix
 * \param data matric data
-* \param nrow number of rows
-* \param ncol number columns
+* \param num_row number of rows
+* \param num_col number columns
 * \param parameters additional parameters
 * \param reference used to align bin mapper with other dataset, nullptr means not used
 * \param out created dataset
@@ -75,8 +75,8 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromCSC_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromMat_R(
   LGBM_SE data,
-  LGBM_SE nrow,
-  LGBM_SE ncol,
+  SEXP num_row,
+  SEXP num_col,
   LGBM_SE parameters,
   LGBM_SE reference,
   LGBM_SE out
@@ -94,7 +94,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromMat_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetSubset_R(
   LGBM_SE handle,
   LGBM_SE used_row_indices,
-  LGBM_SE len_used_row_indices,
+  SEXP len_used_row_indices,
   LGBM_SE parameters,
   LGBM_SE out
 );
@@ -157,7 +157,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetField_R(
   LGBM_SE handle,
   LGBM_SE field_name,
   LGBM_SE field_data,
-  LGBM_SE num_element
+  SEXP num_element
 );
 
 /*!
@@ -342,7 +342,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterUpdateOneIterCustom_R(
   LGBM_SE handle,
   LGBM_SE grad,
   LGBM_SE hess,
-  LGBM_SE len
+  SEXP len
 );
 
 /*!
@@ -407,7 +407,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEvalNames_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEval_R(
   LGBM_SE handle,
-  LGBM_SE data_idx,
+  SEXP data_idx,
   LGBM_SE out_result
 );
 
@@ -420,7 +420,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEval_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetNumPredict_R(
   LGBM_SE handle,
-  LGBM_SE data_idx,
+  SEXP data_idx,
   LGBM_SE out
 );
 
@@ -434,7 +434,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetNumPredict_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetPredict_R(
   LGBM_SE handle,
-  LGBM_SE data_idx,
+  SEXP data_idx,
   LGBM_SE out_result
 );
 
@@ -452,12 +452,12 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetPredict_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForFile_R(
   LGBM_SE handle,
   LGBM_SE data_filename,
-  LGBM_SE data_has_header,
-  LGBM_SE is_rawscore,
-  LGBM_SE is_leafidx,
-  LGBM_SE is_predcontrib,
-  LGBM_SE start_iteration,
-  LGBM_SE num_iteration,
+  SEXP data_has_header,
+  SEXP is_rawscore,
+  SEXP is_leafidx,
+  SEXP is_predcontrib,
+  SEXP start_iteration,
+  SEXP num_iteration,
   LGBM_SE parameter,
   LGBM_SE result_filename
 );
@@ -474,12 +474,12 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForFile_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterCalcNumPredict_R(
   LGBM_SE handle,
-  LGBM_SE num_row,
-  LGBM_SE is_rawscore,
-  LGBM_SE is_leafidx,
-  LGBM_SE is_predcontrib,
-  LGBM_SE start_iteration,
-  LGBM_SE num_iteration,
+  SEXP num_row,
+  SEXP is_rawscore,
+  SEXP is_leafidx,
+  SEXP is_predcontrib,
+  SEXP start_iteration,
+  SEXP num_iteration,
   LGBM_SE out_len
 );
 
@@ -492,7 +492,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterCalcNumPredict_R(
 * \param indptr pointer to row headers
 * \param indices findex
 * \param data fvalue
-* \param nindptr number of cols in the matrix + 1
+* \param num_indptr number of cols in the matrix + 1
 * \param nelem number of non-zero elements in the matrix
 * \param num_row number of rows
 * \param is_rawscore
@@ -506,14 +506,14 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForCSC_R(
   LGBM_SE indptr,
   LGBM_SE indices,
   LGBM_SE data,
-  LGBM_SE nindptr,
-  LGBM_SE nelem,
-  LGBM_SE num_row,
-  LGBM_SE is_rawscore,
-  LGBM_SE is_leafidx,
-  LGBM_SE is_predcontrib,
-  LGBM_SE start_iteration,
-  LGBM_SE num_iteration,
+  SEXP num_indptr,
+  SEXP nelem,
+  SEXP num_row,
+  SEXP is_rawscore,
+  SEXP is_leafidx,
+  SEXP is_predcontrib,
+  SEXP start_iteration,
+  SEXP num_iteration,
   LGBM_SE parameter,
   LGBM_SE out_result
 );
@@ -525,8 +525,8 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForCSC_R(
 *               for leaf index, its length is equal to num_class * num_data * num_iteration
 * \param handle handle
 * \param data pointer to the data space
-* \param nrow number of rows
-* \param ncol number columns
+* \param num_row number of rows
+* \param num_col number columns
 * \param is_rawscore
 * \param is_leafidx
 * \param num_iteration number of iteration for prediction, <= 0 means no limit
@@ -536,13 +536,13 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForCSC_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForMat_R(
   LGBM_SE handle,
   LGBM_SE data,
-  LGBM_SE nrow,
-  LGBM_SE ncol,
-  LGBM_SE is_rawscore,
-  LGBM_SE is_leafidx,
-  LGBM_SE is_predcontrib,
-  LGBM_SE start_iteration,
-  LGBM_SE num_iteration,
+  SEXP num_row,
+  SEXP num_col,
+  SEXP is_rawscore,
+  SEXP is_leafidx,
+  SEXP is_predcontrib,
+  SEXP start_iteration,
+  SEXP num_iteration,
   LGBM_SE parameter,
   LGBM_SE out_result
 );
@@ -556,8 +556,8 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForMat_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModel_R(
   LGBM_SE handle,
-  LGBM_SE num_iteration,
-  LGBM_SE feature_importance_type,
+  SEXP num_iteration,
+  SEXP feature_importance_type,
   LGBM_SE filename
 );
 
@@ -570,9 +570,9 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModel_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModelToString_R(
   LGBM_SE handle,
-  LGBM_SE num_iteration,
-  LGBM_SE feature_importance_type,
-  LGBM_SE buffer_len,
+  SEXP num_iteration,
+  SEXP feature_importance_type,
+  SEXP buffer_len,
   LGBM_SE actual_len,
   LGBM_SE out_str
 );
@@ -586,9 +586,9 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModelToString_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterDumpModel_R(
   LGBM_SE handle,
-  LGBM_SE num_iteration,
-  LGBM_SE feature_importance_type,
-  LGBM_SE buffer_len,
+  SEXP num_iteration,
+  SEXP feature_importance_type,
+  SEXP buffer_len,
   LGBM_SE actual_len,
   LGBM_SE out_str
 );


### PR DESCRIPTION
This is another step towards #3016. It proposed using R's standard interface to handle integers passed into the C++ side (for things like array size, buffer size, number of iterations, etc.).

Changes in this PR:

* use R builtin `SEXP` type for any arguments passed from R to C++ that should be read-only integers
* use R builtin `Rf_asInteger()` to convert those SEXP objects to ints (replacing LightGBM's `R_AS_INT`)
* fix minor inconsistencies between `lightgbm_R.h` and `lightgbm_R.cpp` (e.g. parameter named `nrow` in the header file and `num_row` in the implementation)

### Background

There is not a scalar integer type in R. When you run some code like `x <- 1L`, R creates a length-one **array** (referred to in R as a "vector").

To treat such data as an integer, instead of an integer array, in C/C++, it's necessary to extract the first element of that array into a new `int`. R provides a convenience function, `Rf_asInteger()`, for exactly that purpose.

See https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Some-convenience-functions for more details.

### Notes for Reviewers

This does not rely on #4242