### PR TITLE
[ci] use wch1/r-debug image in Solaris tests

### DIFF
--- a/.ci/test_r_package_solaris.sh
+++ b/.ci/test_r_package_solaris.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-sh build-cran-package.sh || exit -1
-
 apt-get install --no-install-recommends -y \
   libcurl4-openssl-dev \
   libxml2-dev \
   libssl-dev
 
-log_file="rhub_logs.txt"
 Rscript -e "install.packages('rhub', dependencies = c('Depends', 'Imports', 'LinkingTo'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())" || exit -1
 
+sh build-cran-package.sh || exit -1
+
+log_file="rhub_logs.txt"
 Rscript ./.ci/run_rhub_solaris_checks.R lightgbm_*.tar.gz $log_file || exit -1

--- a/.github/workflows/r_solaris.yml
+++ b/.github/workflows/r_solaris.yml
@@ -9,7 +9,7 @@ jobs:
     name: solaris-cran
     timeout-minutes: 120
     runs-on: ubuntu-latest
-    container: rocker/r-base
+    container: wch1/r-debug
     env:
       SECRETS_WORKFLOW: ${{ secrets.WORKFLOW }}
     steps:
@@ -19,7 +19,6 @@ jobs:
           apt-get update
           apt-get install --no-install-recommends -y \
             curl \
-            git \
             jq
       - name: Checkout repository
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -19,7 +19,6 @@ jobs:
           apt-get update
           apt-get install --no-install-recommends -y \
             curl \
-            git \
             jq
       - name: Checkout repository
         uses: actions/checkout@v2.3.4


### PR DESCRIPTION
As a result of the changes #3946 , which introduce `vignettes/` to the R package (part of #1944), building the R package with `R CMD build` will include installing the package, since it must be installed to create vignette outputs.

To make this work in the existing Solaris CI job, two changes are required:

* `pandoc` must be available in the container used to build the package before submitting it to R Hub
* `{lightgbm}`'s dependencies must be installed *before* running `sh build-cran-package.sh`.

This PR proposes both of those changes. It proposes the re-organization of `test_r_package_solaris.sh` just to make the diff of #3946 slightly smaller and easier to review.

Changing the image used in the Solaris job (to one that already has `pandoc` installed) needs to be done in a separate PR, since GitHub Actions configs for jobs triggered by comments are sourced from `master`  (https://github.com/microsoft/LightGBM/pull/4397#issuecomment-866790489).