### PR TITLE
WIP: [ci] remove pin on dask and distributed in CI (fixes #4285)

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -104,14 +104,7 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-# temporary fix for https://github.com/microsoft/LightGBM/issues/4285
-if [[ $PYTHON_VERSION == "3.6" ]]; then
-    DASK_DEPENDENCIES="dask distributed"
-else
-    DASK_DEPENDENCIES="dask=2021.4.0 distributed=2021.4.0"
-fi
-
-conda install -q -y -n $CONDA_ENV cloudpickle ${DASK_DEPENDENCIES} joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
 pip install graphviz  # python-graphviz from Anaconda is not allowed to be installed with Python 3.9
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -104,8 +104,11 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle dask-core distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
-pip install graphviz  # python-graphviz from Anaconda is not allowed to be installed with Python 3.9
+conda install -q -y -n $CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+pip install \
+    dask \
+    distributed \
+    graphviz  # python-graphviz from Anaconda is not allowed to be installed with Python 3.9
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     # fix "OMP: Error #15: Initializing libiomp5.dylib, but found libomp.dylib already initialized." (OpenMP library conflict due to conda's MKL)

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -104,7 +104,7 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle dask-core distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
 pip install graphviz  # python-graphviz from Anaconda is not allowed to be installed with Python 3.9
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -104,11 +104,8 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
-pip install \
-    dask \
-    distributed \
-    graphviz  # python-graphviz from Anaconda is not allowed to be installed with Python 3.9
+conda install -q -y -n $CONDA_ENV cloudpickle dask-core distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+pip install graphviz  # python-graphviz from Anaconda is not allowed to be installed with Python 3.9
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     # fix "OMP: Error #15: Initializing libiomp5.dylib, but found libomp.dylib already initialized." (OpenMP library conflict due to conda's MKL)

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -104,7 +104,7 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+conda install -q -y -n $CONDA_ENV cloudpickle dask-core distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
 pip install graphviz  # python-graphviz from Anaconda is not allowed to be installed with Python 3.9
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then


### PR DESCRIPTION
https://github.com/microsoft/LightGBM/pull/4288 introduced explicit pins on `dask` and `distributed` in this project's CI jobs, due to https://github.com/dask/distributed/issues/4819.

Starting from `dask` / `distributed` 2021.5.0, Dask maintainers decided to pin `distributed` like `dask=={version}` to avoid such issues in the future. See https://github.com/dask/community/issues/155#issuecomment-841399732

`dask-core` and `distributed` 2021.5.0 are now available from the default conda channels. As soon as `dask` is available there as well, I think the workaround from #4288 can be reverted.

* `distributed 2021.5.0`: https://repo.anaconda.com/pkgs/main/linux-64/
* `dask-core 2021.5.0`: https://repo.anaconda.com/pkgs/main/noarch/
* `dask (currently 2021.4.0)`: https://repo.anaconda.com/pkgs/main/noarch/

Just opening this PR for visibility. I think it will fail until `dask` is uploaded too