### PR TITLE
[WIP] Use the latest gcc version in macOS CI jobs

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "gcc" ]]; then
-    export CXX=g++-10
-    export CC=gcc-10
+    export CXX=g++-11
+    export CC=gcc-11
 elif [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "clang" ]]; then
     export CXX=clang++
     export CC=clang


### PR DESCRIPTION
Noticed the following in our logs:
```
...

Warning: gcc 11.2.0 is already installed and up-to-date.
To reinstall 11.2.0, run:
  brew reinstall gcc

...

-- The C compiler identification is GNU 10.3.0
-- The CXX compiler identification is GNU 10.3.0

...
```

GitHub Actions macOS image has multiple preinstalled gcc versions.

> gcc-9 (Homebrew GCC 9.4.0) 9.4.0 - available by `gcc-9` alias
    gcc-10 (Homebrew GCC 10.3.0) 10.3.0 - available by `gcc-10` alias
    gcc-11 (Homebrew GCC 11.2.0) 11.2.0 - available by `gcc-11` alias
    https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#language-and-runtime

This is why our `master` is not failing with these lines
https://github.com/microsoft/LightGBM/blob/a77260f03eb735923125024b0f36df9f63a6e0f3/.ci/test.sh#L3-L5
