### PR TITLE
[ci][tests][python] remove assertion for `filename` that is no longer true with new version of graphviz

### DIFF
--- a/tests/python_package_test/test_plotting.py
+++ b/tests/python_package_test/test_plotting.py
@@ -172,7 +172,6 @@ def test_create_tree_digraph(breast_cancer_split):
     graph.render(view=False)
     assert isinstance(graph, graphviz.Digraph)
     assert graph.name == 'Tree4'
-    assert graph.filename == 'Tree4.gv'
     assert len(graph.node_attr) == 1
     assert graph.node_attr['color'] == 'red'
     assert len(graph.graph_attr) == 0


### PR DESCRIPTION
New `0.18` version of graphviz was released about 7 hours ago: https://pypi.org/project/graphviz/#history.
In new version something was broken (I guess due to [refactoring the internal class hierarchy](https://github.com/xflr6/graphviz/blob/master/CHANGES.rst#version-018)) and default value for the `filename` argument was changed.
> **filename** – Filename for saving the source (defaults to `name` + `'.gv'`).
   https://graphviz.readthedocs.io/en/stable/api.html#graphviz.Digraph

So our test started to fail with the following assertion error:
```
        graph.render(view=False)
        assert isinstance(graph, graphviz.Digraph)
        assert graph.name == 'Tree4'
>       assert graph.filename == 'Tree4.gv'
E       AssertionError: assert 'Digraph.gv' == 'Tree4.gv'
E         - Tree4.gv
E         + Digraph.gv
```
https://github.com/microsoft/LightGBM/runs/4131382043?check_suite_focus=true#step:5:1686

I suggest simply remove this assertion as it doesn't related to LightGBM API as we just pass `kwargs` to `Digraph` constructor as-is:
https://github.com/microsoft/LightGBM/blob/aafedd8a1c57432ac3e38e4af236c00c6c54e84c/python-package/lightgbm/plotting.py#L664-L666
... <some calls of internal functions that don't modify `kwargs` in any way >
https://github.com/microsoft/LightGBM/blob/aafedd8a1c57432ac3e38e4af236c00c6c54e84c/python-package/lightgbm/plotting.py#L496