### PR TITLE
[R-package] remove unused '...' in Booster constructor

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -23,11 +23,9 @@ Booster <- R6::R6Class(
     initialize = function(params = list(),
                           train_set = NULL,
                           modelfile = NULL,
-                          model_str = NULL,
-                          ...) {
+                          model_str = NULL) {
 
       # Create parameters and handle
-      params <- append(params, list(...))
       handle <- NULL
 
       # Attempts to create a handle for the dataset


### PR DESCRIPTION
Contributes to #4310 (based on https://github.com/microsoft/LightGBM/issues/4226#issuecomment-829473584).

This proposes removing the `...` from the constructor of the `Booster` class in the R package. That class is not exported from the R package, so its constructor can be considered a private API and this change should be considered non-breaking (similar to #4338).

Removing this use of `...` makes the package's code slightly stricter, which reduces the risk of bugs.

### Notes for Reviewers

Internal calls of the `Booster` class always use that class's existing keyword arguments.

https://github.com/microsoft/LightGBM/blob/86ead2050c006b984e88396e0e380304bac114d1/R-package/R/lgb.Booster.R#L812

https://github.com/microsoft/LightGBM/blob/86ead2050c006b984e88396e0e380304bac114d1/R-package/R/lgb.Booster.R#L819

https://github.com/microsoft/LightGBM/blob/86ead2050c006b984e88396e0e380304bac114d1/R-package/R/lgb.train.R#L264

https://github.com/microsoft/LightGBM/blob/86ead2050c006b984e88396e0e380304bac114d1/R-package/R/lgb.cv.R#L341

Found with `git grep -E 'Booster\$new'`.