### PR TITLE
[R-package] remove unused variable R_SCRIPT in configure.win

### DIFF
--- a/R-package/configure.win
+++ b/R-package/configure.win
@@ -5,7 +5,6 @@
 # find compiler and flags #
 ###########################
 
-R_SCRIPT="${R_HOME}/bin${R_ARCH_BIN}/Rscript"
 R_EXE="${R_HOME}/bin${R_ARCH_BIN}/R"
 CC=`"${R_EXE}" CMD config CC`
 


### PR DESCRIPTION
Another small thing I noticed in the R package's `configure` scripts while looking into #4131 .

The variable `R_SCRIPT` is unused in `configure.win`. It isn't something special (for example, you won't see it mentioned in https://cran.r-project.org/doc/manuals/R-exts.html). So I'm very confident it can be removed.

This PR proposes removing it.