### PR TITLE
[python] Make dummy classes constructible with any arguments

### DIFF
--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -101,20 +101,17 @@ except ImportError:
     class _LGBMModelBase:  # type: ignore
         """Dummy class for sklearn.base.BaseEstimator."""
 
-        def __init__(self, *args, **kwargs):
-            pass
+        pass
 
     class _LGBMClassifierBase:  # type: ignore
         """Dummy class for sklearn.base.ClassifierMixin."""
 
-        def __init__(self, *args, **kwargs):
-            pass
+        pass
 
     class _LGBMRegressorBase:  # type: ignore
         """Dummy class for sklearn.base.RegressorMixin."""
 
-        def __init__(self, *args, **kwargs):
-            pass
+        pass
 
     _LGBMLabelEncoder = None
     LGBMNotFittedError = ValueError

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -14,12 +14,14 @@ except ImportError:
     class pd_Series:  # type: ignore
         """Dummy class for pandas.Series."""
 
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class pd_DataFrame:  # type: ignore
         """Dummy class for pandas.DataFrame."""
 
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     concat = None
     is_dtype_sparse = None
@@ -52,7 +54,8 @@ except ImportError:
     class dt_DataTable:  # type: ignore
         """Dummy class for datatable.DataTable."""
 
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
 
 """sklearn"""
@@ -98,17 +101,20 @@ except ImportError:
     class _LGBMModelBase:  # type: ignore
         """Dummy class for sklearn.base.BaseEstimator."""
 
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class _LGBMClassifierBase:  # type: ignore
         """Dummy class for sklearn.base.ClassifierMixin."""
 
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class _LGBMRegressorBase:  # type: ignore
         """Dummy class for sklearn.base.RegressorMixin."""
 
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     _LGBMLabelEncoder = None
     LGBMNotFittedError = ValueError
@@ -143,19 +149,23 @@ except ImportError:
     class Client:  # type: ignore
         """Dummy class for dask.distributed.Client."""
 
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class dask_Array:  # type: ignore
         """Dummy class for dask.array.Array."""
 
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class dask_DataFrame:  # type: ignore
         """Dummy class for dask.dataframe.DataFrame."""
 
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class dask_Series:  # type: ignore
         """Dummy class for dask.dataframe.Series."""
 
-        pass
+        def __init__(self, *args, **kwargs):
+            pass


### PR DESCRIPTION
Refer to the following thread https://github.com/microsoft/LightGBM/pull/4639#discussion_r720068911. Making dummy classes constructible with any arguments may help to write tests.

I'm not overriding default `__init__()` method for three internal classes (prefixed with `_`) because doing that for two of them (`_LGBMRegressorBase` and `_LGBMClassifierBase`) makes `autosummary` Sphinx extension to fail because of inheritance issues.