### PR TITLE
[ci] Temporary pin dask version at CI

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -114,11 +114,11 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-# temporary fix for https://github.com/microsoft/LightGBM/issues/4285
+# temporary fix for https://github.com/microsoft/LightGBM/issues/4769
 if [[ $PYTHON_VERSION == "3.6" ]]; then
     DASK_DEPENDENCIES="dask distributed"
 else
-    DASK_DEPENDENCIES="dask=2021.9.1" "distributed=2021.9.1"
+    DASK_DEPENDENCIES="dask=2021.9.1 distributed=2021.9.1"
 fi
 
 conda install -q -y -n $CONDA_ENV cloudpickle ${DASK_DEPENDENCIES} joblib matplotlib numpy pandas psutil pytest scikit-learn scipy

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -114,7 +114,14 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle "dask=2021.9.1" "distributed=2021.9.1" joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+# temporary fix for https://github.com/microsoft/LightGBM/issues/4285
+if [[ $PYTHON_VERSION == "3.6" ]]; then
+    DASK_DEPENDENCIES="dask distributed"
+else
+    DASK_DEPENDENCIES="dask=2021.9.1" "distributed=2021.9.1"
+fi
+
+conda install -q -y -n $CONDA_ENV cloudpickle ${DASK_DEPENDENCIES} joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
 pip install graphviz  # python-graphviz from Anaconda is not allowed to be installed with Python 3.9
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -114,7 +114,7 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-conda install -q -y -n $CONDA_ENV cloudpickle dask distributed joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+conda install -q -y -n $CONDA_ENV cloudpickle "dask=2021.9.1" "distributed=2021.9.1" joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
 pip install graphviz  # python-graphviz from Anaconda is not allowed to be installed with Python 3.9
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - fix_dask
+    - master
   tags:
     include:
     - v*

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - master
+    - fix_dask
   tags:
     include:
     - v*


### PR DESCRIPTION
Previous Dask version works fine on our CI.
Closed #4769.

`2021.9.1` Dask version isn't available for Python <3.7, so don't pin version to use the latest available (`2021.3.0`).