### PR TITLE
[ci] ignore certificates for kitware apt channel in CUDA jobs (fixes #4646)

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -98,9 +98,15 @@ else  # Linux
                 clang \
                 libomp-dev
         fi
-        curl -sL https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add -
+        curl \
+            -s \
+            -L \
+            --insecure \
+            https://apt.kitware.com/keys/kitware-archive-latest.asc \
+        | apt-key add -
         apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" -y
-        apt-get update
+        apt-get --allow-unauthenticated upgrade -y
+        apt-get --allow-unauthenticated update -y
         apt-get install --no-install-recommends -y \
             cmake
     else

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/boostorg/compute
 [submodule "eigen"]
 	path = external_libs/eigen
-	url = https://gitlab.com/libeigen/eigen.git
+	url = https://gitlab.com/cantonios/eigen.git
 [submodule "external_libs/fmt"]
 	path = external_libs/fmt
 	url = https://github.com/fmtlib/fmt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/boostorg/compute
 [submodule "eigen"]
 	path = external_libs/eigen
-	url = https://gitlab.com/cantonios/eigen.git
+	url = https://gitlab.com/libeigen/eigen.git
 [submodule "external_libs/fmt"]
 	path = external_libs/fmt
 	url = https://github.com/fmtlib/fmt.git


### PR DESCRIPTION
Attempts to fix the blocking CI issue on CUDA jobs (#4646). See that issue for more investigation.

Basically, I believe that the `nvidia/cuda` images (last updated 9/20/2021) are using a client somewhere that is using one or more certificates relying on the Let's Encrypt root certificate that expired 9/30/2021.

This PR patches `.ci/setup.sh` to say "just trust the kitware apt repository and don't check it's certificate" for CUDA jobs.

### Notes for Reviewers

I'm going to open an issue later today on the issues page for the `nvidia/cuda` images, asking them to update their images. But at least for now, I hope this PR will unblock LightGBM's CI.