### PR TITLE
[R-package] deprecate uses of '...' in Dataset slice() method

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -506,7 +506,7 @@ Dataset <- R6::R6Class(
           "Dataset$slice(): Found the following passed through '...': "
           , paste(names(additional_params), collapse = ", ")
           , ". These are ignored and should be removed. "
-          , "In future releases of lightgbm, this warning will become an error. "
+          , "In future releases of lightgbm, this warning will become an error."
         ))
       }
 

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -500,6 +500,15 @@ Dataset <- R6::R6Class(
     # Slice dataset
     slice = function(idxset, ...) {
 
+      additional_params <- list(...)
+      if (length(additional_params) > 0L) {
+        warning(paste0(
+          "Dataset$slice(): Found the following passed through '...': "
+          , paste(names(additional_params), collapse = ", ")
+          , ". These are ignored and should be removed. In future releases of lightgbm, this warning will become an error. "
+        ))
+      }
+
       # Perform slicing
       return(
         Dataset$new(

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -505,7 +505,8 @@ Dataset <- R6::R6Class(
         warning(paste0(
           "Dataset$slice(): Found the following passed through '...': "
           , paste(names(additional_params), collapse = ", ")
-          , ". These are ignored and should be removed. In future releases of lightgbm, this warning will become an error. "
+          , ". These are ignored and should be removed. "
+          , "In future releases of lightgbm, this warning will become an error. "
         ))
       }
 


### PR DESCRIPTION
Another step towards #4226 as part of #4310. 

This PR proposes adding a deprecation warning on uses of additional parameters passed through `...` in `Dataset$slice()` in the R package.