### PR TITLE
[docs] [R-package] use CRAN-style builds when building pkgdown site

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -278,7 +278,7 @@ def generate_r_docs(app):
             , run_dont_run = TRUE \
             , seed = 42L \
             , preview = FALSE \
-            , new_process = TRUE \
+            , new_process = FALSE \
         )
         " || exit -1
     cd {CURR_PATH.parent}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -256,7 +256,6 @@ def generate_r_docs(app):
         -y \
         -c conda-forge \
         -n r_env \
-            cmake=3.21.0=h8897547_0 \
             r-base=4.1.0=hb67fd72_2 \
             r-data.table=1.14.0=r41hcfec24a_0 \
             r-jsonlite=1.7.2=r41hcfec24a_0 \
@@ -267,7 +266,8 @@ def generate_r_docs(app):
     export TAR=/bin/tar
     cd {CURR_PATH.parent}
     export R_LIBS="$CONDA_PREFIX/lib/R/library"
-    Rscript build_r.R || exit -1
+    sh build-cran-package.sh || exit -1
+    R CMD INSTALL lightgbm_*.tar.gz || exit -1
     cd {CURR_PATH.parent / "lightgbm_r"}
     Rscript -e "roxygen2::roxygenize(load = 'installed')" || exit -1
     Rscript -e "pkgdown::build_site( \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,7 +267,7 @@ def generate_r_docs(app):
     cd {CURR_PATH.parent}
     export R_LIBS="$CONDA_PREFIX/lib/R/library"
     sh build-cran-package.sh || exit -1
-    R CMD INSTALL lightgbm_*.tar.gz || exit -1
+    R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit -1
     cd {CURR_PATH.parent / "lightgbm_r"}
     Rscript -e "roxygen2::roxygenize(load = 'installed')" || exit -1
     Rscript -e "pkgdown::build_site( \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -268,6 +268,9 @@ def generate_r_docs(app):
     export R_LIBS="$CONDA_PREFIX/lib/R/library"
     sh build-cran-package.sh || exit -1
     R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit -1
+    cp -R \
+        {CURR_PATH.parent / "R-package" / "pkgdown"} \
+        {CURR_PATH.parent / "lightgbm_r" / "pkgdown"}
     cd {CURR_PATH.parent / "lightgbm_r"}
     Rscript -e "roxygen2::roxygenize(load = 'installed')" || exit -1
     Rscript -e "pkgdown::build_site( \
@@ -278,7 +281,7 @@ def generate_r_docs(app):
             , run_dont_run = TRUE \
             , seed = 42L \
             , preview = FALSE \
-            , new_process = FALSE \
+            , new_process = TRUE \
         )
         " || exit -1
     cd {CURR_PATH.parent}


### PR DESCRIPTION
This PR proposes using CRAN-style builds of the R package on readthedocs (RTD).

Advantages of this approach over CMake builds:

* (maybe) faster RTD builds, since `cmake` does not need to be installed
* easier updates of the `conda` R dependencies for RTD builds
* reduced risk of failures when the RTD images change (since the CRAN package is optimized for portability)
* another step towards publishing vignettes on the `{pkgdown}` site (contributes to #1944)
    - I say this because I'm going to propose on #3946 that we only build vignettes for CRAN-style builds of the R package