### PR TITLE
[R-package] consolidate duplicate lists of Dataset info keys

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -2,7 +2,7 @@
 #               Wrapped in a function to take advantage of lazy evaluation
 #               (so it doesn't matter what order R sources files during installation).
 # [return] A character vector of names.
-.INFO_KEYS() <- function() {
+.INFO_KEYS <- function() {
   return(c("label", "weight", "init_score", "group"))
 }
 

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -1,3 +1,11 @@
+# [description] List of valid keys for "info" arguments in lgb.Dataset.
+#               Wrapped in a function to take advantage of lazy evaluation
+#               (so it doesn't matter what order R sources files during installation).
+# [return] A character vector of names.
+.INFO_KEYS() <- function() {
+  return(c("label", "weight", "init_score", "group"))
+}
+
 #' @importFrom methods is
 #' @importFrom R6 R6Class
 Dataset <- R6::R6Class(
@@ -39,14 +47,11 @@ Dataset <- R6::R6Class(
       # Check for additional parameters
       additional_params <- list(...)
 
-      # Create known attributes list
-      INFO_KEYS <- c("label", "weight", "init_score", "group")
-
       # Check if attribute key is in the known attribute list
       for (key in names(additional_params)) {
 
         # Key existing
-        if (key %in% INFO_KEYS) {
+        if (key %in% .INFO_KEYS()) {
 
           # Store as info
           info[[key]] <- additional_params[[key]]
@@ -413,12 +418,9 @@ Dataset <- R6::R6Class(
     # Get information
     getinfo = function(name) {
 
-      # Create known attributes list
-      INFONAMES <- c("label", "weight", "init_score", "group")
-
       # Check if attribute key is in the known attribute list
-      if (!is.character(name) || length(name) != 1L || !name %in% INFONAMES) {
-        stop("getinfo: name must one of the following: ", paste0(sQuote(INFONAMES), collapse = ", "))
+      if (!is.character(name) || length(name) != 1L || !name %in% .INFO_KEYS()) {
+        stop("getinfo: name must one of the following: ", paste0(sQuote(.INFO_KEYS()), collapse = ", "))
       }
 
       # Check for info name and handle
@@ -467,12 +469,9 @@ Dataset <- R6::R6Class(
     # Set information
     setinfo = function(name, info) {
 
-      # Create known attributes list
-      INFONAMES <- c("label", "weight", "init_score", "group")
-
       # Check if attribute key is in the known attribute list
-      if (!is.character(name) || length(name) != 1L || !name %in% INFONAMES) {
-        stop("setinfo: name must one of the following: ", paste0(sQuote(INFONAMES), collapse = ", "))
+      if (!is.character(name) || length(name) != 1L || !name %in% .INFO_KEYS()) {
+        stop("setinfo: name must one of the following: ", paste0(sQuote(.INFO_KEYS()), collapse = ", "))
       }
 
       # Check for type of information


### PR DESCRIPTION
As part of adding a deprecation warning about the removal of `...` support in the R package (per https://github.com/microsoft/LightGBM/issues/4226#issuecomment-829473584), I wanted to be able to give different warnings in items passed through `...` in `lgb.Dataset()` based on whether they are params (e.g. `max_bin`) or "info" elements (e.g. `init_score`).

I realized that there are three duplicate places where the R package stores the list of valid keys for "info".

This PR proposes consolidating them into a single place, to reduce the risk of inconsistencies and simplify the code a bit.