### PR TITLE
[python][sklearn] add `n_estimators_` and `n_iter_` post-fit attributes

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -848,15 +848,23 @@ class LGBMModel(_LGBMModelBase):
         return self._objective
 
     @property
-    def n_estimators_(self):
-        """:obj:`int`: The concrete number of boosted trees this model contains after fitting."""
+    def n_estimators_(self) -> int:
+        """:obj:`int`: True number of boosting iterations performed.
+
+        This might be less than parameter ``n_estimators`` if early stopping was enabled or
+        if boosting stopped early due to limits on complexity like ``min_gain_to_split``.
+        """
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError('No n_estimators found. Need to call fit beforehand.')
         return self._Booster.current_iteration()
 
     @property
-    def n_iter_(self):
-        """:obj:`int`: Number of iterations of the boosting process."""
+    def n_iter_(self) -> int:
+        """:obj:`int`: True number of boosting iterations performed.
+
+        This might be less than parameter ``n_estimators`` if early stopping was enabled or
+        if boosting stopped early due to limits on complexity like ``min_gain_to_split``.
+        """
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError('No n_iter found. Need to call fit beforehand.')
         return self._Booster.current_iteration()

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -848,6 +848,20 @@ class LGBMModel(_LGBMModelBase):
         return self._objective
 
     @property
+    def n_estimators_(self):
+        """:obj:`int`: The concrete number of boosted trees this model contains after fitting."""
+        if not self.__sklearn_is_fitted__():
+            raise LGBMNotFittedError('No n_estimators found. Need to call fit beforehand.')
+        return self._Booster.current_iteration()
+
+    @property
+    def n_iter_(self):
+        """:obj:`int`: Number of iterations of the boosting process."""
+        if not self.__sklearn_is_fitted__():
+            raise LGBMNotFittedError('No n_iter found. Need to call fit beforehand.')
+        return self._Booster.current_iteration()
+
+    @property
     def booster_(self):
         """Booster: The underlying Booster of this model."""
         if not self.__sklearn_is_fitted__():

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1158,6 +1158,17 @@ def test_continue_training_with_model():
     assert gbm.evals_result_['valid_0']['multi_logloss'][-1] < init_gbm.evals_result_['valid_0']['multi_logloss'][-1]
 
 
+def test_actual_number_of_trees():
+    X = [[1, 2, 3], [1, 2, 3]]
+    y = [1, 1]
+    n_estimators = 5
+    gbm = lgb.LGBMRegressor(n_estimators=n_estimators).fit(X, y)
+    assert gbm.n_estimators == n_estimators
+    assert gbm.n_estimators_ == 1
+    assert gbm.n_iter_ == 1
+    np.testing.assert_array_equal(gbm.predict(np.array(X) * 10), y)
+
+
 # sklearn < 0.22 requires passing "attributes" argument
 @pytest.mark.skipif(sk_version < parse_version('0.22'), reason='scikit-learn version is less than 0.22')
 def test_check_is_fitted():


### PR DESCRIPTION
Ease access to the **real** number of boosted iterations performed during the training.
`n_estimators_` is added to highlight the possible difference between initially passed `n_estimators` and the actual number of iterations.
`n_iter_` is added to mimic `HistGradientBoosting[Regressor/Classifier]` interface.
https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.HistGradientBoostingRegressor.html#sklearn.ensemble.HistGradientBoostingRegressor.n_iter_