### PR TITLE
fix param name

### DIFF
--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -141,7 +141,7 @@ class GBDT : public GBDTBase {
   /*!
   * \brief Training logic
   * \param gradients nullptr for using default objective, otherwise use self-defined boosting
-  * \param Hessians nullptr for using default objective, otherwise use self-defined boosting
+  * \param hessians nullptr for using default objective, otherwise use self-defined boosting
   * \return True if cannot train any more
   */
   bool TrainOneIter(const score_t* gradients, const score_t* hessians) override;

--- a/src/treelearner/gpu_tree_learner.h
+++ b/src/treelearner/gpu_tree_learner.h
@@ -138,10 +138,10 @@ class GPUTreeLearner: public SerialTreeLearner {
    *                     Set to nullptr to skip copy to GPU.
    * \param num_data Number of data examples to be included in histogram
    * \param gradients Array of gradients for all examples.
-   * \param Hessians Array of Hessians for all examples.
+   * \param hessians Array of Hessians for all examples.
    * \param ordered_gradients Ordered gradients will be generated and copied to GPU when gradients is not nullptr,
    *                     Set gradients to nullptr to skip copy to GPU.
-   * \param ordered_hessians Ordered Hessians will be generated and copied to GPU when Hessians is not nullptr,
+   * \param ordered_hessians Ordered Hessians will be generated and copied to GPU when hessians is not nullptr,
    *                     Set Hessians to nullptr to skip copy to GPU.
    * \return true if GPU kernel is launched, false if GPU is not used
   */

--- a/src/treelearner/gpu_tree_learner.h
+++ b/src/treelearner/gpu_tree_learner.h
@@ -142,7 +142,7 @@ class GPUTreeLearner: public SerialTreeLearner {
    * \param ordered_gradients Ordered gradients will be generated and copied to GPU when gradients is not nullptr,
    *                     Set gradients to nullptr to skip copy to GPU.
    * \param ordered_hessians Ordered Hessians will be generated and copied to GPU when hessians is not nullptr,
-   *                     Set Hessians to nullptr to skip copy to GPU.
+   *                     Set hessians to nullptr to skip copy to GPU.
    * \return true if GPU kernel is launched, false if GPU is not used
   */
   bool ConstructGPUHistogramsAsync(


### PR DESCRIPTION
Correction of #4250.

`hessians` here is a param name (`const score_t* hessians`) and should be written from a small letter.