### PR TITLE
[R-package] remove unnecessary library() calls in tests

### DIFF
--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -1,6 +1,3 @@
-library(lightgbm)
-library(Matrix)
-
 context("testing lgb.Dataset functionality")
 
 data(agaricus.test, package = "lightgbm")


### PR DESCRIPTION
This PR proposes removing two unnecessary `library()` calls in the R package's tests. Using `{testthat}`, it's rarely necessary to call `library()` for dependencies from inside test scripts.

### Notes for Reviewers

I thought it was fun and interesting to note that the two calls removed in this PR have been there since the very first PR that introduced the R package!

#168 (January 2017)