### PR TITLE
[tests] fix deprecation numpy warning

### DIFF
--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -170,7 +170,7 @@ def test_sequence(tmpdir, sample_count, batch_size, include_0_and_nan, num_seq):
     # Test for validation set.
     # Select some random rows as valid data.
     rng = np.random.default_rng()  # Pass integer to set seed when needed.
-    valid_idx = (rng.random(10) * nrow).astype(np.int)
+    valid_idx = (rng.random(10) * nrow).astype(np.int32)
     valid_data = data[valid_idx, :]
     valid_X = valid_data[:, :-1]
     valid_Y = valid_data[:, -1]


### PR DESCRIPTION
```
  /__w/1/s/tests/python_package_test/test_basic.py:173: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```