### PR TITLE
[ci] add h5 files into `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,6 +384,7 @@ lightgbm.model
 *.model
 *.pkl
 *.bin
+*.h5
 
 # macOS
 **/.DS_Store


### PR DESCRIPTION
Due to
https://github.com/microsoft/LightGBM/blob/c359896e9bdbbbf89af5e186dd07080a40545452/examples/python-guide/dataset_from_multi_hdf5.py#L89-L90