### PR TITLE
[fix] fix Reservoir Sampling in Sample of random.h (fix #4371 and #4134)

### DIFF
--- a/include/LightGBM/utils/random.h
+++ b/include/LightGBM/utils/random.h
@@ -82,13 +82,10 @@ class Random {
           ret.push_back(i);
         }
       }
-    } else if (K == 1) {
-      int v = NextInt(0, N);
-      ret.push_back(v);
     } else {
       std::set<int> sample_set;
       for (int r = N - K; r < N; ++r) {
-        int v = NextInt(0, r);
+        int v = NextInt(0, r + 1);
         if (!sample_set.insert(v).second) {
           sample_set.insert(r);
         }


### PR DESCRIPTION
Thanks @DexGroves for pointing out the bug in the Reservoir Sampling. It turns out the fix for #4134 in #4324 did not remove the root cause. The real problem is the `+1` being missing in `int v = NextInt(0, r);`. This should solves both #4134 and #4371.