### PR TITLE
[doc] Add link to Neptune hyperparam tuning guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ FLAML (AutoML library for hyperparameter optimization): https://github.com/micro
 
 Optuna (hyperparameter optimization framework): https://github.com/optuna/optuna
 
-Neptune (metadata store: data versioning, experiment tracking and model registry): https://github.com/neptune-ai/neptune-client
+Neptune (ML metadata store: data versioning, experiment tracking and model registry): https://github.com/neptune-ai/neptune-client
 
 Julia-package: https://github.com/IQVIA-ML/LightGBM.jl
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Next you may want to read:
 - [**Laurae++ interactive documentation**](https://sites.google.com/view/lauraepp/parameters) is a detailed guide for hyperparameters.
 - [**FLAML**](https://www.microsoft.com/en-us/research/project/fast-and-lightweight-automl-for-large-scale-data/articles/flaml-a-fast-and-lightweight-automl-library/) provides automated tuning for LightGBM ([code examples](https://github.com/microsoft/FLAML/blob/main/notebook/flaml_lightgbm.ipynb)).
 - [**Optuna Hyperparameter Tuner**](https://medium.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b7095e99258) provides automated tuning for LightGBM hyperparameters ([code examples](https://github.com/optuna/optuna/tree/master/examples/lightgbm)).
-- [**Understanding LightGBM Parameters (and How to Tune Them)**](https://neptune.ai/blog/lightgbm-parameters-guide)
+- [**Understanding LightGBM Parameters (and How to Tune Them)**](https://neptune.ai/blog/lightgbm-parameters-guide).
 
 Documentation for contributors:
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Next you may want to read:
 - [**Laurae++ interactive documentation**](https://sites.google.com/view/lauraepp/parameters) is a detailed guide for hyperparameters.
 - [**FLAML**](https://www.microsoft.com/en-us/research/project/fast-and-lightweight-automl-for-large-scale-data/articles/flaml-a-fast-and-lightweight-automl-library/) provides automated tuning for LightGBM ([code examples](https://github.com/microsoft/FLAML/blob/main/notebook/flaml_lightgbm.ipynb)).
 - [**Optuna Hyperparameter Tuner**](https://medium.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b7095e99258) provides automated tuning for LightGBM hyperparameters ([code examples](https://github.com/optuna/optuna/tree/master/examples/lightgbm)).
-- [**Understanding LightGBM Parameters (and How to Tune Them)**](https://neptune.ai/blog/lightgbm-parameters-guide).
+- [**Understanding LightGBM Parameters (and How to Tune Them using Neptune)**](https://neptune.ai/blog/lightgbm-parameters-guide).
 
 Documentation for contributors:
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ FLAML (AutoML library for hyperparameter optimization): https://github.com/micro
 
 Optuna (hyperparameter optimization framework): https://github.com/optuna/optuna
 
+Neptune + LightGBM integration: https://bit.ly/37MX3Mw
+
 Julia-package: https://github.com/IQVIA-ML/LightGBM.jl
 
 JPMML (Java PMML converter): https://github.com/jpmml/jpmml-lightgbm

--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ FLAML (AutoML library for hyperparameter optimization): https://github.com/micro
 
 Optuna (hyperparameter optimization framework): https://github.com/optuna/optuna
 
-Neptune (ML metadata store: data versioning, experiment tracking and model registry): https://github.com/neptune-ai/neptune-client
-
 Julia-package: https://github.com/IQVIA-ML/LightGBM.jl
 
 JPMML (Java PMML converter): https://github.com/jpmml/jpmml-lightgbm

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Next you may want to read:
 - [**Laurae++ interactive documentation**](https://sites.google.com/view/lauraepp/parameters) is a detailed guide for hyperparameters.
 - [**FLAML**](https://www.microsoft.com/en-us/research/project/fast-and-lightweight-automl-for-large-scale-data/articles/flaml-a-fast-and-lightweight-automl-library/) provides automated tuning for LightGBM ([code examples](https://github.com/microsoft/FLAML/blob/main/notebook/flaml_lightgbm.ipynb)).
 - [**Optuna Hyperparameter Tuner**](https://medium.com/optuna/lightgbm-tuner-new-optuna-integration-for-hyperparameter-optimization-8b7095e99258) provides automated tuning for LightGBM hyperparameters ([code examples](https://github.com/optuna/optuna/tree/master/examples/lightgbm)).
+- [**Understanding LightGBM Parameters (and How to Tune Them)**](https://neptune.ai/blog/lightgbm-parameters-guide)
 
 Documentation for contributors:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ FLAML (AutoML library for hyperparameter optimization): https://github.com/micro
 
 Optuna (hyperparameter optimization framework): https://github.com/optuna/optuna
 
-Neptune + LightGBM integration: https://bit.ly/37MX3Mw
+Neptune (metadata store: data versioning, experiment tracking and model registry): https://github.com/neptune-ai/neptune-client
 
 Julia-package: https://github.com/IQVIA-ML/LightGBM.jl
 


### PR DESCRIPTION
Hi,

I'm Prince Canuma a Data Scientist and DevRel at [Neptune.ai](https://neptune.ai),

We have created a [Neptune + LightGBM integration](https://docs.neptune.ai/integrations-and-supported-tools/model-training/lightgbm) that allows LightGBM users to **automatically log** the following metadata to Neptune:

* training and validation metrics
* parameters
* feature names, num_features and num_rows for the train_set
* hardware consumption (CPU, GPU, Memory)
* stdout and stderr logs
* training code and git commit information

We are looking for ways to let users of LightGBM know this integration exists, is available and is up to date. To ensure the latter, we want to collaborate with you in future versions of LightGBM.

Finally, besides the README are there other ways you would recommend divulging this information? If so, please let us know! 

We want to let LightGBM users know about the Neptune + LightGBM integration.

Kind regards!
