### PR TITLE
[python-package] use f-strings for concatenation in examples/python-guide/logistic_regression.py

### DIFF
--- a/examples/python-guide/logistic_regression.py
+++ b/examples/python-guide/logistic_regression.py
@@ -113,5 +113,5 @@ A = [experiment('binary', label_type='binary', data=DATA)['time']
      for k in range(K)]
 B = [experiment('xentropy', label_type='binary', data=DATA)['time']
      for k in range(K)]
-print('Best `binary` time: ' + str(min(A)))
-print('Best `xentropy` time: ' + str(min(B)))
+print(f"Best `binary` time: {str(min(A))}")
+print(f"Best `xentropy` time: {str(min(B))}")

--- a/examples/python-guide/logistic_regression.py
+++ b/examples/python-guide/logistic_regression.py
@@ -1,9 +1,7 @@
 # coding: utf-8
 """Comparison of `binary` and `xentropy` objectives.
-
 BLUF: The `xentropy` objective does logistic regression and generalizes
 to the case where labels are probabilistic (i.e. numbers between 0 and 1).
-
 Details: Both `binary` and `xentropy` minimize the log loss and use
 `boost_from_average = TRUE` by default. Possibly the only difference
 between them with default settings is that `binary` may achieve a slight
@@ -54,7 +52,6 @@ def log_loss(preds, labels):
 
 def experiment(objective, label_type, data):
     """Measure performance of an objective.
-
     Parameters
     ----------
     objective : string 'binary' or 'xentropy'
@@ -63,7 +60,6 @@ def experiment(objective, label_type, data):
         Type of the label.
     data : dict
         Data for training.
-
     Returns
     -------
     result : dict
@@ -71,7 +67,7 @@ def experiment(objective, label_type, data):
     """
     np.random.seed(0)
     nrounds = 5
-    lgb_data = data['lgb_with_' + label_type + '_labels']
+    lgb_data = data[f"lgb_with_{label_type}_labels"]
     params = {
         'objective': objective,
         'feature_fraction': 1,
@@ -81,7 +77,7 @@ def experiment(objective, label_type, data):
     time_zero = time.time()
     gbm = lgb.train(params, lgb_data, num_boost_round=nrounds)
     y_fitted = gbm.predict(data['X'])
-    y_true = data[label_type + '_labels']
+    y_true = data[f"{label_type}_labels"]
     duration = time.time() - time_zero
     return {
         'time': duration,


### PR DESCRIPTION
Contributes to #4136.

Updated  `.\examples\python-guide\logistic_regression.py`  file