### PR TITLE
[docs] document CLI behavior when label_column is omitted

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -762,6 +762,8 @@ Dataset Parameters
 
    -  add a prefix ``name:`` for column name, e.g. ``label=name:is_click``
 
+   -  if omitted, the first column in the training data is used as the label
+
    -  **Note**: works only in case of loading data directly from file
 
 -  ``weight_column`` :raw-html:`<a id="weight_column" title="Permalink to this parameter" href="#weight_column">&#x1F517;&#xFE0E;</a>`, default = ``""``, type = int or string, aliases: ``weight``

--- a/examples/binary_classification/train.conf
+++ b/examples/binary_classification/train.conf
@@ -26,6 +26,9 @@ metric_freq = 1
 # true if need output metric for training data, alias: tranining_metric, train_metric
 is_training_metric = true
 
+# column in data to use as label
+label_column = 0
+
 # number of bins for feature bucket, 255 is a recommend setting, it can save memories, and also has good accuracy. 
 max_bin = 255
 

--- a/examples/lambdarank/train.conf
+++ b/examples/lambdarank/train.conf
@@ -29,6 +29,9 @@ metric_freq = 1
 # true if need output metric for training data, alias: tranining_metric, train_metric
 is_training_metric = true
 
+# column in data to use as label
+label_column = 0
+
 # number of bins for feature bucket, 255 is a recommend setting, it can save memories, and also has good accuracy. 
 max_bin = 255
 

--- a/examples/multiclass_classification/train.conf
+++ b/examples/multiclass_classification/train.conf
@@ -41,6 +41,9 @@ metric_freq = 1
 # true if need output metric for training data, alias: tranining_metric, train_metric
 is_training_metric = true
 
+# column in data to use as label
+label_column = 0
+
 # number of bins for feature bucket, 255 is a recommend setting, it can save memories, and also has good accuracy. 
 max_bin = 255
 

--- a/examples/parallel_learning/train.conf
+++ b/examples/parallel_learning/train.conf
@@ -26,6 +26,9 @@ metric_freq = 1
 # true if need output metric for training data, alias: tranining_metric, train_metric
 is_training_metric = true
 
+# column in data to use as label
+label_column = 0
+
 # number of bins for feature bucket, 255 is a recommend setting, it can save memories, and also has good accuracy. 
 max_bin = 255
 

--- a/examples/regression/train.conf
+++ b/examples/regression/train.conf
@@ -26,6 +26,9 @@ metric_freq = 1
 # true if need output metric for training data, alias: tranining_metric, train_metric
 is_training_metric = true
 
+# column in data to use as label
+label_column = 0
+
 # number of bins for feature bucket, 255 is a recommend setting, it can save memories, and also has good accuracy. 
 max_bin = 255
 

--- a/examples/xendcg/train.conf
+++ b/examples/xendcg/train.conf
@@ -29,6 +29,9 @@ metric_freq = 1
 # true if need output metric for training data, alias: tranining_metric, train_metric
 is_training_metric = true
 
+# column in data to use as label
+label_column = 0
+
 # number of bins for feature bucket, 255 is a recommend setting, it can save memories, and also has good accuracy. 
 max_bin = 255
 

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -657,6 +657,7 @@ struct Config {
   // desc = used to specify the label column
   // desc = use number for index, e.g. ``label=0`` means column\_0 is the label
   // desc = add a prefix ``name:`` for column name, e.g. ``label=name:is_click``
+  // desc = if omitted, the first column in the training data is used as the label
   // desc = **Note**: works only in case of loading data directly from file
   std::string label_column = "";
 


### PR DESCRIPTION
Answering [this stack overflow question](https://stackoverflow.com/questions/68482580/in-the-example-regression-which-is-the-target-column/68506958#68506958) tonight, I wasn't able to figure out from LightGBM's documentation that, when using the CLI, if `label_column` is omitted from `train.conf`, LightGBM defaults to using the first column in the training data as the target.

I had to figure this out from source code

* `Dataset.label_idx_`  is initialized to 0: https://github.com/microsoft/LightGBM/blob/a8ee487aca35363fafa027e6b7695976045096b3/src/io/dataset_loader.cpp#L22
* `Dataset.label_idx_` is only overridden if label_column is provided in the config: https://github.com/microsoft/LightGBM/blob/a8ee487aca35363fafa027e6b7695976045096b3/src/io/dataset_loader.cpp#L48-L57

This PR proposes two small changes to make this clearer for new users of the CLI:

* adds a line to the docs for https://lightgbm.readthedocs.io/en/latest/Parameters.html#label_column explaining this behavior
* adds `label_column` to all of the training configs in `examples/`, to nudge users who copy those configs as a reference to explicitly define `label_column` in their own configs