### PR TITLE
[R-package] remove uses of ... in Predictor constructor

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -501,7 +501,8 @@ Booster <- R6::R6Class(
                        predleaf = FALSE,
                        predcontrib = FALSE,
                        header = FALSE,
-                       reshape = FALSE, ...) {
+                       reshape = FALSE,
+                       ...) {
 
       # Check if number of iteration is non existent
       if (is.null(num_iteration)) {
@@ -513,7 +514,11 @@ Booster <- R6::R6Class(
       }
 
       # Predict on new data
-      predictor <- Predictor$new(private$handle, ...)
+      params <- list(...)
+      predictor <- Predictor$new(
+        modelfile = private$handle
+        , params = params
+      )
       return(
         predictor$predict(
           data = data
@@ -531,7 +536,7 @@ Booster <- R6::R6Class(
 
     # Transform into predictor
     to_predictor = function() {
-      return(Predictor$new(private$handle))
+      return(Predictor$new(modelfile = private$handle))
     },
 
     # Used for save

--- a/R-package/R/lgb.Predictor.R
+++ b/R-package/R/lgb.Predictor.R
@@ -27,8 +27,7 @@ Predictor <- R6::R6Class(
     },
 
     # Initialize will create a starter model
-    initialize = function(modelfile, ...) {
-      params <- list(...)
+    initialize = function(modelfile, params = list()) {
       private$params <- lgb.params2str(params = params)
       handle <- NULL
 

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -132,7 +132,7 @@ lgb.train <- function(params = list(),
 
   # Check for boosting from a trained model
   if (is.character(init_model)) {
-    predictor <- Predictor$new(init_model)
+    predictor <- Predictor$new(modelfile = init_model)
   } else if (lgb.is.Booster(x = init_model)) {
     predictor <- init_model$to_predictor()
   }


### PR DESCRIPTION
Contributes to #4226

This PR proposes removing the use of `...` from the constructor for the `Predictor` class in the R package. That class is not exported in the package's namespace, so this is not a user-facing breaking change.

Removing this use of `...` makes the package's code slightly stricter, which reduces the risk of bugs.