### PR TITLE
[tests][dask] add missing compute() in Dask test

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -280,7 +280,7 @@ def test_classifier(output, task, boosting_type, tree_learner, cluster):
             pred_early_stop_margin=1.0,
             pred_early_stop_freq=2,
             raw_score=True
-        )
+        ).compute()
         p1_proba = dask_classifier.predict_proba(dX).compute()
         p1_pred_leaf = dask_classifier.predict(dX, pred_leaf=True)
         p1_local = dask_classifier.to_local().predict(X)


### PR DESCRIPTION
Adds a missing `.compute()` call in the Dask tests, see https://github.com/microsoft/LightGBM/pull/4399/files#r659165339.