### PR TITLE
[ci] replace uses of backticks in test.sh with $()

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -40,9 +40,9 @@ if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     pip install --user -r requirements.txt
     # check reStructuredText formatting
     cd $BUILD_DIRECTORY/python-package
-    rstcheck --report warning `find . -type f -name "*.rst"` || exit -1
+    rstcheck --report warning $(find . -type f -name "*.rst") || exit -1
     cd $BUILD_DIRECTORY/docs
-    rstcheck --report warning --ignore-directives=autoclass,autofunction,doxygenfile `find . -type f -name "*.rst"` || exit -1
+    rstcheck --report warning --ignore-directives=autoclass,autofunction,doxygenfile $(find . -type f -name "*.rst") || exit -1
     # build docs
     make html || exit -1
     if [[ $TASK == "check-links" ]]; then


### PR DESCRIPTION
I've been experimenting with [`shellcheck`](https://github.com/koalaman/shellcheck) recently in some projects.

I ran it over all of this project's shell scripts tonight, like this:

```shell
brew install shellcheck
shell_scripts=$(
    git ls-files \
    | grep -E "\.sh$"
)

shellcheck \
    --color=never \
    --format=gcc \
    $shell_scripts
```

This PR proposes fixing one type of warning raised by `shellcheck`. 

```text
.ci/test.sh:43:31: note: Use $(...) notation instead of legacy backticked `...`. [SC2006]
.ci/test.sh:45:86: note: Use $(...) notation instead of legacy backticked `...`. [SC2006]
```

See https://github.com/koalaman/shellcheck/wiki/SC2006 for some background on why `$()` should be preferred to backticks for inline expressions.