### PR TITLE
[R-package] fix inaccurate error message in Dataset get_colnames() method

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -410,7 +410,7 @@ Dataset <- R6::R6Class(
 
       } else {
 
-        # Trying to work with unknown dimensions is not possible
+        # Trying to work with unknown formats is not possible
         stop(
           "Dataset$get_colnames(): cannot get column names before dataset has been constructed, please call "
           , "lgb.Dataset.construct() explicitly"

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -412,8 +412,8 @@ Dataset <- R6::R6Class(
 
         # Trying to work with unknown dimensions is not possible
         stop(
-          "dim: cannot get dimensions before dataset has been constructed, please call "
-          , "lgb.Dataset.construct explicitly"
+          "Dataset$get_colnames(): cannot get column names before dataset has been constructed, please call "
+          , "lgb.Dataset.construct() explicitly"
         )
 
       }


### PR DESCRIPTION
Noticed while working on #4586.

An error message in `Dataset$get_colnames()` currently references `Dataset$dim()`, which is inaccurate and might lead to confusion.

This PR fixes that error message.