### PR TITLE
[python] Improving the syntax of `print`s in `simple_example.py` and `sklearn_example.py`

### DIFF
--- a/examples/python-guide/simple_example.py
+++ b/examples/python-guide/simple_example.py
@@ -47,4 +47,5 @@ print('Starting predicting...')
 # predict
 y_pred = gbm.predict(X_test, num_iteration=gbm.best_iteration)
 # eval
-print('The rmse of prediction is:', mean_squared_error(y_test, y_pred) ** 0.5)
+rmse_test = mean_squared_error(y_test, y_pred) ** 0.5
+print(f'The RMSE of prediction is: {rmse_test}')

--- a/examples/python-guide/sklearn_example.py
+++ b/examples/python-guide/sklearn_example.py
@@ -30,10 +30,11 @@ print('Starting predicting...')
 # predict
 y_pred = gbm.predict(X_test, num_iteration=gbm.best_iteration_)
 # eval
-print('The rmse of prediction is:', mean_squared_error(y_test, y_pred) ** 0.5)
+rmse_test = mean_squared_error(y_test, y_pred) ** 0.5
+print(f'The RMSE of prediction is: {rmse_test}')
 
 # feature importances
-print('Feature importances:', list(gbm.feature_importances_))
+print(f'Feature importances: {list(gbm.feature_importances_)}')
 
 
 # self-defined eval metric
@@ -69,8 +70,10 @@ print('Starting predicting...')
 # predict
 y_pred = gbm.predict(X_test, num_iteration=gbm.best_iteration_)
 # eval
-print('The rmsle of prediction is:', rmsle(y_test, y_pred)[1])
-print('The rae of prediction is:', rae(y_test, y_pred)[1])
+rmsle_test = rmsle(y_test, y_pred)[1]
+rae_test = rae(y_test, y_pred)[1]
+print(f'The RMSLE of prediction is: {rmsle_test}')
+print(f'The RAE of prediction is: {rae_test}')
 
 # other scikit-learn modules
 estimator = lgb.LGBMRegressor(num_leaves=31)
@@ -83,4 +86,4 @@ param_grid = {
 gbm = GridSearchCV(estimator, param_grid, cv=3)
 gbm.fit(X_train, y_train)
 
-print('Best parameters found by grid search are:', gbm.best_params_)
+print(f'Best parameters found by grid search are: {gbm.best_params_}')


### PR DESCRIPTION
Based on comments https://github.com/microsoft/LightGBM/pull/4386#pullrequestreview-686376988 and https://github.com/microsoft/LightGBM/pull/4386#discussion_r655295441.

These files are already marked as done in #4136 because there were no old string formatting methods there, only `print`s.