### PR TITLE
[dask] find all needed ports in each host at once (fixes #4458)

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -32,6 +32,7 @@ _PredictionDtype = Union[Type[np.float32], Type[np.float64], Type[np.int32], Typ
 
 HostWorkers = namedtuple('HostWorkers', ['default', 'all'])
 
+
 class _DatasetNames(Enum):
     """Placeholder names used by lightgbm.dask internals to say 'also evaluate the training data'.
 
@@ -84,7 +85,7 @@ def _find_n_open_ports(n: int) -> List[int]:
 
 
 def _group_workers_by_host(worker_addresses: Iterable[str]) -> Dict[str, HostWorkers]:
-    """Group al worker addresses by hostname.
+    """Group all worker addresses by hostname.
 
     Returns
     -------
@@ -105,9 +106,10 @@ def _assign_open_ports_to_workers(
     client: Client,
     host_to_workers: Dict[str, HostWorkers]
 ) -> Dict[str, int]:
-    """Assigns an open port to each worker.
+    """Assign an open port to each worker.
 
     Returns
+    -------
     worker_to_port: dict
         mapping from worker address to an open port.
     """

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -30,7 +30,7 @@ _DaskVectorLike = Union[dask_Array, dask_Series]
 _DaskPart = Union[np.ndarray, pd_DataFrame, pd_Series, ss.spmatrix]
 _PredictionDtype = Union[Type[np.float32], Type[np.float64], Type[np.int32], Type[np.int64]]
 
-HostWorkers = namedtuple('HostWorkers', ['default', 'all'])
+_HostWorkers = namedtuple('HostWorkers', ['default', 'all'])
 
 
 class _DatasetNames(Enum):
@@ -72,19 +72,19 @@ def _find_n_open_ports(n: int) -> List[int]:
     ports : list of int
         n random open ports on localhost.
     """
-    skts = []
+    sockets = []
     for _ in range(n):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.bind(('', 0))
-        skts.append(s)
+        sockets.append(s)
     ports = []
-    for s in skts:
+    for s in sockets:
         ports.append(s.getsockname()[1])
         s.close()
     return ports
 
 
-def _group_workers_by_host(worker_addresses: Iterable[str]) -> Dict[str, HostWorkers]:
+def _group_workers_by_host(worker_addresses: Iterable[str]) -> Dict[str, _HostWorkers]:
     """Group all worker addresses by hostname.
 
     Returns
@@ -92,11 +92,11 @@ def _group_workers_by_host(worker_addresses: Iterable[str]) -> Dict[str, HostWor
     host_to_workers : dict
         mapping from hostname to all its workers.
     """
-    host_to_workers: Dict[str, HostWorkers] = {}
+    host_to_workers: Dict[str, _HostWorkers] = {}
     for address in worker_addresses:
         hostname = urlparse(address).hostname
         if hostname not in host_to_workers:
-            host_to_workers[hostname] = HostWorkers(default=address, all=[address])
+            host_to_workers[hostname] = _HostWorkers(default=address, all=[address])
         else:
             host_to_workers[hostname].all.append(address)
     return host_to_workers
@@ -104,7 +104,7 @@ def _group_workers_by_host(worker_addresses: Iterable[str]) -> Dict[str, HostWor
 
 def _assign_open_ports_to_workers(
     client: Client,
-    host_to_workers: Dict[str, HostWorkers]
+    host_to_workers: Dict[str, _HostWorkers]
 ) -> Dict[str, int]:
     """Assign an open port to each worker.
 

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -450,7 +450,7 @@ def test_group_workers_by_host():
     hosts = [f'0.0.0.{i}' for i in range(2)]
     workers = [f'tcp://{host}:{p}' for p in range(2) for host in hosts]
     expected = {
-        host: lgb.dask.HostWorkers(
+        host: lgb.dask._HostWorkers(
             default=f'tcp://{host}:0',
             all=[f'tcp://{host}:0', f'tcp://{host}:1']
         )


### PR DESCRIPTION
This replaces my initial proposal (#3823) of using `client.run` to find an open port in each worker, since that could produce collisions (#4057, #4458) when one host had more than one worker process running in it (as is the case with `LocalCluster`). The collisions problem was solved in #4133, however it would be desirable to not have any collisions at all, which is what this (hopefully) achieves.