### PR TITLE
[ci] Revert temp workaround for `freetype` version

### DIFF
--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -106,7 +106,7 @@ if (($env:TASK -eq "regular") -or (($env:APPVEYOR -eq "true") -and ($env:TASK -e
   cd $env:BUILD_SOURCESDIRECTORY/examples/python-guide
   @("import matplotlib", "matplotlib.use('Agg')") + (Get-Content "plot_example.py") | Set-Content "plot_example.py"
   (Get-Content "plot_example.py").replace('graph.render(view=True)', 'graph.render(view=False)') | Set-Content "plot_example.py"  # prevent interactive window mode
-  conda install -q -y -n $env:CONDA_ENV "freetype=2.10.4" h5py ipywidgets notebook
+  conda install -q -y -n $env:CONDA_ENV h5py ipywidgets notebook
   foreach ($file in @(Get-ChildItem *.py)) {
     @("import sys, warnings", "warnings.showwarning = lambda message, category, filename, lineno, file=None, line=None: sys.stdout.write(warnings.formatwarning(message, category, filename, lineno, line))") + (Get-Content $file) | Set-Content $file
     python $file ; Check-Output $?


### PR DESCRIPTION
This reverts commit d62378b45314c2688deef7333ae16fcc9863d881.

Something was changed in Windows environments and we don't need that workaround anymore.