### PR TITLE
[R-package] remove unused argument in early stopping callback

### DIFF
--- a/R-package/R/callback.R
+++ b/R-package/R/callback.R
@@ -324,7 +324,7 @@ cb.early.stop <- function(stopping_rounds, first_metric_only = FALSE, verbose = 
   }
 
   # Create callback
-  callback <- function(env, finalize = FALSE) {
+  callback <- function(env) {
 
     # Check for empty evaluation
     if (is.null(eval_len)) {


### PR DESCRIPTION
Noticed tonight that the function returned by `cb.early.stop()` has an argument `finalize = FALSE`.

That argument's value is never referenced, and no existing code expects to pass it. This PR proposes removing it.

The places where callbacks are executed only pass a single argument, `env`:

https://github.com/microsoft/LightGBM/blob/28c3c45d3be82f115630c4a887a0cf5e611ef5e0/R-package/R/lgb.train.R#L288-L290

https://github.com/microsoft/LightGBM/blob/28c3c45d3be82f115630c4a887a0cf5e611ef5e0/R-package/R/lgb.train.R#L329-L331

https://github.com/microsoft/LightGBM/blob/28c3c45d3be82f115630c4a887a0cf5e611ef5e0/R-package/R/lgb.cv.R#L367-L369

https://github.com/microsoft/LightGBM/blob/28c3c45d3be82f115630c4a887a0cf5e611ef5e0/R-package/R/lgb.cv.R#L393-L395

I'm also confident in this change because there are multiple unit tests checking that early stopping works correctly in the R package, for example:

https://github.com/microsoft/LightGBM/blob/28c3c45d3be82f115630c4a887a0cf5e611ef5e0/R-package/tests/testthat/test_basic.R#L576

### Notes for Reviewers

This is not a user-facing breaking change because all callbacks are internal to the package (since #2479 is still open).