### PR TITLE
[SWIG] fix compiler warning about unused variable in SWIG

### DIFF
--- a/swig/StringArray.i
+++ b/swig/StringArray.i
@@ -31,7 +31,7 @@
     StringArrayHandle StringArrayHandle_create(size_t num_strings, size_t string_size) {
         try {
             return new StringArray(num_strings, string_size);
-        } catch (std::bad_alloc &e) {
+        } catch (std::bad_alloc &/*e*/) {
             return nullptr;
         }
     }

--- a/swig/StringArray_API_extensions.i
+++ b/swig/StringArray_API_extensions.i
@@ -54,7 +54,7 @@
 
         try {
             strings.reset(new StringArray(eval_counts, string_size));
-        } catch (std::bad_alloc &e) {
+        } catch (std::bad_alloc &/*e*/) {
             LGBM_SetLastError("Failure to allocate memory.");
             return nullptr;
         }
@@ -92,7 +92,7 @@
 
         try {
             strings.reset(new StringArray(num_features, max_feature_name_size));
-        } catch (std::bad_alloc &e) {
+        } catch (std::bad_alloc &/*e*/) {
             LGBM_SetLastError("Failure to allocate memory.");
             return nullptr;
         }
@@ -131,7 +131,7 @@
                                                    nullptr));
         try {
             strings.reset(new StringArray(num_features, max_feature_name_size));
-        } catch (std::bad_alloc &e) {
+        } catch (std::bad_alloc &/*e*/) {
             LGBM_SetLastError("Failure to allocate memory.");
             return nullptr;
         }


### PR DESCRIPTION
```
D:\a\1\s\build\java\lightgbmlibJAVA_wrap.cxx(792): warning C4101: 'e': unreferenced local variable [D:\a\1\s\build\_lightgbm_swig.vcxproj]
D:\a\1\s\build\java\lightgbmlibJAVA_wrap.cxx(887): warning C4101: 'e': unreferenced local variable [D:\a\1\s\build\_lightgbm_swig.vcxproj]
D:\a\1\s\build\java\lightgbmlibJAVA_wrap.cxx(925): warning C4101: 'e': unreferenced local variable [D:\a\1\s\build\_lightgbm_swig.vcxproj]
D:\a\1\s\build\java\lightgbmlibJAVA_wrap.cxx(964): warning C4101: 'e': unreferenced local variable [D:\a\1\s\build\_lightgbm_swig.vcxproj]
```