### PR TITLE
[ci] bump CUDA version from 11.4.0 to 11.4.2 at CI

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -45,6 +45,7 @@ jobs:
                 curl \
                 git \
                 gnupg-agent \
+                lsb-release \
                 software-properties-common
             curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
             sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" -y
@@ -86,7 +87,13 @@ jobs:
             $ROOT_DOCKER_FOLDER/.ci/setup.sh || exit -1
             $ROOT_DOCKER_FOLDER/.ci/test.sh || exit -1
             EOF
-            docker run --env-file docker.env -v "$GITHUB_WORKSPACE":"$ROOT_DOCKER_FOLDER" --rm --gpus all "nvcr.io/nvidia/cuda:${{ matrix.cuda_version }}-devel" /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
+            cuda_version="${{ matrix.cuda_version }}"
+            cuda_major=${cuda_version%%.*}
+            docker_img="nvcr.io/nvidia/cuda:${cuda_version}-devel"
+            if [[ ${cuda_major} -gt 10 ]]; then
+                docker_img="${docker_img}-ubuntu$(lsb_release -rs)" 
+            fi
+            docker run --env-file docker.env -v "$GITHUB_WORKSPACE":"$ROOT_DOCKER_FOLDER" --rm --gpus all "$docker_img" /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
   all-successful:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
     runs-on: ubuntu-latest

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -26,7 +26,7 @@ jobs:
           - method: source
             compiler: gcc
             python_version: 3.7
-            cuda_version: "11.4.0"
+            cuda_version: "11.4.2"
           - method: pip
             compiler: clang
             python_version: 3.8


### PR DESCRIPTION
Starting from `11.4.1` version you have to specify OS as a part of image.
https://ngc.nvidia.com/catalog/containers/nvidia:cuda/tags