### PR TITLE
[R-package] allow use of custom R executable when building CRAN package

### DIFF
--- a/.ci/test_r_package_valgrind.sh
+++ b/.ci/test_r_package_valgrind.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 RDscriptvalgrind -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())" || exit -1
-sh build-cran-package.sh || exit -1
+sh build-cran-package.sh \
+  --r-executable=RDvalgrind \
+  || exit -1
 RDvalgrind CMD INSTALL --preclean --install-tests lightgbm_*.tar.gz || exit -1
 
 cd R-package/tests

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -195,7 +195,7 @@ jobs:
         shell: bash
         run: |
           RDscript${{ matrix.r_customization }} -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
-          sh build-cran-package.sh
+          sh build-cran-package.sh --r-executable=RD${{ matrix.r_customization }}
           RD${{ matrix.r_customization }} CMD INSTALL lightgbm_*.tar.gz || exit -1
       - name: Run tests with sanitizers
         shell: bash

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -394,7 +394,7 @@ RDscript${R_CUSTOMIZATION} \
   -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
 
 # install lightgbm
-sh build-cran-package.sh
+sh build-cran-package.sh --r-executable=RD${R_CUSTOMIZATION}
 RD${R_CUSTOMIZATION} \
   CMD INSTALL lightgbm_*.tar.gz
 
@@ -423,7 +423,8 @@ docker run \
 
 RDscriptvalgrind -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
 
-sh build-cran-package.sh
+sh build-cran-package.sh \
+    --r-executable=RDvalgrind
 
 RDvalgrind CMD INSTALL \
     --preclean \

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -31,6 +31,7 @@ while [ $# -gt 0 ]; do
     *)
       echo "invalid argument '${1}'"
       exit -1
+      ;;
   esac
   shift
 done

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -4,10 +4,38 @@
 #     Prepare a source distribution of the R package
 #     to be submitted to CRAN.
 #
+# [arguments] 
+#
+#     --r-executable Customize the R executable used by `R CMD build`.
+#                    Useful if building the R package in an environment with
+#                    non-standard builds of R, such as those provided in
+#                    https://github.com/wch/r-debug.
+#
 # [usage]
+#
+#     # default usage
 #     sh build-cran-package.sh
+#
+#     # custom R build
+#     sh build-cran-package.sh --r-executable=RDvalgrind
 
 set -e
+
+LGB_R_EXECUTABLE=R
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --r-executable=*)
+      LGB_R_EXECUTABLE="${1#*=}"
+      ;;
+    *)
+      echo "invalid argument '${1}'"
+      exit -1
+  esac
+  shift
+done
+
+echo "Building lightgbm with R executable: ${LGB_R_EXECUTABLE}"
 
 ORIG_WD="$(pwd)"
 TEMP_R_DIR="$(pwd)/lightgbm_r"
@@ -140,7 +168,7 @@ cd "${TEMP_R_DIR}"
 
 cd "${ORIG_WD}"
 
-R CMD build \
+"${LGB_R_EXECUTABLE}" CMD build \
     --keep-empty-dirs \
     lightgbm_r
 


### PR DESCRIPTION
There are several CI jobs in this project which rely on non-standard builds of `R`:

* valgrind: https://github.com/microsoft/LightGBM/blob/d574fcbd0095f772ab4cfc5c14d4894dd8dc6c0f/.ci/test_r_package_valgrind.sh#L5
* sanitizers: https://github.com/microsoft/LightGBM/blob/d574fcbd0095f772ab4cfc5c14d4894dd8dc6c0f/.github/workflows/r_package.yml#L197

Those custom builds of R also have their own libraries of installed R packages. Consider the following:

```shell
docker run \
  --rm \
  -it \
  wch1/r-debug:latest \
  /bin/bash

# confirm R and RD don't have {data.table}
# result --> Error in library(data.table) : there is no package called ‘data.table’
Rscript -e "library(data.table)"
RDscript -e "library(data.table)"

# install {data.table} for R only
Rscript -e "install.packages('data.table', repos = 'https://cran.r-project.org')"

# check again...{data.table} can be library()'d with R/Rscript, but not RD/RDscript
Rscript -e "library(data.table)"
RDscript -e "library(data.table)"
```

![image](https://user-images.githubusercontent.com/7608904/139555435-3b8fb8e1-bb9f-44bc-8f7c-fd8503ee9c36.png)

This project's CI jobs using custom R builds all rely on the script `build-cran-package.sh` to build the package. That script has its R executable hard-coded to `R`.

https://github.com/microsoft/LightGBM/blob/d574fcbd0095f772ab4cfc5c14d4894dd8dc6c0f/build-cran-package.sh#L143

Until now, this hasn't caused any issues. Since this project doesn't use vignettes, `R CMD build` is just lightweight code that moves files around and creates a `.tar.gz` with those files in it.

However, as of #3946, `R CMD build` will actually install `{lightgbm}`, so that it can build vignette outputs (as noted in #4752). Once that happens, it will be problematic to mix builds of R, e.g. to use `RDsanscript -e "install.packages(...)"` to install dependencies and then `R CMD build` to build `{lightgbm}`.

Noticed this when the sanitizer builds failed on #3946 . e.g. https://github.com/microsoft/LightGBM/runs/4053638309?check_suite_focus=true failed with the following error

> Error in loadVignetteBuilder(pkgdir, TRUE) : 
  vignette builder 'knitr' not found
Execution halted

### What this PR changes

This PR proposes allowing customization of the R executable used by `build-cran-package.sh`. It also changes existing CI jobs using custom R builds to take advantage of that feature.

Pushing similar changes to #3946 fixed the issues I mentioned above, so I'm confident this will work.

### Why not also allow this customization for CMake-based builds?

I decided not to propose a similar change to `build_r.R` (the build script for CMake-based builds), just to avoid this PR getting larger and to avoid further complicating that already-complex script. If someone requests such a change to `build_r.R` I'd support it, but I don't think we should add it until we receive such a request.