### PR TITLE
[R-package] Use R standard routines to access character data in C++

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -452,7 +452,7 @@ Booster <- R6::R6Class(
         , private$handle
         , as.integer(num_iteration)
         , as.integer(feature_importance_type)
-        , lgb.c_str(x = filename)
+        , filename
       )
 
       return(invisible(self))

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -90,7 +90,7 @@ Booster <- R6::R6Class(
           # Create booster from model
           .Call(
             LGBM_BoosterCreateFromModelfile_R
-            , lgb.c_str(x = modelfile)
+            , modelfile
             , handle
           )
 
@@ -104,7 +104,7 @@ Booster <- R6::R6Class(
           # Create booster from model
           .Call(
             LGBM_BoosterLoadModelFromString_R
-            , lgb.c_str(x = model_str)
+            , model_str
             , handle
           )
 

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -202,7 +202,7 @@ Dataset <- R6::R6Class(
 
           .Call(
             LGBM_DatasetCreateFromFile_R
-            , lgb.c_str(x = private$raw_data)
+            , private$raw_data
             , params_str
             , ref_handle
             , handle
@@ -436,7 +436,7 @@ Dataset <- R6::R6Class(
         .Call(
           LGBM_DatasetSetFeatureNames_R
           , private$handle
-          , lgb.c_str(x = merged_name)
+          , merged_name
         )
 
       }
@@ -468,7 +468,7 @@ Dataset <- R6::R6Class(
         .Call(
           LGBM_DatasetGetFieldSize_R
           , private$handle
-          , lgb.c_str(x = name)
+          , name
           , info_len
         )
 
@@ -486,7 +486,7 @@ Dataset <- R6::R6Class(
           .Call(
             LGBM_DatasetGetField_R
             , private$handle
-            , lgb.c_str(x = name)
+            , name
             , ret
           )
 
@@ -527,7 +527,7 @@ Dataset <- R6::R6Class(
           .Call(
             LGBM_DatasetSetField_R
             , private$handle
-            , lgb.c_str(x = name)
+            , name
             , info
             , length(info)
           )
@@ -678,7 +678,7 @@ Dataset <- R6::R6Class(
       .Call(
         LGBM_DatasetSaveBinary_R
         , private$handle
-        , lgb.c_str(x = fname)
+        , fname
       )
       return(invisible(self))
     }

--- a/R-package/R/lgb.Predictor.R
+++ b/R-package/R/lgb.Predictor.R
@@ -39,7 +39,7 @@ Predictor <- R6::R6Class(
         # Create handle on it
         .Call(
           LGBM_BoosterCreateFromModelfile_R
-          , lgb.c_str(x = modelfile)
+          , modelfile
           , handle
         )
         private$need_free_handle <- TRUE
@@ -117,7 +117,7 @@ Predictor <- R6::R6Class(
           , as.integer(start_iteration)
           , as.integer(num_iteration)
           , private$params
-          , lgb.c_str(x = tmp_filename)
+          , tmp_filename
         )
 
         # Get predictions from file

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -89,10 +89,10 @@ lgb.params2str <- function(params, ...) {
 
   # Check ret length
   if (length(ret) == 0L) {
-    return(lgb.c_str(x = ""))
+    return("")
   }
 
-  return(lgb.c_str(x = paste0(ret, collapse = " ")))
+  return(paste0(ret, collapse = " "))
 
 }
 
@@ -154,13 +154,6 @@ lgb.check_interaction_constraints <- function(interaction_constraints, column_na
 
 }
 
-lgb.c_str <- function(x) {
-
-  ret <- charToRaw(as.character(x))
-  ret <- c(ret, as.raw(0L))
-  return(ret)
-
-}
 
 lgb.check.r6.class <- function(object, name) {
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -64,13 +64,13 @@ SEXP LGBM_GetLastError_R() {
   return out;
 }
 
-SEXP LGBM_DatasetCreateFromFile_R(LGBM_SE filename,
+SEXP LGBM_DatasetCreateFromFile_R(SEXP filename,
   LGBM_SE parameters,
   LGBM_SE reference,
   LGBM_SE out) {
   R_API_BEGIN();
   DatasetHandle handle = nullptr;
-  CHECK_CALL(LGBM_DatasetCreateFromFile(R_CHAR_PTR(filename), R_CHAR_PTR(parameters),
+  CHECK_CALL(LGBM_DatasetCreateFromFile(CHAR(Rf_asChar(filename)), R_CHAR_PTR(parameters),
     R_GET_PTR(reference), &handle));
   R_SET_PTR(out, handle);
   R_API_END();
@@ -140,9 +140,9 @@ SEXP LGBM_DatasetGetSubset_R(LGBM_SE handle,
 }
 
 SEXP LGBM_DatasetSetFeatureNames_R(LGBM_SE handle,
-  LGBM_SE feature_names) {
+  SEXP feature_names) {
   R_API_BEGIN();
-  auto vec_names = Split(R_CHAR_PTR(feature_names), '\t');
+  auto vec_names = Split(CHAR(Rf_asChar(feature_names)), '\t');
   std::vector<const char*> vec_sptr;
   int len = static_cast<int>(vec_names.size());
   for (int i = 0; i < len; ++i) {
@@ -183,10 +183,10 @@ SEXP LGBM_DatasetGetFeatureNames_R(LGBM_SE handle,
 }
 
 SEXP LGBM_DatasetSaveBinary_R(LGBM_SE handle,
-  LGBM_SE filename) {
+  SEXP filename) {
   R_API_BEGIN();
   CHECK_CALL(LGBM_DatasetSaveBinary(R_GET_PTR(handle),
-    R_CHAR_PTR(filename)));
+    CHAR(Rf_asChar(filename))));
   R_API_END();
 }
 
@@ -200,12 +200,12 @@ SEXP LGBM_DatasetFree_R(LGBM_SE handle) {
 }
 
 SEXP LGBM_DatasetSetField_R(LGBM_SE handle,
-  LGBM_SE field_name,
+  SEXP field_name,
   SEXP field_data,
   SEXP num_element) {
   R_API_BEGIN();
   int len = static_cast<int>(Rf_asInteger(num_element));
-  const char* name = R_CHAR_PTR(field_name);
+  const char* name = CHAR(Rf_asChar(field_name));
   if (!strcmp("group", name) || !strcmp("query", name)) {
     std::vector<int32_t> vec(len);
 #pragma omp parallel for schedule(static, 512) if (len >= 1024)
@@ -227,10 +227,10 @@ SEXP LGBM_DatasetSetField_R(LGBM_SE handle,
 }
 
 SEXP LGBM_DatasetGetField_R(LGBM_SE handle,
-  LGBM_SE field_name,
+  SEXP field_name,
   SEXP field_data) {
   R_API_BEGIN();
-  const char* name = R_CHAR_PTR(field_name);
+  const char* name = CHAR(Rf_asChar(field_name));
   int out_len = 0;
   int out_type = 0;
   const void* res;
@@ -260,10 +260,10 @@ SEXP LGBM_DatasetGetField_R(LGBM_SE handle,
 }
 
 SEXP LGBM_DatasetGetFieldSize_R(LGBM_SE handle,
-  LGBM_SE field_name,
+  SEXP field_name,
   SEXP out) {
   R_API_BEGIN();
-  const char* name = R_CHAR_PTR(field_name);
+  const char* name = CHAR(Rf_asChar(field_name));
   int out_len = 0;
   int out_type = 0;
   const void* res;
@@ -320,22 +320,22 @@ SEXP LGBM_BoosterCreate_R(LGBM_SE train_data,
   R_API_END();
 }
 
-SEXP LGBM_BoosterCreateFromModelfile_R(LGBM_SE filename,
+SEXP LGBM_BoosterCreateFromModelfile_R(SEXP filename,
   LGBM_SE out) {
   R_API_BEGIN();
   int out_num_iterations = 0;
   BoosterHandle handle = nullptr;
-  CHECK_CALL(LGBM_BoosterCreateFromModelfile(R_CHAR_PTR(filename), &out_num_iterations, &handle));
+  CHECK_CALL(LGBM_BoosterCreateFromModelfile(CHAR(Rf_asChar(filename)), &out_num_iterations, &handle));
   R_SET_PTR(out, handle);
   R_API_END();
 }
 
-SEXP LGBM_BoosterLoadModelFromString_R(LGBM_SE model_str,
+SEXP LGBM_BoosterLoadModelFromString_R(SEXP model_str,
   LGBM_SE out) {
   R_API_BEGIN();
   int out_num_iterations = 0;
   BoosterHandle handle = nullptr;
-  CHECK_CALL(LGBM_BoosterLoadModelFromString(R_CHAR_PTR(model_str), &out_num_iterations, &handle));
+  CHECK_CALL(LGBM_BoosterLoadModelFromString(CHAR(Rf_asChar(model_str)), &out_num_iterations, &handle));
   R_SET_PTR(out, handle);
   R_API_END();
 }
@@ -511,7 +511,7 @@ int GetPredictType(SEXP is_rawscore, SEXP is_leafidx, SEXP is_predcontrib) {
 }
 
 SEXP LGBM_BoosterPredictForFile_R(LGBM_SE handle,
-  LGBM_SE data_filename,
+  SEXP data_filename,
   SEXP data_has_header,
   SEXP is_rawscore,
   SEXP is_leafidx,
@@ -519,12 +519,12 @@ SEXP LGBM_BoosterPredictForFile_R(LGBM_SE handle,
   SEXP start_iteration,
   SEXP num_iteration,
   LGBM_SE parameter,
-  LGBM_SE result_filename) {
+  SEXP result_filename) {
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
-  CHECK_CALL(LGBM_BoosterPredictForFile(R_GET_PTR(handle), R_CHAR_PTR(data_filename),
+  CHECK_CALL(LGBM_BoosterPredictForFile(R_GET_PTR(handle), CHAR(Rf_asChar(data_filename)),
     Rf_asInteger(data_has_header), pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), R_CHAR_PTR(parameter),
-    R_CHAR_PTR(result_filename)));
+    CHAR(Rf_asChar(result_filename))));
   R_API_END();
 }
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -65,12 +65,12 @@ SEXP LGBM_GetLastError_R() {
 }
 
 SEXP LGBM_DatasetCreateFromFile_R(SEXP filename,
-  LGBM_SE parameters,
+  SEXP parameters,
   LGBM_SE reference,
   LGBM_SE out) {
   R_API_BEGIN();
   DatasetHandle handle = nullptr;
-  CHECK_CALL(LGBM_DatasetCreateFromFile(CHAR(Rf_asChar(filename)), R_CHAR_PTR(parameters),
+  CHECK_CALL(LGBM_DatasetCreateFromFile(CHAR(Rf_asChar(filename)), CHAR(Rf_asChar(parameters)),
     R_GET_PTR(reference), &handle));
   R_SET_PTR(out, handle);
   R_API_END();
@@ -82,7 +82,7 @@ SEXP LGBM_DatasetCreateFromCSC_R(SEXP indptr,
   SEXP num_indptr,
   SEXP nelem,
   SEXP num_row,
-  LGBM_SE parameters,
+  SEXP parameters,
   LGBM_SE reference,
   LGBM_SE out) {
   R_API_BEGIN();
@@ -96,7 +96,7 @@ SEXP LGBM_DatasetCreateFromCSC_R(SEXP indptr,
   DatasetHandle handle = nullptr;
   CHECK_CALL(LGBM_DatasetCreateFromCSC(p_indptr, C_API_DTYPE_INT32, p_indices,
     p_data, C_API_DTYPE_FLOAT64, nindptr, ndata,
-    nrow, R_CHAR_PTR(parameters), R_GET_PTR(reference), &handle));
+    nrow, CHAR(Rf_asChar(parameters)), R_GET_PTR(reference), &handle));
   R_SET_PTR(out, handle);
   R_API_END();
 }
@@ -104,7 +104,7 @@ SEXP LGBM_DatasetCreateFromCSC_R(SEXP indptr,
 SEXP LGBM_DatasetCreateFromMat_R(SEXP data,
   SEXP num_row,
   SEXP num_col,
-  LGBM_SE parameters,
+  SEXP parameters,
   LGBM_SE reference,
   LGBM_SE out) {
   R_API_BEGIN();
@@ -113,7 +113,7 @@ SEXP LGBM_DatasetCreateFromMat_R(SEXP data,
   double* p_mat = REAL(data);
   DatasetHandle handle = nullptr;
   CHECK_CALL(LGBM_DatasetCreateFromMat(p_mat, C_API_DTYPE_FLOAT64, nrow, ncol, COL_MAJOR,
-    R_CHAR_PTR(parameters), R_GET_PTR(reference), &handle));
+    CHAR(Rf_asChar(parameters)), R_GET_PTR(reference), &handle));
   R_SET_PTR(out, handle);
   R_API_END();
 }
@@ -121,7 +121,7 @@ SEXP LGBM_DatasetCreateFromMat_R(SEXP data,
 SEXP LGBM_DatasetGetSubset_R(LGBM_SE handle,
   SEXP used_row_indices,
   SEXP len_used_row_indices,
-  LGBM_SE parameters,
+  SEXP parameters,
   LGBM_SE out) {
   R_API_BEGIN();
   int len = Rf_asInteger(len_used_row_indices);
@@ -133,7 +133,7 @@ SEXP LGBM_DatasetGetSubset_R(LGBM_SE handle,
   }
   DatasetHandle res = nullptr;
   CHECK_CALL(LGBM_DatasetGetSubset(R_GET_PTR(handle),
-    idxvec.data(), len, R_CHAR_PTR(parameters),
+    idxvec.data(), len, CHAR(Rf_asChar(parameters)),
     &res));
   R_SET_PTR(out, res);
   R_API_END();
@@ -275,10 +275,10 @@ SEXP LGBM_DatasetGetFieldSize_R(LGBM_SE handle,
   R_API_END();
 }
 
-SEXP LGBM_DatasetUpdateParamChecking_R(LGBM_SE old_params,
-  LGBM_SE new_params) {
+SEXP LGBM_DatasetUpdateParamChecking_R(SEXP old_params,
+  SEXP new_params) {
   R_API_BEGIN();
-  CHECK_CALL(LGBM_DatasetUpdateParamChecking(R_CHAR_PTR(old_params), R_CHAR_PTR(new_params)));
+  CHECK_CALL(LGBM_DatasetUpdateParamChecking(CHAR(Rf_asChar(old_params)), CHAR(Rf_asChar(new_params))));
   R_API_END();
 }
 
@@ -311,11 +311,11 @@ SEXP LGBM_BoosterFree_R(LGBM_SE handle) {
 }
 
 SEXP LGBM_BoosterCreate_R(LGBM_SE train_data,
-  LGBM_SE parameters,
+  SEXP parameters,
   LGBM_SE out) {
   R_API_BEGIN();
   BoosterHandle handle = nullptr;
-  CHECK_CALL(LGBM_BoosterCreate(R_GET_PTR(train_data), R_CHAR_PTR(parameters), &handle));
+  CHECK_CALL(LGBM_BoosterCreate(R_GET_PTR(train_data), CHAR(Rf_asChar(parameters)), &handle));
   R_SET_PTR(out, handle);
   R_API_END();
 }
@@ -362,9 +362,9 @@ SEXP LGBM_BoosterResetTrainingData_R(LGBM_SE handle,
 }
 
 SEXP LGBM_BoosterResetParameter_R(LGBM_SE handle,
-  LGBM_SE parameters) {
+  SEXP parameters) {
   R_API_BEGIN();
-  CHECK_CALL(LGBM_BoosterResetParameter(R_GET_PTR(handle), R_CHAR_PTR(parameters)));
+  CHECK_CALL(LGBM_BoosterResetParameter(R_GET_PTR(handle), CHAR(Rf_asChar(parameters))));
   R_API_END();
 }
 
@@ -518,12 +518,12 @@ SEXP LGBM_BoosterPredictForFile_R(LGBM_SE handle,
   SEXP is_predcontrib,
   SEXP start_iteration,
   SEXP num_iteration,
-  LGBM_SE parameter,
+  SEXP parameter,
   SEXP result_filename) {
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
   CHECK_CALL(LGBM_BoosterPredictForFile(R_GET_PTR(handle), CHAR(Rf_asChar(data_filename)),
-    Rf_asInteger(data_has_header), pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), R_CHAR_PTR(parameter),
+    Rf_asInteger(data_has_header), pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), CHAR(Rf_asChar(parameter)),
     CHAR(Rf_asChar(result_filename))));
   R_API_END();
 }
@@ -557,7 +557,7 @@ SEXP LGBM_BoosterPredictForCSC_R(LGBM_SE handle,
   SEXP is_predcontrib,
   SEXP start_iteration,
   SEXP num_iteration,
-  LGBM_SE parameter,
+  SEXP parameter,
   SEXP out_result) {
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
@@ -574,7 +574,7 @@ SEXP LGBM_BoosterPredictForCSC_R(LGBM_SE handle,
   CHECK_CALL(LGBM_BoosterPredictForCSC(R_GET_PTR(handle),
     p_indptr, C_API_DTYPE_INT32, p_indices,
     p_data, C_API_DTYPE_FLOAT64, nindptr, ndata,
-    nrow, pred_type,  Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), R_CHAR_PTR(parameter), &out_len, ptr_ret));
+    nrow, pred_type,  Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), CHAR(Rf_asChar(parameter)), &out_len, ptr_ret));
   R_API_END();
 }
 
@@ -587,7 +587,7 @@ SEXP LGBM_BoosterPredictForMat_R(LGBM_SE handle,
   SEXP is_predcontrib,
   SEXP start_iteration,
   SEXP num_iteration,
-  LGBM_SE parameter,
+  SEXP parameter,
   SEXP out_result) {
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
@@ -600,7 +600,7 @@ SEXP LGBM_BoosterPredictForMat_R(LGBM_SE handle,
   int64_t out_len;
   CHECK_CALL(LGBM_BoosterPredictForMat(R_GET_PTR(handle),
     p_mat, C_API_DTYPE_FLOAT64, nrow, ncol, COL_MAJOR,
-    pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), R_CHAR_PTR(parameter), &out_len, ptr_ret));
+    pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), CHAR(Rf_asChar(parameter)), &out_len, ptr_ret));
 
   R_API_END();
 }

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -608,9 +608,9 @@ SEXP LGBM_BoosterPredictForMat_R(LGBM_SE handle,
 SEXP LGBM_BoosterSaveModel_R(LGBM_SE handle,
   SEXP num_iteration,
   SEXP feature_importance_type,
-  LGBM_SE filename) {
+  SEXP filename) {
   R_API_BEGIN();
-  CHECK_CALL(LGBM_BoosterSaveModel(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), R_CHAR_PTR(filename)));
+  CHECK_CALL(LGBM_BoosterSaveModel(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), CHAR(Rf_asChar(filename))));
   R_API_END();
 }
 

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -33,7 +33,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_GetLastError_R();
 * \return 0 when succeed, -1 when failure happens
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromFile_R(
-  LGBM_SE filename,
+  SEXP filename,
   LGBM_SE parameters,
   LGBM_SE reference,
   LGBM_SE out
@@ -108,7 +108,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetSubset_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetFeatureNames_R(
   LGBM_SE handle,
-  LGBM_SE feature_names
+  SEXP feature_names
 );
 
 /*!
@@ -132,7 +132,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetFeatureNames_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSaveBinary_R(
   LGBM_SE handle,
-  LGBM_SE filename
+  SEXP filename
 );
 
 /*!
@@ -156,7 +156,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetFree_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetField_R(
   LGBM_SE handle,
-  LGBM_SE field_name,
+  SEXP field_name,
   SEXP field_data,
   SEXP num_element
 );
@@ -170,7 +170,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetField_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetFieldSize_R(
   LGBM_SE handle,
-  LGBM_SE field_name,
+  SEXP field_name,
   SEXP out
 );
 
@@ -183,7 +183,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetFieldSize_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetField_R(
   LGBM_SE handle,
-  LGBM_SE field_name,
+  SEXP field_name,
   SEXP field_data
 );
 
@@ -251,7 +251,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterFree_R(
 * \return 0 when succeed, -1 when failure happens
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterCreateFromModelfile_R(
-  LGBM_SE filename,
+  SEXP filename,
   LGBM_SE out
 );
 
@@ -262,7 +262,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterCreateFromModelfile_R(
 * \return 0 when succeed, -1 when failure happens
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterLoadModelFromString_R(
-  LGBM_SE model_str,
+  SEXP model_str,
   LGBM_SE out
 );
 
@@ -452,7 +452,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetPredict_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForFile_R(
   LGBM_SE handle,
-  LGBM_SE data_filename,
+  SEXP data_filename,
   SEXP data_has_header,
   SEXP is_rawscore,
   SEXP is_leafidx,
@@ -460,7 +460,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForFile_R(
   SEXP start_iteration,
   SEXP num_iteration,
   LGBM_SE parameter,
-  LGBM_SE result_filename
+  SEXP result_filename
 );
 
 /*!

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -34,7 +34,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_GetLastError_R();
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromFile_R(
   SEXP filename,
-  LGBM_SE parameters,
+  SEXP parameters,
   LGBM_SE reference,
   LGBM_SE out
 );
@@ -59,7 +59,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromCSC_R(
   SEXP num_indptr,
   SEXP nelem,
   SEXP num_row,
-  LGBM_SE parameters,
+  SEXP parameters,
   LGBM_SE reference,
   LGBM_SE out
 );
@@ -78,7 +78,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetCreateFromMat_R(
   SEXP data,
   SEXP num_row,
   SEXP num_col,
-  LGBM_SE parameters,
+  SEXP parameters,
   LGBM_SE reference,
   LGBM_SE out
 );
@@ -96,7 +96,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetSubset_R(
   LGBM_SE handle,
   SEXP used_row_indices,
   SEXP len_used_row_indices,
-  LGBM_SE parameters,
+  SEXP parameters,
   LGBM_SE out
 );
 
@@ -194,8 +194,8 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetField_R(
  * \return 0 when succeed, -1 when failure happens
  */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetUpdateParamChecking_R(
-  LGBM_SE old_params,
-  LGBM_SE new_params
+  SEXP old_params,
+  SEXP new_params
 );
 
 /*!
@@ -231,7 +231,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetNumFeature_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterCreate_R(
   LGBM_SE train_data,
-  LGBM_SE parameters,
+  SEXP parameters,
   LGBM_SE out
 );
 
@@ -307,7 +307,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterResetTrainingData_R(
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterResetParameter_R(
   LGBM_SE handle,
-  LGBM_SE parameters
+  SEXP parameters
 );
 
 /*!
@@ -459,7 +459,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForFile_R(
   SEXP is_predcontrib,
   SEXP start_iteration,
   SEXP num_iteration,
-  LGBM_SE parameter,
+  SEXP parameter,
   SEXP result_filename
 );
 
@@ -515,7 +515,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForCSC_R(
   SEXP is_predcontrib,
   SEXP start_iteration,
   SEXP num_iteration,
-  LGBM_SE parameter,
+  SEXP parameter,
   SEXP out_result
 );
 
@@ -544,7 +544,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterPredictForMat_R(
   SEXP is_predcontrib,
   SEXP start_iteration,
   SEXP num_iteration,
-  LGBM_SE parameter,
+  SEXP parameter,
   SEXP out_result
 );
 

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -559,7 +559,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModel_R(
   LGBM_SE handle,
   SEXP num_iteration,
   SEXP feature_importance_type,
-  LGBM_SE filename
+  SEXP filename
 );
 
 /*!

--- a/R-package/tests/testthat/test_utils.R
+++ b/R-package/tests/testthat/test_utils.R
@@ -35,8 +35,8 @@ test_that("lgb.params2str() works as expected for empty lists", {
     out_str <- lgb.params2str(
         params = list()
     )
-    expect_identical(class(out_str), "raw")
-    expect_equal(out_str, lgb.c_str(""))
+    expect_identical(class(out_str), "character")
+    expect_equal(out_str, "")
 })
 
 test_that("lgb.params2str() works as expected for a key in params with multiple different-length elements", {
@@ -50,10 +50,9 @@ test_that("lgb.params2str() works as expected for a key in params with multiple 
     out_str <- lgb.params2str(
         params = params
     )
-    expect_identical(class(out_str), "raw")
-    out_as_char <- rawToChar(out_str)
+    expect_identical(class(out_str), "character")
     expect_identical(
-        out_as_char
+        out_str
         , "objective=magic metric=a,ab,abc,abcdefg nrounds=10 learning_rate=0.0000001"
     )
 })


### PR DESCRIPTION
Another step towards #3016.

Similar to the changes for numeric data in #4247, this proposes replacing moost uses of the LightGBM-custom `R_CHAR_PTR` with R's standard interface for accessing character data. Unlike that PR, this requires two steps...extracting a `CHARSXP` from the object passed in from R, then getting a pointer to its data (`char *`). That results in a pattern like this:

```cpp
CHAR(Rf_asChar(filename))
```

As a result of these changes, the utility function `lgb.c_str()` is no longer necessary.

### Notes for Reviewers

1. #4034 is not fixed by this change, but it is partially fixed. As of this PR, the reproducible examples in that issue yield `[LightGBM] [Fatal] Unknown format of training data.` instead of `[LightGBM] [Fatal] Data file ��?��V doesn't exist.`. That can be addressed in a followup PR.

2. `R_CHAR_PTR` cannot be completely removed in this PR, because it is still used in `EncodeChar`. That can be addressed in a future PR.

https://github.com/microsoft/LightGBM/blob/bb88d92ef27acc0731bf3b348920560410aa2e78/R-package/src/lightgbm_R.cpp#L46-L57

### References

* https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Handling-character-data
* https://github.com/dmlc/xgboost/blob/b35dd76dca6dfa9151394da847567ce99fa76085/R-package/src/xgboost_R.cc#L72