### PR TITLE
[R-package] Handle integer types more accurate in R-to-C interface

### DIFF
--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -531,7 +531,7 @@ SEXP LGBM_BoosterGetNumPredict_R(SEXP handle,
   SEXP out) {
   R_API_BEGIN();
   int64_t len;
-  CHECK_CALL(LGBM_BoosterGetNumPredict(R_ExternalPtrAddr(handle), Rf_asInteger(data_idx), &len));
+  CHECK_CALL(LGBM_BoosterGetNumPredict(R_ExternalPtrAddr(handle), static_cast<int>Rf_asInteger(data_idx), &len));
   INTEGER(out)[0] = static_cast<int>(len);
   R_API_END();
 }

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -696,8 +696,8 @@ SEXP LGBM_BoosterDumpModel_R(SEXP handle,
   R_API_BEGIN();
   int64_t out_len = 0;
   int64_t buf_len = 1024 * 1024;
-  int64_t num_iter = static_cast<int64_t>Rf_asInteger(num_iteration);
-  int64_t importance_type = static_cast<int64_t>Rf_asInteger(feature_importance_type);
+  int num_iter = Rf_asInteger(num_iteration);
+  int importance_type = Rf_asInteger(feature_importance_type);
   std::vector<char> inner_char_buf(buf_len);
   CHECK_CALL(LGBM_BoosterDumpModel(R_ExternalPtrAddr(handle), 0, num_iter, importance_type, buf_len, &out_len, inner_char_buf.data()));
   // if the model string was larger than the initial buffer, allocate a bigger buffer and try again

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -521,7 +521,7 @@ SEXP LGBM_BoosterGetEval_R(SEXP handle,
   CHECK_CALL(LGBM_BoosterGetEvalCounts(R_ExternalPtrAddr(handle), &len));
   double* ptr_ret = REAL(out_result);
   int out_len;
-  CHECK_CALL(LGBM_BoosterGetEval(R_ExternalPtrAddr(handle), static_cast<int>Rf_asInteger(data_idx), &out_len, ptr_ret));
+  CHECK_CALL(LGBM_BoosterGetEval(R_ExternalPtrAddr(handle), static_cast<int>(Rf_asInteger(data_idx)), &out_len, ptr_ret));
   CHECK_EQ(out_len, len);
   R_API_END();
 }
@@ -531,7 +531,7 @@ SEXP LGBM_BoosterGetNumPredict_R(SEXP handle,
   SEXP out) {
   R_API_BEGIN();
   int64_t len;
-  CHECK_CALL(LGBM_BoosterGetNumPredict(R_ExternalPtrAddr(handle), static_cast<int>Rf_asInteger(data_idx), &len));
+  CHECK_CALL(LGBM_BoosterGetNumPredict(R_ExternalPtrAddr(handle), static_cast<int>(Rf_asInteger(data_idx)), &len));
   INTEGER(out)[0] = static_cast<int>(len);
   R_API_END();
 }
@@ -542,7 +542,7 @@ SEXP LGBM_BoosterGetPredict_R(SEXP handle,
   R_API_BEGIN();
   double* ptr_ret = REAL(out_result);
   int64_t out_len;
-  CHECK_CALL(LGBM_BoosterGetPredict(R_ExternalPtrAddr(handle), Rf_asInteger(data_idx), &out_len, ptr_ret));
+  CHECK_CALL(LGBM_BoosterGetPredict(R_ExternalPtrAddr(handle), static_cast<int>(Rf_asInteger(data_idx)), &out_len, ptr_ret));
   R_API_END();
 }
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -624,7 +624,7 @@ SEXP LGBM_BoosterPredictForCSC_R(SEXP handle,
   CHECK_CALL(LGBM_BoosterPredictForCSC(R_ExternalPtrAddr(handle),
     p_indptr, C_API_DTYPE_INT32, p_indices,
     p_data, C_API_DTYPE_FLOAT64, nindptr, ndata,
-    nrow, pred_type, static_cast<int64>(Rf_asInteger(start_iteration)), static_cast<int64>(Rf_asInteger(num_iteration)),
+    nrow, pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration),
     CHAR(Rf_asChar(parameter)), &out_len, ptr_ret));
   R_API_END();
 }

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -531,7 +531,7 @@ SEXP LGBM_BoosterGetNumPredict_R(SEXP handle,
   SEXP out) {
   R_API_BEGIN();
   int64_t len;
-  CHECK_CALL(LGBM_BoosterGetNumPredict(R_ExternalPtrAddr(handle), static_cast<int>(Rf_asInteger(data_idx)), &len));
+  CHECK_CALL(LGBM_BoosterGetNumPredict(R_ExternalPtrAddr(handle), Rf_asInteger(data_idx), &len));
   INTEGER(out)[0] = static_cast<int>(len);
   R_API_END();
 }

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -445,7 +445,7 @@ SEXP LGBM_BoosterGetCurrentIteration_R(SEXP handle,
   int out_iteration;
   R_API_BEGIN();
   CHECK_CALL(LGBM_BoosterGetCurrentIteration(R_ExternalPtrAddr(handle), &out_iteration));
-  INTEGER(out)[0] = static_cast<int>(out_iteration);
+  INTEGER(out)[0] = out_iteration;
   R_API_END();
 }
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -573,8 +573,7 @@ SEXP LGBM_BoosterPredictForFile_R(SEXP handle,
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
   CHECK_CALL(LGBM_BoosterPredictForFile(R_ExternalPtrAddr(handle), CHAR(Rf_asChar(data_filename)),
-    Rf_asInteger(data_has_header), pred_type, Rf_asInteger(start_iteration),
-    Rf_asInteger(num_iteration), CHAR(Rf_asChar(parameter)),
+    Rf_asInteger(data_has_header), pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), CHAR(Rf_asChar(parameter)),
     CHAR(Rf_asChar(result_filename))));
   R_API_END();
 }

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -521,7 +521,7 @@ SEXP LGBM_BoosterGetEval_R(SEXP handle,
   CHECK_CALL(LGBM_BoosterGetEvalCounts(R_ExternalPtrAddr(handle), &len));
   double* ptr_ret = REAL(out_result);
   int out_len;
-  CHECK_CALL(LGBM_BoosterGetEval(R_ExternalPtrAddr(handle), static_cast<int>(Rf_asInteger(data_idx)), &out_len, ptr_ret));
+  CHECK_CALL(LGBM_BoosterGetEval(R_ExternalPtrAddr(handle), Rf_asInteger(data_idx), &out_len, ptr_ret));
   CHECK_EQ(out_len, len);
   R_API_END();
 }

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -423,7 +423,7 @@ SEXP LGBM_BoosterUpdateOneIterCustom_R(SEXP handle,
   SEXP len) {
   int is_finished = 0;
   R_API_BEGIN();
-  int int_len = Rf_asInteger(len);
+  int int_len = static_cast<int>Rf_asInteger(len);
   std::vector<float> tgrad(int_len), thess(int_len);
 #pragma omp parallel for schedule(static, 512) if (int_len >= 1024)
   for (int j = 0; j < int_len; ++j) {

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -132,7 +132,7 @@ SEXP LGBM_DatasetGetSubset_R(SEXP handle,
   SEXP parameters) {
   SEXP ret;
   R_API_BEGIN();
-  int32_t len = static_cast<int32_t>Rf_asInteger(len_used_row_indices);
+  int32_t len = static_cast<int32_t>(Rf_asInteger(len_used_row_indices));
   std::vector<int32_t> idxvec(len);
   // convert from one-based to zero-based index
 #pragma omp parallel for schedule(static, 512) if (len >= 1024)
@@ -423,7 +423,7 @@ SEXP LGBM_BoosterUpdateOneIterCustom_R(SEXP handle,
   SEXP len) {
   int is_finished = 0;
   R_API_BEGIN();
-  int int_len = static_cast<int>Rf_asInteger(len);
+  int int_len = static_cast<int>(Rf_asInteger(len));
   std::vector<float> tgrad(int_len), thess(int_len);
 #pragma omp parallel for schedule(static, 512) if (int_len >= 1024)
   for (int j = 0; j < int_len; ++j) {

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -673,8 +673,8 @@ SEXP LGBM_BoosterSaveModelToString_R(SEXP handle,
   R_API_BEGIN();
   int64_t out_len = 0;
   int64_t buf_len = 1024 * 1024;
-  int64_t num_iter = static_cast<int64_t>Rf_asInteger(num_iteration);
-  int64_t importance_type = static_cast<int64_t>Rf_asInteger(feature_importance_type);
+  int num_iter = Rf_asInteger(num_iteration);
+  int importance_type = Rf_asInteger(feature_importance_type);
   std::vector<char> inner_char_buf(buf_len);
   CHECK_CALL(LGBM_BoosterSaveModelToString(R_ExternalPtrAddr(handle), 0, num_iter, importance_type, buf_len, &out_len, inner_char_buf.data()));
   // if the model string was larger than the initial buffer, allocate a bigger buffer and try again

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -542,7 +542,7 @@ SEXP LGBM_BoosterGetPredict_R(SEXP handle,
   R_API_BEGIN();
   double* ptr_ret = REAL(out_result);
   int64_t out_len;
-  CHECK_CALL(LGBM_BoosterGetPredict(R_ExternalPtrAddr(handle), static_cast<int>(Rf_asInteger(data_idx)), &out_len, ptr_ret));
+  CHECK_CALL(LGBM_BoosterGetPredict(R_ExternalPtrAddr(handle), Rf_asInteger(data_idx), &out_len, ptr_ret));
   R_API_END();
 }
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -521,7 +521,7 @@ SEXP LGBM_BoosterGetEval_R(SEXP handle,
   CHECK_CALL(LGBM_BoosterGetEvalCounts(R_ExternalPtrAddr(handle), &len));
   double* ptr_ret = REAL(out_result);
   int out_len;
-  CHECK_CALL(LGBM_BoosterGetEval(R_ExternalPtrAddr(handle), Rf_asInteger(data_idx), &out_len, ptr_ret));
+  CHECK_CALL(LGBM_BoosterGetEval(R_ExternalPtrAddr(handle), static_cast<int>Rf_asInteger(data_idx), &out_len, ptr_ret));
   CHECK_EQ(out_len, len);
   R_API_END();
 }

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -590,8 +590,8 @@ SEXP LGBM_BoosterCalcNumPredict_R(SEXP handle,
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
   int64_t len = 0;
-  CHECK_CALL(LGBM_BoosterCalcNumPredict(R_ExternalPtrAddr(handle), Rf_asInteger(num_row),
-    pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), &len));
+  CHECK_CALL(LGBM_BoosterCalcNumPredict(R_ExternalPtrAddr(handle), static_cast<int>(Rf_asInteger(num_row)),
+    pred_type, static_cast<int>(Rf_asInteger(start_iteration)), static_cast<int>(Rf_asInteger(num_iteration)), &len));
   INTEGER(out_len)[0] = static_cast<int>(len);
   R_API_END();
 }

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -614,7 +614,7 @@ SEXP LGBM_BoosterPredictForCSC_R(SEXP handle,
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
 
   const int* p_indptr = INTEGER(indptr);
-  const int32_t* p_indices = static_cast<int32_t>(INTEGER(indices));
+  const int32_t* p_indices = reinterpret_cast<const int32_t*>(INTEGER(indices));
   const double* p_data = REAL(data);
 
   int64_t nindptr = static_cast<int64_t>Rf_asInteger(num_indptr);

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -590,8 +590,8 @@ SEXP LGBM_BoosterCalcNumPredict_R(SEXP handle,
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
   int64_t len = 0;
-  CHECK_CALL(LGBM_BoosterCalcNumPredict(R_ExternalPtrAddr(handle), static_cast<int>(Rf_asInteger(num_row)),
-    pred_type, static_cast<int>(Rf_asInteger(start_iteration)), static_cast<int>(Rf_asInteger(num_iteration)), &len));
+  CHECK_CALL(LGBM_BoosterCalcNumPredict(R_ExternalPtrAddr(handle), Rf_asInteger(num_row),
+    pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), &len));
   INTEGER(out_len)[0] = static_cast<int>(len);
   R_API_END();
 }

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -642,8 +642,8 @@ SEXP LGBM_BoosterPredictForMat_R(SEXP handle,
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
 
-  int32_t nrow = Rf_asInteger(num_row);
-  int32_t ncol = Rf_asInteger(num_col);
+  int32_t nrow = static_cast<int32_t>Rf_asInteger(num_row);
+  int32_t ncol = static_cast<int32_t>Rf_asInteger(num_col);
 
   const double* p_mat = REAL(data);
   double* ptr_ret = REAL(out_result);

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -573,7 +573,8 @@ SEXP LGBM_BoosterPredictForFile_R(SEXP handle,
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
   CHECK_CALL(LGBM_BoosterPredictForFile(R_ExternalPtrAddr(handle), CHAR(Rf_asChar(data_filename)),
-    Rf_asInteger(data_has_header), pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), CHAR(Rf_asChar(parameter)),
+    static_cast<int>(Rf_asInteger(data_has_header)), pred_type, static_cast<int>(Rf_asInteger(start_iteration)),
+    static_cast<int>(Rf_asInteger(num_iteration)), CHAR(Rf_asChar(parameter)),
     CHAR(Rf_asChar(result_filename))));
   R_API_END();
 }

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -423,7 +423,7 @@ SEXP LGBM_BoosterUpdateOneIterCustom_R(SEXP handle,
   SEXP len) {
   int is_finished = 0;
   R_API_BEGIN();
-  int int_len = static_cast<int>(Rf_asInteger(len));
+  int int_len = Rf_asInteger(len);
   std::vector<float> tgrad(int_len), thess(int_len);
 #pragma omp parallel for schedule(static, 512) if (int_len >= 1024)
   for (int j = 0; j < int_len; ++j) {

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -231,7 +231,7 @@ SEXP LGBM_DatasetSetField_R(SEXP handle,
   SEXP field_data,
   SEXP num_element) {
   R_API_BEGIN();
-  int len = static_cast<int>(Rf_asInteger(num_element));
+  int len = Rf_asInteger(num_element);
   const char* name = CHAR(Rf_asChar(field_name));
   if (!strcmp("group", name) || !strcmp("query", name)) {
     std::vector<int32_t> vec(len);

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -313,7 +313,7 @@ SEXP LGBM_DatasetGetNumData_R(SEXP handle, SEXP out) {
   int nrow;
   R_API_BEGIN();
   CHECK_CALL(LGBM_DatasetGetNumData(R_ExternalPtrAddr(handle), &nrow));
-  INTEGER(out)[0] = static_cast<int>(nrow);
+  INTEGER(out)[0] = nrow;
   R_API_END();
 }
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -132,11 +132,11 @@ SEXP LGBM_DatasetGetSubset_R(SEXP handle,
   SEXP parameters) {
   SEXP ret;
   R_API_BEGIN();
-  int len = static_cast<int>Rf_asInteger(len_used_row_indices);
-  std::vector<int> idxvec(len);
+  int32_t len = static_cast<int32_t>Rf_asInteger(len_used_row_indices);
+  std::vector<int32_t> idxvec(len);
   // convert from one-based to zero-based index
 #pragma omp parallel for schedule(static, 512) if (len >= 1024)
-  for (int i = 0; i < len; ++i) {
+  for (int32_t i = 0; i < len; ++i) {
     idxvec[i] = INTEGER(used_row_indices)[i] - 1;
   }
   DatasetHandle res = nullptr;

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -298,7 +298,7 @@ SEXP LGBM_DatasetGetFieldSize_R(SEXP handle,
   if (!strcmp("group", name) || !strcmp("query", name)) {
     out_len -= 1;
   }
-  INTEGER(out)[0] = static_cast<int>(out_len);
+  INTEGER(out)[0] = out_len;
   R_API_END();
 }
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -573,8 +573,8 @@ SEXP LGBM_BoosterPredictForFile_R(SEXP handle,
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
   CHECK_CALL(LGBM_BoosterPredictForFile(R_ExternalPtrAddr(handle), CHAR(Rf_asChar(data_filename)),
-    static_cast<int>(Rf_asInteger(data_has_header)), pred_type, static_cast<int>(Rf_asInteger(start_iteration)),
-    static_cast<int>(Rf_asInteger(num_iteration)), CHAR(Rf_asChar(parameter)),
+    Rf_asInteger(data_has_header), pred_type, Rf_asInteger(start_iteration),
+    Rf_asInteger(num_iteration), CHAR(Rf_asChar(parameter)),
     CHAR(Rf_asChar(result_filename))));
   R_API_END();
 }

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -132,7 +132,7 @@ SEXP LGBM_DatasetGetSubset_R(SEXP handle,
   SEXP parameters) {
   SEXP ret;
   R_API_BEGIN();
-  int len = Rf_asInteger(len_used_row_indices);
+  int len = static_cast<int>Rf_asInteger(len_used_row_indices);
   std::vector<int> idxvec(len);
   // convert from one-based to zero-based index
 #pragma omp parallel for schedule(static, 512) if (len >= 1024)

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -614,7 +614,7 @@ SEXP LGBM_BoosterPredictForCSC_R(SEXP handle,
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
 
   const int* p_indptr = INTEGER(indptr);
-  const int* p_indices = INTEGER(indices);
+  const int32_t* p_indices = static_cast<int32_t>(INTEGER(indices));
   const double* p_data = REAL(data);
 
   int64_t nindptr = static_cast<int64_t>Rf_asInteger(num_indptr);
@@ -625,7 +625,8 @@ SEXP LGBM_BoosterPredictForCSC_R(SEXP handle,
   CHECK_CALL(LGBM_BoosterPredictForCSC(R_ExternalPtrAddr(handle),
     p_indptr, C_API_DTYPE_INT32, p_indices,
     p_data, C_API_DTYPE_FLOAT64, nindptr, ndata,
-    nrow, pred_type,  Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), CHAR(Rf_asChar(parameter)), &out_len, ptr_ret));
+    nrow, pred_type, static_cast<int64>(Rf_asInteger(start_iteration)), static_cast<int64>(Rf_asInteger(num_iteration)),
+    CHAR(Rf_asChar(parameter)), &out_len, ptr_ret));
   R_API_END();
 }
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -624,8 +624,7 @@ SEXP LGBM_BoosterPredictForCSC_R(SEXP handle,
   CHECK_CALL(LGBM_BoosterPredictForCSC(R_ExternalPtrAddr(handle),
     p_indptr, C_API_DTYPE_INT32, p_indices,
     p_data, C_API_DTYPE_FLOAT64, nindptr, ndata,
-    nrow, pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration),
-    CHAR(Rf_asChar(parameter)), &out_len, ptr_ret));
+    nrow, pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), CHAR(Rf_asChar(parameter)), &out_len, ptr_ret));
   R_API_END();
 }
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -671,8 +671,8 @@ SEXP LGBM_BoosterSaveModelToString_R(SEXP handle,
   R_API_BEGIN();
   int64_t out_len = 0;
   int64_t buf_len = 1024 * 1024;
-  int64_t num_iter = Rf_asInteger(num_iteration);
-  int64_t importance_type = Rf_asInteger(feature_importance_type);
+  int64_t num_iter = static_cast<int64_t>Rf_asInteger(num_iteration);
+  int64_t importance_type = static_cast<int64_t>Rf_asInteger(feature_importance_type);
   std::vector<char> inner_char_buf(buf_len);
   CHECK_CALL(LGBM_BoosterSaveModelToString(R_ExternalPtrAddr(handle), 0, num_iter, importance_type, buf_len, &out_len, inner_char_buf.data()));
   // if the model string was larger than the initial buffer, allocate a bigger buffer and try again
@@ -694,8 +694,8 @@ SEXP LGBM_BoosterDumpModel_R(SEXP handle,
   R_API_BEGIN();
   int64_t out_len = 0;
   int64_t buf_len = 1024 * 1024;
-  int64_t num_iter = Rf_asInteger(num_iteration);
-  int64_t importance_type = Rf_asInteger(feature_importance_type);
+  int64_t num_iter = static_cast<int64_t>Rf_asInteger(num_iteration);
+  int64_t importance_type = static_cast<int64_t>Rf_asInteger(feature_importance_type);
   std::vector<char> inner_char_buf(buf_len);
   CHECK_CALL(LGBM_BoosterDumpModel(R_ExternalPtrAddr(handle), 0, num_iter, importance_type, buf_len, &out_len, inner_char_buf.data()));
   // if the model string was larger than the initial buffer, allocate a bigger buffer and try again

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -616,9 +616,9 @@ SEXP LGBM_BoosterPredictForCSC_R(SEXP handle,
   const int* p_indices = INTEGER(indices);
   const double* p_data = REAL(data);
 
-  int64_t nindptr = Rf_asInteger(num_indptr);
-  int64_t ndata = Rf_asInteger(nelem);
-  int64_t nrow = Rf_asInteger(num_row);
+  int64_t nindptr = static_cast<int64_t>Rf_asInteger(num_indptr);
+  int64_t ndata = static_cast<int64_t>Rf_asInteger(nelem);
+  int64_t nrow = static_cast<int64_t>Rf_asInteger(num_row);
   double* ptr_ret = REAL(out_result);
   int64_t out_len;
   CHECK_CALL(LGBM_BoosterPredictForCSC(R_ExternalPtrAddr(handle),

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -406,7 +406,7 @@ SEXP LGBM_BoosterGetNumClasses_R(SEXP handle,
   int num_class;
   R_API_BEGIN();
   CHECK_CALL(LGBM_BoosterGetNumClasses(R_ExternalPtrAddr(handle), &num_class));
-  INTEGER(out)[0] = static_cast<int>(num_class);
+  INTEGER(out)[0] = num_class;
   R_API_END();
 }
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -322,7 +322,7 @@ SEXP LGBM_DatasetGetNumFeature_R(SEXP handle,
   int nfeature;
   R_API_BEGIN();
   CHECK_CALL(LGBM_DatasetGetNumFeature(R_ExternalPtrAddr(handle), &nfeature));
-  INTEGER(out)[0] = static_cast<int>(nfeature);
+  INTEGER(out)[0] = nfeature;
   R_API_END();
 }
 

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -137,7 +137,7 @@ SEXP LGBM_DatasetGetSubset_R(SEXP handle,
   // convert from one-based to zero-based index
 #pragma omp parallel for schedule(static, 512) if (len >= 1024)
   for (int32_t i = 0; i < len; ++i) {
-    idxvec[i] = INTEGER(used_row_indices)[i] - 1;
+    idxvec[i] = static_cast<int32_t>(INTEGER(used_row_indices)[i] - 1);
   }
   DatasetHandle res = nullptr;
   CHECK_CALL(LGBM_DatasetGetSubset(R_ExternalPtrAddr(handle),

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -616,9 +616,9 @@ SEXP LGBM_BoosterPredictForCSC_R(SEXP handle,
   const int32_t* p_indices = reinterpret_cast<const int32_t*>(INTEGER(indices));
   const double* p_data = REAL(data);
 
-  int64_t nindptr = static_cast<int64_t>Rf_asInteger(num_indptr);
-  int64_t ndata = static_cast<int64_t>Rf_asInteger(nelem);
-  int64_t nrow = static_cast<int64_t>Rf_asInteger(num_row);
+  int64_t nindptr = static_cast<int64_t>(Rf_asInteger(num_indptr));
+  int64_t ndata = static_cast<int64_t>(Rf_asInteger(nelem));
+  int64_t nrow = static_cast<int64_t>(Rf_asInteger(num_row));
   double* ptr_ret = REAL(out_result);
   int64_t out_len;
   CHECK_CALL(LGBM_BoosterPredictForCSC(R_ExternalPtrAddr(handle),
@@ -642,8 +642,8 @@ SEXP LGBM_BoosterPredictForMat_R(SEXP handle,
   R_API_BEGIN();
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
 
-  int32_t nrow = static_cast<int32_t>Rf_asInteger(num_row);
-  int32_t ncol = static_cast<int32_t>Rf_asInteger(num_col);
+  int32_t nrow = static_cast<int32_t>(Rf_asInteger(num_row));
+  int32_t ncol = static_cast<int32_t>(Rf_asInteger(num_col));
 
   const double* p_mat = REAL(data);
   double* ptr_ret = REAL(out_result);


### PR DESCRIPTION
Fix compilation warnings like the following one
```
C:\Users\runneradmin\RtmpMzXGiG\R.INSTALL11384d93526b\lightgbm\src\src\lightgbm_R.cpp(670,3): warning C4244: 'argument': conversion from 'int64_t' to 'int', possible loss of data [C:\Users\runneradmin\RtmpMzXGiG\R.INSTALL11384d93526b\lightgbm\src\build\_lightgbm.vcxproj]
```

Checked all `Rf_asInteger` and `INTEGER` calls and tried to bring data types in the consistency with original ones from 
https://github.com/microsoft/LightGBM/blob/master/include/LightGBM/c_api.h.