### PR TITLE
[R-package] remove lgb.last_error() and LGBM_GetLastError_R()

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -15,16 +15,6 @@ lgb.is.null.handle <- function(x) {
   )
 }
 
-# [description] Get the most recent error stored on the C++ side and raise it
-#               as an R error.
-lgb.last_error <- function() {
-  err_msg <- .Call(
-    LGBM_GetLastError_R
-  )
-  stop("api error: ", err_msg)
-  return(invisible(NULL))
-}
-
 lgb.params2str <- function(params) {
 
   # Check for a list as input

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -42,14 +42,6 @@
 using LightGBM::Common::Split;
 using LightGBM::Log;
 
-SEXP LGBM_GetLastError_R() {
-  SEXP out;
-  out = PROTECT(Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(out, 0, Rf_mkChar(LGBM_GetLastError()));
-  UNPROTECT(1);
-  return out;
-}
-
 SEXP LGBM_HandleIsNull_R(SEXP handle) {
   return Rf_ScalarLogical(R_ExternalPtrAddr(handle) == NULL);
 }
@@ -712,7 +704,6 @@ SEXP LGBM_BoosterDumpModel_R(SEXP handle,
 
 // .Call() calls
 static const R_CallMethodDef CallEntries[] = {
-  {"LGBM_GetLastError_R"              , (DL_FUNC) &LGBM_GetLastError_R              , 0},
   {"LGBM_HandleIsNull_R"              , (DL_FUNC) &LGBM_HandleIsNull_R              , 1},
   {"LGBM_DatasetCreateFromFile_R"     , (DL_FUNC) &LGBM_DatasetCreateFromFile_R     , 3},
   {"LGBM_DatasetCreateFromCSC_R"      , (DL_FUNC) &LGBM_DatasetCreateFromCSC_R      , 8},

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -12,12 +12,6 @@
 #include <Rinternals.h>
 
 /*!
-* \brief get string message of the last error
-* \return err_msg string with error information
-*/
-LIGHTGBM_C_EXPORT SEXP LGBM_GetLastError_R();
-
-/*!
 * \brief check if an R external pointer (like a Booster or Dataset handle) is a null pointer
 * \param handle handle for a Booster, Dataset, or Predictor
 * \return R logical, TRUE if the handle is a null pointer

--- a/R-package/tests/testthat/test_utils.R
+++ b/R-package/tests/testthat/test_utils.R
@@ -48,30 +48,6 @@ test_that("lgb.params2str() works as expected for a key in params with multiple 
     )
 })
 
-context("lgb.last_error")
-
-test_that("lgb.last_error() throws an error if there are no errors", {
-    expect_error({
-        lgb.last_error()
-    }, regexp = "Everything is fine")
-})
-
-test_that("lgb.last_error() correctly returns errors from the C++ side", {
-    testthat::skip(paste0(
-        "Skipping this test because it causes valgrind to think "
-        , "there is a memory leak, and needs to be rethought"
-    ))
-    data(agaricus.train, package = "lightgbm")
-    train <- agaricus.train
-    dvalid1 <- lgb.Dataset(
-        data = train$data
-        , label = as.matrix(rnorm(5L))
-    )
-    expect_error({
-        dvalid1$construct()
-    }, regexp = "[LightGBM] [Fatal] Length of label is not same with #data", fixed = TRUE)
-})
-
 context("lgb.check.eval")
 
 test_that("lgb.check.eval works as expected with no metric", {

--- a/build_r.R
+++ b/build_r.R
@@ -372,7 +372,7 @@ writeLines(description_contents, DESCRIPTION_FILE)
 # CMake-based builds can't currently use R's builtin routine registration,
 # so have to update NAMESPACE manually, with a statement like this:
 #
-# useDynLib(lib_lightgbm, LGBM_GetLastError_R, LGBM_DatasetCreateFromFile_R, ...)
+# useDynLib(lib_lightgbm, LGBM_DatasetCreateFromFile_R, ...)
 #
 # See https://cran.r-project.org/doc/manuals/r-release/R-exts.html#useDynLib for
 # documentation of this approach, where the NAMESPACE file uses a statement like


### PR DESCRIPTION
It seems that #4163 removed the last uses of the internal helper function `lgb.last_error()` in the R package. This PR proposes removing that function and its C++ counterpart, `LGBM_GetLastError_R()`. It's no longer necessary for the R package to reach into the C++ side and get the last error, since as of #4163 and other refactoring, C++ calls will raise R errors whenever one is thrown.

https://github.com/microsoft/LightGBM/blob/28c3c45d3be82f115630c4a887a0cf5e611ef5e0/R-package/src/lightgbm_R.cpp#L36-L38

Removing this code should have all the usual benefits of removing unused code...faster compilation, smaller library size, reduced maintenance burden, etc.