### PR TITLE
Replace division of exponential in Gamma loss

### DIFF
--- a/src/objective/regression_objective.hpp
+++ b/src/objective/regression_objective.hpp
@@ -689,14 +689,14 @@ class RegressionGammaLoss : public RegressionPoissonLoss {
     if (weights_ == nullptr) {
       #pragma omp parallel for schedule(static)
       for (data_size_t i = 0; i < num_data_; ++i) {
-        gradients[i] = static_cast<score_t>(1.0 - label_[i] / std::exp(score[i]));
-        hessians[i] = static_cast<score_t>(label_[i] / std::exp(score[i]));
+        gradients[i] = static_cast<score_t>(1.0 - label_[i] * std::exp(-score[i]));
+        hessians[i] = static_cast<score_t>(label_[i] * std::exp(-score[i]));
       }
     } else {
       #pragma omp parallel for schedule(static)
       for (data_size_t i = 0; i < num_data_; ++i) {
-        gradients[i] = static_cast<score_t>(1.0 - label_[i] / std::exp(score[i]) * weights_[i]);
-        hessians[i] = static_cast<score_t>(label_[i] / std::exp(score[i]) * weights_[i]);
+        gradients[i] = static_cast<score_t>(1.0 - label_[i] * std::exp(-score[i]) * weights_[i]);
+        hessians[i] = static_cast<score_t>(label_[i] * std::exp(-score[i]) * weights_[i]);
       }
     }
   }


### PR DESCRIPTION
This PR replaces `/ exp(x)` by `* exp(-x)` in the Gamma deviance objective.

It was a finding in #4283.