### PR TITLE
Add 'nrounds' as an alias for 'num_iterations' (fixes #4743)

### DIFF
--- a/R-package/R/aliases.R
+++ b/R-package/R/aliases.R
@@ -113,6 +113,7 @@
             , "num_trees"
             , "num_round"
             , "num_rounds"
+            , "nrounds"
             , "num_boost_round"
             , "n_estimators"
             , "max_iter"

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -230,16 +230,23 @@ test_that("lightgbm() accepts nrounds as either a top-level argument or paramete
     )
     , save_name = tempfile(fileext = ".model")
   )
+  
+  top_level_l2 <- top_level_bst$eval_train()[[1L]][["value"]]
+  param_l2    <- param_bst$eval_train()[[1L]][["value"]]
+  both_l2      <- both_customized$eval_train()[[1L]][["value"]]
 
-  expect_equal(param_bst$current_iter(), top_level_bst$current_iter())
-  expect_equal(param_bst$best_score
-               , top_level_bst$best_score
-               , tolerance = TOLERANCE)
+  # check type just to be sure the subsetting didn't return a NULL
+  expect_true(is.numeric(top_level_l2))
+  expect_true(is.numeric(param_l2))
+  expect_true(is.numeric(both_l2))
+  
+  # check that model produces identical performance
+  expect_identical(top_level_l2, param_l2)
+  expect_identical(both_l2, param_l2)
 
-  expect_equal(param_bst$current_iter(), both_customized$current_iter())
-  expect_equal(param_bst$best_score
-               , both_customized$best_score
-               , tolerance = TOLERANCE)
+  expect_identical(param_bst$current_iter(), top_level_bst$current_iter())
+  expect_identical(param_bst$current_iter(), both_customized$current_iter())
+
 })
 
 test_that("lightgbm() performs evaluation on validation sets if they are provided", {
@@ -520,6 +527,75 @@ test_that("lgb.train() rejects negative or 0 value passed to nrounds", {
     }, "nrounds should be greater than zero")
   }
 })
+
+
+test_that("lgb.train() accepts nrounds as either a top-level argument or parameter", {
+  nrounds <- 15L
+  
+  set.seed(708L)
+  top_level_bst <- lgb.train(
+    data = lgb.Dataset(
+      train$data
+      , label = train$label
+    )
+    , nrounds = nrounds
+    , params = list(
+      objective = "regression"
+      , metric = "l2"
+      , num_leaves = 5L
+      , save_name = tempfile(fileext = ".model")
+    )
+  )
+  
+  set.seed(708L)
+  param_bst <- lgb.train(
+    data = lgb.Dataset(
+      train$data
+      , label = train$label
+    )
+    , params = list(
+      objective = "regression"
+      , metric = "l2"
+      , num_leaves = 5L
+      , nrounds = nrounds
+      , save_name = tempfile(fileext = ".model")
+    )
+  )
+  
+  set.seed(708L)
+  both_customized <- lgb.train(
+    data = lgb.Dataset(
+      train$data
+      , label = train$label
+    )
+    , nrounds = 20L
+    , params = list(
+      objective = "regression"
+      , metric = "l2"
+      , num_leaves = 5L
+      , nrounds = nrounds
+      , save_name = tempfile(fileext = ".model")
+    )
+  )
+  
+  top_level_l2 <- top_level_bst$eval_train()[[1L]][["value"]]
+  params_l2    <- param_bst$eval_train()[[1L]][["value"]]
+  both_l2      <- both_customized$eval_train()[[1L]][["value"]]
+  
+  # check type just to be sure the subsetting didn't return a NULL
+  expect_true(is.numeric(top_level_l2))
+  expect_true(is.numeric(params_l2))
+  expect_true(is.numeric(both_l2))
+  
+  # check that model produces identical performance
+  expect_identical(top_level_l2, params_l2)
+  expect_identical(both_l2, params_l2)
+  
+  expect_identical(param_bst$current_iter(), top_level_bst$current_iter())
+  expect_identical(param_bst$current_iter(), both_customized$current_iter())
+  
+})
+
 
 test_that("lgb.train() throws an informative error if 'data' is not an lgb.Dataset", {
   bad_values <- list(

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -188,6 +188,60 @@ test_that("lightgbm() rejects negative or 0 value passed to nrounds", {
   }
 })
 
+test_that("lightgbm() accepts nrounds as either a top-level argument or parameter", {
+  nrounds <- 15L
+
+  set.seed(708L)
+  top_level_bst <- lightgbm(
+    data = train$data
+    , label = train$label
+    , nrounds = nrounds
+    , params = list(
+      objective = "regression"
+      , metric = "l2"
+      , num_leaves = 5L
+    )
+    , save_name = tempfile(fileext = ".model")
+  )
+
+  set.seed(708L)
+  param_bst <- lightgbm(
+    data = train$data
+    , label = train$label
+    , params = list(
+      objective = "regression"
+      , metric = "l2"
+      , num_leaves = 5L
+      , nrounds = nrounds
+    )
+    , save_name = tempfile(fileext = ".model")
+  )
+
+  set.seed(708L)
+  both_customized <- lightgbm(
+    data = train$data
+    , label = train$label
+    , nrounds = 20L
+    , params = list(
+      objective = "regression"
+      , metric = "l2"
+      , num_leaves = 5L
+      , nrounds = nrounds
+    )
+    , save_name = tempfile(fileext = ".model")
+  )
+
+  expect_equal(param_bst$current_iter(), top_level_bst$current_iter())
+  expect_equal(param_bst$best_score
+               , top_level_bst$best_score
+               , tolerance = TOLERANCE)
+
+  expect_equal(param_bst$current_iter(), both_customized$current_iter())
+  expect_equal(param_bst$best_score
+               , both_customized$best_score
+               , tolerance = TOLERANCE)
+})
+
 test_that("lightgbm() performs evaluation on validation sets if they are provided", {
   set.seed(708L)
   dvalid1 <- lgb.Dataset(

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -232,20 +232,21 @@ test_that("lightgbm() accepts nrounds as either a top-level argument or paramete
   )
   
   top_level_l2 <- top_level_bst$eval_train()[[1L]][["value"]]
-  param_l2    <- param_bst$eval_train()[[1L]][["value"]]
+  params_l2    <- param_bst$eval_train()[[1L]][["value"]]
   both_l2      <- both_customized$eval_train()[[1L]][["value"]]
 
   # check type just to be sure the subsetting didn't return a NULL
   expect_true(is.numeric(top_level_l2))
-  expect_true(is.numeric(param_l2))
+  expect_true(is.numeric(params_l2))
   expect_true(is.numeric(both_l2))
   
   # check that model produces identical performance
-  expect_identical(top_level_l2, param_l2)
-  expect_identical(both_l2, param_l2)
+  expect_identical(top_level_l2, params_l2)
+  expect_identical(both_l2, params_l2)
 
   expect_identical(param_bst$current_iter(), top_level_bst$current_iter())
   expect_identical(param_bst$current_iter(), both_customized$current_iter())
+  expect_identical(param_bst$current_iter(), nrounds)
 
 })
 
@@ -593,6 +594,7 @@ test_that("lgb.train() accepts nrounds as either a top-level argument or paramet
   
   expect_identical(param_bst$current_iter(), top_level_bst$current_iter())
   expect_identical(param_bst$current_iter(), both_customized$current_iter())
+  expect_identical(param_bst$current_iter(), nrounds)
   
 })
 

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -230,7 +230,7 @@ test_that("lightgbm() accepts nrounds as either a top-level argument or paramete
     )
     , save_name = tempfile(fileext = ".model")
   )
-  
+
   top_level_l2 <- top_level_bst$eval_train()[[1L]][["value"]]
   params_l2    <- param_bst$eval_train()[[1L]][["value"]]
   both_l2      <- both_customized$eval_train()[[1L]][["value"]]
@@ -239,7 +239,7 @@ test_that("lightgbm() accepts nrounds as either a top-level argument or paramete
   expect_true(is.numeric(top_level_l2))
   expect_true(is.numeric(params_l2))
   expect_true(is.numeric(both_l2))
-  
+
   # check that model produces identical performance
   expect_identical(top_level_l2, params_l2)
   expect_identical(both_l2, params_l2)
@@ -532,7 +532,7 @@ test_that("lgb.train() rejects negative or 0 value passed to nrounds", {
 
 test_that("lgb.train() accepts nrounds as either a top-level argument or parameter", {
   nrounds <- 15L
-  
+
   set.seed(708L)
   top_level_bst <- lgb.train(
     data = lgb.Dataset(
@@ -547,7 +547,7 @@ test_that("lgb.train() accepts nrounds as either a top-level argument or paramet
       , save_name = tempfile(fileext = ".model")
     )
   )
-  
+
   set.seed(708L)
   param_bst <- lgb.train(
     data = lgb.Dataset(
@@ -562,7 +562,7 @@ test_that("lgb.train() accepts nrounds as either a top-level argument or paramet
       , save_name = tempfile(fileext = ".model")
     )
   )
-  
+
   set.seed(708L)
   both_customized <- lgb.train(
     data = lgb.Dataset(
@@ -578,24 +578,24 @@ test_that("lgb.train() accepts nrounds as either a top-level argument or paramet
       , save_name = tempfile(fileext = ".model")
     )
   )
-  
+
   top_level_l2 <- top_level_bst$eval_train()[[1L]][["value"]]
   params_l2    <- param_bst$eval_train()[[1L]][["value"]]
   both_l2      <- both_customized$eval_train()[[1L]][["value"]]
-  
+
   # check type just to be sure the subsetting didn't return a NULL
   expect_true(is.numeric(top_level_l2))
   expect_true(is.numeric(params_l2))
   expect_true(is.numeric(both_l2))
-  
+
   # check that model produces identical performance
   expect_identical(top_level_l2, params_l2)
   expect_identical(both_l2, params_l2)
-  
+
   expect_identical(param_bst$current_iter(), top_level_bst$current_iter())
   expect_identical(param_bst$current_iter(), both_customized$current_iter())
   expect_identical(param_bst$current_iter(), nrounds)
-  
+
 })
 
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -153,7 +153,7 @@ Core Parameters
 
    -  **Note**: can be used only in CLI version
 
--  ``num_iterations`` :raw-html:`<a id="num_iterations" title="Permalink to this parameter" href="#num_iterations">&#x1F517;&#xFE0E;</a>`, default = ``100``, type = int, aliases: ``num_iteration``, ``n_iter``, ``num_tree``, ``num_trees``, ``num_round``, ``num_rounds``, ``num_boost_round``, ``n_estimators``, ``max_iter``, constraints: ``num_iterations >= 0``
+-  ``num_iterations`` :raw-html:`<a id="num_iterations" title="Permalink to this parameter" href="#num_iterations">&#x1F517;&#xFE0E;</a>`, default = ``100``, type = int, aliases: ``num_iteration``, ``n_iter``, ``num_tree``, ``num_trees``, ``num_round``, ``num_rounds``, ``nrounds``, ``num_boost_round``, ``n_estimators``, ``max_iter``, constraints: ``num_iterations >= 0``
 
    -  number of boosting iterations
 

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -161,7 +161,7 @@ struct Config {
   // desc = **Note**: can be used only in CLI version
   std::vector<std::string> valid;
 
-  // alias = num_iteration, n_iter, num_tree, num_trees, num_round, num_rounds, num_boost_round, n_estimators, max_iter
+  // alias = num_iteration, n_iter, num_tree, num_trees, num_round, num_rounds, nrounds, num_boost_round, n_estimators, max_iter
   // check = >=0
   // desc = number of boosting iterations
   // desc = **Note**: internally, LightGBM constructs ``num_class * num_iterations`` trees for multi-class classification problems

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -386,6 +386,7 @@ class _ConfigAliases:
                                   "num_trees",
                                   "num_round",
                                   "num_rounds",
+                                  "nrounds",
                                   "num_boost_round",
                                   "n_estimators",
                                   "max_iter"},

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -33,6 +33,7 @@ const std::unordered_map<std::string, std::string>& Config::alias_table() {
   {"num_trees", "num_iterations"},
   {"num_round", "num_iterations"},
   {"num_rounds", "num_iterations"},
+  {"nrounds", "num_iterations"},
   {"num_boost_round", "num_iterations"},
   {"n_estimators", "num_iterations"},
   {"max_iter", "num_iterations"},


### PR DESCRIPTION
This PR addresses #4743, adding `nrounds` as an alias for `num_iterations` so that (within the R package) the top-level `nrounds` parameter may also be passed to the `params` argument of `lightgbm` and `lgb.train`. 

I followed the template of #4637 and the new tests work on my machine (:tm:). Please let me know if I missed anything!