### PR TITLE
[R-package] use C++ compiler for pre-compile checks on Windows

### DIFF
--- a/.ci/test_r_package_valgrind.sh
+++ b/.ci/test_r_package_valgrind.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RDscriptvalgrind -e "install.packages(c('R6', 'data.table', 'jsonlite', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())" || exit -1
+RDscriptvalgrind -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())" || exit -1
 sh build-cran-package.sh || exit -1
 RDvalgrind CMD INSTALL --preclean --install-tests lightgbm_*.tar.gz || exit -1
 

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Install packages
         shell: bash
         run: |
-          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
+          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
           sh build-cran-package.sh
           Rdevel CMD INSTALL lightgbm_*.tar.gz || exit -1
       - name: Run tests with sanitizers
@@ -221,7 +221,7 @@ jobs:
         shell: bash
         run: |
           export PATH=/opt/R-devel/bin/:${PATH}
-          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
+          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
           sh build-cran-package.sh
           R CMD check --as-cran --run-donttest lightgbm_*.tar.gz || exit -1
           if grep -q -E "NOTE|WARNING|ERROR" lightgbm.Rcheck/00check.log; then

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install packages
         shell: bash
         run: |
-          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'roxygen2', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
+          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'roxygen2', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
           sh build-cran-package.sh || exit -1
           R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit -1
       - name: Test documentation

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -374,7 +374,7 @@ docker run \
     -it rhub/rocker-gcc-san \
     /bin/bash
 
-Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
+Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
 
 sh build-cran-package.sh
 
@@ -396,7 +396,7 @@ docker run \
     -it \
         wch1/r-debug
 
-RDscriptvalgrind -e "install.packages(c('R6', 'data.table', 'jsonlite', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
+RDscriptvalgrind -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
 
 sh build-cran-package.sh
 

--- a/R-package/configure.win
+++ b/R-package/configure.win
@@ -10,7 +10,7 @@ CXX11=`"${R_EXE}" CMD config CXX11`
 CXX11STD=`"${R_EXE}" CMD config CXX11STD`
 CXX="${CXX11} ${CXX11STD}"
 CXXFLAGS=`"${R_EXE}" CMD config CXX11FLAGS`
-CPPFLAGS=`"${R_EXE}" CMD config CPPFLAGS
+CPPFLAGS=`"${R_EXE}" CMD config CPPFLAGS`
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""

--- a/R-package/configure.win
+++ b/R-package/configure.win
@@ -6,7 +6,7 @@
 ###########################
 
 R_EXE="${R_HOME}/bin${R_ARCH_BIN}/R"
-CXX=`"${R_EXE}" CMD config CXX`
+CXX=`"${R_EXE}" CMD config CXX11`
 CXXFLAGS=`"${R_EXE}" CMD config CXXFLAGS`
 CPPFLAGS=`"${R_EXE}" CMD config CPPFLAGS`
 

--- a/R-package/configure.win
+++ b/R-package/configure.win
@@ -7,7 +7,9 @@
 
 R_SCRIPT="${R_HOME}/bin${R_ARCH_BIN}/Rscript"
 R_EXE="${R_HOME}/bin${R_ARCH_BIN}/R"
-CC=`"${R_EXE}" CMD config CC`
+CXX=`"${R_EXE}" CMD config CXX`
+CXXFLAGS=`"${R_EXE}" CMD config CXXFLAGS`
+CPPFLAGS=`"${R_EXE}" CMD config CPPFLAGS`
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""
@@ -24,7 +26,7 @@ LGB_CPPFLAGS="${LGB_CPPFLAGS} -DEIGEN_MPL2_ONLY"
 
 ac_mm_prefetch="no"
 
-cat > conftest.c <<EOL
+cat > conftest.cpp <<EOL
 #include <xmmintrin.h>
 int main() {
   int a = 0;
@@ -33,7 +35,7 @@ int main() {
 }
 EOL
 
-${CC} -o conftest conftest.c 2>/dev/null && ./conftest && ac_mm_prefetch="yes"
+${CXX} ${CXXFLAGS} ${CPPFLAGS} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mm_prefetch="yes"
 echo "checking whether MM_PREFETCH works...${ac_mm_prefetch}"
 
 if test "${ac_mm_prefetch}" = "yes";
@@ -46,7 +48,7 @@ fi
 ############
 ac_mm_malloc="no"
 
-cat > conftest.c <<EOL
+cat > conftest.cpp <<EOL
 #include <mm_malloc.h>
 int main() {
     char *a = (char*)_mm_malloc(8, 16);
@@ -55,7 +57,7 @@ int main() {
 }
 EOL
 
-${CC} -o conftest conftest.c 2>/dev/null && ./conftest && ac_mm_malloc="yes"
+${CXX} ${CXXFLAGS} ${CPPFLAGS} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mm_malloc="yes"
 echo "checking whether MM_MALLOC works...${ac_mm_malloc}"
 
 if test "${ac_mm_malloc}" = "yes";

--- a/R-package/configure.win
+++ b/R-package/configure.win
@@ -6,9 +6,11 @@
 ###########################
 
 R_EXE="${R_HOME}/bin${R_ARCH_BIN}/R"
-CXX=`"${R_EXE}" CMD config CXX11`
-CXXFLAGS=`"${R_EXE}" CMD config CXXFLAGS`
-CPPFLAGS=`"${R_EXE}" CMD config CPPFLAGS`
+CXX11=`"${R_EXE}" CMD config CXX11`
+CXX11STD=`"${R_EXE}" CMD config CXX11STD`
+CXX="${CXX11} ${CXX11STD}"
+CXXFLAGS=`"${R_EXE}" CMD config CXX11FLAGS`
+CPPFLAGS=`"${R_EXE}" CMD config CPPFLAGS
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""


### PR DESCRIPTION
Looking into #4131 as part of #4310, I've noticed some other areas for possible improvement in the `configure` and `configure.win` scripts.

This PR fixes one in `configure.win`. I noticed that the mm_prefetch and mm_malloc tests are being run with a C compiler on Windows. They should be done with a C++ compiler, as they are on Linux/Mac

https://github.com/microsoft/LightGBM/blob/5fe27d594285eeaf31d2f1ebfe29453f8c6c6ad3/R-package/configure.ac#L41

and for all CMake-based builds

https://github.com/microsoft/LightGBM/blob/5fe27d594285eeaf31d2f1ebfe29453f8c6c6ad3/CMakeLists.txt#L253

I'm not aware of any problems caused by the fact that these checks were being done by a C compiler, but a C++ compiler is going to be used for compiling `lib_lightgbm`.

### Notes for Reviewers

To understand the difference between `CXXFLAGS` and `CPPFLAGS` and why they are both included, see [the documentation from `R CMD config`](https://svn.r-project.org/R/trunk/src/scripts/config).

> **CPPFLAGS**      C/C++ preprocessor flags, e.g. `-I<dir>` if you have headers in a nonstandard directory `<dir>`
> **CXXFLAGS**      compiler flags for CXX