### PR TITLE
Always respect forced splits, even when feature_fraction < 1.0 (fixes #4601)

### DIFF
--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -468,7 +468,7 @@ int32_t SerialTreeLearner::ForceSplits(Tree* tree, int* left_leaf,
   std::unordered_map<int, SplitInfo> forceSplitMap;
   q.push(std::make_pair(left, *left_leaf));
 
-  // Histogram construction require parent features. 
+  // Histogram construction require parent features.
   std::set<int> force_split_features = FindAllForceFeatures(*forced_split_json_);
   while (!q.empty()) {
     if (BeforeFindBestSplit(tree, *left_leaf, *right_leaf)) {

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -328,7 +328,7 @@ void SerialTreeLearner::FindBestSplits(const Tree* tree) {
 
 void SerialTreeLearner::FindBestSplits(const Tree* tree, const std::set<int>* force_features) {
   std::vector<int8_t> is_feature_used(num_features_, 0);
-#pragma omp parallel for schedule(static, 256) if (num_features_ >= 512)
+  #pragma omp parallel for schedule(static, 256) if (num_features_ >= 512)
   for (int feature_index = 0; feature_index < num_features_; ++feature_index) {
     if (!col_sampler_.is_feature_used_bytree()[feature_index] && (force_features == nullptr || force_features->find(feature_index) == force_features->end())) continue;
     if (parent_leaf_histogram_array_ != nullptr

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <queue>
+#include <set>
 #include <unordered_map>
 #include <utility>
 
@@ -325,8 +326,7 @@ void SerialTreeLearner::FindBestSplits(const Tree* tree) {
   FindBestSplits(tree, nullptr);
 }
 
-void SerialTreeLearner::FindBestSplits(const Tree* tree, const std::set<int>* force_features)
-{
+void SerialTreeLearner::FindBestSplits(const Tree* tree, const std::set<int>* force_features) {
   std::vector<int8_t> is_feature_used(num_features_, 0);
 #pragma omp parallel for schedule(static, 256) if (num_features_ >= 512)
   for (int feature_index = 0; feature_index < num_features_; ++feature_index) {
@@ -344,13 +344,13 @@ void SerialTreeLearner::FindBestSplits(const Tree* tree, const std::set<int>* fo
 #ifdef USE_CUDA
   if (LGBM_config_::current_learner == use_cpu_learner) {
     SerialTreeLearner::ConstructHistograms(is_feature_used, use_subtract);
-  }
-  else {
+  } else {
     ConstructHistograms(is_feature_used, use_subtract);
   }
 #else
   ConstructHistograms(is_feature_used, use_subtract);
 #endif
+
   FindBestSplitsFromHistograms(is_feature_used, use_subtract, tree);
 }
 
@@ -565,8 +565,7 @@ int32_t SerialTreeLearner::ForceSplits(Tree* tree, int* left_leaf,
   return result_count;
 }
 
-void SerialTreeLearner::FindBestSplitsForForceSplitLeaf(Tree* tree, int* left_leaf, int* right_leaf, Json left_force_split_leaf_setting, Json right_force_split_leaf_setting)
-{
+void SerialTreeLearner::FindBestSplitsForForceSplitLeaf(Tree* tree, int* left_leaf, int* right_leaf, Json left_force_split_leaf_setting, Json right_force_split_leaf_setting) {
   // before processing next node from queue, store info for current left/right leaf
   // store "best split" for left and right, even if they might be overwritten by forced split
   if (BeforeFindBestSplit(tree, *left_leaf, *right_leaf)) {

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -332,13 +332,12 @@ void SerialTreeLearner::FindBestSplits(const Tree* tree, const std::set<int>* fo
   for (int feature_index = 0; feature_index < num_features_; ++feature_index) {
     if (!col_sampler_.is_feature_used_bytree()[feature_index] && (force_features == nullptr || force_features->find(feature_index) == force_features->end())) continue;
     if (parent_leaf_histogram_array_ != nullptr
-      && !parent_leaf_histogram_array_[feature_index].is_splittable()) {
+        && !parent_leaf_histogram_array_[feature_index].is_splittable()) {
       smaller_leaf_histogram_array_[feature_index].set_is_splittable(false);
       continue;
     }
     is_feature_used[feature_index] = 1;
   }
-
   bool use_subtract = parent_leaf_histogram_array_ != nullptr;
 
 #ifdef USE_CUDA
@@ -350,7 +349,6 @@ void SerialTreeLearner::FindBestSplits(const Tree* tree, const std::set<int>* fo
 #else
   ConstructHistograms(is_feature_used, use_subtract);
 #endif
-
   FindBestSplitsFromHistograms(is_feature_used, use_subtract, tree);
 }
 

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -168,7 +168,7 @@ class SerialTreeLearner: public TreeLearner {
   int32_t ForceSplits(Tree* tree, int* left_leaf, int* right_leaf,
                       int* cur_depth);
 
-  void FindBestSplitsForForceSplitLeaf(LightGBM::Tree* tree, int* left_leaf, int* right_leaf, Json left, Json right);
+  std::set<int> SerialTreeLearner::FindAllForceFeatures(Json force_split_leaf_setting);
 
   /*!
   * \brief Get the number of data in a leaf

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <random>
 #include <vector>
+#include <set>
 
 #include "col_sampler.hpp"
 #include "data_partition.hpp"

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -142,7 +142,7 @@ class SerialTreeLearner: public TreeLearner {
 
   virtual void FindBestSplits(const Tree* tree);
 
-  virtual void FindBestSplits(const Tree* tree, const std::vector<int8_t>& is_feature_used);
+  virtual void FindBestSplits(const Tree* tree, const std::set<int>* force_features);
 
   virtual void ConstructHistograms(const std::vector<int8_t>& is_feature_used, bool use_subtract);
 

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -142,6 +142,8 @@ class SerialTreeLearner: public TreeLearner {
 
   virtual void FindBestSplits(const Tree* tree);
 
+  virtual void FindBestSplits(const Tree* tree, const std::vector<int8_t>& is_feature_used);
+
   virtual void ConstructHistograms(const std::vector<int8_t>& is_feature_used, bool use_subtract);
 
   virtual void FindBestSplitsFromHistograms(const std::vector<int8_t>& is_feature_used, bool use_subtract, const Tree*);
@@ -164,6 +166,8 @@ class SerialTreeLearner: public TreeLearner {
   /* Force splits with forced_split_json dict and then return num splits forced.*/
   int32_t ForceSplits(Tree* tree, int* left_leaf, int* right_leaf,
                       int* cur_depth);
+
+  void FindBestSplitsForForceSplitLeaf(LightGBM::Tree* tree, int* left_leaf, int* right_leaf, Json left, Json right);
 
   /*!
   * \brief Get the number of data in a leaf

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -168,7 +168,7 @@ class SerialTreeLearner: public TreeLearner {
   int32_t ForceSplits(Tree* tree, int* left_leaf, int* right_leaf,
                       int* cur_depth);
 
-  std::set<int> SerialTreeLearner::FindAllForceFeatures(Json force_split_leaf_setting);
+  std::set<int> FindAllForceFeatures(Json force_split_leaf_setting);
 
   /*!
   * \brief Get the number of data in a leaf

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2914,3 +2914,4 @@ def test_force_split_with_feature_fraction():
     ret = mean_absolute_error(y_test, gbm.predict(X_test))
 
     assert ret < 2.0
+    

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2912,6 +2912,8 @@ def test_force_split_with_feature_fraction():
     }
 
     gbm = lgb.train(params, lgb_train)
-    ret = mean_absolute_error(y_test, gbm.predict(X_test))
+    treesDf = gbm.trees_to_dataframe()
+    assert np.all(treesDf[treesDf.node_depth == 1]['split_feature'] == 'Column_0')
 
+    ret = mean_absolute_error(y_test, gbm.predict(X_test))
     assert ret < 2.0

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2897,7 +2897,11 @@ def test_force_split_with_feature_fraction(tmp_path):
 
     forced_split = {
         "feature": 0,
-        "threshold": 0.5
+        "threshold": 0.5,
+        "right": {
+            "feature": 2,
+            "threshold": 10.0
+        }
     }
 
     tmp_split_file = tmp_path / "forced_split.json"

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2915,4 +2915,3 @@ def test_force_split_with_feature_fraction():
     ret = mean_absolute_error(y_test, gbm.predict(X_test))
 
     assert ret < 2.0
-

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import copy
 import itertools
+import json
 import math
 import pickle
 import platform
@@ -2887,3 +2888,29 @@ def test_dump_model_hook():
     dumped_model_str = str(bst.dump_model(5, 0, object_hook=hook))
     assert "leaf_value" not in dumped_model_str
     assert "LV" in dumped_model_str
+
+def test_force_split_with_feature_fraction():
+    X, y = load_boston(return_X_y=True) 
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    lgb_train = lgb.Dataset(X_train, y_train)
+
+    forced_split = {
+        "feature": 0,
+        "threshold": 0.5
+    }
+
+    with open("forced_split.json", "w") as f:
+        f.write(json.dumps(forced_split))
+
+    params = {
+            "objective": "regression",
+            "feature_fraction": 0.6,
+            "force_col_wise": True,
+            "feature_fraction_seed": 1,
+            "forcedsplits_filename": "forced_split.json"
+        }
+
+    gbm = lgb.train(params, lgb_train)
+    ret = mean_absolute_error(y_test, gbm.predict(X_test))
+
+    assert ret < 2.0

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2890,7 +2890,7 @@ def test_dump_model_hook():
     assert "LV" in dumped_model_str
 
 
-def test_force_split_with_feature_fraction():
+def test_force_split_with_feature_fraction(tmp_path):
     X, y = load_boston(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
     lgb_train = lgb.Dataset(X_train, y_train)
@@ -2900,7 +2900,8 @@ def test_force_split_with_feature_fraction():
         "threshold": 0.5
     }
 
-    with open("forced_split.json", "w") as f:
+    tmp_split_file = tmp_path / "forced_split.json"
+    with open(tmp_split_file, "w") as f:
         f.write(json.dumps(forced_split))
 
     params = {
@@ -2908,7 +2909,7 @@ def test_force_split_with_feature_fraction():
         "feature_fraction": 0.6,
         "force_col_wise": True,
         "feature_fraction_seed": 1,
-        "forcedsplits_filename": "forced_split.json"
+        "forcedsplits_filename": tmp_split_file
     }
 
     gbm = lgb.train(params, lgb_train)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2908,7 +2908,7 @@ def test_force_split_with_feature_fraction(tmp_path):
         "objective": "regression",
         "feature_fraction": 0.6,
         "force_col_wise": True,
-        "feature_fraction_seed": 1,
+        "feature_fraction_seed": 10,
         "forcedsplits_filename": tmp_split_file
     }
 
@@ -2916,7 +2916,8 @@ def test_force_split_with_feature_fraction(tmp_path):
     ret = mean_absolute_error(y_test, gbm.predict(X_test))
     assert ret < 2.0
 
-    dumped_model = gbm.dump_model()["tree_info"]
-    for tree in dumped_model:
+    tree_info = gbm.dump_model()["tree_info"]
+    assert len(tree_info) > 1
+    for tree in tree_info:
         tree_structure = tree["tree_structure"]
         assert tree_structure['split_feature'] == 0

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2915,3 +2915,4 @@ def test_force_split_with_feature_fraction():
     ret = mean_absolute_error(y_test, gbm.predict(X_test))
 
     assert ret < 2.0
+

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2908,7 +2908,7 @@ def test_force_split_with_feature_fraction(tmp_path):
         "objective": "regression",
         "feature_fraction": 0.6,
         "force_col_wise": True,
-        "feature_fraction_seed": 10,
+        "feature_fraction_seed": 1,
         "forcedsplits_filename": tmp_split_file
     }
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2889,8 +2889,9 @@ def test_dump_model_hook():
     assert "leaf_value" not in dumped_model_str
     assert "LV" in dumped_model_str
 
+
 def test_force_split_with_feature_fraction():
-    X, y = load_boston(return_X_y=True) 
+    X, y = load_boston(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
     lgb_train = lgb.Dataset(X_train, y_train)
 
@@ -2903,15 +2904,14 @@ def test_force_split_with_feature_fraction():
         f.write(json.dumps(forced_split))
 
     params = {
-            "objective": "regression",
-            "feature_fraction": 0.6,
-            "force_col_wise": True,
-            "feature_fraction_seed": 1,
-            "forcedsplits_filename": "forced_split.json"
-        }
+        "objective": "regression",
+        "feature_fraction": 0.6,
+        "force_col_wise": True,
+        "feature_fraction_seed": 1,
+        "forcedsplits_filename": "forced_split.json"
+    }
 
     gbm = lgb.train(params, lgb_train)
     ret = mean_absolute_error(y_test, gbm.predict(X_test))
 
     assert ret < 2.0
-    

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2891,11 +2891,6 @@ def test_dump_model_hook():
 
 
 def test_force_split_with_feature_fraction(tmp_path):
-    def check_force_splits(dumped_model):
-        for tree in dumped_model:
-            tree_structure = tree["tree_structure"]
-            assert tree_structure['split_feature'] == 0
-
     X, y = load_boston(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
     lgb_train = lgb.Dataset(X_train, y_train)
@@ -2921,4 +2916,7 @@ def test_force_split_with_feature_fraction(tmp_path):
     ret = mean_absolute_error(y_test, gbm.predict(X_test))
     assert ret < 2.0
 
-    check_force_splits(gbm.dump_model()["tree_info"])
+    dumped_model = gbm.dump_model()["tree_info"]
+    for tree in dumped_model:
+        tree_structure = tree["tree_structure"]
+        assert tree_structure['split_feature'] == 0


### PR DESCRIPTION
Fixes #4601.

Root cause for this issue: The histogram for the force split feature might not construct if feature_fraction < 1.0. And it would failed at SplitInner.

- Only col-wise histogram construction impacted.  row-wise histogram construction would go through all features.
- Only force split settings gain > 0 impacted. If no gain for force_split leaf, the force_split settings would be auto ignored.