### PR TITLE
[ci] only use conda-forge when installing R packages in docs builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -268,6 +268,7 @@ def generate_r_docs(app: Sphinx) -> None:
         -q \
         -y \
         -c conda-forge \
+        --override-channels \
         -n r_env \
             r-base=4.1.0=hb67fd72_2 \
             r-data.table=1.14.0=r41hcfec24a_0 \


### PR DESCRIPTION
For #3946, I'm experimenting with adding `{rmarkdown}` and `{knitr}` explicitly to the conda environment used in readthedocs builds (currently they are included implicitly by installing `{pkgdown}`).

While doing this, I've been testing locally by running the following.

```shell
docker run -it continuumio/miniconda3 /bin/bash

conda create \
    -q \
    -y \
    -c conda-forge \
    -n r_env \
        r-base=4.1.0=hb67fd72_2 \
        r-data.table=1.14.0=r41hcfec24a_0 \
        r-jsonlite=1.7.2=r41hcfec24a_0 \
        r-matrix=1.3_4=r41he454529_0 \
        r-pkgdown=1.6.1=r41hc72bb7e_0 \
        r-roxygen2=7.1.1=r41h03ef668_0
```

From https://github.com/microsoft/LightGBM/blob/1d0d746e7f95ca654ed410f9da1f9161ce0fc7c1/docs/conf.py#L267-L277

I found that environment solves were taking a long time, and remembered that mixing the default channels and conda-forge can lead to longer solve times:

* https://github.com/microsoft/LightGBM/pull/4054#pullrequestreview-607286413
* https://github.com/ContinuumIO/anaconda-issues/issues/11604#issue-564647005

This PR proposes adding `--override-channels` to the `conda create` call used to install dependencies on RTD. Per `conda create --help`.

> --override-channels   Do not search default or .condarc channels. Requires --channel.

In local testing, I found that adding this argument did lead to noticably faster solves. Running the `conda create` statement used in this project's RTD builds took 4m59s without that argument and 3m5s with it! Given that, I'm optimistic it'll lead to faster builds on RTD 😎 

<details><summary>how I tested timings (click me)</summary>

```shell
# pull miniconda image so image-pulling doesn't add to timings
docker pull continuumio/miniconda3

# mixing conda-forge and anaconda default channels
time \
    docker run --rm -it continuumio/miniconda3 \
    conda create \
        -q \
        -y \
        -c conda-forge \
        -n r_env \
            r-base=4.1.0=hb67fd72_2 \
            r-data.table=1.14.0=r41hcfec24a_0 \
            r-jsonlite=1.7.2=r41hcfec24a_0 \
            r-matrix=1.3_4=r41he454529_0 \
            r-pkgdown=1.6.1=r41hc72bb7e_0 \
            r-roxygen2=7.1.1=r41h03ef668_0

# real 4m59.236s
# user 0m0.179s
# sys  0m0.247s

# only conda-forge
time \
    docker run --rm -it continuumio/miniconda3 \
    conda create \
        -q \
        -y \
        -c conda-forge \
        --override-channels \
        -n r_env \
            r-base=4.1.0=hb67fd72_2 \
            r-data.table=1.14.0=r41hcfec24a_0 \
            r-jsonlite=1.7.2=r41hcfec24a_0 \
            r-matrix=1.3_4=r41he454529_0 \
            r-pkgdown=1.6.1=r41hc72bb7e_0 \
            r-roxygen2=7.1.1=r41h03ef668_0

# real 3m5.042s
# user 0m0.173s
# sys  0m0.292s
```

</details>

### Notes for Reviewers

@StrikerRUS could you temporarily enable this branch at https://readthedocs.org/projects/lightgbm/versions/ so we could test?