### PR TITLE
[docs] clarify docs for LGBM_BoosterGetEvalNames and LGBM_BoosterGetEvalCounts (fixes #4264)

### DIFF
--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -575,24 +575,24 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterNumberOfTotalModel(BoosterHandle handle,
                                                      int* out_models);
 
 /*!
- * \brief Get number of evaluation datasets.
+ * \brief Get number of evaluation metrics.
  * \param handle Handle of booster
- * \param[out] out_len Total number of evaluation datasets
+ * \param[out] out_len Total number of evaluation metrics
  * \return 0 when succeed, -1 when failure happens
  */
 LIGHTGBM_C_EXPORT int LGBM_BoosterGetEvalCounts(BoosterHandle handle,
                                                 int* out_len);
 
 /*!
- * \brief Get names of evaluation datasets.
+ * \brief Get names of evaluation metrics.
  * \param handle Handle of booster
  * \param len Number of ``char*`` pointers stored at ``out_strs``.
  *            If smaller than the max size, only this many strings are copied
- * \param[out] out_len Total number of evaluation datasets
+ * \param[out] out_len Total number of evaluation metrics
  * \param buffer_len Size of pre-allocated strings.
  *                   Content is copied up to ``buffer_len - 1`` and null-terminated
  * \param[out] out_buffer_len String sizes required to do the full string copies
- * \param[out] out_strs Names of evaluation datasets, should pre-allocate memory
+ * \param[out] out_strs Names of evaluation metrics, should pre-allocate memory
  * \return 0 when succeed, -1 when failure happens
  */
 LIGHTGBM_C_EXPORT int LGBM_BoosterGetEvalNames(BoosterHandle handle,
@@ -633,7 +633,7 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterGetNumFeature(BoosterHandle handle,
 /*!
  * \brief Get evaluation for training data and validation data.
  * \note
- *   1. You should call ``LGBM_BoosterGetEvalNames`` first to get the names of evaluation datasets.
+ *   1. You should call ``LGBM_BoosterGetEvalNames`` first to get the names of evaluation metrics.
  *   2. You should pre-allocate memory for ``out_results``, you can get its length by ``LGBM_BoosterGetEvalCounts``.
  * \param handle Handle of booster
  * \param data_idx Index of data, 0: training data, 1: 1st validation data, 2: 2nd validation data and so on

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3452,7 +3452,7 @@ class Booster:
                 ctypes.byref(out_num_eval)))
             self.__num_inner_eval = out_num_eval.value
             if self.__num_inner_eval > 0:
-                # Get name of evals
+                # Get name of eval metrics
                 tmp_out_len = ctypes.c_int(0)
                 reserved_string_buffer_size = 255
                 required_string_buffer_size = ctypes.c_size_t(0)


### PR DESCRIPTION
Fixes #4264 .

This PR updates the docs on `LGBM_BoosterGetEvalNames` and `LGBM_BoosterGetEvalCounts` to clarify that those functions refer to evaluation *metrics*, not validation datasets.