### PR TITLE
[fix] skip empty bins when calculating cnt_in_bin in BinMapper::FindBin (fix #4301)

### DIFF
--- a/src/io/bin.cpp
+++ b/src/io/bin.cpp
@@ -411,7 +411,7 @@ namespace LightGBM {
         cnt_in_bin.resize(num_bin_, 0);
         int i_bin = 0;
         for (int i = 0; i < num_distinct_values; ++i) {
-          if (distinct_values[i] > bin_upper_bound_[i_bin]) {
+          while (distinct_values[i] > bin_upper_bound_[i_bin] && i_bin < num_bin_ - 1) {
             ++i_bin;
           }
           cnt_in_bin[i_bin] += counts[i];


### PR DESCRIPTION
As described in https://github.com/microsoft/LightGBM/issues/4301#issuecomment-848622040, this is to fix #4301 by skipping the empty bins when calculating cnt_in_bin in `BinMapper::FindBin`. So that we can correctly decides the `most_freq_bin_`.