### PR TITLE
[R-package] fix OpenMP checking on macOS (fixes #4131)

### DIFF
--- a/R-package/configure
+++ b/R-package/configure
@@ -1695,6 +1695,8 @@ if test -z "${R_HOME}"; then
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
 CXX=`"${R_HOME}/bin/R" CMD config CXX11`
+CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
 LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
 
 # LightGBM-specific flags
@@ -1801,6 +1803,7 @@ fi
 
 if test `uname -s` = "Darwin"
 then
+    OPENMP_CXXFLAGS='-Xclang -fopenmp'
     OPENMP_LIB='-lomp'
     ac_pkg_openmp=no
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenMP will work in a package" >&5
@@ -1830,17 +1833,17 @@ main ()
 
 
 _ACEOF
+    ${CXX} ${CPPFLAGS} ${CXXFLAGS} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
 
-    # test without any additional flags
-    ${CXX} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+    # -Xclang is not portable (it is clang-specific)
+    # if compilation above failed, try without that flag
     if test "${ac_pkg_openmp}" = no; then
         if test -f "./conftest"; then
             rm ./conftest
         fi
-        OPENMP_CXXFLAGS="-Xclang -fopenmp"
-        ${CXX} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+        OPENMP_CXXFLAGS="-fopenmp"
+        ${CXX} ${CPPFLAGS} ${CXXFLAGS} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
     fi
-    echo "${OPENMP_CXXFLAGS}" > /Users/jlamb/Desktop/flags.txt
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${ac_pkg_openmp}" >&5
 $as_echo "${ac_pkg_openmp}" >&6; }

--- a/R-package/configure
+++ b/R-package/configure
@@ -1693,10 +1693,11 @@ if test -z "${R_HOME}"; then
     echo "could not determine R_HOME"
     exit 1
 fi
-CC=`"${R_HOME}/bin/R" CMD config CC`
-CXX=`"${R_HOME}/bin/R" CMD config CXX11`
+CXX11=`"${R_HOME}/bin/R" CMD config CXX11`
+CXX11STD=`"${R_HOME}/bin/R" CMD config CXX11STD`
+CXX="${CXX11} ${CXX11STD}"
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
-CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
 LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
 
 # LightGBM-specific flags

--- a/R-package/configure
+++ b/R-package/configure
@@ -1695,6 +1695,7 @@ if test -z "${R_HOME}"; then
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
 CXX=`"${R_HOME}/bin/R" CMD config CXX11`
+LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""
@@ -1791,25 +1792,19 @@ fi
 # OpenMP #
 ##########
 
-OPENMP_CXXFLAGS=""
-
-if test `uname -s` = "Linux"
-then
-    OPENMP_CXXFLAGS="\$(SHLIB_OPENMP_CXXFLAGS)"
-fi
+OPENMP_CXXFLAGS="\$(SHLIB_OPENMP_CXXFLAGS)"
 
 if test `uname -s` = "Darwin"
 then
-    OPENMP_CXXFLAGS='-Xclang -fopenmp'
     OPENMP_LIB='-lomp'
     ac_pkg_openmp=no
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenMP will work in a package" >&5
 $as_echo_n "checking whether OpenMP will work in a package... " >&6; }
-    ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -1830,7 +1825,7 @@ main ()
 
 
 _ACEOF
-    ${CC} -o conftest conftest.c ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+    ${CXX} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${ac_pkg_openmp}" >&5
 $as_echo "${ac_pkg_openmp}" >&6; }
     if test "${ac_pkg_openmp}" = no; then

--- a/R-package/configure
+++ b/R-package/configure
@@ -1792,7 +1792,12 @@ fi
 # OpenMP #
 ##########
 
-OPENMP_CXXFLAGS="\$(SHLIB_OPENMP_CXXFLAGS)"
+OPENMP_CXXFLAGS=""
+
+if test `uname -s` = "Linux"
+then
+    OPENMP_CXXFLAGS="\$(SHLIB_OPENMP_CXXFLAGS)"
+fi
 
 if test `uname -s` = "Darwin"
 then
@@ -1825,7 +1830,18 @@ main ()
 
 
 _ACEOF
+
+    # test without any additional flags
     ${CXX} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+    if test "${ac_pkg_openmp}" = no; then
+        if test -f "./conftest"; then
+            rm ./conftest
+        fi
+        OPENMP_CXXFLAGS="-Xclang -fopenmp"
+        ${CXX} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+    fi
+    echo "${OPENMP_CXXFLAGS}" > /Users/jlamb/Desktop/flags.txt
+
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${ac_pkg_openmp}" >&5
 $as_echo "${ac_pkg_openmp}" >&6; }
     if test "${ac_pkg_openmp}" = no; then

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -91,7 +91,12 @@ fi
 # OpenMP #
 ##########
 
-OPENMP_CXXFLAGS="\$(SHLIB_OPENMP_CXXFLAGS)"
+OPENMP_CXXFLAGS=""
+
+if test `uname -s` = "Linux"
+then
+    OPENMP_CXXFLAGS="\$(SHLIB_OPENMP_CXXFLAGS)"
+fi
 
 if test `uname -s` = "Darwin"
 then
@@ -111,7 +116,18 @@ then
             )
         ]
     )
+
+    # test without any additional flags
     ${CXX} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+    if test "${ac_pkg_openmp}" = no; then
+        if test -f "./conftest"; then
+            rm ./conftest
+        fi
+        OPENMP_CXXFLAGS="-Xclang -fopenmp"
+        ${CXX} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+    fi
+    echo "${OPENMP_CXXFLAGS}" > /Users/jlamb/Desktop/flags.txt
+
     AC_MSG_RESULT([${ac_pkg_openmp}])
     if test "${ac_pkg_openmp}" = no; then
         OPENMP_CXXFLAGS=''

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -22,6 +22,8 @@ if test -z "${R_HOME}"; then
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
 CXX=`"${R_HOME}/bin/R" CMD config CXX11`
+CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
 LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
 
 # LightGBM-specific flags
@@ -100,6 +102,7 @@ fi
 
 if test `uname -s` = "Darwin"
 then
+    OPENMP_CXXFLAGS='-Xclang -fopenmp'
     OPENMP_LIB='-lomp'
     ac_pkg_openmp=no
     AC_MSG_CHECKING([whether OpenMP will work in a package])
@@ -116,17 +119,17 @@ then
             )
         ]
     )
+    ${CXX} ${CPPFLAGS} ${CXXFLAGS} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
 
-    # test without any additional flags
-    ${CXX} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+    # -Xclang is not portable (it is clang-specific)
+    # if compilation above failed, try without that flag
     if test "${ac_pkg_openmp}" = no; then
         if test -f "./conftest"; then
             rm ./conftest
         fi
-        OPENMP_CXXFLAGS="-Xclang -fopenmp"
-        ${CXX} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+        OPENMP_CXXFLAGS="-fopenmp"
+        ${CXX} ${CPPFLAGS} ${CXXFLAGS} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
     fi
-    echo "${OPENMP_CXXFLAGS}" > /Users/jlamb/Desktop/flags.txt
 
     AC_MSG_RESULT([${ac_pkg_openmp}])
     if test "${ac_pkg_openmp}" = no; then

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -20,7 +20,6 @@ if test -z "${R_HOME}"; then
     echo "could not determine R_HOME"
     exit 1
 fi
-CC=`"${R_HOME}/bin/R" CMD config CC`
 CXX=`"${R_HOME}/bin/R" CMD config CXX11`
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -20,9 +20,11 @@ if test -z "${R_HOME}"; then
     echo "could not determine R_HOME"
     exit 1
 fi
-CXX=`"${R_HOME}/bin/R" CMD config CXX11`
+CXX11=`"${R_HOME}/bin/R" CMD config CXX11`
+CXX11STD=`"${R_HOME}/bin/R" CMD config CXX11STD`
+CXX="${CXX11} ${CXX11STD}"
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
-CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
 LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
 
 # LightGBM-specific flags

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -22,6 +22,7 @@ if test -z "${R_HOME}"; then
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
 CXX=`"${R_HOME}/bin/R" CMD config CXX11`
+LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
 
 # LightGBM-specific flags
 LGB_CPPFLAGS=""
@@ -90,20 +91,14 @@ fi
 # OpenMP #
 ##########
 
-OPENMP_CXXFLAGS=""
-
-if test `uname -s` = "Linux"
-then
-    OPENMP_CXXFLAGS="\$(SHLIB_OPENMP_CXXFLAGS)"
-fi
+OPENMP_CXXFLAGS="\$(SHLIB_OPENMP_CXXFLAGS)"
 
 if test `uname -s` = "Darwin"
 then
-    OPENMP_CXXFLAGS='-Xclang -fopenmp'
     OPENMP_LIB='-lomp'
     ac_pkg_openmp=no
     AC_MSG_CHECKING([whether OpenMP will work in a package])
-    AC_LANG(C)
+    AC_LANG(C++)
     AC_LANG_CONFTEST(
         [
             AC_LANG_PROGRAM(
@@ -116,7 +111,7 @@ then
             )
         ]
     )
-    ${CC} -o conftest conftest.c ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+    ${CXX} ${LDFLAGS} ${OPENMP_CXXFLAGS} ${OPENMP_LIB} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_pkg_openmp=yes
     AC_MSG_RESULT([${ac_pkg_openmp}])
     if test "${ac_pkg_openmp}" = no; then
         OPENMP_CXXFLAGS=''


### PR DESCRIPTION
Fixes #4131.

It makes a few improvements to the way that CRAN-style builds of the R package's `configure` script checks for the presence of OpenMP on macOS.

As a result, **OpenMP detection in the R package should be more reliable, meaning more users can benefit from multi-threading speedups**.

changes:

* passes the result of `R CMD config LDFLAGS` when running the OpenMP check, to ensure that that check uses the same linker flags that R itself will use when compiling `lib_lightgbm`
    - notably, this puts `-L/usr/local/lib` into the statement used to compile a test program, so brew-installed `libomp` will be found
    - this also allows users to install `{lightgbm}` with non-standard install locations for `libomp` by modifying `LDFLAGS` in `~/.R/Makevars`
* adds an additional check using only `-fopenmp` if compilation with `-Xclang -fopenmp` fails
    - this makes OpenMP detection work when compiling a CRAN package using `g++` (on `master`, it fails with a complaint that flag `-Xclang` is not recognized)
    - see https://stackoverflow.com/a/12002492/3986677
* compiles the test program with a C++ compiler instead of a C compiler

### Notes for Reviewers

CRAN prepares precompiled binaries for macOS, so this change should only affect people building from source using the repo, or choosing to do custom compilation from CRAN with something like `install.packages("lightgbm", type = "source")`.

As noted above, this should also help with detection of OpenMP when not using `clang` on Mac.

<details><summary>click here to learn how I tested using g++ on Mac</summary>

I have OpenMP at the following loccations on my laptop.

```shell
find /usr -name 'libomp.dylib'
```

```text
/usr/local/lib/libomp.dylib
/usr/local/Cellar/libomp/12.0.0/lib/libomp.dylib
```

My `~/.R/Makevars` contains only the following.

```shell
CXX=/usr/local/bin/g++-11
CXX11=/usr/local/bin/g++-11
CC=/usr/local/bin/gcc-11
```

When I build the CRAN package from source on `master`, OpenMP isn't found.

```shell
Rscript -e "remove.packages('lightgbm')"
sh build-cran-package.sh
R CMD INSTALL lightgbm_3.2.1.99.tar.gz > out.txt 2>&1
cat out.txt | grep -E "checking whether OpenMP"
```

> checking whether OpenMP will work in a package... no

On this PR, it's found.

</details>