### PR TITLE
Fix undefined behavior with NaN input in CategoricalDecision()

### DIFF
--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -366,13 +366,9 @@ class Tree {
   }
 
   inline int CategoricalDecision(double fval, int node) const {
-    uint8_t missing_type = GetMissingType(decision_type_[node]);
     int int_fval;
     if (std::isnan(fval)) {
-      if (missing_type == MissingType::NaN) {
-        return right_child_[node];
-      }
-      int_fval = 0;
+      return right_child_[node];
     } else {
       int_fval = static_cast<int>(fval);
       if (int_fval < 0) {

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -367,15 +367,17 @@ class Tree {
 
   inline int CategoricalDecision(double fval, int node) const {
     uint8_t missing_type = GetMissingType(decision_type_[node]);
-    int int_fval = static_cast<int>(fval);
-    if (int_fval < 0) {
-      return right_child_[node];;
-    } else if (std::isnan(fval)) {
-      // NaN is always in the right
+    int int_fval;
+    if (std::isnan(fval)) {
       if (missing_type == MissingType::NaN) {
         return right_child_[node];
       }
       int_fval = 0;
+    } else {
+      int_fval = static_cast<int>(fval);
+      if (int_fval < 0) {
+        return right_child_[node];
+      }
     }
     int cat_idx = static_cast<int>(threshold_[node]);
     if (Common::FindInBitset(cat_threshold_.data() + cat_boundaries_[cat_idx],


### PR DESCRIPTION
Currently, the `CategoricalDecision()` function casts the input `fval` into `int`, when `fval` is possibly a NaN (Not-a-Number):

https://github.com/microsoft/LightGBM/blob/5b7a6f3e7150aeb704d1dd2b852d246af3e913a3/include/LightGBM/tree.h#L368-L379

This cast causes undefined behavior when `fval` is NaN. According to https://stackoverflow.com/a/10366541:

> When a finite value of real floating type is converted to an integer type other than _Bool, the fractional part is discarded (i.e., the value is truncated toward zero). **If the value of the integral part cannot be represented by the integer type, the behavior is undefined.**

Casting NaN into `int` may or may not produce a negative value.

Minimal reproducible example, where this is a problem:
```python
import lightgbm as lgb
import numpy as np

X = np.array(30*[[1]] + 30*[[2]] + 30*[[0]])
y = np.array(60 * [5] + 30*[10])
train_data = lgb.Dataset(X, label=y, categorical_feature=[0])
bst = lgb.train({}, train_data, 1)

print(bst.predict(np.array([[np.NaN], [0.0]])))
# prints array([6.5       , 6.99999999])
```
(Example taken from dmlc/treelite#277)
Model plot:
![image](https://user-images.githubusercontent.com/14908678/119469381-95e3e400-bd47-11eb-8a63-f30be5ea31cc.png)

The model produced by the example has `missing_type` field set to `MissingType::None`, indicating that all missing-value inputs should be mapped to 0. However, undefined behavior when casting NaN into `int` makes it uncertain how `CategoricalDecision()` would behave:
* If NaN gets casted into a negative value: `CategoricalDecision()` will return the right child when given the NaN input.
* If NaN gets casted into a positive value: given the NaN input, `CategoricalDecision()` will behave as if it's given an input of 0.

On my machine, casting NaN into `int` produces -2147483648.

**Proposed Fix**. In  `CategoricalDecision()`, check the input `fval` against NaN **first**. The input should be casted into `int` only when it's known to be not NaN.
* The fix eliminates the undefined behavior.
* The fix also ensures that the missing type setting is honored.