### PR TITLE
[R-package] preserve uses of '...' in Dataset slice() method

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -546,21 +546,37 @@ Dataset <- R6::R6Class(
     # Slice dataset
     slice = function(idxset, ...) {
 
-      additional_params <- list(...)
-      if (length(additional_params) > 0L) {
+      additional_keyword_args <- list(...)
+
+      if (length(additional_keyword_args) > 0L) {
         warning(paste0(
           "Dataset$slice(): Found the following passed through '...': "
-          , paste(names(additional_params), collapse = ", ")
+          , paste(names(additional_keyword_args), collapse = ", ")
           , ". These are ignored and should be removed. "
-          , "In future releases of lightgbm, this warning will become an error."
+          , "To change the parameters of a Dataset produced by Dataset$slice(), use Dataset$set_params(). "
+          , "To modify attributes like 'init_score', use Dataset$setinfo(). "
+          , "In future releases of lightgbm, this warning will become an error. "
         ))
+      }
+
+      # extract Dataset attributes passed through '...'
+      #
+      # NOTE: takes advantage of the fact that list[["non-existent-key"]] returns NULL
+      group <- additional_keyword_args[["group"]]
+      init_score <- additional_keyword_args[["init_score"]]
+      label <- additional_keyword_args[["label"]]
+      weight <- additional_keyword_args[["weight"]]
+
+      # remove attributes from '...', so only params are left
+      for (info_key in .INFO_KEYS()) {
+        additional_keyword_args[[info_key]] <- NULL
       }
 
       # Perform slicing
       return(
         Dataset$new(
           data = NULL
-          , params = private$params
+          , params = utils::modifyList(self$get_params(), additional_keyword_args)
           , reference = self
           , colnames = private$colnames
           , categorical_feature = private$categorical_feature
@@ -568,7 +584,10 @@ Dataset <- R6::R6Class(
           , free_raw_data = private$free_raw_data
           , used_indices = sort(idxset, decreasing = FALSE)
           , info = NULL
-          , ...
+          , group = group
+          , init_score = init_score
+          , label = label
+          , weight = weight
         )
       )
 

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -46,6 +46,34 @@ test_that("lgb.Dataset: slice, dim", {
   expect_equal(ncol(dsub1), ncol(test_data))
 })
 
+test_that("Dataset$slice() supports passing additional parameters through '...'", {
+  dtest <- lgb.Dataset(test_data, label = test_label)
+  dtest$construct()
+  dsub1 <- slice(
+    dataset = dtest
+    , idxset = seq_len(42L)
+    , feature_pre_filter = FALSE
+  )
+  dsub1$construct()
+  expect_identical(dtest$get_params(), list())
+  expect_identical(dsub1$get_params(), list(feature_pre_filter = FALSE))
+})
+
+test_that("Dataset$slice() supports passing Dataset attributes through '...'", {
+  dtest <- lgb.Dataset(test_data, label = test_label)
+  dtest$construct()
+  num_subset_rows <- 51L
+  init_score <- rnorm(n = num_subset_rows)
+  dsub1 <- slice(
+    dataset = dtest
+    , idxset = seq_len(num_subset_rows)
+    , init_score = init_score
+  )
+  dsub1$construct()
+  expect_null(dtest$getinfo("init_score"), NULL)
+  expect_identical(dsub1$getinfo("init_score"), init_score)
+})
+
 test_that("lgb.Dataset: colnames", {
   dtest <- lgb.Dataset(test_data, label = test_label)
   expect_equal(colnames(dtest), colnames(test_data))


### PR DESCRIPTION
As mentioned in https://github.com/microsoft/LightGBM/pull/4573#discussion_r698897132, the changes in #4573 (removing `...` from `Dataset$new()`) represent a small regression, since they break the currently-supported behavior of passing additional parameters or attributes like `weight` through `Dataset$slice()`.

This PR restores that behavior, makes the deprecation warning about `...` clearer, and adds unit tests to confirm that that behavior still works.

### Note for Reviewers

When the breaking changes in #4226 are implemented in release 4.0.0, the unit tests introduced in this PR will break and should be removed.