### PR TITLE
[ci] increase timeout for valgrind job to 240 minutes

### DIFF
--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-r-valgrind:
     name: r-package (ubuntu-latest, R-devel, valgrind)
-    timeout-minutes: 180
+    timeout-minutes: 240
     runs-on: ubuntu-latest
     container: wch1/r-debug
     env:


### PR DESCRIPTION
The changes coming in #3946 push the timing for the `valgrind` job very close to its current 3-hour limit.

Based on https://github.com/microsoft/LightGBM/pull/3946#issuecomment-960368528, this PR proposes increasing that timeout to 240 minutes.