### PR TITLE
[ci] Increase timeout value for QEMU builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -150,7 +150,7 @@ jobs:
     PRODUCES_ARTIFACTS: 'true'
   pool:
     vmImage: ubuntu-latest
-  timeoutInMinutes: 150
+  timeoutInMinutes: 180
   strategy:
     matrix:
       bdist:


### PR DESCRIPTION
Seem that previous bump (#4326) is not enough.

> ##[error]The job running on agent Hosted Agent ran longer than the maximum time of 150 minutes.
https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=10344&view=logs&j=c2f9361f-3c13-57db-3206-cee89820d5e3