### PR TITLE
[R-package] use {testthat} SummaryReporter in tests

### DIFF
--- a/R-package/tests/testthat.R
+++ b/R-package/tests/testthat.R
@@ -5,4 +5,5 @@ test_check(
     package = "lightgbm"
     , stop_on_failure = TRUE
     , stop_on_warning = FALSE
+    , reporter = testthat::SummaryReporter$new()
 )


### PR DESCRIPTION
With all the added deprecation warnings from #4226, I found that I wanted to be able to see the warnings generated in the R package's unit tests.

Today, when you run the unit tests outside of `R CMD check`, like this:

```shell
sh build-cran-package.sh
R CMD INSTALL lightgbm_3.2.1.99.tar.gz
cd R-package/tests
Rscript testthat.R
```

You'll just see LightGBM's logs from the C++ side, `{testthat}` context describing the different test sections, and then a line like this at the end.

```text
[ FAIL 0 | WARN 54 | SKIP 2 | PASS 680 ]
```

With the change in this PR, we'll be able to see the actual content of those warnings in CI logs, which I think will help contributors and maintainers assess changes and find opportunities for improvements.

### Notes for Reviewers

See the logs from MSVC R jobs (like https://github.com/microsoft/LightGBM/runs/3446658963) to see the affect of this change, since those jobs us the `Rscript testthat.R` pattern instead of `R CMD check`.

I don't think we should resolve warnings in tests about passing things through `..` until after release 3.3.0 (#4310), so that those tests continue to cover that pattern (since it is *deprecated* but not yet removed).