### PR TITLE
[tests] clarify RuntimeError in distributed tests

### DIFF
--- a/tests/distributed/_test_distributed.py
+++ b/tests/distributed/_test_distributed.py
@@ -148,7 +148,7 @@ class DistributedMockup:
         cmd = [self.executable, f'config={config_path}']
         result = subprocess.run(cmd)
         if result.returncode != 0:
-            raise RuntimeError
+            raise RuntimeError('Error in prediction')
         y_pred = np.loadtxt(str(TESTS_DIR / 'predictions.txt'))
         return y_pred
 


### PR DESCRIPTION
Refer to https://github.com/microsoft/LightGBM/pull/4254#discussion_r659450888.
https://github.com/microsoft/LightGBM/blob/a06899ab72e59aeb635c794962cb19a5880724df/tests/distributed/_test_distributed.py#L135