### PR TITLE
[R-package] quote path variables in build-cran-package.sh

### DIFF
--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -9,13 +9,13 @@
 
 set -e
 
-ORIG_WD=$(pwd)
-TEMP_R_DIR=$(pwd)/lightgbm_r
+ORIG_WD="$(pwd)"
+TEMP_R_DIR="$(pwd)/lightgbm_r"
 
-if test -d ${TEMP_R_DIR}; then
-    rm -r ${TEMP_R_DIR}
+if test -d "${TEMP_R_DIR}"; then
+    rm -r "${TEMP_R_DIR}"
 fi
-mkdir -p ${TEMP_R_DIR}
+mkdir -p "${TEMP_R_DIR}"
 
 CURRENT_DATE=$(date +'%Y-%m-%d')
 
@@ -24,41 +24,41 @@ CURRENT_DATE=$(date +'%Y-%m-%d')
 LGB_VERSION=$(cat VERSION.txt | sed "s/rc/-/g")
 
 # move relevant files
-cp -R R-package/* ${TEMP_R_DIR}
-cp -R include ${TEMP_R_DIR}/src/
-cp -R src/* ${TEMP_R_DIR}/src/
+cp -R R-package/* "${TEMP_R_DIR}"
+cp -R include "${TEMP_R_DIR}/src/"
+cp -R src/* "${TEMP_R_DIR}/src/"
 
 cp \
     external_libs/fast_double_parser/include/fast_double_parser.h \
-    ${TEMP_R_DIR}/src/include/LightGBM
+    "${TEMP_R_DIR}/src/include/LightGBM"
 
-mkdir -p ${TEMP_R_DIR}/src/include/LightGBM/fmt
+mkdir -p "${TEMP_R_DIR}/src/include/LightGBM/fmt"
 cp \
     external_libs/fmt/include/fmt/*.h \
-    ${TEMP_R_DIR}/src/include/LightGBM/fmt/
+    "${TEMP_R_DIR}/src/include/LightGBM/fmt/"
 
 # including only specific files from Eigen, to keep the R package
 # small and avoid redistributing code with licenses incompatible with
 # LightGBM's license
-EIGEN_R_DIR=${TEMP_R_DIR}/src/include/Eigen
-mkdir -p ${EIGEN_R_DIR}
+EIGEN_R_DIR="${TEMP_R_DIR}/src/include/Eigen"
+mkdir -p "${EIGEN_R_DIR}"
 
 modules="Cholesky Core Dense Eigenvalues Geometry Householder Jacobi LU QR SVD"
 for eigen_module in ${modules}; do
-    cp external_libs/eigen/Eigen/${eigen_module} ${EIGEN_R_DIR}/${eigen_module}
+    cp external_libs/eigen/Eigen/${eigen_module} "${EIGEN_R_DIR}/${eigen_module}"
     if [ ${eigen_module} != "Dense" ]; then
-        mkdir -p ${EIGEN_R_DIR}/src/${eigen_module}/
-        cp -R external_libs/eigen/Eigen/src/${eigen_module}/* ${EIGEN_R_DIR}/src/${eigen_module}/
+        mkdir -p "${EIGEN_R_DIR}/src/${eigen_module}/"
+        cp -R external_libs/eigen/Eigen/src/${eigen_module}/* "${EIGEN_R_DIR}/src/${eigen_module}/"
     fi
 done
 
-mkdir -p ${EIGEN_R_DIR}/src/misc
-cp -R external_libs/eigen/Eigen/src/misc/* ${EIGEN_R_DIR}/src/misc/
+mkdir -p "${EIGEN_R_DIR}/src/misc"
+cp -R external_libs/eigen/Eigen/src/misc/* "${EIGEN_R_DIR}/src/misc/"
 
-mkdir -p ${EIGEN_R_DIR}/src/plugins
-cp -R external_libs/eigen/Eigen/src/plugins/* ${EIGEN_R_DIR}/src/plugins/
+mkdir -p "${EIGEN_R_DIR}/src/plugins"
+cp -R external_libs/eigen/Eigen/src/plugins/* "${EIGEN_R_DIR}/src/plugins/"
 
-cd ${TEMP_R_DIR}
+cd "${TEMP_R_DIR}"
 
     # Remove files not needed for CRAN
     echo "Removing files not needed for CRAN"
@@ -138,7 +138,7 @@ cd ${TEMP_R_DIR}
     rm R/*.R.bak
     rm NAMESPACE.bak
 
-cd ${ORIG_WD}
+cd "${ORIG_WD}"
 
 R CMD build \
     --keep-empty-dirs \


### PR DESCRIPTION
LightGBM provides a script, `build-cran-package.sh`, which can be used to produce a CRAN-style source distribution of the R package.

This is effectively user-facing code, since we encourage users to run it while developing or building from `master` to get unreleased features (e.g. https://github.com/microsoft/LightGBM/issues/4259#issuecomment-832900302, https://github.com/microsoft/LightGBM/issues/4464#issuecomment-890454199).

I realized yesterday, working on #3946 , that that script can break if called from a path that has spaces in it.

Consider the following:

```shell
mkdir -p './some files'
cd 'some files'
git clone --recursive https://github.com/microsoft/LightGBM.git
cd LightGBM
sh build-cran-package.sh
```

This errors out like so:

> build-cran-package.sh: line 15: test: /Users/James.Lamb/repos/open-source/some: binary operator expected
cp: /Users/James.Lamb/repos/open-source/some is a directory (not copied).

This PR proposes quoting all shell variables in that script which include paths, which prevents this problem.