### PR TITLE
[ci] skip Dask tests on QEMU builds

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -7,6 +7,7 @@ import random
 import socket
 from itertools import groupby
 from os import getenv
+from platform import machine
 from sys import platform
 
 import pytest
@@ -15,6 +16,8 @@ import lightgbm as lgb
 
 if not platform.startswith('linux'):
     pytest.skip('lightgbm.dask is currently supported in Linux environments', allow_module_level=True)
+if machine() != 'x86_64':
+    pytest.skip('lightgbm.dask tests are currently skipped on some architectures like arm64', allow_module_level=True)
 if not lgb.compat.DASK_INSTALLED:
     pytest.skip('Dask is not installed', allow_module_level=True)
 


### PR DESCRIPTION
See https://github.com/microsoft/LightGBM/pull/4552#issuecomment-914536864 and https://github.com/microsoft/LightGBM/pull/4552#issuecomment-914633031 for background.

This PR proposes skipping Dask tests on QEMU builds, essentially reverting #3996.

I hope this will be a temporary change, but for now I think it's necessary. Timeouts in QEMU builds are blocking development in this repo and have led to a backlog of pull requests starting to pile up.

### Notes for Reviewers

#4595 is still a valuable fix and should be merged.

I'd like to continue to use #4552 as place to test configurations that preserve some or all of the Dask tests in QEMU builds.