### PR TITLE
[ci] Add checks that MM_PREFETCH and MM_MALLOC are used in CRAN builds

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -213,6 +213,32 @@ if [[ $OS_NAME == "macos" ]] && [[ $R_BUILD_TYPE == "cran" ]]; then
     fi
 fi
 
+# this check makes sure that CI builds of the CRAN package
+# actually use MM_PREFETCH preprocessor definition
+if [[ $R_BUILD_TYPE == "cran" ]]; then
+    mm_prefetch_working=$(
+        cat $BUILD_LOG_FILE \
+        | grep --count -E "checking whether MM_PREFETCH work.*yes"
+    )
+    if [[ $mm_prefetch_working -ne 1 ]]; then
+        echo "MM_PREFETCH test was not passed, and should be when testing the CRAN package"
+        exit -1
+    fi
+fi
+
+# this check makes sure that CI builds of the CRAN package
+# actually use MM_MALLOC preprocessor definition
+if [[ $R_BUILD_TYPE == "cran" ]]; then
+    mm_malloc_working=$(
+        cat $BUILD_LOG_FILE \
+        | grep --count -E "checking whether MM_MALLOC work.*yes"
+    )
+    if [[ $mm_malloc_working -ne 1 ]]; then
+        echo "MM_MALLOC test was not passed, and should be when testing the CRAN package"
+        exit -1
+    fi
+fi
+
 # this check makes sure that no "warning: unknown pragma ignored" logs
 # reach the user leading them to believe that something went wrong
 if [[ $R_BUILD_TYPE == "cran" ]]; then

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -232,6 +232,24 @@ if (($env:COMPILER -eq "MINGW") -and ($env:R_BUILD_TYPE -eq "cmake")) {
   }
 }
 
+# Checking that MM_PREFETCH preprocessor definition is actually used in CRAN builds.
+if ($env:R_BUILD_TYPE -eq "cran") {
+  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "checking whether MM_PREFETCH work.*yes"
+  if ($checks.Matches.length -eq 0) {
+    Write-Output "MM_PREFETCH preprocessor definition wasn't used. Check the build logs."
+    Check-Output $False
+  }
+}
+
+# Checking that MM_MALLOC preprocessor definition is actually used in CRAN builds.
+if ($env:R_BUILD_TYPE -eq "cran") {
+  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "checking whether MM_MALLOC work.*yes"
+  if ($checks.Matches.length -eq 0) {
+    Write-Output "MM_MALLOC preprocessor definition wasn't used. Check the build logs."
+    Check-Output $False
+  }
+}
+
 if ($env:COMPILER -eq "MSVC") {
   Write-Output "Running tests with testthat.R"
   cd R-package/tests


### PR DESCRIPTION
Make sure we provide efficient version of LightGBM via CRAN distribution.