### PR TITLE
[tests][python-package] refactor list_to_1d_numpy test to run without pandas installed

### DIFF
--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -510,19 +510,23 @@ def test_choose_param_value():
     assert original_params == expected_params
 
 
-@pytest.mark.skipif(not PANDAS_INSTALLED, reason='pandas is not installed')
-@pytest.mark.parametrize(
-    'y',
-    [
-        np.random.rand(10),
-        np.random.rand(10, 1),
-        pd_Series(np.random.rand(10)),
-        pd_Series(['a', 'b']),
-        [1] * 10,
-        [[1], [2]]
-    ])
+@pytest.mark.parametrize('collection', ['1d_np', '2d_np', 'pd_float', 'pd_str', '1d_list', '2d_list'])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-def test_list_to_1d_numpy(y, dtype):
+def test_list_to_1d_numpy(collection, dtype):
+    collection2y = {
+        '1d_np': np.random.rand(10),
+        '2d_np': np.random.rand(10, 1),
+        'pd_float': np.random.rand(10),
+        'pd_str': ['a', 'b'],
+        '1d_list': [1] * 10,
+        '2d_list': [[1], [2]],
+    }
+    y = collection2y[collection]
+    if collection.startswith('pd'):
+        if not PANDAS_INSTALLED:
+            pytest.skip('pandas is not installed')
+        else:
+            y = pd_Series(y)
     if isinstance(y, np.ndarray) and len(y.shape) == 2:
         with pytest.warns(UserWarning, match='column-vector'):
             lgb.basic.list_to_1d_numpy(y)


### PR DESCRIPTION
Currently `tests/python-package-test/test_basic.py::test_list_to_1d_numpy` uses `pd_Series` within the parametrize calls, which fails when pandas isn't installed. This moves the series creation after checking that pandas is indeed installed and we can be sure that `pd_Series(collection)` will succeed.

Fixes #4638.