### PR TITLE
[ci] upgrade actions/checkout to v2.4.0

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -60,11 +60,9 @@ jobs:
             sudo chmod a+rw /var/run/docker.sock
             sudo systemctl restart docker
       - name: Remove old folder with repository
-        run: |
-          sudo rm -rf $GITHUB_WORKSPACE
-          mkdir -p $GITHUB_WORKSPACE
+        run: sudo rm -rf $GITHUB_WORKSPACE
       - name: Checkout repository
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Remove old folder with repository
         run: sudo rm -rf $GITHUB_WORKSPACE
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Remove old folder with repository
         run: sudo rm -rf $GITHUB_WORKSPACE
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v1
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -60,7 +60,9 @@ jobs:
             sudo chmod a+rw /var/run/docker.sock
             sudo systemctl restart docker
       - name: Remove old folder with repository
-        run: sudo rm -rf $GITHUB_WORKSPACE
+        run: |
+          sudo rm -rf $GITHUB_WORKSPACE
+          mkdir -p $GITHUB_WORKSPACE
       - name: Checkout repository
         uses: actions/checkout@v2.4.0
         with:

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 5
           submodules: false

--- a/.github/workflows/optional_checks.yml
+++ b/.github/workflows/optional_checks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 5
           submodules: false

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -47,7 +47,7 @@ jobs:
             python_version: 3.7
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/r_configure.yml
+++ b/.github/workflows/r_configure.yml
@@ -18,7 +18,7 @@ jobs:
             ca-certificates \
             git
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -137,7 +137,7 @@ jobs:
         shell: pwsh
         run: git config --global core.autocrlf false
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 5
           submodules: true
@@ -187,7 +187,7 @@ jobs:
             compiler: clang
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 5
           submodules: true
@@ -217,7 +217,7 @@ jobs:
           apt-get update --allow-releaseinfo-change
           apt-get install --no-install-recommends -y git
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/r_solaris.yml
+++ b/.github/workflows/r_solaris.yml
@@ -22,7 +22,7 @@ jobs:
             git \
             jq
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -22,7 +22,7 @@ jobs:
             git \
             jq
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -30,7 +30,7 @@ jobs:
           - task: check-docs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 5
           submodules: false
@@ -50,7 +50,7 @@ jobs:
     container: rocker/verse
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/triggering_comments.yml
+++ b/.github/workflows/triggering_comments.yml
@@ -12,7 +12,7 @@ jobs:
       SECRETS_WORKFLOW: ${{ secrets.WORKFLOW }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v2.4.0
       with:
         fetch-depth: 5
         submodules: false


### PR DESCRIPTION
This project's CI jobs running on GitHub Actions use the `actions/checkout` action to clone the repo at the beginning of builds. Most jobs in the repo are currently using v2.3.4 of this action (CUDA jobs are using v1).

This PR proposes upgrading all jobs to v2.4.0, the newest release of that action. Just to keep up with changes there and take advantage of small bugfixes.

See https://github.com/actions/checkout/releases for details on the newest releases of this action.