### PR TITLE
[ci] indicate support of Monterey

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -133,7 +133,7 @@ if [[ $TASK == "sdist" ]]; then
 elif [[ $TASK == "bdist" ]]; then
     if [[ $OS_NAME == "macos" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --plat-name=macosx --python-tag py3 || exit -1
-        mv dist/lightgbm-$LGB_VER-py3-none-macosx.whl dist/lightgbm-$LGB_VER-py3-none-macosx_10_14_x86_64.macosx_10_15_x86_64.macosx_11_0_x86_64.whl
+        mv dist/lightgbm-$LGB_VER-py3-none-macosx.whl dist/lightgbm-$LGB_VER-py3-none-macosx_11_5_x86_64.macosx_11_6_x86_64.macosx_12_0_x86_64.whl
         if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
             cp dist/lightgbm-$LGB_VER-py3-none-macosx*.whl $BUILD_ARTIFACTSTAGINGDIRECTORY
         fi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -133,7 +133,7 @@ if [[ $TASK == "sdist" ]]; then
 elif [[ $TASK == "bdist" ]]; then
     if [[ $OS_NAME == "macos" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --plat-name=macosx --python-tag py3 || exit -1
-        mv dist/lightgbm-$LGB_VER-py3-none-macosx.whl dist/lightgbm-$LGB_VER-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_0_x86_64.whl
+        mv dist/lightgbm-$LGB_VER-py3-none-macosx.whl dist/lightgbm-$LGB_VER-py3-none-macosx_10_14_x86_64.macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_0_x86_64.whl
         if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
             cp dist/lightgbm-$LGB_VER-py3-none-macosx*.whl $BUILD_ARTIFACTSTAGINGDIRECTORY
         fi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -133,7 +133,7 @@ if [[ $TASK == "sdist" ]]; then
 elif [[ $TASK == "bdist" ]]; then
     if [[ $OS_NAME == "macos" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --plat-name=macosx --python-tag py3 || exit -1
-        mv dist/lightgbm-$LGB_VER-py3-none-macosx.whl dist/lightgbm-$LGB_VER-py3-none-macosx_11_5_x86_64.macosx_11_6_x86_64.macosx_12_0_x86_64.whl
+        mv dist/lightgbm-$LGB_VER-py3-none-macosx.whl dist/lightgbm-$LGB_VER-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_0_x86_64.whl
         if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
             cp dist/lightgbm-$LGB_VER-py3-none-macosx*.whl $BUILD_ARTIFACTSTAGINGDIRECTORY
         fi


### PR DESCRIPTION
According to the policy, we indicate support only for the last 3 macOS versions in wheel name: https://github.com/microsoft/LightGBM/pull/2691#issue-549125519.

I believe that "the last 3 macOS  versions" means 3 last major releases like it was before 11.x 

Successfully built bottles for `arm64_monterey`, `arm64_big_sur`, `monterey`, `big_sur`, `catalina`, `mojave` by Homebrew team give some confidence in that LightGBM is indeed compatible with the wide range of macOS versions.
https://github.com/Homebrew/homebrew-core/blob/4060c0ab42d8b9b7168b34f55f12e16a91b27150/Formula/lightgbm.rb#L10-L15

Just FYI, it is now possible to provide one `universal2` wheel for both `x86_64` and `arm64`.
- https://discuss.python.org/t/apple-silicon-and-packaging/4516
- https://github.com/numpy/numpy/issues/18143