### PR TITLE
[python-package] use toarray() instead of todense() in tests and examples

### DIFF
--- a/examples/python-guide/dask/ranking.py
+++ b/examples/python-guide/dask/ranking.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
 
     # make this array dense because we're splitting across
     # a sparse boundary to partition the data
-    X = X.todense()
+    X = X.toarray()
 
     dX = da.from_array(
         x=X,

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1087,7 +1087,7 @@ def test_contribs_sparse_multiclass():
     # convert data to dense and get back same contribs
     contribs_dense = gbm.predict(X_test.toarray(), pred_contrib=True)
     # validate the values are the same
-    contribs_csr_array = np.swapaxes(np.array([sparse_array.todense() for sparse_array in contribs_csr]), 0, 1)
+    contribs_csr_array = np.swapaxes(np.array([sparse_array.toarray() for sparse_array in contribs_csr]), 0, 1)
     contribs_csr_arr_re = contribs_csr_array.reshape((contribs_csr_array.shape[0],
                                                       contribs_csr_array.shape[1] * contribs_csr_array.shape[2]))
     if platform.machine() == 'aarch64':
@@ -1103,7 +1103,7 @@ def test_contribs_sparse_multiclass():
     for perclass_contribs_csc in contribs_csc:
         assert isspmatrix_csc(perclass_contribs_csc)
     # validate the values are the same
-    contribs_csc_array = np.swapaxes(np.array([sparse_array.todense() for sparse_array in contribs_csc]), 0, 1)
+    contribs_csc_array = np.swapaxes(np.array([sparse_array.toarray() for sparse_array in contribs_csc]), 0, 1)
     contribs_csc_array = contribs_csc_array.reshape((contribs_csc_array.shape[0],
                                                      contribs_csc_array.shape[1] * contribs_csc_array.shape[2]))
     if platform.machine() == 'aarch64':


### PR DESCRIPTION
Based on the advice in https://github.com/microsoft/LightGBM/pull/4378#issuecomment-873805964, this PR proposes changing a few uses of `.todense()` called on sparse arrays to `.toarray()`.

This method converts a sparse array to a `np.array`, a better-supported object type than `np.matrix` (the type returned by `.todense()`).

See https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.spmatrix.toarray.html.

### Notes for Reviewers

There are a few other uses of `.todense()` in the Dask tests, but those will be changed as part of #4378.