### PR TITLE
[fix] fix Sample when sampling only one element (fix #4134)

### DIFF
--- a/include/LightGBM/utils/random.h
+++ b/include/LightGBM/utils/random.h
@@ -82,6 +82,9 @@ class Random {
           ret.push_back(i);
         }
       }
+    } else if (K == 1) {
+      int v = NextInt(0, N);
+      ret.push_back(v);
     } else {
       std::set<int> sample_set;
       for (int r = N - K; r < N; ++r) {


### PR DESCRIPTION
This is to fix #4134. Currently, when `K=1`, it is impossible for the `Sample` function to sample the last element. Add a separate case for `K=1`.