### PR TITLE
[python][sklearn] add `__sklearn_is_fitted__()` method to be better compatible with scikit-learn API

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -529,6 +529,9 @@ class LGBMModel(_LGBMModelBase):
             }
         }
 
+    def __sklearn_is_fitted__(self) -> bool:
+        return getattr(self, "fitted_", False)
+
     def get_params(self, deep=True):
         """Get parameters for this estimator.
 


### PR DESCRIPTION
Refer to scikit-learn 1.0 release notes and corresponding PR:
> `Enhancement` `utils.validation.check_is_fitted` now uses `__sklearn_is_fitted__` if available, instead of checking for attributes ending with an underscore.
   https://scikit-learn.org/stable/whats_new/v1.0.html#sklearn-utils
   https://github.com/scikit-learn/scikit-learn/pull/20657

After doing some search over GitHub repos, it looks like that only XGBoost has already adopted that new API:
https://github.com/dmlc/xgboost/pull/7230