### PR TITLE
prefer spaces to tabs in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,9 +405,9 @@ if(USE_SWIG)
             COMMAND "${Java_JAR_EXECUTABLE}" -cf lightgbmlib.jar com)
   else()
     add_custom_command(TARGET _lightgbm_swig POST_BUILD
-	    COMMAND "${Java_JAVAC_EXECUTABLE}" -d . java/*.java
-	    COMMAND cp "${PROJECT_SOURCE_DIR}/*.so" com/microsoft/ml/lightgbm/linux/x86_64
-	    COMMAND "${Java_JAR_EXECUTABLE}" -cf lightgbmlib.jar com)
+      COMMAND "${Java_JAVAC_EXECUTABLE}" -d . java/*.java
+      COMMAND cp "${PROJECT_SOURCE_DIR}/*.so" com/microsoft/ml/lightgbm/linux/x86_64
+      COMMAND "${Java_JAR_EXECUTABLE}" -cf lightgbmlib.jar com)
   endif()
 endif(USE_SWIG)
 


### PR DESCRIPTION
I learned today that @tkruse, the maintainer of `cpplint`, also maintains a static analyzer for `CMakeLists.txt` files, called `cmakelint`!

You can learn about this tool at https://github.com/cmake-lint/cmake-lint.

I ran it over `LightGBM` today, and found that it had mainly cosmetic recommendations:

* "Do not mix upper and lower case commands"
* "Lines should be <= 120 characters long"
* "Expression repeated inside endif; better to use only endif()"
* "Extra spaces between 'if' and its ()"
* "Weird indentation; use 2 spaces"
* "Tab found; please use spaces"

<details><summary>full log and commands I ran (click me)</summary>

Installed on my mac

```shell
pip install --upgrade cmakelint
```

then ran from root of the repo

```shell
cmakelint --linelength=120
```

full logs

```text
CMakeLists.txt:18: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:20: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:20: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:22: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:23: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:24: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:25: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:26: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:27: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:28: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:29: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:30: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:34: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:37: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:37: Extra spaces between 'if' and its () [whitespace/extra]
CMakeLists.txt:38: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:39: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:40: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:40: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:41: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:42: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:43: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:43: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:45: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:46: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:47: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:48: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:49: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:51: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:52: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:53: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:54: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:55: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:56: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:57: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:58: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:59: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:60: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:61: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:62: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:63: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:64: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:65: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:66: Lines should be <= 120 characters long [linelength]
CMakeLists.txt:66: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:67: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:68: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:69: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:71: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:72: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:73: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:74: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:75: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:76: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:77: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:78: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:79: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:80: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:81: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:82: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:83: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:84: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:85: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:86: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:88: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:89: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:91: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:92: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:94: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:95: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:96: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:96: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:99: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:104: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:105: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:106: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:107: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:108: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:109: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:111: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:111: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:113: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:115: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:115: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:117: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:119: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:119: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:121: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:122: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:126: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:128: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:128: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:130: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:132: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:134: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:134: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:136: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:137: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:139: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:139: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:141: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:143: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:144: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:145: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:147: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:147: Extra spaces between 'if' and its () [whitespace/extra]
CMakeLists.txt:148: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:149: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:150: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:151: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:151: Extra spaces between 'if' and its () [whitespace/extra]
CMakeLists.txt:153: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:154: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:155: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:157: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:157: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:159: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:160: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:161: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:163: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:164: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:165: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:165: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:166: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:166: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:168: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:169: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:170: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:173: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:174: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:175: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:176: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:177: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:178: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:179: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:180: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:181: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:182: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:183: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:184: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:188: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:190: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:192: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:193: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:194: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:197: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:197: Extra spaces between 'if' and its () [whitespace/extra]
CMakeLists.txt:198: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:199: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:200: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:202: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:203: Weird indentation; use 2 spaces [whitespace/indent]
CMakeLists.txt:204: Weird indentation; use 2 spaces [whitespace/indent]
CMakeLists.txt:206: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:207: Weird indentation; use 2 spaces [whitespace/indent]
CMakeLists.txt:208: Weird indentation; use 2 spaces [whitespace/indent]
CMakeLists.txt:210: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:211: Weird indentation; use 2 spaces [whitespace/indent]
CMakeLists.txt:212: Weird indentation; use 2 spaces [whitespace/indent]
CMakeLists.txt:215: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:216: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:218: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:219: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:220: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:221: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:222: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:223: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:224: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:225: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:226: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:231: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:233: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:233: Extra spaces between 'foreach' and its () [whitespace/extra]
CMakeLists.txt:234: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:235: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:236: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:237: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:238: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:239: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:240: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:241: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:241: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:243: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:244: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:245: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:246: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:247: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:250: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:250: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:252: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:253: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:262: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:263: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:265: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:267: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:268: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:277: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:278: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:280: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:282: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:283: Lines should be <= 120 characters long [linelength]
CMakeLists.txt:284: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:286: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:288: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:289: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:291: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:292: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:294: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:295: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:297: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:298: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:300: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:302: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:304: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:316: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:318: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:320: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:321: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:322: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:324: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:325: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:325: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:332: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:334: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:335: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:337: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:339: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:340: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:340: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:342: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:343: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:344: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:344: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:346: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:353: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:355: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:355: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:358: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:359: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:363: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:364: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:365: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:365: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:367: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:367: Extra spaces between 'if' and its () [whitespace/extra]
CMakeLists.txt:368: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:369: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:370: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:371: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:371: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:373: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:374: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:375: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:375: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:377: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:378: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:380: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:381: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:382: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:384: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:386: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:387: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:388: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:389: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:391: Lines should be <= 120 characters long [linelength]
CMakeLists.txt:392: Lines should be <= 120 characters long [linelength]
CMakeLists.txt:394: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:395: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:399: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:400: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:401: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:404: Lines should be <= 120 characters long [linelength]
CMakeLists.txt:406: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:407: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:408: Tab found; please use spaces [whitespace/tabs]
CMakeLists.txt:409: Tab found; please use spaces [whitespace/tabs]
CMakeLists.txt:410: Tab found; please use spaces [whitespace/tabs]
CMakeLists.txt:411: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:412: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:412: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:414: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:417: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:417: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:419: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:420: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:423: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:424: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:424: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:426: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:429: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:429: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:431: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:433: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:434: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:436: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:437: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:438: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:439: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:440: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:441: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:442: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:444: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:445: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:446: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:451: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:452: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:457: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:457: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:459: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:462: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:462: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:464: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:465: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:470: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:470: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:471: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:471: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:473: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:474: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:476: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:478: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:478: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:479: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:479: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:482: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:483: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:484: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:485: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:486: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:487: Do not use mixed case commands [readability/wonkycase]
CMakeLists.txt:492: Do not use mixed case commands [readability/wonkycase]
CMakeLists.txt:493: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:494: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:495: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:496: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:497: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:506: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:507: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:508: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:509: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:509: Expression repeated inside endif; better to use only endif() [readability/logic]
CMakeLists.txt:510: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:511: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:512: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:514: Do not mix upper and lower case commands [readability/mixedcase]
CMakeLists.txt:519: Do not mix upper and lower case commands [readability/mixedcase]
Total Errors: 346
```

</details>

This PR proposes fixing just one of those issues.

```text
CMakeLists.txt:408: Tab found; please use spaces [whitespace/tabs]
CMakeLists.txt:409: Tab found; please use spaces [whitespace/tabs]
CMakeLists.txt:410: Tab found; please use spaces [whitespace/tabs]
```

I don't think this is causing any problems, but fixing it might help to prevent strange parsing issues from different versions of `cmake`.

### Notes for Reviewers

@StrikerRUS , what do you think about running this in the `lint` task in CI? It's available from PyPI, has [no additional dependencies](https://github.com/cmake-lint/cmake-lint/blob/f214fecd42cef2aa623742dc9888725bc99d32ba/setup.py#L39), and runs very fast (< 1 second on my Mac).

I'm not sure that it will catch any bugs that wouldn't be caught by our other tests, but it will enforce some consistency in syntax, which might reduce the maintenance effort for PRs that change CMakeLists.txt.