### PR TITLE
[R-package] fix inaccurate comments, remove unnecessary comments

### DIFF
--- a/R-package/R/callback.R
+++ b/R-package/R/callback.R
@@ -365,17 +365,13 @@ cb.early.stop <- function(stopping_rounds, first_metric_only, verbose) {
           # Check if early stopping is required
           if (cur_iter - best_iter[i] >= stopping_rounds) {
 
-            # Check if model is not null
             if (!is.null(env$model)) {
               env$model$best_score <- best_score[i]
               env$model$best_iter <- best_iter[i]
             }
 
-            # Print message if verbose
             if (isTRUE(verbose)) {
-
               print(paste0("Early stopping, best iteration is: ", best_msg[[i]]))
-
             }
 
             # Store best iteration and stop
@@ -386,13 +382,12 @@ cb.early.stop <- function(stopping_rounds, first_metric_only, verbose) {
         }
 
       if (!isTRUE(env$met_early_stop) && cur_iter == env$end_iteration) {
-        # Check if model is not null
+
         if (!is.null(env$model)) {
           env$model$best_score <- best_score[i]
           env$model$best_iter <- best_iter[i]
         }
 
-        # Print message if verbose
         if (isTRUE(verbose)) {
           print(paste0("Did not meet early stopping, best iteration is: ", best_msg[[i]]))
         }
@@ -427,7 +422,6 @@ add.cb <- function(cb_list, cb) {
   # Set names of elements
   names(cb_list) <- callback.names(cb_list = cb_list)
 
-  # Check for existence
   if ("cb.early.stop" %in% names(cb_list)) {
 
     # Concatenate existing elements
@@ -438,7 +432,6 @@ add.cb <- function(cb_list, cb) {
 
   }
 
-  # Return element
   return(cb_list)
 
 }

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -912,7 +912,6 @@ lgb.Dataset.create.valid <- function(dataset,
                                      params = list(),
                                      ...) {
 
-  # Check if dataset is not a dataset
   if (!lgb.is.Dataset(x = dataset)) {
     stop("lgb.Dataset.create.valid: input data should be an lgb.Dataset object")
   }
@@ -958,12 +957,10 @@ lgb.Dataset.create.valid <- function(dataset,
 #' @export
 lgb.Dataset.construct <- function(dataset) {
 
-  # Check if dataset is not a dataset
   if (!lgb.is.Dataset(x = dataset)) {
     stop("lgb.Dataset.construct: input data should be an lgb.Dataset object")
   }
 
-  # Construct the dataset
   return(invisible(dataset$construct()))
 
 }
@@ -1003,7 +1000,6 @@ dim.lgb.Dataset <- function(x, ...) {
     ))
   }
 
-  # Check if dataset is not a dataset
   if (!lgb.is.Dataset(x = x)) {
     stop("dim.lgb.Dataset: input data should be an lgb.Dataset object")
   }
@@ -1039,7 +1035,6 @@ dim.lgb.Dataset <- function(x, ...) {
 #' @export
 dimnames.lgb.Dataset <- function(x) {
 
-  # Check if dataset is not a dataset
   if (!lgb.is.Dataset(x = x)) {
     stop("dimnames.lgb.Dataset: input data should be an lgb.Dataset object")
   }
@@ -1114,7 +1109,6 @@ slice <- function(dataset, ...) {
 #' @export
 slice.lgb.Dataset <- function(dataset, idxset, ...) {
 
-  # Check if dataset is not a dataset
   if (!lgb.is.Dataset(x = dataset)) {
     stop("slice.lgb.Dataset: input dataset should be an lgb.Dataset object")
   }
@@ -1177,7 +1171,6 @@ getinfo.lgb.Dataset <- function(dataset, name, ...) {
     ))
   }
 
-  # Check if dataset is not a dataset
   if (!lgb.is.Dataset(x = dataset)) {
     stop("getinfo.lgb.Dataset: input dataset should be an lgb.Dataset object")
   }

--- a/R-package/R/lgb.convert_with_rules.R
+++ b/R-package/R/lgb.convert_with_rules.R
@@ -10,9 +10,9 @@
     )
 }
 
-# [description] check a data frame or data table for columns tthat are any
-#               type other than numeric and integer. This is used by lgb.convert()
-#               and lgb.convert_with_rules() too warn if more action is needed by users
+# [description] check a data frame or data table for columns that are any
+#               type other than numeric and integer. This is used by lgb.convert_with_rules()
+#               to warn if more action is needed by users
 #               before a dataset can be converted to a lgb.Dataset.
 .warn_for_unconverted_columns <- function(df, function_name) {
     column_classes <- .get_column_classes(df = df)

--- a/R-package/R/lgb.importance.R
+++ b/R-package/R/lgb.importance.R
@@ -38,7 +38,6 @@
 #' @export
 lgb.importance <- function(model, percentage = TRUE) {
 
-  # Check if model is a lightgbm model
   if (!lgb.is.Booster(x = model)) {
     stop("'model' has to be an object of class lgb.Booster")
   }

--- a/R-package/R/lgb.interprete.R
+++ b/R-package/R/lgb.interprete.R
@@ -205,10 +205,8 @@ single.row.interprete <- function(tree_dt, num_class, tree_index_mat, leaf_index
 
   }
 
-  # Check for numbe rof classes larger than 1
   if (num_class == 1L) {
 
-    # First interpretation element
     tree_interpretation_dt <- tree_interpretation[[1L]]
 
   } else {


### PR DESCRIPTION
This PR proposes a few changes to comments in the source code of the R package. Some things I've noticed while looking closely at that code a lot recently, working on #4310.

* removes reference to `lgb.convert()` (was removed about a year ago, in #3269)
   - I also checked for other uses with `git grep -E "lgb\.convert"`...did not find any
* removes comments that do not add any additional information about what the code is doing or why it's doing it (similar to changes in #4383)

for example:

```r
# Check if dataset is not a dataset
if (!lgb.is.Dataset(x = dataset)) {
```