### PR TITLE
[dask] fix typehint on _pad_eval_names()

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -89,7 +89,7 @@ def _remove_list_padding(*args: Any) -> List[List[Any]]:
     return [[z for z in arg if z is not None] for arg in args]
 
 
-def _pad_eval_names(lgbm_model: LGBMModel, required_names: Optional[List[str]] = None) -> LGBMModel:
+def _pad_eval_names(lgbm_model: LGBMModel, required_names: List[str]) -> LGBMModel:
     """Append missing (key, value) pairs to a LightGBM model's evals_result_ and best_score_ OrderedDict attrs based on a set of required eval_set names.
 
     Allows users to rely on expected eval_set names being present when fitting DaskLGBM estimators with ``eval_set``.


### PR DESCRIPTION
Following up on https://github.com/microsoft/LightGBM/pull/4101#pullrequestreview-693527253 (cc @ffineis just so you know this is what I was talking about in that comment).

The function `lightgbm.dask._pad_eval_names()` currently has a type hint suggesting that argument `required_names` could be `None`, but its code doesn't handle that case. The `for` loop below would fail with an error complaining about `NoneType` not being iterable.

https://github.com/microsoft/LightGBM/blob/b5502d19b2b462f665e3d1edbaa70c0d6472bca4/python-package/lightgbm/dask.py#L98

I don't think it is actually possible for that argument to ever be `None`, because of

https://github.com/microsoft/LightGBM/blob/b5502d19b2b462f665e3d1edbaa70c0d6472bca4/python-package/lightgbm/dask.py#L186-L189

https://github.com/microsoft/LightGBM/blob/b5502d19b2b462f665e3d1edbaa70c0d6472bca4/python-package/lightgbm/dask.py#L279

This PR proposes updating the type hint.

### Notes for Reviewers

Noting that in the future, this is the type of thing that will be caught by `mypy` (#3867). Running `mypy --ignore-missing-import python-package/lightgbm` yields the following.

> python-package/lightgbm/dask.py:98: error: Item "None" of "Optional[List[str]]" has no attribute "__iter__" (not iterable)