### PR TITLE
[ci] use flag '--allow-releaseinfo-change' in some 'apt-get update' calls

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Install Git before checkout
         shell: bash
         run: |
-          apt update -y
+          apt-get update --allow-releaseinfo-change
           apt-get install --no-install-recommends -y git
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
@@ -210,7 +210,7 @@ jobs:
       - name: Install Git before checkout
         shell: bash
         run: |
-          apt update -y
+          apt-get update --allow-releaseinfo-change
           apt-get install --no-install-recommends -y git
       - name: Checkout repository
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Install Git before checkout
         shell: bash
         run: |
-          apt-get update
+          apt update -y
           apt-get install --no-install-recommends -y git
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
@@ -210,7 +210,7 @@ jobs:
       - name: Install Git before checkout
         shell: bash
         run: |
-          apt-get update
+          apt update -y
           apt-get install --no-install-recommends -y git
       - name: Checkout repository
         uses: actions/checkout@v2.3.4


### PR DESCRIPTION
On PRs I opened within the last hour (#4522, #4523), the `r-package (ubuntu-latest, R-devel, GCC ASAN/UBSAN) (pull_request)` job is failing.

> E: Repository 'http://deb.debian.org/debian testing InRelease' changed its 'Codename' value from 'bullseye' to 'bookworm'
Error: Process completed with exit code 100.

https://github.com/microsoft/LightGBM/pull/4523/checks?check_run_id=3332073359

After some research, I think this could be fixed by preferring `apt update` to `apt-get update`. A similar error was reported a few hours ago in https://www.mail-archive.com/debian-user@lists.debian.org/msg772749.html, and responses in that thread suggest that running `apt update` in place of `apt-get update` can fix it (e.g. https://www.mail-archive.com/debian-user@lists.debian.org/msg772763.html).

As far as I can tell from that thread, this is happening because of this combination of factors:

1. there was a new Debian release today: https://wiki.debian.org/DebianReleases#Production_Releases
2. some package(s) shipped in that release with bad metadata related to that new release
3. `apt-get update` does not install new dependencies of upgradeable software (https://linuxhint.com/diff_apt_vs_aptget/)

Opening this PR to replace calls to `apt-get update` with `apt update` in R jobs using `rhub/` container images.

### Notes for Reviewers

It's possible similar changes will need to be made for other jobs in the future, and maybe even that we should completely prefer `apt` to `apt-get`, but that requires more research and I think it's outside of the scope of this PR.