### PR TITLE
[fix] fix GatherInfoForThresholdNumerical boundary (fix #4286)

### DIFF
--- a/src/treelearner/feature_histogram.hpp
+++ b/src/treelearner/feature_histogram.hpp
@@ -572,7 +572,7 @@ class FeatureHistogram {
     const double cnt_factor = num_data / sum_hessian;
     // from right to left, and we don't need data in bin0
     for (; t >= t_end; --t) {
-      if (static_cast<uint32_t>(t + offset) < threshold) {
+      if (static_cast<uint32_t>(t + offset) <= threshold) {
         break;
       }
 


### PR DESCRIPTION
This is to fix #4286. In `GatherInfoForThresholdNumerical `, since it is calculating the right sum statistics, it should break when `static_cast<uint32_t>(t + offset) <= threshold` instead of `static_cast<uint32_t>(t + offset) < threshold`. Because data with bin value `<= threshold` are split into the left child node.