### PR TITLE
[R-package] move Rinternals.h closer to where it is used

### DIFF
--- a/R-package/src/R_object_helper.h
+++ b/R-package/src/R_object_helper.h
@@ -15,10 +15,6 @@
 
 #include <cstdint>
 
-#define R_NO_REMAP
-#define R_USE_C99_IN_CXX
-#include <Rinternals.h>
-
 #define NAMED_BITS 16
 struct lgbm_sxpinfo {
   unsigned int type : 5;

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -6,6 +6,11 @@
 #define LIGHTGBM_R_H_
 
 #include <LightGBM/c_api.h>
+
+#define R_NO_REMAP
+#define R_USE_C99_IN_CXX
+#include <Rinternals.h>
+
 #include "R_object_helper.h"
 
 /*!


### PR DESCRIPTION
Another small steps towards #3016 (removing `R-package/src/R_object_helper.h`).

Today, to use things from `Rinternals.h`, the code in `lightgbm_R.h` includes `R_object_helper.h` which includes `Rinternals.h`.

This proposes moving that `#include` of `Rinternals.h` into `lightgbm_R.h`, the first place it is needed.