### PR TITLE
Log warning instead of fatal when parsing float get under/overflow.

### DIFF
--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -347,7 +347,7 @@ inline static const char* AtofPrecise(const char* p, double* out) {
     Log::Fatal("no conversion to double for: %s", p);
   }
   if (errno == ERANGE) {
-    Log::Fatal("convert to double got underflow or overflow: %s", p);
+    Log::Warning("convert to double got underflow or overflow: %s", p);
   }
   return end2;
 }

--- a/tests/cpp_tests/test_common.cpp
+++ b/tests/cpp_tests/test_common.cpp
@@ -103,11 +103,6 @@ TEST_F(AtofPreciseTest, CornerCases) {
   }
 }
 
-TEST_F(AtofPreciseTest, UnderOverFlow) {
-  double got = 0;
-  ASSERT_THROW(LightGBM::Common::AtofPrecise("1e+400", &got),  std::runtime_error);
-}
-
 TEST_F(AtofPreciseTest, ErrorInput) {
   double got = 0;
   ASSERT_THROW(LightGBM::Common::AtofPrecise("x1", &got),  std::runtime_error);


### PR DESCRIPTION
For texts that resolve to infinity, under or overflow should be accepted.

This should resolve unit test failure mention in #4330.