### PR TITLE
[docs] remove extra spaces in comments and docs

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -805,8 +805,8 @@ predict.lgb.Booster <- function(object,
 
 #' @name lgb.load
 #' @title Load LightGBM model
-#' @description  Load LightGBM takes in either a file path or model string.
-#'               If both are provided, Load will default to loading from file
+#' @description Load LightGBM takes in either a file path or model string.
+#'              If both are provided, Load will default to loading from file
 #' @param filename path of model file
 #' @param model_str a str containing the model
 #'

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -555,7 +555,7 @@ lgb.stratified.folds <- function(y, k = 10L) {
       ## of samples in a class is less than k, nothing is producd here.
       seqVector <- rep(seq_len(k), numInClass[i] %/% k)
 
-      ## Add enough random integers to get  length(seqVector) == numInClass[i]
+      ## Add enough random integers to get length(seqVector) == numInClass[i]
       if (numInClass[i] %% k > 0L) {
         seqVector <- c(seqVector, sample.int(k, numInClass[i] %% k))
       }

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -55,7 +55,7 @@ model <- lgb.cv(
 install.packages("lightgbm", repos = "https://cran.r-project.org")
 ```
 
-This is the easiest way to install `{lightgbm}`. It does not require `CMake` or `Visual Studio`, and  should work well on many different operating systems and compilers.
+This is the easiest way to install `{lightgbm}`. It does not require `CMake` or `Visual Studio`, and should work well on many different operating systems and compilers.
 
 Each CRAN package is also available on [LightGBM releases](https://github.com/microsoft/LightGBM/releases), with a name like `lightgbm-{VERSION}-r-cran.tar.gz`.
 

--- a/R-package/man/lgb.load.Rd
+++ b/R-package/man/lgb.load.Rd
@@ -16,7 +16,7 @@ lgb.Booster
 }
 \description{
 Load LightGBM takes in either a file path or model string.
-              If both are provided, Load will default to loading from file
+             If both are provided, Load will default to loading from file
 }
 \examples{
 \donttest{

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -112,7 +112,7 @@ SEXP LGBM_DatasetGetSubset_R(LGBM_SE handle,
   R_API_BEGIN();
   int len = Rf_asInteger(len_used_row_indices);
   std::vector<int> idxvec(len);
-  // convert from one-based to  zero-based index
+  // convert from one-based to zero-based index
 #pragma omp parallel for schedule(static, 512) if (len >= 1024)
   for (int i = 0; i < len; ++i) {
     idxvec[i] = INTEGER(used_row_indices)[i] - 1;

--- a/include/LightGBM/network.h
+++ b/include/LightGBM/network.h
@@ -63,13 +63,13 @@ class RecursiveHalvingMap {
   int neighbor;
   /*! \brief ranks[i] means the machines that will communicate with on i-th communication*/
   std::vector<int> ranks;
-  /*! \brief  send_block_start[i] means send block start index at i-th communication*/
+  /*! \brief send_block_start[i] means send block start index at i-th communication*/
   std::vector<int> send_block_start;
-  /*! \brief  send_block_start[i] means send block size at i-th communication*/
+  /*! \brief send_block_start[i] means send block size at i-th communication*/
   std::vector<int> send_block_len;
-  /*! \brief  send_block_start[i] means recv block start index at i-th communication*/
+  /*! \brief send_block_start[i] means recv block start index at i-th communication*/
   std::vector<int> recv_block_start;
-  /*! \brief  send_block_start[i] means recv block size  at i-th communication*/
+  /*! \brief send_block_start[i] means recv block size at i-th communication*/
   std::vector<int> recv_block_len;
 
   RecursiveHalvingMap();

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -208,7 +208,7 @@ class GBDT : public GBDTBase {
   * \brief Get number of prediction for one data
   * \param start_iteration Start index of the iteration to predict
   * \param num_iteration number of used iterations
-  * \param is_pred_leaf True if predicting  leaf index
+  * \param is_pred_leaf True if predicting leaf index
   * \param is_pred_contrib True if predicting feature contribution
   * \return number of prediction
   */

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -1388,7 +1388,7 @@ std::vector<std::vector<double>> DatasetLoader::GetForcedBins(std::string forced
         int feature_num = forced_bins_arr[i]["feature"].int_value();
         CHECK_LT(feature_num, num_total_features);
         if (categorical_features.count(feature_num)) {
-          Log::Warning("Feature %d is categorical. Will ignore forced bins for this  feature.", feature_num);
+          Log::Warning("Feature %d is categorical. Will ignore forced bins for this feature.", feature_num);
         } else {
           std::vector<Json> bounds_arr = forced_bins_arr[i]["bin_upper_bound"].array_items();
           for (size_t j = 0; j < bounds_arr.size(); ++j) {

--- a/src/treelearner/monotone_constraints.hpp
+++ b/src/treelearner/monotone_constraints.hpp
@@ -1097,7 +1097,7 @@ class AdvancedLeafConstraints : public IntermediateLeafConstraints {
       uint32_t threshold = tree_->threshold_in_bin(parent_idx);
 
       // by going up, more information about the position of the
-      // original leaf  are gathered so the starting and ending
+      // original leaf are gathered so the starting and ending
       // thresholds can be updated, which will save some time later
       if ((feature_for_constraint == inner_feature) && is_split_numerical) {
         if (is_in_right_child) {


### PR DESCRIPTION
This PR fixes a few places with unnecessary extra spaces in comments, docs, or log messages. Just some minor cleanup that might slightly help with actions like searching for things using `git grep` or `grep -R`.