### PR TITLE
[docs][python] add `datatable` to the mocked modules during docs building process and sort them alphabetically

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,8 +41,18 @@ sys.path.insert(0, str(LIB_PATH))
 INTERNAL_REF_REGEX = compile(r"(?P<url>\.\/.+)(?P<extension>\.rst)(?P<anchor>$|#)")
 
 # -- mock out modules
-MOCK_MODULES = ['numpy', 'scipy', 'scipy.sparse',
-                'sklearn', 'matplotlib', 'pandas', 'graphviz', 'dask', 'dask.distributed']
+MOCK_MODULES = [
+    'dask',
+    'dask.distributed',
+    'datatable',
+    'graphviz',
+    'matplotlib',
+    'numpy',
+    'pandas',
+    'scipy',
+    'scipy.sparse',
+    'sklearn'
+]
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()
 


### PR DESCRIPTION
I think it's better to add `datatable` because we try to import it here
https://github.com/microsoft/LightGBM/blob/d62378b45314c2688deef7333ae16fcc9863d881/python-package/lightgbm/compat.py#L43