### PR TITLE
Partially resolve [CLI] Categorical: Read string and convert to int on the fly #789 (closed in favour #2303)

### DIFF
--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -168,7 +168,7 @@ def test_create_tree_digraph(breast_cancer_split):
 
     graph = lgb.create_tree_digraph(gbm, tree_index=3,
                                     show_info=['split_gain', 'internal_value', 'internal_weight'],
-                                    name='Tree4', node_attr={'color': 'red'})
+                                    name='Tree4', node_attr={'color': 'red'}, decode_categorical = True)
     graph.render(view=False)
     assert isinstance(graph, graphviz.Digraph)
     assert graph.name == 'Tree4'

--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -162,13 +162,12 @@ def test_create_tree_digraph(breast_cancer_split):
     constraints = [-1, 1] * int(X_train.shape[1] / 2)
     gbm = lgb.LGBMClassifier(n_estimators=10, num_leaves=3, silent=True, monotone_constraints=constraints)
     gbm.fit(X_train, y_train, verbose=False)
-
     with pytest.raises(IndexError):
         lgb.create_tree_digraph(gbm, tree_index=83)
 
     graph = lgb.create_tree_digraph(gbm, tree_index=3,
                                     show_info=['split_gain', 'internal_value', 'internal_weight'],
-                                    name='Tree4', node_attr={'color': 'red'}, decode_categorical = True)
+                                    name='Tree4', node_attr={'color': 'red'}, decode_categorical=True)
     graph.render(view=False)
     assert isinstance(graph, graphviz.Digraph)
     assert graph.name == 'Tree4'


### PR DESCRIPTION
Hi team! 
I extensively used create_tree_digraph function and found that there is no way to show categorical features values as they were initially before the internal encoding. It seems that there should be a possibility to decode these categorical variables to be displayed with their initial values in graph. 
I've found issue #789 connected to this problem. It's also included in #2302 feature requests issue.

For now it's only fixed for the "create_tree_digraph" function with decode_categorical as optional parameter set by default to False.

Please let me know if this is reasonable feature and fix.