### PR TITLE
[docs] add information about installing libgomp

### DIFF
--- a/docs/Python-Intro.rst
+++ b/docs/Python-Intro.rst
@@ -28,6 +28,23 @@ To verify your installation, try to ``import lightgbm`` in Python:
 
     import lightgbm as lgb
 
+You may also need to install the GCC OpenMP library if you see `OSError: libgomp.so.1: cannot open shared object file: No such file or directory` when trying to import lightgbm.
+
+yum (e.g. Centos, RedHat, Amazon Linux)
+::
+
+    yum install libgomp
+
+dnf (e.g. Fedora)
+::
+
+    dnf install libgomp
+
+apt (e.g. Ubuntu, Debian)
+::
+
+    apt install libgomp1
+
 Data Interface
 --------------
 


### PR DESCRIPTION
On the python instructions, add information about installing libgomp
because it may not be installed by default and is required for
lightgbm to run.


This is to address #4484