### PR TITLE
consolidate duplicate conditions in TextReader

### DIFF
--- a/include/LightGBM/utils/text_reader.h
+++ b/include/LightGBM/utils/text_reader.h
@@ -198,8 +198,10 @@ class TextReader {
         [&filter_fun, &out_used_data_indices, this]
     (INDEX_T line_idx , const char* buffer, size_t size) {
       bool is_used = filter_fun(line_idx);
-      if (is_used) { out_used_data_indices->push_back(line_idx); }
-      if (is_used) { lines_.emplace_back(buffer, size); }
+      if (is_used) {
+        out_used_data_indices->push_back(line_idx);
+        lines_.emplace_back(buffer, size);
+      }
     });
     return total_cnt;
   }
@@ -213,8 +215,8 @@ class TextReader {
          &out_sampled_data]
     (INDEX_T line_idx, const char* buffer, size_t size) {
       bool is_used = filter_fun(line_idx);
-      if (is_used) { out_used_data_indices->push_back(line_idx); }
       if (is_used) {
+        out_used_data_indices->push_back(line_idx);
         if (cur_sample_cnt < sample_cnt) {
           out_sampled_data->emplace_back(buffer, size);
           ++cur_sample_cnt;


### PR DESCRIPTION
I started exploring [`cppcheck`](http://cppcheck.sourceforge.net/), a static analyzer for C++ projects, tonight.

This PR proposes fixing one of the warnings raised by that tool. It caught some cases where two consecutive code blocks were guarded by identical `if()` conditions. Consolidating those blocks removes two unnecessary checks.

```text
include/LightGBM/utils/text_reader.h:202:11: style: The if condition is the same as the previous if condition [duplicateCondition]
      if (is_used) { lines_.emplace_back(buffer, size); }
          ^
include/LightGBM/utils/text_reader.h:201:11: note: First condition
      if (is_used) { out_used_data_indices->push_back(line_idx); }
          ^
include/LightGBM/utils/text_reader.h:202:11: note: Second condition
      if (is_used) { lines_.emplace_back(buffer, size); }
          ^
include/LightGBM/utils/text_reader.h:217:11: style: The if condition is the same as the previous if condition [duplicateCondition]
      if (is_used) {
          ^
include/LightGBM/utils/text_reader.h:216:11: note: First condition
      if (is_used) { out_used_data_indices->push_back(line_idx); }
          ^
include/LightGBM/utils/text_reader.h:217:11: note: Second condition
      if (is_used) {
          ^
```

<details><summary>how I ran 'cppcheck' (click me)</summary>

On my Mac, I installed it with homebrew.

```shell
brew install cpplint
```

Then ran the command from the root of the repo, with the following command.

```shell
cppcheck \
    --force \
    --enable=all \
    --std=c11 \
    -I include/ \
    R-package/src \
> cppcheck.txt 2>&1
```

* `--force` says "test all combinations of `#ifdef`s" (by default, `cppcheck` will only check 12 combinations).
* `--enable=all` says "show all types of warnings"

NOTE: I only checked `R-package/src` in this example because I wanted to start by checking that relatively limited piece of LightGBM. Checking everything inn `src/` (from the package root) returns a ton of notes. More opportunities for improvements in the future!

</details>

