### PR TITLE
[CUDA] fix CUDA memory error by reducing block number (#4315)

### DIFF
--- a/src/treelearner/cuda_kernel_launcher.cu
+++ b/src/treelearner/cuda_kernel_launcher.cu
@@ -38,20 +38,20 @@ void cuda_histogram(
     if (leaf_num_data == num_data) {
       if (use_all_features) {
         if (!is_constant_hessian)
-          histogram16<<<16*num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
+          histogram16<<<num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
         else
-           histogram16<<<16*num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
+           histogram16<<<num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6_const, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
       } else {
         if (!is_constant_hessian)
-           histogram16_fulldata<<<16*num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
+           histogram16_fulldata<<<num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
         else
-           histogram16_fulldata<<<16*num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
+           histogram16_fulldata<<<num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6_const, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
       }
@@ -59,20 +59,20 @@ void cuda_histogram(
       if (use_all_features) {
         // seems all features is always enabled, so this should be the same as fulldata
         if (!is_constant_hessian)
-          histogram16<<<16*num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
+          histogram16<<<num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
         else
-          histogram16<<<16*num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
+          histogram16<<<num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6_const, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
       } else {
         if (!is_constant_hessian)
-          histogram16<<<16*num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
+          histogram16<<<num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
         else
-          histogram16<<<16*num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
+          histogram16<<<num_workgroups, 16, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6_const, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
       }
@@ -81,20 +81,20 @@ void cuda_histogram(
     if (leaf_num_data == num_data) {
       if (use_all_features) {
         if (!is_constant_hessian)
-          histogram64<<<4*num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
+          histogram64<<<num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
         else
-          histogram64<<<4*num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
+          histogram64<<<num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6_const, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
       } else {
         if (!is_constant_hessian)
-          histogram64_fulldata<<<4*num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
+          histogram64_fulldata<<<num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
         else
-          histogram64_fulldata<<<4*num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
+          histogram64_fulldata<<<num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6_const, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
       }
@@ -102,20 +102,20 @@ void cuda_histogram(
       if (use_all_features) {
         // seems all features is always enabled, so this should be the same as fulldata
         if (!is_constant_hessian)
-          histogram64<<<4*num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
+          histogram64<<<num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
         else
-          histogram64<<<4*num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
+          histogram64<<<num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6_const, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
       } else {
         if (!is_constant_hessian)
-          histogram64<<<4*num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
+          histogram64<<<num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
         else
-          histogram64<<<4*num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
+          histogram64<<<num_workgroups, 64, 0, stream>>>(arg0, arg1, arg2,
                   arg3, arg4, arg5,
                   arg6_const, arg7, arg8, static_cast<acc_type*>(arg9), exp_workgroups_per_feature);
       }


### PR DESCRIPTION
By using the log from https://github.com/microsoft/LightGBM/blob/master/src/treelearner/cuda_tree_learner.cpp#L334, we could see the CUDA memory allocated is 18000000 bytes,  when running the example code of https://github.com/microsoft/LightGBM/issues/4315. But by adding a log on https://github.com/microsoft/LightGBM/blob/master/src/treelearner/kernels/histogram_16_64_256.cu#L148, I found that the access offset defined by `feature_id * feature_size` is much larger than 18000000 bytes. This is the cause of the memory accessing error.
Actually, the `feature_id` is already the identity number of these dense features, so we don't need, and can't multiply the `num_workgroups` for CUDA kernel in https://github.com/microsoft/LightGBM/blob/master/src/treelearner/cuda_kernel_launcher.cu

I have already tested some self-made cases for LightGBM(CUDA) with and without multiply of `num_workgroups` in the CUDA kernel. The test results show that they could reach the same model accuracy or loss.