### PR TITLE
[R-package] remove unused code in lgb.params2str()

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -24,7 +24,8 @@ lgb.last_error <- function() {
   stop("api error: ", err_msg)
   return(invisible(NULL))
 }
-lgb.params2str <- function(params, ...) {
+
+lgb.params2str <- function(params) {
 
   # Check for a list as input
   if (!identical(class(params), "list")) {
@@ -33,24 +34,6 @@ lgb.params2str <- function(params, ...) {
 
   # Split parameter names
   names(params) <- gsub("\\.", "_", names(params))
-
-  # Merge parameters from the params and the dots-expansion
-  dot_params <- list(...)
-  names(dot_params) <- gsub("\\.", "_", names(dot_params))
-
-  # Check for identical parameters
-  if (length(intersect(names(params), names(dot_params))) > 0L) {
-    stop(
-      "Same parameters in "
-      , sQuote("params")
-      , " and in the call are not allowed. Please check your "
-      , sQuote("params")
-      , " list"
-    )
-  }
-
-  # Merge parameters
-  params <- c(params, dot_params)
 
   # Setup temporary variable
   ret <- list()


### PR DESCRIPTION
While starting to work on adding a deprecation warning for uses of `...` in the R package (as part of #4310), I found some unused code that I think can be removed.

`lgb.params2str()`, an internal-only utility function, is only ever called with the single keyword argument `params`.

This PR proposes removing `...` from that function's signature.

Contributes to #4226