### PR TITLE
[python] add type hints in docs/conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from re import compile
 from shutil import copytree
 from subprocess import PIPE, Popen
+from typing import Any, List
 from unittest.mock import Mock
 
 import sphinx
@@ -51,7 +52,7 @@ class InternalRefTransform(Transform):
     default_priority = 210
     """Numerical priority of this transform, 0 through 999."""
 
-    def apply(self, **kwargs):
+    def apply(self, **kwargs: Any) -> None:
         """Apply the transform to the document tree."""
         for section in self.document.traverse(reference):
             if section.get("refuri") is not None:
@@ -63,7 +64,7 @@ class IgnoredDirective(Directive):
 
     has_content = True
 
-    def run(self):
+    def run(self) -> List:
         """Do nothing."""
         return []
 
@@ -197,7 +198,7 @@ htmlhelp_basename = 'LightGBMdoc'
 latex_logo = str(CURR_PATH / 'logo' / 'LightGBM_logo_black_text_small.png')
 
 
-def generate_doxygen_xml(app):
+def generate_doxygen_xml(app: Any) -> None:
     """Generate XML documentation for C API by Doxygen.
 
     Parameters
@@ -242,7 +243,7 @@ def generate_doxygen_xml(app):
         raise Exception(f"An error has occurred while executing Doxygen\n{e}")
 
 
-def generate_r_docs(app):
+def generate_r_docs(app: Any) -> None:
     """Generate documentation for R-package.
 
     Parameters
@@ -304,7 +305,7 @@ def generate_r_docs(app):
         raise Exception(f"An error has occurred while generating documentation for R-package\n{e}")
 
 
-def setup(app):
+def setup(app: Any) -> None:
     """Add new elements at Sphinx initialization time.
 
     Parameters

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -204,7 +204,7 @@ def generate_doxygen_xml(app: Sphinx) -> None:
 
     Parameters
     ----------
-    app : Sphinx
+    app : sphinx.application.Sphinx
         The application object representing the Sphinx process.
     """
     doxygen_args = [
@@ -249,7 +249,7 @@ def generate_r_docs(app: Sphinx) -> None:
 
     Parameters
     ----------
-    app : Sphinx
+    app : sphinx.application.Sphinx
         The application object representing the Sphinx process.
     """
     commands = f"""
@@ -311,7 +311,7 @@ def setup(app: Sphinx) -> None:
 
     Parameters
     ----------
-    app : Sphinx
+    app : sphinx.application.Sphinx
         The application object representing the Sphinx process.
     """
     first_run = not (CURR_PATH / '_FIRST_RUN.flag').exists()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ import sphinx
 from docutils.nodes import reference
 from docutils.parsers.rst import Directive
 from docutils.transforms import Transform
+from sphinx.application import Sphinx
 from sphinx.errors import VersionRequirementError
 
 CURR_PATH = Path(__file__).absolute().parent
@@ -198,12 +199,12 @@ htmlhelp_basename = 'LightGBMdoc'
 latex_logo = str(CURR_PATH / 'logo' / 'LightGBM_logo_black_text_small.png')
 
 
-def generate_doxygen_xml(app: Any) -> None:
+def generate_doxygen_xml(app: Sphinx) -> None:
     """Generate XML documentation for C API by Doxygen.
 
     Parameters
     ----------
-    app : object
+    app : Sphinx
         The application object representing the Sphinx process.
     """
     doxygen_args = [
@@ -243,12 +244,12 @@ def generate_doxygen_xml(app: Any) -> None:
         raise Exception(f"An error has occurred while executing Doxygen\n{e}")
 
 
-def generate_r_docs(app: Any) -> None:
+def generate_r_docs(app: Sphinx) -> None:
     """Generate documentation for R-package.
 
     Parameters
     ----------
-    app : object
+    app : Sphinx
         The application object representing the Sphinx process.
     """
     commands = f"""
@@ -305,12 +306,12 @@ def generate_r_docs(app: Any) -> None:
         raise Exception(f"An error has occurred while generating documentation for R-package\n{e}")
 
 
-def setup(app: Any) -> None:
+def setup(app: Sphinx) -> None:
     """Add new elements at Sphinx initialization time.
 
     Parameters
     ----------
-    app : object
+    app : Sphinx
         The application object representing the Sphinx process.
     """
     first_run = not (CURR_PATH / '_FIRST_RUN.flag').exists()


### PR DESCRIPTION
Adds type hints to code in `docs/conf.py`, as part of #3756.

### Notes for Reviewers

#3756 has been open for about 8 months now, so I think it's ok for maintainers to start picking up the work to finish it and not wait any longer for outside contributors to find it from searches for `good first issue`.

Better type hints will improve the ability of `mypy` to catch issues (#3868 ).