### PR TITLE
[R-package] Use R standard routines to access numeric and integer array data in C++

### DIFF
--- a/R-package/src/R_object_helper.h
+++ b/R-package/src/R_object_helper.h
@@ -102,8 +102,6 @@ typedef union { VECTOR_SER s; double align; } SEXPREC_ALIGN;
 
 #define R_CHAR_PTR(x)  (reinterpret_cast<char*>DATAPTR(x))
 
-#define R_INT_PTR(x)   (reinterpret_cast<int*> DATAPTR(x))
-
 #define R_AS_INT(x)    (*(reinterpret_cast<int*> DATAPTR(x)))
 
 #define R_IS_NULL(x)   ((*reinterpret_cast<LGBM_SE>(x)).sxpinfo.type == 0)

--- a/R-package/src/R_object_helper.h
+++ b/R-package/src/R_object_helper.h
@@ -104,8 +104,6 @@ typedef union { VECTOR_SER s; double align; } SEXPREC_ALIGN;
 
 #define R_INT_PTR(x)   (reinterpret_cast<int*> DATAPTR(x))
 
-#define R_REAL_PTR(x)  (reinterpret_cast<double*> DATAPTR(x))
-
 #define R_AS_INT(x)    (*(reinterpret_cast<int*> DATAPTR(x)))
 
 #define R_IS_NULL(x)   ((*reinterpret_cast<LGBM_SE>(x)).sxpinfo.type == 0)

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -97,7 +97,7 @@ SEXP LGBM_DatasetCreateFromCSC_R(LGBM_SE indptr,
   R_API_END();
 }
 
-SEXP LGBM_DatasetCreateFromMat_R(LGBM_SE data,
+SEXP LGBM_DatasetCreateFromMat_R(SEXP data,
   LGBM_SE num_row,
   LGBM_SE num_col,
   LGBM_SE parameters,
@@ -106,7 +106,7 @@ SEXP LGBM_DatasetCreateFromMat_R(LGBM_SE data,
   R_API_BEGIN();
   int32_t nrow = static_cast<int32_t>(R_AS_INT(num_row));
   int32_t ncol = static_cast<int32_t>(R_AS_INT(num_col));
-  double* p_mat = R_REAL_PTR(data);
+  double* p_mat = REAL(data);
   DatasetHandle handle = nullptr;
   CHECK_CALL(LGBM_DatasetCreateFromMat(p_mat, C_API_DTYPE_FLOAT64, nrow, ncol, COL_MAJOR,
     R_CHAR_PTR(parameters), R_GET_PTR(reference), &handle));

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -54,7 +54,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromFile_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromCSC_R(
   LGBM_SE indptr,
   LGBM_SE indices,
-  LGBM_SE data,
+  SEXP data,
   LGBM_SE nindptr,
   LGBM_SE nelem,
   LGBM_SE num_row,
@@ -156,7 +156,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetFree_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetField_R(
   LGBM_SE handle,
   LGBM_SE field_name,
-  LGBM_SE field_data,
+  SEXP field_data,
   LGBM_SE num_element
 );
 
@@ -183,7 +183,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetFieldSize_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetField_R(
   LGBM_SE handle,
   LGBM_SE field_name,
-  LGBM_SE field_data
+  SEXP field_data
 );
 
 /*!
@@ -340,8 +340,8 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterUpdateOneIter_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterUpdateOneIterCustom_R(
   LGBM_SE handle,
-  LGBM_SE grad,
-  LGBM_SE hess,
+  SEXP grad,
+  SEXP hess,
   LGBM_SE len
 );
 
@@ -372,7 +372,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetCurrentIteration_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetUpperBoundValue_R(
     LGBM_SE handle,
-    LGBM_SE out_result
+    SEXP out_result
 );
 
 /*!
@@ -383,7 +383,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetUpperBoundValue_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetLowerBoundValue_R(
     LGBM_SE handle,
-    LGBM_SE out_result
+    SEXP out_result
 );
 
 /*!
@@ -408,7 +408,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEvalNames_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEval_R(
   LGBM_SE handle,
   LGBM_SE data_idx,
-  LGBM_SE out_result
+  SEXP out_result
 );
 
 /*!
@@ -435,7 +435,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetNumPredict_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetPredict_R(
   LGBM_SE handle,
   LGBM_SE data_idx,
-  LGBM_SE out_result
+  SEXP out_result
 );
 
 /*!
@@ -505,7 +505,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForCSC_R(
   LGBM_SE handle,
   LGBM_SE indptr,
   LGBM_SE indices,
-  LGBM_SE data,
+  SEXP data,
   LGBM_SE nindptr,
   LGBM_SE nelem,
   LGBM_SE num_row,
@@ -515,7 +515,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForCSC_R(
   LGBM_SE start_iteration,
   LGBM_SE num_iteration,
   LGBM_SE parameter,
-  LGBM_SE out_result
+  SEXP out_result
 );
 
 /*!
@@ -535,7 +535,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForCSC_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForMat_R(
   LGBM_SE handle,
-  LGBM_SE data,
+  SEXP data,
   LGBM_SE nrow,
   LGBM_SE ncol,
   LGBM_SE is_rawscore,
@@ -544,7 +544,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForMat_R(
   LGBM_SE start_iteration,
   LGBM_SE num_iteration,
   LGBM_SE parameter,
-  LGBM_SE out_result
+  SEXP out_result
 );
 
 /*!

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -74,7 +74,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromCSC_R(
 * \return 0 when succeed, -1 when failure happens
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromMat_R(
-  LGBM_SE data,
+  SEXP data,
   LGBM_SE nrow,
   LGBM_SE ncol,
   LGBM_SE parameters,

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -17,7 +17,7 @@
 */
 LIGHTGBM_C_EXPORT LGBM_SE LGBM_GetLastError_R(
     LGBM_SE buf_len,
-    LGBM_SE actual_len,
+    SEXP actual_len,
     LGBM_SE err_msg
 );
 
@@ -52,8 +52,8 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromFile_R(
 * \return 0 when succeed, -1 when failure happens
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromCSC_R(
-  LGBM_SE indptr,
-  LGBM_SE indices,
+  SEXP indptr,
+  SEXP indices,
   SEXP data,
   LGBM_SE nindptr,
   LGBM_SE nelem,
@@ -93,7 +93,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromMat_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetSubset_R(
   LGBM_SE handle,
-  LGBM_SE used_row_indices,
+  SEXP used_row_indices,
   LGBM_SE len_used_row_indices,
   LGBM_SE parameters,
   LGBM_SE out
@@ -119,7 +119,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetFeatureNames_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetFeatureNames_R(
   LGBM_SE handle,
   LGBM_SE buf_len,
-  LGBM_SE actual_len,
+  SEXP actual_len,
   LGBM_SE feature_names
 );
 
@@ -170,7 +170,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetField_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetFieldSize_R(
   LGBM_SE handle,
   LGBM_SE field_name,
-  LGBM_SE out
+  SEXP out
 );
 
 /*!
@@ -205,7 +205,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetUpdateParamChecking_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetNumData_R(
   LGBM_SE handle,
-  LGBM_SE out
+  SEXP out
 );
 
 /*!
@@ -216,7 +216,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetNumData_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetNumFeature_R(
   LGBM_SE handle,
-  LGBM_SE out
+  SEXP out
 );
 
 // --- start Booster interfaces
@@ -317,7 +317,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterResetParameter_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetNumClasses_R(
   LGBM_SE handle,
-  LGBM_SE out
+  SEXP out
 );
 
 /*!
@@ -361,7 +361,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterRollbackOneIter_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetCurrentIteration_R(
   LGBM_SE handle,
-  LGBM_SE out
+  SEXP out
 );
 
 /*!
@@ -394,7 +394,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetLowerBoundValue_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEvalNames_R(
   LGBM_SE handle,
   LGBM_SE buf_len,
-  LGBM_SE actual_len,
+  SEXP actual_len,
   LGBM_SE eval_names
 );
 
@@ -421,7 +421,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEval_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetNumPredict_R(
   LGBM_SE handle,
   LGBM_SE data_idx,
-  LGBM_SE out
+  SEXP out
 );
 
 /*!
@@ -480,7 +480,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterCalcNumPredict_R(
   LGBM_SE is_predcontrib,
   LGBM_SE start_iteration,
   LGBM_SE num_iteration,
-  LGBM_SE out_len
+  SEXP out_len
 );
 
 /*!
@@ -503,8 +503,8 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterCalcNumPredict_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForCSC_R(
   LGBM_SE handle,
-  LGBM_SE indptr,
-  LGBM_SE indices,
+  SEXP indptr,
+  SEXP indices,
   SEXP data,
   LGBM_SE nindptr,
   LGBM_SE nelem,
@@ -573,7 +573,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModelToString_R(
   LGBM_SE num_iteration,
   LGBM_SE feature_importance_type,
   LGBM_SE buffer_len,
-  LGBM_SE actual_len,
+  SEXP actual_len,
   LGBM_SE out_str
 );
 
@@ -589,7 +589,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterDumpModel_R(
   LGBM_SE num_iteration,
   LGBM_SE feature_importance_type,
   LGBM_SE buffer_len,
-  LGBM_SE actual_len,
+  SEXP actual_len,
   LGBM_SE out_str
 );
 


### PR DESCRIPTION
Another step towards #3016.

Fixes #4216.

Changes in this PR:

* removes LightGBM-custom pointers to R data (`R_REAL_PTR()`, `R_INT_PTR()`) with the standard equivalents from `Rinternals.h` (`REAL()`, `INTEGER()`)
* converts arguments on the C++ side that are accessed that way from `LGBM_SE` to `SEXP`

### Description

R is a dynamically-typed language. You can run code like `x <- c(1, 2, 3)` without declaring that `x` is a numeric array, and R will just figure it out.

R makes this possible by storing data for an object in a structure called a `SEXPREC`. That structure will contain different data based on the R class (integer, character, function, etc.). Libraries can reference that data in C code using a type, `SEXP`, provided by `Rinternals.h`. Libraries can also get a pointer to a particular type of data within a `SEXPREC` using other functions provided by `Rinternals.h`, for example `REAL()` to get a pointer to its numeric data.

As described in #4216, the internal details of the `SEXPREC` struct can change between different versions of R. `SEXP` is the official R API into that struct, and by using it libraries can reliably stay compatible with multiple R versions.

This PR's changes fix a bug that currently exists when using `{lightgbm}` with R 3.6, and protects `{lightgbm}` from similar bugs in the future.

For more details on this, see https://cran.r-project.org/doc/manuals/r-release/R-ints.html#SEXPs.

### Notes for Reviewers

This PR does not depend on #4242 or #4247