### PR TITLE
[c_api] Improve ANSI compatibility by avoiding <stdbool.h>

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -80,7 +80,8 @@ if [[ $TASK == "lint" ]]; then
     echo "Linting R code"
     Rscript ${BUILD_DIRECTORY}/.ci/lint_r_code.R ${BUILD_DIRECTORY} || exit -1
     echo "Linting C++ code"
-    cpplint --filter=-build/c++11,-build/include_subdir,-build/header_guard,-whitespace/line_length --recursive ./src ./include ./R-package ./swig ./tests || exit -1
+    cpplint --filter=-build/c++11,-build/include_subdir,-build/header_guard,-whitespace/line_length,-runtime/printf ./include/LightGBM/c_api.h || exit -1
+    cpplint --filter=-build/c++11,-build/include_subdir,-build/header_guard,-whitespace/line_length --recursive --exclude=./include/LightGBM/c_api.h ./src ./include ./R-package ./swig ./tests || exit -1
     cmake_files=$(find . -name CMakeLists.txt -o -path "*/cmake/*.cmake")
     cmakelint --linelength=120 ${cmake_files} || true
     exit 0

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -80,8 +80,7 @@ if [[ $TASK == "lint" ]]; then
     echo "Linting R code"
     Rscript ${BUILD_DIRECTORY}/.ci/lint_r_code.R ${BUILD_DIRECTORY} || exit -1
     echo "Linting C++ code"
-    cpplint --filter=-build/c++11,-build/include_subdir,-build/header_guard,-whitespace/line_length,-runtime/printf ./include/LightGBM/c_api.h || exit -1
-    cpplint --filter=-build/c++11,-build/include_subdir,-build/header_guard,-whitespace/line_length --recursive --exclude=./include/LightGBM/c_api.h ./src ./include ./R-package ./swig ./tests || exit -1
+    cpplint --filter=-build/c++11,-build/include_subdir,-build/header_guard,-whitespace/line_length --recursive ./src ./include ./R-package ./swig ./tests || exit -1
     cmake_files=$(find . -name CMakeLists.txt -o -path "*/cmake/*.cmake")
     cmakelint --linelength=120 ${cmake_files} || true
     exit 0

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -23,7 +23,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdbool.h>
 #endif
 
 
@@ -434,12 +433,12 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetAddFeaturesFrom(DatasetHandle target,
 /* --- start Booster interfaces */
 
 /*!
-* \brief Get boolean representing whether booster is fitting linear trees.
+* \brief Get int representing whether booster is fitting linear trees.
 * \param handle Handle of booster
 * \param[out] out The address to hold linear trees indicator
 * \return 0 when succeed, -1 when failure happens
 */
-LIGHTGBM_C_EXPORT int LGBM_BoosterGetLinear(BoosterHandle handle, bool* out);
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetLinear(BoosterHandle handle, int* out);
 
 /*!
  * \brief Create a new boosting learner.
@@ -1355,11 +1354,17 @@ static char* LastErrorMsg() { static THREAD_LOCAL char err_msg[512] = "Everythin
 #endif
 /*!
  * \brief Set string message of the last error.
+ * \note
+ * This will call unsafe ``sprintf`` when compiled using C standards before C99.
  * \param msg Error message
  */
 INLINE_FUNCTION void LGBM_SetLastError(const char* msg) {
   const int err_buf_len = 512;
+#if !defined(__cplusplus) && (!defined(__STDC__) || (__STDC_VERSION__ < 199901L))
+  sprintf(LastErrorMsg(), "%s", msg);
+#else
   snprintf(LastErrorMsg(), err_buf_len, "%s", msg);
+#endif
 }
 
 #endif  /* LIGHTGBM_C_API_H_ */

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -1365,10 +1365,10 @@ static char* LastErrorMsg() { static THREAD_LOCAL char err_msg[512] = "Everythin
  * \param msg Error message
  */
 INLINE_FUNCTION void LGBM_SetLastError(const char* msg) {
-  const int err_buf_len = 512;
 #if !defined(__cplusplus) && (!defined(__STDC__) || (__STDC_VERSION__ < 199901L))
   sprintf(LastErrorMsg(), "%s", msg);  /* NOLINT(runtime/printf) */
 #else
+  const int err_buf_len = 512;
   snprintf(LastErrorMsg(), err_buf_len, "%s", msg);
 #endif
 }

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -1361,7 +1361,7 @@ static char* LastErrorMsg() { static THREAD_LOCAL char err_msg[512] = "Everythin
 INLINE_FUNCTION void LGBM_SetLastError(const char* msg) {
   const int err_buf_len = 512;
 #if !defined(__cplusplus) && (!defined(__STDC__) || (__STDC_VERSION__ < 199901L))
-  sprintf(LastErrorMsg(), "%s", msg);
+  sprintf(LastErrorMsg(), "%s", msg);  /* NOLINT(runtime/printf) */
 #else
   snprintf(LastErrorMsg(), err_buf_len, "%s", msg);
 #endif

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3566,7 +3566,7 @@ class Booster:
         predictor = self._to_predictor(deepcopy(kwargs))
         leaf_preds = predictor.predict(data, -1, pred_leaf=True)
         nrow, ncol = leaf_preds.shape
-        out_is_linear = ctypes.c_bool(False)
+        out_is_linear = ctypes.c_int(0)
         _safe_call(_LIB.LGBM_BoosterGetLinear(
             self.handle,
             ctypes.byref(out_is_linear)))
@@ -3575,7 +3575,7 @@ class Booster:
             params=self.params,
             default_value=None
         )
-        new_params["linear_tree"] = out_is_linear.value
+        new_params["linear_tree"] = bool(out_is_linear.value)
         train_set = Dataset(data, label, silent=True, params=new_params)
         new_params['refit_decay_rate'] = decay_rate
         new_booster = Booster(new_params, train_set)

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1660,7 +1660,7 @@ int LGBM_BoosterGetNumClasses(BoosterHandle handle, int* out_len) {
 int LGBM_BoosterGetLinear(BoosterHandle handle, int* out) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
-  if(ref_booster->GetBoosting()->IsLinear()) {
+  if (ref_booster->GetBoosting()->IsLinear()) {
     *out = 1;
   } else {
     *out = 0;

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1657,10 +1657,14 @@ int LGBM_BoosterGetNumClasses(BoosterHandle handle, int* out_len) {
   API_END();
 }
 
-int LGBM_BoosterGetLinear(BoosterHandle handle, bool* out) {
+int LGBM_BoosterGetLinear(BoosterHandle handle, int* out) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
-  *out = ref_booster->GetBoosting()->IsLinear();
+  if(ref_booster->GetBoosting()->IsLinear()) {
+    *out = 1;
+  } else {
+    *out = 0;
+  }
   API_END();
 }
 


### PR DESCRIPTION
Mentioned in https://github.com/microsoft/LightGBM/issues/4609, these edits improve ANSI C compatibility by removing reliance on stdbool.h. These edits may cause a compiler warning for existing code which passes a `_Bool` pointer as `out`. However, given the brief tenure of ANSI C compatibility, it seems unlikely there will be much breakage.