### PR TITLE
[R-package] remove temporary files created in configure.win

### DIFF
--- a/R-package/configure.win
+++ b/R-package/configure.win
@@ -37,6 +37,8 @@ int main() {
 EOL
 
 ${CXX} ${CXXFLAGS} ${CPPFLAGS} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mm_prefetch="yes"
+rm -f ./conftest
+rm -f ./conftest.cpp
 echo "checking whether MM_PREFETCH works...${ac_mm_prefetch}"
 
 if test "${ac_mm_prefetch}" = "yes";
@@ -59,6 +61,8 @@ int main() {
 EOL
 
 ${CXX} ${CXXFLAGS} ${CPPFLAGS} -o conftest conftest.cpp 2>/dev/null && ./conftest && ac_mm_malloc="yes"
+rm -f ./conftest
+rm -f ./conftest.cpp
 echo "checking whether MM_MALLOC works...${ac_mm_malloc}"
 
 if test "${ac_mm_malloc}" = "yes";


### PR DESCRIPTION
On Windows builds in #3946, I see the following NOTE from `R CMD check`

```text
* checking top-level files ... NOTE

Non-standard file/directory found at top level:

  'conftest.cpp'
```

Example build: https://github.com/microsoft/LightGBM/runs/3367486204?check_suite_focus=true.

After pushing the same change from this PR to #3946, I can confirm that this `R CMD check` NOTE no longer shows up in `cran` Windows builds. e.g. https://github.com/microsoft/LightGBM/runs/4053638197?check_suite_focus=true.

The file `conftest.cpp` is created by tests run in `configure.win` which compile test programs to figure out compiler flags to use when compiling LightGBM.

https://github.com/microsoft/LightGBM/blob/dcae8dd5696cb35f105680ecc1de15feede250a1/R-package/configure.win#L30

https://github.com/microsoft/LightGBM/blob/dcae8dd5696cb35f105680ecc1de15feede250a1/R-package/configure.win#L52

This PR proposes adding code to `configure.win` to ensure that such files are removed as soon as those tests are done.

### Shouldn't a similar change be made in `configure.ac` / `configure`?

I don't think this is necessary for `configure.ac` because I believe `configure` (created by `autoconf`) handles that automatically through the use of `autoconf`'s `AC_LANG_CONFTEST` directive.

https://github.com/microsoft/LightGBM/blob/dcae8dd5696cb35f105680ecc1de15feede250a1/R-package/configure#L1530

### Why haven't we seen this note from `R CMD check` before?

I think this is only being observed in #3946 because with vignettes added, `R CMD build` has to install the package to build it (since `R CMD build` bundles the vignette HTML into source packages by default).