### PR TITLE
[ci] Increase timeout value for QEMU builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -150,7 +150,7 @@ jobs:
     PRODUCES_ARTIFACTS: 'true'
   pool:
     vmImage: ubuntu-latest
-  timeoutInMinutes: 120
+  timeoutInMinutes: 150
   strategy:
     matrix:
       bdist:


### PR DESCRIPTION
`120` is too close to values reported in https://github.com/microsoft/LightGBM/pull/3996#issuecomment-845068961 and can sometimes be not enough to finish all tests (for example, here https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=10157&view=logs&j=c2f9361f-3c13-57db-3206-cee89820d5e3). Sorry, I had to think about this in #3996.