### PR TITLE
[dask] pass additional predict() parameters through when input is a Dask Array

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -570,7 +570,8 @@ def _predict(
             pred_leaf=pred_leaf,
             pred_contrib=pred_contrib,
             dtype=dtype,
-            drop_axis=1
+            drop_axis=1,
+            **kwargs
         )
     else:
         raise TypeError(f'Data must be either Dask Array or Dask DataFrame. Got {type(data)}.')

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -272,6 +272,8 @@ def test_classifier(output, task, boosting_type, tree_learner, cluster):
         )
         dask_classifier = dask_classifier.fit(dX, dy, sample_weight=dw)
         p1 = dask_classifier.predict(dX)
+        p1_raw = dask_classifier.predict(dX, raw_score=True).compute()
+        p1_first_iter = dask_classifier.predict(dX, start_iteration=0, num_iteration=1, raw_score=True).compute()
         p1_proba = dask_classifier.predict_proba(dX).compute()
         p1_pred_leaf = dask_classifier.predict(dX, pred_leaf=True)
         p1_local = dask_classifier.to_local().predict(X)
@@ -296,6 +298,10 @@ def test_classifier(output, task, boosting_type, tree_learner, cluster):
             assert_eq(p1_proba, p2_proba, atol=0.03)
             assert_eq(p1_local, p2)
             assert_eq(p1_local, y)
+
+        # extra predict() parameters should be passed through correctly
+        with pytest.raises(AssertionError):
+            assert_eq(p1_raw, p1_first_iter)
 
         # pref_leaf values should have the right shape
         # and values that look like valid tree nodes
@@ -487,6 +493,8 @@ def test_regressor(output, boosting_type, tree_learner, cluster):
 
         s1 = _r2_score(dy, p1)
         p1 = p1.compute()
+        p1_raw = dask_regressor.predict(dX, raw_score=True).compute()
+        p1_first_iter = dask_regressor.predict(dX, start_iteration=0, num_iteration=1, raw_score=True).compute()
         p1_local = dask_regressor.to_local().predict(X)
         s1_local = dask_regressor.to_local().score(X, y)
 
@@ -515,6 +523,10 @@ def test_regressor(output, boosting_type, tree_learner, cluster):
 
         assert_eq(p1, y, rtol=0.5, atol=50.)
         assert_eq(p2, y, rtol=0.5, atol=50.)
+
+        # extra predict() parameters should be passed through correctly
+        with pytest.raises(AssertionError):
+            assert_eq(p1_raw, p1_first_iter)
 
         # be sure LightGBM actually used at least one categorical column,
         # and that it was correctly treated as a categorical feature
@@ -680,6 +692,8 @@ def test_ranker(output, group, boosting_type, tree_learner, cluster):
         rnkvec_dask = dask_ranker.predict(dX)
         rnkvec_dask = rnkvec_dask.compute()
         p1_pred_leaf = dask_ranker.predict(dX, pred_leaf=True)
+        p1_raw = dask_ranker.predict(dX, raw_score=True).compute()
+        p1_first_iter = dask_ranker.predict(dX, start_iteration=0, num_iteration=1, raw_score=True).compute()
         rnkvec_dask_local = dask_ranker.to_local().predict(X)
 
         local_ranker = lgb.LGBMRanker(**params)
@@ -692,6 +706,10 @@ def test_ranker(output, group, boosting_type, tree_learner, cluster):
         assert dcor > 0.6
         assert spearmanr(rnkvec_dask, rnkvec_local).correlation > 0.8
         assert_eq(rnkvec_dask, rnkvec_dask_local)
+
+        # extra predict() parameters should be passed through correctly
+        with pytest.raises(AssertionError):
+            assert_eq(p1_raw, p1_first_iter)
 
         # pref_leaf values should have the right shape
         # and values that look like valid tree nodes

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -273,7 +273,7 @@ def test_classifier(output, task, boosting_type, tree_learner, cluster):
         dask_classifier = dask_classifier.fit(dX, dy, sample_weight=dw)
         p1 = dask_classifier.predict(dX)
         p1_raw = dask_classifier.predict(dX, raw_score=True).compute()
-        p1_first_iter = dask_classifier.predict(dX, start_iteration=0, num_iteration=1, raw_score=True).compute()
+        p1_first_iter_raw = dask_classifier.predict(dX, start_iteration=0, num_iteration=1, raw_score=True).compute()
         p1_proba = dask_classifier.predict_proba(dX).compute()
         p1_pred_leaf = dask_classifier.predict(dX, pred_leaf=True)
         p1_local = dask_classifier.to_local().predict(X)
@@ -301,7 +301,7 @@ def test_classifier(output, task, boosting_type, tree_learner, cluster):
 
         # extra predict() parameters should be passed through correctly
         with pytest.raises(AssertionError):
-            assert_eq(p1_raw, p1_first_iter)
+            assert_eq(p1_raw, p1_first_iter_raw)
 
         # pref_leaf values should have the right shape
         # and values that look like valid tree nodes
@@ -494,7 +494,7 @@ def test_regressor(output, boosting_type, tree_learner, cluster):
         s1 = _r2_score(dy, p1)
         p1 = p1.compute()
         p1_raw = dask_regressor.predict(dX, raw_score=True).compute()
-        p1_first_iter = dask_regressor.predict(dX, start_iteration=0, num_iteration=1, raw_score=True).compute()
+        p1_first_iter_raw = dask_regressor.predict(dX, start_iteration=0, num_iteration=1, raw_score=True).compute()
         p1_local = dask_regressor.to_local().predict(X)
         s1_local = dask_regressor.to_local().score(X, y)
 
@@ -526,7 +526,7 @@ def test_regressor(output, boosting_type, tree_learner, cluster):
 
         # extra predict() parameters should be passed through correctly
         with pytest.raises(AssertionError):
-            assert_eq(p1_raw, p1_first_iter)
+            assert_eq(p1_raw, p1_first_iter_raw)
 
         # be sure LightGBM actually used at least one categorical column,
         # and that it was correctly treated as a categorical feature
@@ -693,7 +693,7 @@ def test_ranker(output, group, boosting_type, tree_learner, cluster):
         rnkvec_dask = rnkvec_dask.compute()
         p1_pred_leaf = dask_ranker.predict(dX, pred_leaf=True)
         p1_raw = dask_ranker.predict(dX, raw_score=True).compute()
-        p1_first_iter = dask_ranker.predict(dX, start_iteration=0, num_iteration=1, raw_score=True).compute()
+        p1_first_iter_raw = dask_ranker.predict(dX, start_iteration=0, num_iteration=1, raw_score=True).compute()
         rnkvec_dask_local = dask_ranker.to_local().predict(X)
 
         local_ranker = lgb.LGBMRanker(**params)
@@ -709,7 +709,7 @@ def test_ranker(output, group, boosting_type, tree_learner, cluster):
 
         # extra predict() parameters should be passed through correctly
         with pytest.raises(AssertionError):
-            assert_eq(p1_raw, p1_first_iter)
+            assert_eq(p1_raw, p1_first_iter_raw)
 
         # pref_leaf values should have the right shape
         # and values that look like valid tree nodes

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -274,6 +274,13 @@ def test_classifier(output, task, boosting_type, tree_learner, cluster):
         p1 = dask_classifier.predict(dX)
         p1_raw = dask_classifier.predict(dX, raw_score=True).compute()
         p1_first_iter_raw = dask_classifier.predict(dX, start_iteration=0, num_iteration=1, raw_score=True).compute()
+        p1_early_stop_raw = dask_classifier.predict(
+            dX,
+            pred_early_stop=True,
+            pred_early_stop_margin=1.0,
+            pred_early_stop_freq=2,
+            raw_score=True
+        )
         p1_proba = dask_classifier.predict_proba(dX).compute()
         p1_pred_leaf = dask_classifier.predict(dX, pred_leaf=True)
         p1_local = dask_classifier.to_local().predict(X)
@@ -302,6 +309,9 @@ def test_classifier(output, task, boosting_type, tree_learner, cluster):
         # extra predict() parameters should be passed through correctly
         with pytest.raises(AssertionError):
             assert_eq(p1_raw, p1_first_iter_raw)
+
+        with pytest.raises(AssertionError):
+            assert_eq(p1_raw, p1_early_stop_raw)
 
         # pref_leaf values should have the right shape
         # and values that look like valid tree nodes


### PR DESCRIPTION
`.predict()` in the Dask estimators allows users to pass additional prediction parameters (https://lightgbm.readthedocs.io/en/latest/Parameters.html#predict-parameters) through `**kwargs`. To be applied correctly, those `**kwargs` have to be passed through several layers of function calls inside the package.

One of those pass-throughs is currently missing, and as a result additional prediction parameters will be silently ignored when data passed to `.predict()` is a Dask Array.

This PR proposes fixing that and adding tests confirming that additional parameters are being passed through correctly.

### Notes for Reviewers

I looked at `lightgbm.basic._InnerPredictor.predict()` for the names of specific parameters to be passed through.

https://github.com/microsoft/LightGBM/blob/bd21efed4f9dfffa5119775c835e1097d078085b/python-package/lightgbm/basic.py#L661-L663