### PR TITLE
factor out .size() checks in GetDataType()

### DIFF
--- a/src/io/parser.cpp
+++ b/src/io/parser.cpp
@@ -184,7 +184,8 @@ DataType GetDataType(const char* filename, bool header,
   int tab_cnt = 0;
   int colon_cnt = 0;
   GetStatistic(lines[0].c_str(), &comma_cnt, &tab_cnt, &colon_cnt);
-  if (lines.size() == 1) {
+  int num_lines = lines.size();
+  if (num_lines == 1) {
     if (colon_cnt > 0) {
       type = DataType::LIBSVM;
     } else if (tab_cnt > 0) {
@@ -192,7 +193,7 @@ DataType GetDataType(const char* filename, bool header,
     } else if (comma_cnt > 0) {
       type = DataType::CSV;
     }
-  } else if (lines.size() > 1) {
+  } else {
     int comma_cnt2 = 0;
     int tab_cnt2 = 0;
     int colon_cnt2 = 0;
@@ -206,7 +207,7 @@ DataType GetDataType(const char* filename, bool header,
     }
     if (type == DataType::TSV || type == DataType::CSV) {
       // valid the type
-      for (size_t i = 2; i < lines.size(); ++i) {
+      for (size_t i = 2; i < num_lines; ++i) {
         GetStatistic(lines[i].c_str(), &comma_cnt2, &tab_cnt2, &colon_cnt2);
         if (type == DataType::TSV && tab_cnt2 != tab_cnt) {
           type = DataType::INVALID;

--- a/src/io/parser.cpp
+++ b/src/io/parser.cpp
@@ -184,7 +184,7 @@ DataType GetDataType(const char* filename, bool header,
   int tab_cnt = 0;
   int colon_cnt = 0;
   GetStatistic(lines[0].c_str(), &comma_cnt, &tab_cnt, &colon_cnt);
-  int num_lines = lines.size();
+  size_t num_lines = lines.size();
   if (num_lines == 1) {
     if (colon_cnt > 0) {
       type = DataType::LIBSVM;


### PR DESCRIPTION
`GetDataType()` is used by code that reads from text files, to determine whether file is a CSV, TSV, or LibSVM format.

`cppcheck` raises the following warning about that function's implementation (#4359):

```text
src/io/parser.cpp:195:27: style: Condition 'lines.size()>1' is always true [knownConditionTrueFalse]
  } else if (lines.size() > 1) {
                          ^
src/io/parser.cpp:187:20: note: Assuming that condition 'lines.size()==1' is not redundant
  if (lines.size() == 1) {
                   ^
src/io/parser.cpp:195:27: note: Condition 'lines.size()>1' is always true
  } else if (lines.size() > 1) {
                          ^
```

This is pointing out, correctly, that the code in that function has a structure like this pseudo code

```text
if lines.size() == 0:
    do_something()
elif lines.size() == 1:
    do_something_else()
elif lines.size() > 1:
    do_another_thing()
```

And that by the time the code reaches that third condition, it must be true that `lines.size() > 1` (since `.size()` cannot be negative and has already been determined to not be 0 or 1).

This PR removes that check, and also takes the opportunity to remove duplicate calls to `.size()`. Note that I didn't replace this `lines.empty()` call with `num_lines == 0` because `.empty()` is a special method that is guaranteed to be O(1).

https://github.com/microsoft/LightGBM/blob/a926d4fe939118b6377455220e44ca9ded5b964e/src/io/parser.cpp#L180
