### PR TITLE
[docs] replace broken mmlspark notebook link in docs

### DIFF
--- a/docs/Parallel-Learning-Guide.rst
+++ b/docs/Parallel-Learning-Guide.rst
@@ -455,7 +455,7 @@ Example
 
 .. _MMLSpark: https://aka.ms/spark
 
-.. _this MMLSpark example: https://github.com/Azure/mmlspark/blob/master/notebooks/samples/LightGBM%20-%20Quantile%20Regression%20for%20Drug%20Discovery.ipynb
+.. _this MMLSpark example: https://github.com/Azure/mmlspark/blob/master/notebooks/samples/LightGBM%20-%20Overview.ipynb
 
 .. _the Dask Array documentation: https://docs.dask.org/en/latest/array.html
 


### PR DESCRIPTION
The most recent `link checks` job failed.

```text
URL        `https://github.com/Azure/mmlspark/blob/master/notebooks/samples/LightGBM%20-%20Quantile%20Regression%20for%20Drug%20Discovery.ipynb'
Name       `this MMLSpark example'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/Parallel-Learning-Guide.html, line 273, col 8
Real URL   https://github.com/Azure/mmlspark/blob/master/notebooks/samples/LightGBM%20-%20Quantile%20Regression%20for%20Drug%20Discovery.ipynb
Check time 0.464 seconds
Result     Error: 404 Not Found
```

reference: https://github.com/microsoft/LightGBM/runs/2618067011?check_suite_focus=true

Seems that `mmlspark` removed their LightGBM Quantile Regression example yesterday. See https://github.com/Azure/mmlspark/pull/1043.

This PR proposes updating the documentation to point to a different LightGBM `mmlspark` notebook.
