### PR TITLE
[python] allow to pass some params as pathlib.Path objects

### DIFF
--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -3,7 +3,7 @@
 
 Contributors: https://github.com/microsoft/LightGBM/graphs/contributors.
 """
-import os
+from pathlib import Path
 
 from .basic import Booster, Dataset, Sequence, register_logger
 from .callback import early_stopping, print_evaluation, record_evaluation, reset_parameter
@@ -23,11 +23,9 @@ except ImportError:
     pass
 
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-
-if os.path.isfile(os.path.join(dir_path, 'VERSION.txt')):
-    with open(os.path.join(dir_path, 'VERSION.txt')) as version_file:
-        __version__ = version_file.read().strip()
+_version_path = Path(__file__).parent.absolute() / 'VERSION.txt'
+if _version_path.is_file():
+    __version__ = _version_path.read_text(encoding='utf-8').strip()
 
 __all__ = ['Dataset', 'Booster', 'CVBooster', 'Sequence',
            'register_logger',

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -254,6 +254,7 @@ def param_dict_to_str(data):
 
 class _TempFile:
     """Proxy class to workaround errors on Windows."""
+
     def __enter__(self):
         with NamedTemporaryFile(prefix="lightgbm_tmp_", delete=True) as f:
             self.name = f.name

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -3,6 +3,7 @@
 import collections
 import copy
 from operator import attrgetter
+from pathlib import Path
 
 import numpy as np
 
@@ -76,7 +77,7 @@ def train(params, train_set, num_boost_round=100,
         If you want to get i-th row preds in j-th class, the access way is preds[j * num_data + i].
         To ignore the default metric corresponding to the used objective,
         set the ``metric`` parameter to the string ``"None"`` in ``params``.
-    init_model : string, Booster or None, optional (default=None)
+    init_model : string, pathlib.Path, Booster or None, optional (default=None)
         Filename of LightGBM model or Booster instance used for continue training.
     feature_name : list of strings or 'auto', optional (default="auto")
         Feature names.
@@ -161,7 +162,7 @@ def train(params, train_set, num_boost_round=100,
 
     if num_boost_round <= 0:
         raise ValueError("num_boost_round should be greater than zero.")
-    if isinstance(init_model, str):
+    if isinstance(init_model, (str, Path)):
         predictor = _InnerPredictor(model_file=init_model, pred_parameter=params)
     elif isinstance(init_model, Booster):
         predictor = init_model._to_predictor(dict(init_model.params, **params))
@@ -470,7 +471,7 @@ def cv(params, train_set, num_boost_round=100,
         If you want to get i-th row preds in j-th class, the access way is preds[j * num_data + i].
         To ignore the default metric corresponding to the used objective,
         set ``metrics`` to the string ``"None"``.
-    init_model : string, Booster or None, optional (default=None)
+    init_model : string, pathlib.Path, Booster or None, optional (default=None)
         Filename of LightGBM model or Booster instance used for continue training.
     feature_name : list of strings or 'auto', optional (default="auto")
         Feature names.
@@ -545,7 +546,7 @@ def cv(params, train_set, num_boost_round=100,
 
     if num_boost_round <= 0:
         raise ValueError("num_boost_round should be greater than zero.")
-    if isinstance(init_model, str):
+    if isinstance(init_model, (str, Path)):
         predictor = _InnerPredictor(model_file=init_model, pred_parameter=params)
     elif isinstance(init_model, Booster):
         predictor = init_model._to_predictor(dict(init_model.params, **params))

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 """Find the path to LightGBM dynamic library files."""
-import os
+from os import environ
+from pathlib import Path
 from platform import system
 from typing import List
 
@@ -13,27 +14,26 @@ def find_lib_path() -> List[str]:
     lib_path: list of strings
        List of all found library paths to LightGBM.
     """
-    if os.environ.get('LIGHTGBM_BUILD_DOC', False):
+    if environ.get('LIGHTGBM_BUILD_DOC', False):
         # we don't need lib_lightgbm while building docs
         return []
 
-    curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+    curr_path = Path(__file__).parent.absolute()
     dll_path = [curr_path,
-                os.path.join(curr_path, '../../'),
-                os.path.join(curr_path, 'compile'),
-                os.path.join(curr_path, '../compile'),
-                os.path.join(curr_path, '../../lib/')]
+                curr_path.parents[1],
+                curr_path / 'compile',
+                curr_path.parent / 'compile',
+                curr_path.parents[1] / 'lib']
     if system() in ('Windows', 'Microsoft'):
-        dll_path.append(os.path.join(curr_path, '../compile/Release/'))
-        dll_path.append(os.path.join(curr_path, '../compile/windows/x64/DLL/'))
-        dll_path.append(os.path.join(curr_path, '../../Release/'))
-        dll_path.append(os.path.join(curr_path, '../../windows/x64/DLL/'))
-        dll_path = [os.path.join(p, 'lib_lightgbm.dll') for p in dll_path]
+        dll_path.append(curr_path.parent / 'compile' / 'Release')
+        dll_path.append(curr_path.parent / 'compile' / 'windows' / 'x64' / 'DLL')
+        dll_path.append(curr_path.parents[1] / 'Release')
+        dll_path.append(curr_path.parents[1] / 'windows' / 'x64' / 'DLL')
+        dll_path = [p / 'lib_lightgbm.dll' for p in dll_path]
     else:
-        dll_path = [os.path.join(p, 'lib_lightgbm.so') for p in dll_path]
-    lib_path = [p for p in dll_path if os.path.exists(p) and os.path.isfile(p)]
+        dll_path = [p / 'lib_lightgbm.so' for p in dll_path]
+    lib_path = [str(p) for p in dll_path if p.is_file()]
     if not lib_path:
-        dll_path = [os.path.realpath(p) for p in dll_path]
-        new_line = "\n"
-        raise Exception(f'Cannot find lightgbm library file in following paths:{new_line}{new_line.join(dll_path)}')
+        dll_path_joined = '\n'.join(map(str, dll_path))
+        raise Exception(f'Cannot find lightgbm library file in following paths:\n{dll_path_joined}')
     return lib_path

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -256,7 +256,7 @@ _lgbmmodel_doc_fit = (
     callbacks : list of callback functions or None, optional (default=None)
         List of callback functions that are applied at each iteration.
         See Callbacks in Python API for more information.
-    init_model : string, Booster, LGBMModel or None, optional (default=None)
+    init_model : string, pathlib.Path, Booster, LGBMModel or None, optional (default=None)
         Filename of LightGBM model, Booster instance or LGBMModel instance used for continue training.
 
     Returns

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -49,8 +49,8 @@ def test_basic(tmp_path):
     assert bst.lower_bound() == pytest.approx(-2.9040190126976606)
     assert bst.upper_bound() == pytest.approx(3.3182142872462883)
 
-    tname = str(tmp_path / "svm_light.dat")
-    model_file = str(tmp_path / "model.txt")
+    tname = tmp_path / "svm_light.dat"
+    model_file = tmp_path / "model.txt"
 
     bst.save_model(model_file)
     pred_from_matr = bst.predict(X_test)
@@ -153,8 +153,8 @@ def test_sequence(tmpdir, sample_count, batch_size, include_0_and_nan, num_seq):
     X = data[:, :-1]
     Y = data[:, -1]
 
-    npy_bin_fname = str(tmpdir / 'data_from_npy.bin')
-    seq_bin_fname = str(tmpdir / 'data_from_seq.bin')
+    npy_bin_fname = tmpdir / 'data_from_npy.bin'
+    seq_bin_fname = tmpdir / 'data_from_seq.bin'
 
     # Create dataset from numpy array directly.
     ds = lgb.Dataset(X, label=Y, params=params)
@@ -175,9 +175,9 @@ def test_sequence(tmpdir, sample_count, batch_size, include_0_and_nan, num_seq):
     valid_X = valid_data[:, :-1]
     valid_Y = valid_data[:, -1]
 
-    valid_npy_bin_fname = str(tmpdir / 'valid_data_from_npy.bin')
-    valid_seq_bin_fname = str(tmpdir / 'valid_data_from_seq.bin')
-    valid_seq2_bin_fname = str(tmpdir / 'valid_data_from_seq2.bin')
+    valid_npy_bin_fname = tmpdir / 'valid_data_from_npy.bin'
+    valid_seq_bin_fname = tmpdir / 'valid_data_from_seq.bin'
+    valid_seq2_bin_fname = tmpdir / 'valid_data_from_seq2.bin'
 
     valid_ds = lgb.Dataset(valid_X, label=valid_Y, params=params, reference=ds)
     valid_ds.save_binary(valid_npy_bin_fname)
@@ -268,10 +268,10 @@ def test_add_features_equal_data_on_alternating_used_unused(tmp_path):
         d1 = lgb.Dataset(X[:, :j], feature_name=names[:j]).construct()
         d2 = lgb.Dataset(X[:, j:], feature_name=names[j:]).construct()
         d1.add_features_from(d2)
-        d1name = str(tmp_path / "d1.txt")
+        d1name = tmp_path / "d1.txt"
         d1._dump_text(d1name)
         d = lgb.Dataset(X, feature_name=names).construct()
-        dname = str(tmp_path / "d.txt")
+        dname = tmp_path / "d.txt"
         d._dump_text(dname)
         with open(d1name, 'rt') as d1f:
             d1txt = d1f.read()
@@ -297,8 +297,8 @@ def test_add_features_same_booster_behaviour(tmp_path):
         for k in range(10):
             b.update()
             b1.update()
-        dname = str(tmp_path / "d.txt")
-        d1name = str(tmp_path / "d1.txt")
+        dname = tmp_path / "d.txt"
+        d1name = tmp_path / "d1.txt"
         b1.save_model(d1name)
         b.save_model(dname)
         with open(dname, 'rt') as df:
@@ -352,7 +352,7 @@ def test_cegb_affects_behavior(tmp_path):
     base = lgb.Booster(train_set=ds)
     for k in range(10):
         base.update()
-    basename = str(tmp_path / "basename.txt")
+    basename = tmp_path / "basename.txt"
     base.save_model(basename)
     with open(basename, 'rt') as f:
         basetxt = f.read()
@@ -364,7 +364,7 @@ def test_cegb_affects_behavior(tmp_path):
         booster = lgb.Booster(train_set=ds, params=case)
         for k in range(10):
             booster.update()
-        casename = str(tmp_path / "casename.txt")
+        casename = tmp_path / "casename.txt"
         booster.save_model(casename)
         with open(casename, 'rt') as f:
             casetxt = f.read()
@@ -391,13 +391,13 @@ def test_cegb_scaling_equalities(tmp_path):
         for k in range(10):
             booster1.update()
             booster2.update()
-        p1name = str(tmp_path / "p1.txt")
+        p1name = tmp_path / "p1.txt"
         # Reset booster1's parameters to p2, so the parameter section of the file matches.
         booster1.reset_parameter(p2)
         booster1.save_model(p1name)
         with open(p1name, 'rt') as f:
             p1txt = f.read()
-        p2name = str(tmp_path / "p2.txt")
+        p2name = tmp_path / "p2.txt"
         booster2.save_model(p2name)
         with open(p2name, 'rt') as f:
             p2txt = f.read()

--- a/tests/python_package_test/test_consistency.py
+++ b/tests/python_package_test/test_consistency.py
@@ -24,7 +24,7 @@ class FileLoader:
                         self.params[key] = value if key != 'num_trees' else int(value)
 
     def load_dataset(self, suffix, is_sparse=False):
-        filename = self.path(suffix)
+        filename = str(self.path(suffix))
         if is_sparse:
             X, Y = load_svmlight_file(filename, dtype=np.float64, zero_based=True)
             return X, Y, filename
@@ -62,7 +62,7 @@ class FileLoader:
                 assert a == b, f
 
     def path(self, suffix):
-        return str(self.directory / f'{self.prefix}{suffix}')
+        return self.directory / f'{self.prefix}{suffix}'
 
 
 def test_binary():

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2261,9 +2261,8 @@ def test_forced_bins():
     x[:, 0] = np.arange(0, 1, 0.01)
     x[:, 1] = -np.arange(0, 1, 0.01)
     y = np.arange(0, 1, 0.01)
-    forcedbins_filename = str(
-        Path(__file__).absolute().parents[2] / 'examples' / 'regression' / 'forced_bins.json'
-    )
+    forcedbins_filename = (Path(__file__).absolute().parents[2] / 'examples'
+                           / 'regression' / 'forced_bins.json')
     params = {'objective': 'regression_l1',
               'max_bin': 5,
               'forcedbins_filename': forcedbins_filename,
@@ -2285,9 +2284,8 @@ def test_forced_bins():
     est = lgb.train(params, lgb_x, num_boost_round=20)
     predicted = est.predict(new_x)
     assert len(np.unique(predicted)) == 3
-    params['forcedbins_filename'] = str(
-        Path(__file__).absolute().parents[2] / 'examples' / 'regression' / 'forced_bins2.json'
-    )
+    params['forcedbins_filename'] = (Path(__file__).absolute().parents[2] / 'examples'
+                                     / 'regression' / 'forced_bins2.json')
     params['max_bin'] = 11
     lgb_x = lgb.Dataset(x[:, :1], label=y)
     est = lgb.train(params, lgb_x, num_boost_round=50)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2261,8 +2261,9 @@ def test_forced_bins():
     x[:, 0] = np.arange(0, 1, 0.01)
     x[:, 1] = -np.arange(0, 1, 0.01)
     y = np.arange(0, 1, 0.01)
-    forcedbins_filename = (Path(__file__).absolute().parents[2] / 'examples'
-                           / 'regression' / 'forced_bins.json')
+    forcedbins_filename = (
+        Path(__file__).absolute().parents[2] / 'examples' / 'regression' / 'forced_bins.json'
+    )
     params = {'objective': 'regression_l1',
               'max_bin': 5,
               'forcedbins_filename': forcedbins_filename,
@@ -2284,8 +2285,9 @@ def test_forced_bins():
     est = lgb.train(params, lgb_x, num_boost_round=20)
     predicted = est.predict(new_x)
     assert len(np.unique(predicted)) == 3
-    params['forcedbins_filename'] = (Path(__file__).absolute().parents[2] / 'examples'
-                                     / 'regression' / 'forced_bins2.json')
+    params['forcedbins_filename'] = (
+        Path(__file__).absolute().parents[2] / 'examples' / 'regression' / 'forced_bins2.json'
+    )
     params['max_bin'] = 11
     lgb_x = lgb.Dataset(x[:, :1], label=y)
     est = lgb.train(params, lgb_x, num_boost_round=50)


### PR DESCRIPTION
Allow to pass filenames as `libpath.Path` objects. Now path-like objects can be used in both named arguments and `params` dictionary (`kwargs`).

Contributes to #4416.