### PR TITLE
[R-package] resolve test warning about is.na() and handles

### DIFF
--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -82,7 +82,8 @@ test_that("lgb.Dataset: Dataset should be able to construct from matrix and retu
     , lightgbm:::lgb.params2str(params = list())
     , ref_handle
   )
-  expect_false(is.na(handle))
+  expect_is(handle, "externalptr")
+  expect_false(is.null(handle))
   .Call(LGBM_DatasetFree_R, handle)
   handle <- NULL
 })


### PR DESCRIPTION
This PR resolves the following warning in the R package's tests, which was probably introduced in #4265

> Warning message:
    In is.na(handle) :
    is.na() applied to non-(list or vector) of type 'externalptr'