### PR TITLE
[RFC][python] deprecate `silent` and standalone `verbose` args. Prefer global `verbose` param

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1440,7 +1440,7 @@ class Dataset:
                              f'Please use {key} argument of the Dataset constructor to pass this parameter.')
         # user can set verbose with params, it has higher priority
         if silent != "warn":
-            _log_warning("'silent' argument is deprecated and will be removed in 4.0.0 release. "
+            _log_warning("'silent' argument is deprecated and will be removed in a future release of LightGBM. "
                          "Pass 'verbose' parameter via 'params' instead.")
         else:
             silent = False
@@ -2494,8 +2494,8 @@ class Booster:
         params = {} if params is None else deepcopy(params)
         # user can set verbose with params, it has higher priority
         if silent != 'warn':
-            _log_warning("'silent' argument is deprecated and will be removed in 4.0.0 release. "
-                         "Pass 'verbose' parameter via keyword arguments instead.")
+            _log_warning("'silent' argument is deprecated and will be removed in a future release of LightGBM. "
+                         "Pass 'verbose' parameter via 'params' instead.")
         else:
             silent = False
         if not any(verbose_alias in params for verbose_alias in _ConfigAliases.get("verbosity")) and silent:
@@ -3296,7 +3296,7 @@ class Booster:
         if verbose in {'warn', '_silent_false'}:
             verbose = verbose == 'warn'
         else:
-            _log_warning("'verbose' argument is deprecated and will be removed in 4.0.0 release.")
+            _log_warning("'verbose' argument is deprecated and will be removed in a future release of LightGBM.")
         if verbose:
             _log_info(f'Finished loading model, total used {int(out_num_iterations.value)} iterations')
         self.__num_class = out_num_class.value

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1123,7 +1123,7 @@ class Dataset:
     """Dataset in LightGBM."""
 
     def __init__(self, data, label=None, reference=None,
-                 weight=None, group=None, init_score=None, silent=False,
+                 weight=None, group=None, init_score=None, silent='warn',
                  feature_name='auto', categorical_feature='auto', params=None,
                  free_raw_data=True):
         """Initialize Dataset.
@@ -1439,6 +1439,11 @@ class Dataset:
                 _log_warning(f'{key} keyword has been found in `params` and will be ignored.\n'
                              f'Please use {key} argument of the Dataset constructor to pass this parameter.')
         # user can set verbose with params, it has higher priority
+        if silent != "warn":
+            _log_warning("'silent' argument is deprecated and will be removed in 4.0.0 release. "
+                         "Pass 'verbose' parameter via 'params' instead.")
+        else:
+            silent = False
         if not any(verbose_alias in params for verbose_alias in _ConfigAliases.get("verbosity")) and silent:
             params["verbose"] = -1
         # get categorical features
@@ -1769,7 +1774,7 @@ class Dataset:
         return self
 
     def create_valid(self, data, label=None, weight=None, group=None,
-                     init_score=None, silent=False, params=None):
+                     init_score=None, silent='warn', params=None):
         """Create validation data align with current Dataset.
 
         Parameters
@@ -2462,7 +2467,7 @@ class Dataset:
 class Booster:
     """Booster in LightGBM."""
 
-    def __init__(self, params=None, train_set=None, model_file=None, model_str=None, silent=False):
+    def __init__(self, params=None, train_set=None, model_file=None, model_str=None, silent='warn'):
         """Initialize the Booster.
 
         Parameters
@@ -2488,6 +2493,11 @@ class Booster:
         self.best_score = {}
         params = {} if params is None else deepcopy(params)
         # user can set verbose with params, it has higher priority
+        if silent != 'warn':
+            _log_warning("'silent' argument is deprecated and will be removed in 4.0.0 release. "
+                         "Pass 'verbose' parameter via keyword arguments instead.")
+        else:
+            silent = False
         if not any(verbose_alias in params for verbose_alias in _ConfigAliases.get("verbosity")) and silent:
             params["verbose"] = -1
         if train_set is not None:
@@ -2574,7 +2584,7 @@ class Booster:
             self.__num_class = out_num_class.value
             self.pandas_categorical = _load_pandas_categorical(file_name=model_file)
         elif model_str is not None:
-            self.model_from_string(model_str, not silent)
+            self.model_from_string(model_str, verbose="_silent_false")
         else:
             raise TypeError('Need at least one training dataset or model file or model string '
                             'to create Booster instance')
@@ -3255,7 +3265,7 @@ class Booster:
             ctypes.c_int(end_iteration)))
         return self
 
-    def model_from_string(self, model_str, verbose=True):
+    def model_from_string(self, model_str, verbose='warn'):
         """Load Booster from a string.
 
         Parameters
@@ -3283,6 +3293,10 @@ class Booster:
         _safe_call(_LIB.LGBM_BoosterGetNumClasses(
             self.handle,
             ctypes.byref(out_num_class)))
+        if verbose not in {'warn', '_silent_false'}:
+            _log_warning("'verbose' argument is deprecated and will be removed in 4.0.0 release.")
+        else:
+            verbose = not verbose == '_silent_false'
         if verbose:
             _log_info(f'Finished loading model, total used {int(out_num_iterations.value)} iterations')
         self.__num_class = out_num_class.value

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3293,10 +3293,10 @@ class Booster:
         _safe_call(_LIB.LGBM_BoosterGetNumClasses(
             self.handle,
             ctypes.byref(out_num_class)))
-        if verbose not in {'warn', '_silent_false'}:
-            _log_warning("'verbose' argument is deprecated and will be removed in 4.0.0 release.")
+        if verbose in {'warn', '_silent_false'}:
+            verbose = verbose == 'warn'
         else:
-            verbose = not verbose == '_silent_false'
+            _log_warning("'verbose' argument is deprecated and will be removed in 4.0.0 release.")
         if verbose:
             _log_info(f'Finished loading model, total used {int(out_num_iterations.value)} iterations')
         self.__num_class = out_num_class.value

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1108,7 +1108,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
         reg_lambda: float = 0.,
         random_state: Optional[Union[int, np.random.RandomState]] = None,
         n_jobs: int = -1,
-        silent: bool = True,
+        silent: bool = "warn",
         importance_type: str = 'split',
         client: Optional[Client] = None,
         **kwargs: Any
@@ -1288,7 +1288,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         reg_lambda: float = 0.,
         random_state: Optional[Union[int, np.random.RandomState]] = None,
         n_jobs: int = -1,
-        silent: bool = True,
+        silent: bool = "warn",
         importance_type: str = 'split',
         client: Optional[Client] = None,
         **kwargs: Any
@@ -1448,7 +1448,7 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
         reg_lambda: float = 0.,
         random_state: Optional[Union[int, np.random.RandomState]] = None,
         n_jobs: int = -1,
-        silent: bool = True,
+        silent: bool = "warn",
         importance_type: str = 'split',
         client: Optional[Client] = None,
         **kwargs: Any

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -299,7 +299,7 @@ def train(
     for dataset_name, eval_name, score, _ in evaluation_result_list:
         booster.best_score[dataset_name][eval_name] = score
     if not keep_training_booster:
-        booster.model_from_string(booster.model_to_string(), False).free_dataset()
+        booster.model_from_string(booster.model_to_string(), verbose='_silent_false').free_dataset()
     return booster
 
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -591,7 +591,7 @@ class LGBMModel(_LGBMModelBase):
         params = self.get_params()
         # user can set verbose with kwargs, it has higher priority
         if self.silent != "warn":
-            _log_warning("'silent' argument is deprecated and will be removed in 4.0.0 release. "
+            _log_warning("'silent' argument is deprecated and will be removed in a future release of LightGBM. "
                          "Pass 'verbose' parameter via keyword arguments instead.")
             silent = self.silent
         else:

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -369,7 +369,7 @@ class LGBMModel(_LGBMModelBase):
         reg_lambda: float = 0.,
         random_state: Optional[Union[int, np.random.RandomState]] = None,
         n_jobs: int = -1,
-        silent: bool = True,
+        silent: Union[bool, str] = 'warn',
         importance_type: str = 'split',
         **kwargs
     ):
@@ -590,7 +590,13 @@ class LGBMModel(_LGBMModelBase):
         evals_result = {}
         params = self.get_params()
         # user can set verbose with kwargs, it has higher priority
-        if not any(verbose_alias in params for verbose_alias in _ConfigAliases.get("verbosity")) and self.silent:
+        if self.silent != "warn":
+            _log_warning("'silent' argument is deprecated and will be removed in 4.0.0 release. "
+                         "Pass 'verbose' parameter via keyword arguments instead.")
+            silent = self.silent
+        else:
+            silent = True
+        if not any(verbose_alias in params for verbose_alias in _ConfigAliases.get("verbosity")) and silent:
             params['verbose'] = -1
         params.pop('silent', None)
         params.pop('importance_type', None)


### PR DESCRIPTION
Proposing this PR to include in #4310

> I also think this release could be a good opportunity for maintainers to think carefully about what breaking changes might be made (in addition to #3234) in a 4.0.0 release, and to add deprecation warnings for them in the 3.3.0 release.

Having multiple params and arguments that control verbosity is quite confusing, see https://github.com/microsoft/LightGBM/issues/1157#issuecomment-395257431. I believe leaving only `verbose` keyword argument, that is described in our [general parameters guide](https://lightgbm.readthedocs.io/en/latest/Parameters.html#verbosity) and which one that a lot of users is used to simply set to `-1`, will simplify user experience and decrease the maintainance burden for us.