### PR TITLE
[tests][dask] reduce number of collisions tests

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -148,7 +148,7 @@ elif [[ $TASK == "bdist" ]]; then
         fi
     fi
     pip install --user $BUILD_DIRECTORY/python-package/dist/*.whl || exit -1
-    pytest --durations=0 $BUILD_DIRECTORY/tests || exit -1
+    pytest $BUILD_DIRECTORY/tests || exit -1
     exit 0
 fi
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -207,7 +207,7 @@ fi
 make _lightgbm -j4 || exit -1
 
 cd $BUILD_DIRECTORY/python-package && python setup.py install --precompile --user || exit -1
-pytest $BUILD_DIRECTORY/tests || exit -1
+pytest --durations=0 $BUILD_DIRECTORY/tests || exit -1
 
 if [[ $TASK == "regular" ]]; then
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -148,7 +148,7 @@ elif [[ $TASK == "bdist" ]]; then
         fi
     fi
     pip install --user $BUILD_DIRECTORY/python-package/dist/*.whl || exit -1
-    pytest $BUILD_DIRECTORY/tests || exit -1
+    pytest --durations=0 $BUILD_DIRECTORY/tests || exit -1
     exit 0
 fi
 
@@ -207,7 +207,7 @@ fi
 make _lightgbm -j4 || exit -1
 
 cd $BUILD_DIRECTORY/python-package && python setup.py install --precompile --user || exit -1
-pytest --durations=0 $BUILD_DIRECTORY/tests || exit -1
+pytest $BUILD_DIRECTORY/tests || exit -1
 
 if [[ $TASK == "regular" ]]; then
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -465,7 +465,7 @@ def test_assign_open_ports_to_workers(cluster):
         workers = client.scheduler_info()['workers'].keys()
         n_workers = len(workers)
         host_to_workers = lgb.dask._group_workers_by_host(workers)
-        for _ in range(1_000):
+        for _ in range(25):
             worker_address_to_port = lgb.dask._assign_open_ports_to_workers(client, host_to_workers)
             found_ports = worker_address_to_port.values()
             assert len(found_ports) == n_workers


### PR DESCRIPTION
The recent change of the search for open ports for the dask interface (#4498) removed the collisions and to make sure we never got any the test ran 1,000 times, which is too much for the QEMU CI job (https://github.com/microsoft/LightGBM/pull/4498#discussion_r682665570).

This reduces the number of times the collisions are tested to 25 (as suggested in https://github.com/microsoft/LightGBM/pull/4498#discussion_r682809148).