### PR TITLE
sync for init score of binary objective function

### DIFF
--- a/src/objective/binary_objective.hpp
+++ b/src/objective/binary_objective.hpp
@@ -152,6 +152,10 @@ class BinaryLogloss: public ObjectiveFunction {
         suml += is_pos_(label_[i]);
       }
     }
+    if (Network::num_machines() > 1) {
+      suml = Network::GlobalSyncUpBySum(suml);
+      sumw = Network::GlobalSyncUpBySum(sumw);
+    }
     double pavg = suml / sumw;
     pavg = std::min(pavg, 1.0 - kEpsilon);
     pavg = std::max<double>(pavg, kEpsilon);


### PR DESCRIPTION
when training a binary classifier in distribution mode, the init score should depend on all training dataset, not local training dataset