### PR TITLE
[R-package] remove defaults in internal functions

### DIFF
--- a/R-package/R/callback.R
+++ b/R-package/R/callback.R
@@ -111,7 +111,7 @@ cb.reset.parameters <- function(new_params) {
 }
 
 # Format the evaluation metric string
-format.eval.string <- function(eval_res, eval_err = NULL) {
+format.eval.string <- function(eval_res, eval_err) {
 
   # Check for empty evaluation string
   if (is.null(eval_res) || length(eval_res) == 0L) {
@@ -158,7 +158,7 @@ merge.eval.string <- function(env) {
 
 }
 
-cb.print.evaluation <- function(period = 1L) {
+cb.print.evaluation <- function(period) {
 
   # Create callback
   callback <- function(env) {
@@ -271,7 +271,7 @@ cb.record.evaluation <- function() {
 
 }
 
-cb.early.stop <- function(stopping_rounds, first_metric_only = FALSE, verbose = TRUE) {
+cb.early.stop <- function(stopping_rounds, first_metric_only, verbose) {
 
   factor_to_bigger_better <- NULL
   best_iter <- NULL

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -509,7 +509,7 @@ generate.cv.folds <- function(nfold, nrows, stratified, label, group, params) {
 # It was borrowed from caret::createFolds and simplified
 # by always returning an unnamed list of fold indices.
 #' @importFrom stats quantile
-lgb.stratified.folds <- function(y, k = 10L) {
+lgb.stratified.folds <- function(y, k) {
 
   ## Group the numeric data based on their magnitudes
   ## and sample within those groups.


### PR DESCRIPTION
The bug discovered in #4360 was missed for a long time because `lgb.cv()` relied on an internal function which set a default for a keyword argument. That default meant that it was possible for a bug of the form "an argument from `lgb.cv()` is not being passed through to this internal function" was possible.

This PR proposes removing other defaults in internal functions, to prevent similar issues in the future. I did not find any cases where the functions changed in this PR were being called without an explicit value for every keyword argument, so this is just defensive and should not change any current behavior for users.