### PR TITLE
[R-package] move creation of character vectors in some methods to C++ side

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -466,7 +466,6 @@ Booster <- R6::R6Class(
         num_iteration <- self$best_iter
       }
 
-      # Call buffer
       model_str <- .Call(
           LGBM_BoosterSaveModelToString_R
           , private$handle

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -666,41 +666,20 @@ Booster <- R6::R6Class(
 
       # Check for evaluation names emptiness
       if (is.null(private$eval_names)) {
-
-        # Get evaluation names
-        buf_len <- as.integer(1024L * 1024L)
-        act_len <- 0L
-        buf <- raw(buf_len)
-        .Call(
+        eval_names <- .Call(
           LGBM_BoosterGetEvalNames_R
           , private$handle
-          , buf_len
-          , act_len
-          , buf
         )
-        if (act_len > buf_len) {
-          buf_len <- act_len
-          buf <- raw(buf_len)
-          .Call(
-            LGBM_BoosterGetEvalNames_R
-            , private$handle
-            , buf_len
-            , act_len
-            , buf
-          )
-        }
-        names <- lgb.encode.char(arr = buf, len = act_len)
 
         # Check names' length
-        if (nchar(names) > 0L) {
+        if (length(eval_names) > 0L) {
 
           # Parse and store privately names
-          names <- strsplit(names, "\t")[[1L]]
-          private$eval_names <- names
+          private$eval_names <- eval_names
 
           # some metrics don't map cleanly to metric names, for example "ndcg@1" is just the
           # ndcg metric evaluated at the first "query result" in learning-to-rank
-          metric_names <- gsub("@.*", "", names)
+          metric_names <- gsub("@.*", "", eval_names)
           private$higher_better_inner_eval <- .METRICS_HIGHER_BETTER()[metric_names]
 
         }

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -466,40 +466,15 @@ Booster <- R6::R6Class(
         num_iteration <- self$best_iter
       }
 
-      # Create buffer
-      buf_len <- as.integer(1024L * 1024L)
-      act_len <- 0L
-      buf <- raw(buf_len)
-
       # Call buffer
-      .Call(
+      model_str <- .Call(
           LGBM_BoosterSaveModelToString_R
           , private$handle
           , as.integer(num_iteration)
           , as.integer(feature_importance_type)
-          , buf_len
-          , act_len
-          , buf
       )
 
-      # Check for buffer content
-      if (act_len > buf_len) {
-        buf_len <- act_len
-        buf <- raw(buf_len)
-        .Call(
-          LGBM_BoosterSaveModelToString_R
-          , private$handle
-          , as.integer(num_iteration)
-          , as.integer(feature_importance_type)
-          , buf_len
-          , act_len
-          , buf
-        )
-      }
-
-      return(
-        lgb.encode.char(arr = buf, len = act_len)
-      )
+      return(model_str)
 
     },
 
@@ -511,36 +486,14 @@ Booster <- R6::R6Class(
         num_iteration <- self$best_iter
       }
 
-      buf_len <- as.integer(1024L * 1024L)
-      act_len <- 0L
-      buf <- raw(buf_len)
-      .Call(
+      model_str <- .Call(
         LGBM_BoosterDumpModel_R
         , private$handle
         , as.integer(num_iteration)
         , as.integer(feature_importance_type)
-        , buf_len
-        , act_len
-        , buf
       )
 
-      if (act_len > buf_len) {
-        buf_len <- act_len
-        buf <- raw(buf_len)
-        .Call(
-          LGBM_BoosterDumpModel_R
-          , private$handle
-          , as.integer(num_iteration)
-          , as.integer(feature_importance_type)
-          , buf_len
-          , act_len
-          , buf
-        )
-      }
-
-      return(
-        lgb.encode.char(arr = buf, len = act_len)
-      )
+      return(model_str)
 
     },
 

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -369,31 +369,10 @@ Dataset <- R6::R6Class(
 
       # Check for handle
       if (!lgb.is.null.handle(x = private$handle)) {
-
-        # Get feature names and write them
-        buf_len <- as.integer(1024L * 1024L)
-        act_len <- 0L
-        buf <- raw(buf_len)
-        .Call(
+        private$colnames <- .Call(
           LGBM_DatasetGetFeatureNames_R
           , private$handle
-          , buf_len
-          , act_len
-          , buf
         )
-        if (act_len > buf_len) {
-          buf_len <- act_len
-          buf <- raw(buf_len)
-          .Call(
-            LGBM_DatasetGetFeatureNames_R
-            , private$handle
-            , buf_len
-            , act_len
-            , buf
-          )
-        }
-        cnames <- lgb.encode.char(arr = buf, len = act_len)
-        private$colnames <- as.character(base::strsplit(cnames, "\t")[[1L]])
         return(private$colnames)
 
       } else if (is.matrix(private$raw_data) || methods::is(private$raw_data, "dgCMatrix")) {

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -18,13 +18,6 @@ lgb.is.null.handle <- function(x) {
   return(is.null(x) || is.na(x))
 }
 
-lgb.encode.char <- function(arr, len) {
-  if (!is.raw(arr)) {
-    stop("lgb.encode.char: Can only encode from raw type")
-  }
-  return(rawToChar(arr[seq_len(len)]))
-}
-
 # [description] Get the most recent error stored on the C++ side and raise it
 #               as an R error.
 lgb.last_error <- function() {

--- a/R-package/src/R_object_helper.h
+++ b/R-package/src/R_object_helper.h
@@ -96,8 +96,6 @@ typedef union { VECTOR_SER s; double align; } SEXPREC_ALIGN;
 
 #define DATAPTR(x)     ((reinterpret_cast<SEXPREC_ALIGN*>(x)) + 1)
 
-#define R_CHAR_PTR(x)  (reinterpret_cast<char*>DATAPTR(x))
-
 #define R_IS_NULL(x)   ((*reinterpret_cast<LGBM_SE>(x)).sxpinfo.type == 0)
 
 // 64bit pointer

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -460,8 +460,6 @@ SEXP LGBM_BoosterGetEvalNames_R(LGBM_SE handle) {
   // if any eval names were larger than allocated size,
   // allow for a larger size and try again
   if (required_string_size > reserved_string_size) {
-    std::vector<std::vector<char>> names(len);
-    std::vector<char*> ptr_names(len);
     for (int i = 0; i < len; ++i) {
       names[i].resize(required_string_size);
       ptr_names[i] = names[i].data();
@@ -476,7 +474,6 @@ SEXP LGBM_BoosterGetEvalNames_R(LGBM_SE handle) {
         ptr_names.data()));
   }
   CHECK_EQ(out_len, len);
-  CHECK_GE(reserved_string_size, required_string_size);
   eval_names = PROTECT(Rf_allocVector(STRSXP, len));
   for (int i = 0; i < len; ++i) {
     SET_STRING_ELT(eval_names, i, Rf_mkChar(ptr_names[i]));

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -641,12 +641,14 @@ SEXP LGBM_BoosterSaveModelToString_R(LGBM_SE handle,
   R_API_BEGIN();
   int64_t out_len = 0;
   int64_t buf_len = 1024 * 1024;
+  int64_t num_iter = Rf_asInteger(num_iteration);
+  int64_t importance_type = Rf_asInteger(feature_importance_type);
   std::vector<char> inner_char_buf(buf_len);
-  CHECK_CALL(LGBM_BoosterSaveModelToString(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
+  CHECK_CALL(LGBM_BoosterSaveModelToString(R_GET_PTR(handle), 0, num_iter, importance_type, buf_len, &out_len, inner_char_buf.data()));
   // if the model string was larger than the initial buffer, allocate a bigger buffer and try again
   if (out_len > buf_len) {
     inner_char_buf.resize(out_len);
-    CHECK_CALL(LGBM_BoosterSaveModelToString(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), out_len, &out_len, inner_char_buf.data()));
+    CHECK_CALL(LGBM_BoosterSaveModelToString(R_GET_PTR(handle), 0, num_iter, importance_type, out_len, &out_len, inner_char_buf.data()));
   }
   model_str = PROTECT(Rf_allocVector(STRSXP, 1));
   SET_STRING_ELT(model_str, 0, Rf_mkChar(inner_char_buf.data()));
@@ -662,12 +664,14 @@ SEXP LGBM_BoosterDumpModel_R(LGBM_SE handle,
   R_API_BEGIN();
   int64_t out_len = 0;
   int64_t buf_len = 1024 * 1024;
+  int64_t num_iter = Rf_asInteger(num_iteration);
+  int64_t importance_type = Rf_asInteger(feature_importance_type);
   std::vector<char> inner_char_buf(buf_len);
-  CHECK_CALL(LGBM_BoosterDumpModel(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
+  CHECK_CALL(LGBM_BoosterDumpModel(R_GET_PTR(handle), 0, num_iter, importance_type, buf_len, &out_len, inner_char_buf.data()));
   // if the model string was larger than the initial buffer, allocate a bigger buffer and try again
   if (out_len > buf_len) {
     inner_char_buf.resize(out_len);
-    CHECK_CALL(LGBM_BoosterDumpModel(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), out_len, &out_len, inner_char_buf.data()));
+    CHECK_CALL(LGBM_BoosterDumpModel(R_GET_PTR(handle), 0, num_iter, importance_type, out_len, &out_len, inner_char_buf.data()));
   }
   model_str = PROTECT(Rf_allocVector(STRSXP, 1));
   SET_STRING_ELT(model_str, 0, Rf_mkChar(inner_char_buf.data()));

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -162,6 +162,10 @@ SEXP LGBM_DatasetGetFeatureNames_R(LGBM_SE handle) {
   // if any feature names were larger than allocated size,
   // allow for a larger size and try again
   if (required_string_size > reserved_string_size) {
+    for (int i = 0; i < len; ++i) {
+      names[i].resize(required_string_size);
+      ptr_names[i] = names[i].data();
+    }
     CHECK_CALL(
       LGBM_DatasetGetFeatureNames(
         R_GET_PTR(handle),
@@ -172,7 +176,6 @@ SEXP LGBM_DatasetGetFeatureNames_R(LGBM_SE handle) {
         ptr_names.data()));
   }
   CHECK_EQ(len, out_len);
-  CHECK_GE(reserved_string_size, required_string_size);
   feature_names = PROTECT(Rf_allocVector(STRSXP, len));
   for (int i = 0; i < len; ++i) {
     SET_STRING_ELT(feature_names, i, Rf_mkChar(ptr_names[i]));
@@ -457,6 +460,12 @@ SEXP LGBM_BoosterGetEvalNames_R(LGBM_SE handle) {
   // if any eval names were larger than allocated size,
   // allow for a larger size and try again
   if (required_string_size > reserved_string_size) {
+    std::vector<std::vector<char>> names(len);
+    std::vector<char*> ptr_names(len);
+    for (int i = 0; i < len; ++i) {
+      names[i].resize(required_string_size);
+      ptr_names[i] = names[i].data();
+    }
     CHECK_CALL(
       LGBM_BoosterGetEvalNames(
         R_GET_PTR(handle),

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -142,12 +142,12 @@ SEXP LGBM_DatasetSetFeatureNames_R(LGBM_SE handle,
 SEXP LGBM_DatasetGetFeatureNames_R(LGBM_SE handle) {
   SEXP feature_names;
   R_API_BEGIN();
-  int num_features = 0;
-  CHECK_CALL(LGBM_DatasetGetNumFeature(R_GET_PTR(handle), &num_features));
+  int len = 0;
+  CHECK_CALL(LGBM_DatasetGetNumFeature(R_GET_PTR(handle), &len));
   const size_t reserved_string_size = 256;
-  std::vector<std::vector<char>> names(num_features);
-  std::vector<char*> ptr_names(num_features);
-  for (int i = 0; i < num_features; ++i) {
+  std::vector<std::vector<char>> names(len);
+  std::vector<char*> ptr_names(len);
+  for (int i = 0; i < len; ++i) {
     names[i].resize(reserved_string_size);
     ptr_names[i] = names[i].data();
   }
@@ -156,17 +156,13 @@ SEXP LGBM_DatasetGetFeatureNames_R(LGBM_SE handle) {
   CHECK_CALL(
     LGBM_DatasetGetFeatureNames(
       R_GET_PTR(handle),
-      num_features,
-      &out_len,
-      reserved_string_size,
-      &required_string_size,
-      ptr_names.data()
-    )
-  );
-  CHECK_EQ(num_features, out_len);
+      len, &out_len,
+      reserved_string_size, &required_string_size,
+      ptr_names.data()));
+  CHECK_EQ(len, out_len);
   CHECK_GE(reserved_string_size, required_string_size);
-  feature_names = PROTECT(Rf_allocVector(STRSXP, num_features));
-  for (int i = 0; i < num_features; ++i) {
+  feature_names = PROTECT(Rf_allocVector(STRSXP, len));
+  for (int i = 0; i < len; ++i) {
     SET_STRING_ELT(feature_names, i, Rf_mkChar(ptr_names[i]));
   }
   UNPROTECT(1);
@@ -427,13 +423,13 @@ SEXP LGBM_BoosterGetLowerBoundValue_R(LGBM_SE handle,
 SEXP LGBM_BoosterGetEvalNames_R(LGBM_SE handle) {
   SEXP eval_names;
   R_API_BEGIN();
-  int num_eval_sets;
-  CHECK_CALL(LGBM_BoosterGetEvalCounts(R_GET_PTR(handle), &num_eval_sets));
+  int len;
+  CHECK_CALL(LGBM_BoosterGetEvalCounts(R_GET_PTR(handle), &len));
 
   const size_t reserved_string_size = 128;
-  std::vector<std::vector<char>> names(num_eval_sets);
-  std::vector<char*> ptr_names(num_eval_sets);
-  for (int i = 0; i < num_eval_sets; ++i) {
+  std::vector<std::vector<char>> names(len);
+  std::vector<char*> ptr_names(len);
+  for (int i = 0; i < len; ++i) {
     names[i].resize(reserved_string_size);
     ptr_names[i] = names[i].data();
   }
@@ -443,17 +439,13 @@ SEXP LGBM_BoosterGetEvalNames_R(LGBM_SE handle) {
   CHECK_CALL(
     LGBM_BoosterGetEvalNames(
       R_GET_PTR(handle),
-      num_eval_sets,
-      &out_len,
-      reserved_string_size,
-      &required_string_size,
-      ptr_names.data()
-    )
-  );
-  CHECK_EQ(out_len, num_eval_sets);
+      len, &out_len,
+      reserved_string_size, &required_string_size,
+      ptr_names.data()));
+  CHECK_EQ(out_len, len);
   CHECK_GE(reserved_string_size, required_string_size);
-  eval_names = PROTECT(Rf_allocVector(STRSXP, num_eval_sets));
-  for (int i = 0; i < num_eval_sets; ++i) {
+  eval_names = PROTECT(Rf_allocVector(STRSXP, len));
+  for (int i = 0; i < len; ++i) {
     SET_STRING_ELT(eval_names, i, Rf_mkChar(ptr_names[i]));
   }
   UNPROTECT(1);
@@ -620,22 +612,11 @@ SEXP LGBM_BoosterSaveModelToString_R(LGBM_SE handle,
   int64_t out_len = 0;
   int64_t buf_len = 1024 * 1024;
   std::vector<char> inner_char_buf(buf_len);
-  CHECK_CALL(LGBM_BoosterSaveModelToString(
-    R_GET_PTR(handle),
-    0,
-    Rf_asInteger(num_iteration),
-    Rf_asInteger(feature_importance_type),
-    buf_len,
-    &out_len,
-    inner_char_buf.data()
-  ));
-
+  CHECK_CALL(LGBM_BoosterSaveModelToString(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
   model_str = PROTECT(Rf_allocVector(STRSXP, 1));
   SET_STRING_ELT(model_str, 0, Rf_mkChar(inner_char_buf.data()));
   UNPROTECT(1);
   return model_str;
-
-  // EncodeChar(out_str, inner_char_buf.data(), buffer_len, actual_len, static_cast<size_t>(out_len));
   R_API_END();
 }
 
@@ -647,22 +628,11 @@ SEXP LGBM_BoosterDumpModel_R(LGBM_SE handle,
   int64_t out_len = 0;
   int64_t buf_len = 1024 * 1024;
   std::vector<char> inner_char_buf(buf_len);
-  CHECK_CALL(LGBM_BoosterDumpModel(
-    R_GET_PTR(handle),
-    0,
-    Rf_asInteger(num_iteration),
-    Rf_asInteger(feature_importance_type),
-    buf_len,
-    &out_len,
-    inner_char_buf.data()
-  ));
-
+  CHECK_CALL(LGBM_BoosterDumpModel(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
   model_str = PROTECT(Rf_allocVector(STRSXP, 1));
   SET_STRING_ELT(model_str, 0, Rf_mkChar(inner_char_buf.data()));
   UNPROTECT(1);
   return model_str;
-
-  // EncodeChar(out_str, inner_char_buf.data(), buffer_len, actual_len, static_cast<size_t>(out_len));
   R_API_END();
 }
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -645,8 +645,8 @@ SEXP LGBM_BoosterSaveModelToString_R(LGBM_SE handle,
   CHECK_CALL(LGBM_BoosterSaveModelToString(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
   // if the model string was larger than the initial buffer, allocate a bigger buffer and try again
   if (out_len > buf_len) {
-    buf_len = out_len;
-    CHECK_CALL(LGBM_BoosterSaveModelToString(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
+    inner_char_buf.resize(out_len);
+    CHECK_CALL(LGBM_BoosterSaveModelToString(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), out_len, &out_len, inner_char_buf.data()));
   }
   model_str = PROTECT(Rf_allocVector(STRSXP, 1));
   SET_STRING_ELT(model_str, 0, Rf_mkChar(inner_char_buf.data()));
@@ -666,8 +666,8 @@ SEXP LGBM_BoosterDumpModel_R(LGBM_SE handle,
   CHECK_CALL(LGBM_BoosterDumpModel(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
   // if the model string was larger than the initial buffer, allocate a bigger buffer and try again
   if (out_len > buf_len) {
-    buf_len = out_len;
-    CHECK_CALL(LGBM_BoosterDumpModel(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
+    inner_char_buf.resize(out_len);
+    CHECK_CALL(LGBM_BoosterDumpModel(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), out_len, &out_len, inner_char_buf.data()));
   }
   model_str = PROTECT(Rf_allocVector(STRSXP, 1));
   SET_STRING_ELT(model_str, 0, Rf_mkChar(inner_char_buf.data()));

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -613,6 +613,11 @@ SEXP LGBM_BoosterSaveModelToString_R(LGBM_SE handle,
   int64_t buf_len = 1024 * 1024;
   std::vector<char> inner_char_buf(buf_len);
   CHECK_CALL(LGBM_BoosterSaveModelToString(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
+  // if the model string was larger than the initial buffer, allocate a bigger buffer and try again
+  if (out_len > buf_len) {
+    buf_len = out_len;
+    CHECK_CALL(LGBM_BoosterSaveModelToString(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
+  }
   model_str = PROTECT(Rf_allocVector(STRSXP, 1));
   SET_STRING_ELT(model_str, 0, Rf_mkChar(inner_char_buf.data()));
   UNPROTECT(1);
@@ -629,6 +634,11 @@ SEXP LGBM_BoosterDumpModel_R(LGBM_SE handle,
   int64_t buf_len = 1024 * 1024;
   std::vector<char> inner_char_buf(buf_len);
   CHECK_CALL(LGBM_BoosterDumpModel(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
+  // if the model string was larger than the initial buffer, allocate a bigger buffer and try again
+  if (out_len > buf_len) {
+    buf_len = out_len;
+    CHECK_CALL(LGBM_BoosterDumpModel(R_GET_PTR(handle), 0, Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), buf_len, &out_len, inner_char_buf.data()));
+  }
   model_str = PROTECT(Rf_allocVector(STRSXP, 1));
   SET_STRING_ELT(model_str, 0, Rf_mkChar(inner_char_buf.data()));
   UNPROTECT(1);

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -159,6 +159,18 @@ SEXP LGBM_DatasetGetFeatureNames_R(LGBM_SE handle) {
       len, &out_len,
       reserved_string_size, &required_string_size,
       ptr_names.data()));
+  // if any feature names were larger than allocated size,
+  // allow for a larger size and try again
+  if (required_string_size > reserved_string_size) {
+    CHECK_CALL(
+      LGBM_DatasetGetFeatureNames(
+        R_GET_PTR(handle),
+        len,
+        &out_len,
+        required_string_size,
+        &required_string_size,
+        ptr_names.data()));
+  }
   CHECK_EQ(len, out_len);
   CHECK_GE(reserved_string_size, required_string_size);
   feature_names = PROTECT(Rf_allocVector(STRSXP, len));
@@ -442,6 +454,18 @@ SEXP LGBM_BoosterGetEvalNames_R(LGBM_SE handle) {
       len, &out_len,
       reserved_string_size, &required_string_size,
       ptr_names.data()));
+  // if any eval names were larger than allocated size,
+  // allow for a larger size and try again
+  if (required_string_size > reserved_string_size) {
+    CHECK_CALL(
+      LGBM_BoosterGetEvalNames(
+        R_GET_PTR(handle),
+        len,
+        &out_len,
+        required_string_size,
+        &required_string_size,
+        ptr_names.data()));
+  }
   CHECK_EQ(out_len, len);
   CHECK_GE(reserved_string_size, required_string_size);
   eval_names = PROTECT(Rf_allocVector(STRSXP, len));

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -385,14 +385,11 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetLowerBoundValue_R(
 
 /*!
 * \brief Get Name of eval
-* \param eval_names eval names
+* \param handle Handle of booster
 * \return 0 when succeed, -1 when failure happens
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEvalNames_R(
-  LGBM_SE handle,
-  SEXP buf_len,
-  SEXP actual_len,
-  LGBM_SE eval_names
+  LGBM_SE handle
 );
 
 /*!

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -383,9 +383,9 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetLowerBoundValue_R(
 );
 
 /*!
-* \brief Get Name of eval
+* \brief Get names of eval metrics
 * \param handle Handle of booster
-* \return R character vector with names of eval sets
+* \return R character vector with names of eval metrics
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEvalNames_R(
   LGBM_SE handle
@@ -588,7 +588,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModelToString_R(
 );
 
 /*!
-* \brief dump model to json
+* \brief dump model to JSON
 * \param handle Booster handle
 * \param num_iteration, <= 0 means save all
 * \param feature_importance_type type of feature importance, 0: split, 1: gain

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -559,16 +559,12 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModel_R(
 * \brief create string containing model
 * \param handle handle
 * \param num_iteration, <= 0 means save all
-* \param out_str string of model
 * \return 0 when succeed, -1 when failure happens
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModelToString_R(
   LGBM_SE handle,
   SEXP num_iteration,
-  SEXP feature_importance_type,
-  SEXP buffer_len,
-  SEXP actual_len,
-  LGBM_SE out_str
+  SEXP feature_importance_type
 );
 
 /*!
@@ -581,10 +577,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModelToString_R(
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterDumpModel_R(
   LGBM_SE handle,
   SEXP num_iteration,
-  SEXP feature_importance_type,
-  SEXP buffer_len,
-  SEXP actual_len,
-  LGBM_SE out_str
+  SEXP feature_importance_type
 );
 
 #endif  // LIGHTGBM_R_H_

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -114,14 +114,10 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetFeatureNames_R(
 /*!
 * \brief save feature names to Dataset
 * \param handle handle
-* \param feature_names feature names
 * \return 0 when succeed, -1 when failure happens
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetFeatureNames_R(
-  LGBM_SE handle,
-  SEXP buf_len,
-  SEXP actual_len,
-  LGBM_SE feature_names
+  LGBM_SE handle
 );
 
 /*!

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -101,7 +101,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetSubset_R(
 * \brief save feature names to Dataset
 * \param handle handle
 * \param feature_names feature names
-* \return R NULL value
+* \return R character vector of feature names
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetFeatureNames_R(
   LGBM_SE handle,
@@ -385,7 +385,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetLowerBoundValue_R(
 /*!
 * \brief Get Name of eval
 * \param handle Handle of booster
-* \return 0 when succeed, -1 when failure happens
+* \return R character vector with names of eval sets
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterGetEvalNames_R(
   LGBM_SE handle
@@ -579,7 +579,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModel_R(
 * \param handle Booster handle
 * \param num_iteration, <= 0 means save all
 * \param feature_importance_type type of feature importance, 0: split, 1: gain
-* \return length-1 R character vector with model string
+* \return R character vector (length=1) with model string
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModelToString_R(
   LGBM_SE handle,
@@ -592,7 +592,7 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModelToString_R(
 * \param handle Booster handle
 * \param num_iteration, <= 0 means save all
 * \param feature_importance_type type of feature importance, 0: split, 1: gain
-* \return length-1 R character vector with model JSON
+* \return R character vector (length=1) with model JSON
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterDumpModel_R(
   LGBM_SE handle,

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -112,9 +112,9 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetSetFeatureNames_R(
 );
 
 /*!
-* \brief save feature names to Dataset
-* \param handle handle
-* \return 0 when succeed, -1 when failure happens
+* \brief get feature names from Dataset
+* \param handle Dataset handle
+* \return an R character vector with feature names from the Dataset or NULL if no feature names
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetFeatureNames_R(
   LGBM_SE handle
@@ -557,9 +557,10 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModel_R(
 
 /*!
 * \brief create string containing model
-* \param handle handle
+* \param handle Booster handle
 * \param num_iteration, <= 0 means save all
-* \return 0 when succeed, -1 when failure happens
+* \param feature_importance_type type of feature importance, 0: split, 1: gain
+* \return length-1 R character vector with model string
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModelToString_R(
   LGBM_SE handle,
@@ -569,10 +570,10 @@ LIGHTGBM_C_EXPORT SEXP LGBM_BoosterSaveModelToString_R(
 
 /*!
 * \brief dump model to json
-* \param handle handle
+* \param handle Booster handle
 * \param num_iteration, <= 0 means save all
-* \param out_str json format string of model
-* \return 0 when succeed, -1 when failure happens
+* \param feature_importance_type type of feature importance, 0: split, 1: gain
+* \return length-1 R character vector with model JSON
 */
 LIGHTGBM_C_EXPORT SEXP LGBM_BoosterDumpModel_R(
   LGBM_SE handle,

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -278,3 +278,21 @@ test_that("lgb.Dataset: should be able to run lgb.cv() immediately after using l
 
   expect_is(bst, "lgb.CVBooster")
 })
+
+test_that("lgb.Dataset: should be able to use and retrieve long feature names", {
+  # set one feature to a value longer than the default buffer size used
+  # in LGBM_DatasetGetFeatureNames_R
+  feature_names <- names(iris)
+  long_name <- paste0(rep("a", 1e3), collapse = "")
+  feature_names[1L] <- long_name
+  names(iris) <- feature_names
+  # check that feature name survived the trip from R to C++ and back
+  dtrain <- lgb.Dataset(
+    data = as.matrix(iris[, -5L])
+    , label = as.numeric(iris$Species) - 1L
+  )
+  dtrain$construct()
+  col_names <- dtrain$get_colnames()
+  expect_equal(col_names[1L], long_name)
+  expect_equal(nchar(col_names[1L]), 1e3)
+})

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -283,7 +283,7 @@ test_that("lgb.Dataset: should be able to use and retrieve long feature names", 
   # set one feature to a value longer than the default buffer size used
   # in LGBM_DatasetGetFeatureNames_R
   feature_names <- names(iris)
-  long_name <- paste0(rep("a", 1e3), collapse = "")
+  long_name <- paste0(rep("a", 1000L), collapse = "")
   feature_names[1L] <- long_name
   names(iris) <- feature_names
   # check that feature name survived the trip from R to C++ and back
@@ -294,5 +294,5 @@ test_that("lgb.Dataset: should be able to use and retrieve long feature names", 
   dtrain$construct()
   col_names <- dtrain$get_colnames()
   expect_equal(col_names[1L], long_name)
-  expect_equal(nchar(col_names[1L]), 1e3)
+  expect_equal(nchar(col_names[1L]), 1000L)
 })

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -256,6 +256,8 @@ test_that("Saving a large model to string should work", {
     )
 
     pred <- predict(bst, train$data)
+    pred_leaf_indx <- predict(bst, train$data, predleaf = TRUE)
+    pred_raw_score <- predict(bst, train$data, rawscore = TRUE)
     model_string <- bst$save_model_to_string()
 
     # make sure this test is still producing a model bigger than the default
@@ -273,7 +275,11 @@ test_that("Saving a large model to string should work", {
         model_str = model_string
     )
     pred2 <- predict(bst2, train$data)
+    pred2_leaf_indx <- predict(bst2, train$data, predleaf = TRUE)
+    pred2_raw_score <- predict(bst2, train$data, rawscore = TRUE)
     expect_identical(pred, pred2)
+    expect_identical(pred_leaf_indx, pred2_leaf_indx)
+    expect_identical(pred_raw_score, pred2_raw_score)
 })
 
 test_that("Saving a large model to JSON should work", {

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -294,7 +294,7 @@ test_that("Saving a large model to JSON should work", {
     model_json <- bst$dump_model()
 
     # make sure this test is still producing a model bigger than the default
-    # buffer size used in LGBM_BoosterSaveModelToString
+    # buffer size used in LGBM_BoosterDumpModel_R
     expect_gt(nchar(model_json), 1024L * 1024L)
 
     # check that it is valid JSON that looks like a LightGBM model

--- a/R-package/tests/testthat/test_utils.R
+++ b/R-package/tests/testthat/test_utils.R
@@ -1,12 +1,3 @@
-context("lgb.encode.char")
-
-test_that("lgb.encode.char throws an informative error if it is passed a non-raw input", {
-    x <- "some-string"
-    expect_error({
-        lgb.encode.char(x)
-    }, regexp = "Can only encode from raw type")
-})
-
 context("lgb.check.r6.class")
 
 test_that("lgb.check.r6.class() should return FALSE for NULL input", {


### PR DESCRIPTION
Another step towards #3016.

Resolves https://github.com/microsoft/LightGBM/pull/4155#discussion_r623899919.

This PR affects the following functions that return an R character vector:

* `LGBM_DatasetGetFeatureNames_R()`
* `LGBM_BoosterGetEvalNames_R()`
* `LGBM_BoosterSaveModelToString_R()`
* `LGBM_BoosterDumpModel_R()`

Currently, a buffer and an R character vector are allocated on the R side, then the corresponding C++ functions are called to write model data to that buffer and, eventually, copy it into that character vector.

This PR proposes simplifying that interaction by just creating that character vector from the C++ side and returning it to R. This has the following benefits:

* eliminates some unnecessary computation, like joining all eval names into one tab-separated string and then splitting it back apart on the R side
* removes code from the R package that was involved in managing buffers
* removes unnecessary code on the C++ side (`EncodeChar`, `R_CHAR_PTR`), replacing some LightGBM-custom stuff with standard routines available from R

### References

* https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Handling-character-data