### PR TITLE
[ci] [R-package] increase timeout on valgrind job

### DIFF
--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-r-valgrind:
     name: r-package (ubuntu-latest, R-devel, valgrind)
-    timeout-minutes: 300
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     container: wch1/r-debug
     env:

--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-r-valgrind:
     name: r-package (ubuntu-latest, R-devel, valgrind)
-    timeout-minutes: 120
+    timeout-minutes: 300
     runs-on: ubuntu-latest
     container: wch1/r-debug
     env:


### PR DESCRIPTION
See https://github.com/microsoft/LightGBM/pull/4391#issuecomment-864273568 and this failed job with a timeout of 180 minutes (https://github.com/microsoft/LightGBM/actions/runs/959047226).

It seems recently-added R package tests (or maybe some combination of that and changes in the C++ side) has led to the valgrind jobs exceeding 120 minutes. As a reminder, R runs substantially slower under valgrind (https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Using-valgrind).