### PR TITLE
[tests] fix compiler warning about types conversion in cpp tests

### DIFF
--- a/tests/cpp_tests/test_array_args.cpp
+++ b/tests/cpp_tests/test_array_args.cpp
@@ -18,7 +18,7 @@ TEST(Partition, JustWorks) {
   std::vector<score_t> gradients({0.5f, 5.0f, 1.0f, 2.0f, 2.0f});
   data_size_t middle_begin, middle_end;
 
-  ArrayArgs<score_t>::Partition(&gradients, 0, gradients.size(), &middle_begin, &middle_end);
+  ArrayArgs<score_t>::Partition(&gradients, 0, static_cast<int>(gradients.size()), &middle_begin, &middle_end);
 
   EXPECT_EQ(gradients[middle_begin + 1], gradients[middle_end - 1]);
   EXPECT_GT(gradients[0], gradients[middle_begin + 1]);
@@ -28,14 +28,14 @@ TEST(Partition, JustWorks) {
 TEST(Partition, PartitionOneElement) {
   std::vector<score_t> gradients({0.5f});
   data_size_t middle_begin, middle_end;
-  ArrayArgs<score_t>::Partition(&gradients, 0, gradients.size(), &middle_begin, &middle_end);
+  ArrayArgs<score_t>::Partition(&gradients, 0, static_cast<int>(gradients.size()), &middle_begin, &middle_end);
   EXPECT_EQ(gradients[middle_begin + 1], gradients[middle_end - 1]);
 }
 
 TEST(Partition, Empty) {
   std::vector<score_t> gradients;
   data_size_t middle_begin, middle_end;
-  ArrayArgs<score_t>::Partition(&gradients, 0, gradients.size(), &middle_begin, &middle_end);
+  ArrayArgs<score_t>::Partition(&gradients, 0, static_cast<int>(gradients.size()), &middle_begin, &middle_end);
 
   EXPECT_EQ(middle_begin, -1);
   EXPECT_EQ(middle_end, 0);
@@ -44,7 +44,7 @@ TEST(Partition, Empty) {
 TEST(Partition, AllEqual) {
   std::vector<score_t> gradients({0.5f, 0.5f, 0.5f});
   data_size_t middle_begin, middle_end;
-  ArrayArgs<score_t>::Partition(&gradients, 0, gradients.size(), &middle_begin, &middle_end);
+  ArrayArgs<score_t>::Partition(&gradients, 0, static_cast<int>(gradients.size()), &middle_begin, &middle_end);
 
   EXPECT_EQ(gradients[middle_begin + 1], gradients[middle_end - 1]);
   EXPECT_EQ(middle_begin, -1);


### PR DESCRIPTION
https://github.com/microsoft/LightGBM/blob/b918b5b2ff2dd776527e134f26eb8c0f0f096cfa/include/LightGBM/utils/array_args.h#L101

```
D:\a\1\s\tests\cpp_tests\test_array_args.cpp(21): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data [D:\a\1\s\build\testlightgbm.vcxproj]
D:\a\1\s\tests\cpp_tests\test_array_args.cpp(31): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data [D:\a\1\s\build\testlightgbm.vcxproj]
D:\a\1\s\tests\cpp_tests\test_array_args.cpp(38): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data [D:\a\1\s\build\testlightgbm.vcxproj]
D:\a\1\s\tests\cpp_tests\test_array_args.cpp(47): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data [D:\a\1\s\build\testlightgbm.vcxproj]
```