### PR TITLE
[R-package] pass R-configured compiler flags to checks in configure

### DIFF
--- a/.ci/test_r_package_valgrind.sh
+++ b/.ci/test_r_package_valgrind.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RDscriptvalgrind -e "install.packages(c('R6', 'data.table', 'jsonlite', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())" || exit -1
+RDscriptvalgrind -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())" || exit -1
 sh build-cran-package.sh || exit -1
 RDvalgrind CMD INSTALL --preclean --install-tests lightgbm_*.tar.gz || exit -1
 

--- a/R-package/configure
+++ b/R-package/configure
@@ -1694,7 +1694,6 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
-CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 CXX=`"${R_HOME}/bin/R" CMD config CXX11`
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
@@ -1833,7 +1832,7 @@ main ()
 
 
 _ACEOF
-    ${CC} ${CFLAGS} -o conftest conftest.c ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+    ${CC} -o conftest conftest.c ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${ac_pkg_openmp}" >&5
 $as_echo "${ac_pkg_openmp}" >&6; }
     if test "${ac_pkg_openmp}" = no; then

--- a/R-package/configure
+++ b/R-package/configure
@@ -1699,6 +1699,12 @@ CXX11STD=`"${R_HOME}/bin/R" CMD config CXX11STD`
 CXX="${CXX11} ${CXX11STD}"
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
+ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""
@@ -1716,12 +1722,6 @@ LGB_CPPFLAGS="${LGB_CPPFLAGS} -DEIGEN_MPL2_ONLY"
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether MM_PREFETCH works" >&5
 $as_echo_n "checking whether MM_PREFETCH works... " >&6; }
 ac_mmprefetch=no
-ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -1757,12 +1757,6 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether MM_MALLOC works" >&5
 $as_echo_n "checking whether MM_MALLOC works... " >&6; }
 ac_mm_malloc=no
-ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 

--- a/R-package/configure
+++ b/R-package/configure
@@ -1694,9 +1694,11 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
-CXX=`"${R_HOME}/bin/R" CMD config CXX11`
+CXX11=`"${R_HOME}/bin/R" CMD config CXX11`
+CXX11STD=`"${R_HOME}/bin/R" CMD config CXX11STD`
+CXX="${CXX11} ${CXX11STD}"
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
-CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""

--- a/R-package/configure
+++ b/R-package/configure
@@ -1694,7 +1694,10 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
+CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 CXX=`"${R_HOME}/bin/R" CMD config CXX11`
+CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""
@@ -1739,7 +1742,7 @@ main ()
 
 
 _ACEOF
-${CXX} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mmprefetch=yes
+${CXX} ${CPPFLAGS} ${CXXFLAGS} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mmprefetch=yes
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${ac_mmprefetch}" >&5
 $as_echo "${ac_mmprefetch}" >&6; }
 if test "${ac_mmprefetch}" = yes; then
@@ -1780,7 +1783,7 @@ main ()
 
 
 _ACEOF
-${CXX} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mm_malloc=yes
+${CXX} ${CPPFLAGS} ${CXXFLAGS} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mm_malloc=yes
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${ac_mm_malloc}" >&5
 $as_echo "${ac_mm_malloc}" >&6; }
 if test "${ac_mm_malloc}" = yes; then
@@ -1830,7 +1833,7 @@ main ()
 
 
 _ACEOF
-    ${CC} -o conftest conftest.c ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+    ${CC} ${CFLAGS} -o conftest conftest.c ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${ac_pkg_openmp}" >&5
 $as_echo "${ac_pkg_openmp}" >&6; }
     if test "${ac_pkg_openmp}" = no; then

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -21,7 +21,10 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
+CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 CXX=`"${R_HOME}/bin/R" CMD config CXX11`
+CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""
@@ -53,7 +56,7 @@ AC_LANG_CONFTEST(
         )
     ]
 )
-${CXX} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mmprefetch=yes
+${CXX} ${CPPFLAGS} ${CXXFLAGS} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mmprefetch=yes
 AC_MSG_RESULT([${ac_mmprefetch}])
 if test "${ac_mmprefetch}" = yes; then
     LGB_CPPFLAGS+=" -DMM_PREFETCH=1"
@@ -80,7 +83,7 @@ AC_LANG_CONFTEST(
         )
     ]
 )
-${CXX} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mm_malloc=yes
+${CXX} ${CPPFLAGS} ${CXXFLAGS} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mm_malloc=yes
 AC_MSG_RESULT([${ac_mm_malloc}])
 if test "${ac_mm_malloc}" = yes; then
     LGB_CPPFLAGS+=" -DMM_MALLOC=1"
@@ -116,7 +119,7 @@ then
             )
         ]
     )
-    ${CC} -o conftest conftest.c ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+    ${CC} ${CFLAGS} -o conftest conftest.c ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
     AC_MSG_RESULT([${ac_pkg_openmp}])
     if test "${ac_pkg_openmp}" = no; then
         OPENMP_CXXFLAGS=''

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -26,6 +26,7 @@ CXX11STD=`"${R_HOME}/bin/R" CMD config CXX11STD`
 CXX="${CXX11} ${CXX11STD}"
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
+AC_LANG(C++)
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""
@@ -42,7 +43,6 @@ LGB_CPPFLAGS="${LGB_CPPFLAGS} -DEIGEN_MPL2_ONLY"
 
 AC_MSG_CHECKING([whether MM_PREFETCH works])
 ac_mmprefetch=no
-AC_LANG(C++)
 AC_LANG_CONFTEST(
     [
         AC_LANG_PROGRAM(
@@ -69,7 +69,6 @@ fi
 
 AC_MSG_CHECKING([whether MM_MALLOC works])
 ac_mm_malloc=no
-AC_LANG(C++)
 AC_LANG_CONFTEST(
     [
         AC_LANG_PROGRAM(

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -21,7 +21,6 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
-CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 CXX=`"${R_HOME}/bin/R" CMD config CXX11`
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
@@ -119,7 +118,7 @@ then
             )
         ]
     )
-    ${CC} ${CFLAGS} -o conftest conftest.c ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+    ${CC} -o conftest conftest.c ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
     AC_MSG_RESULT([${ac_pkg_openmp}])
     if test "${ac_pkg_openmp}" = no; then
         OPENMP_CXXFLAGS=''

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -21,9 +21,11 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
-CXX=`"${R_HOME}/bin/R" CMD config CXX11`
+CXX11=`"${R_HOME}/bin/R" CMD config CXX11`
+CXX11STD=`"${R_HOME}/bin/R" CMD config CXX11STD`
+CXX="${CXX11} ${CXX11STD}"
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
-CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""


### PR DESCRIPTION
Investigating #4131 , I've been re-reading [the section of "Writing R Extensions" that discusses `configure` scripts](https://cran.r-project.org/doc/manuals/R-exts.html#Configure-and-cleanup).

I believe the R package's current `configure` script is not currently following some of that manual's advice. When it does configure tests (e.g. to check for an included `mm_malloc`), it isn't passing through the compiler flags that R will use when compiling `lib_lightgbm`.

> You will very likely need to ensure that the same C compiler and compiler flags are used in the configure tests as when compiling R or your package

> You can use `R CMD config` to get the value of the basic configuration variables... If you do, it is essential that you use both the command and the appropriate flags, so that for example `CC` must always be used with `CFLAGS`

> Packages written with C++ need to pick up the details for the C++ compiler and switch the current language to C++ 

This PR ensures that the relevant flags are passed through to those checks.