### PR TITLE
[python] add type hints to _safe_call 

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -113,7 +113,7 @@ _LIB = _load_lib()
 NUMERIC_TYPES = (int, float, bool)
 
 
-def _safe_call(ret):
+def _safe_call(ret: int) -> None:
     """Check the return value from C API call.
 
     Parameters


### PR DESCRIPTION
This add type hints to _safe_call() as described in #3756