### PR TITLE
[ci] use pure `endif()` and `endfunction()` without expression inside in `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ OPTION(__INTEGRATE_OPENCL "Set to ON if building LightGBM with the OpenCL ICD Lo
 
 if(APPLE)
   OPTION(APPLE_OUTPUT_DYLIB "Output dylib shared library" OFF)
-endif(APPLE)
+endif()
 
 if(__INTEGRATE_OPENCL)
   cmake_minimum_required(VERSION 3.11)
@@ -37,10 +37,10 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
 if(USE_SANITIZER)
   if(MSVC)
     message(FATAL_ERROR "Sanitizers are not supported with MSVC.")
-  endif(MSVC)
+  endif()
   include(cmake/Sanitizer.cmake)
   enable_sanitizers("${ENABLED_SANITIZERS}")
-endif(USE_SANITIZER)
+endif()
 
 if(__INTEGRATE_OPENCL)
   set(__INTEGRATE_OPENCL ON CACHE BOOL "" FORCE)
@@ -93,7 +93,7 @@ if(USE_SWIG)
       FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/com/microsoft/ml/lightgbm/linux/x86_64")
       include_directories($ENV{JAVA_HOME}/include/linux)
   endif()
-endif(USE_SWIG)
+endif()
 
 SET(EIGEN_DIR "${PROJECT_SOURCE_DIR}/external_libs/eigen")
 include_directories(${EIGEN_DIR})
@@ -108,33 +108,33 @@ if(__BUILD_FOR_R)
     message(STATUS "LIBR_CORE_LIBRARY: ${LIBR_CORE_LIBRARY}")
     include_directories(${LIBR_INCLUDE_DIRS})
     ADD_DEFINITIONS(-DLGB_R_BUILD)
-endif(__BUILD_FOR_R)
+endif()
 
 if(USE_TIMETAG)
     ADD_DEFINITIONS(-DTIMETAG)
-endif(USE_TIMETAG)
+endif()
 
 if(USE_DEBUG)
     ADD_DEFINITIONS(-DDEBUG)
-endif(USE_DEBUG)
+endif()
 
 if(USE_MPI)
     find_package(MPI REQUIRED)
     ADD_DEFINITIONS(-DUSE_MPI)
 else()
     ADD_DEFINITIONS(-DUSE_SOCKET)
-endif(USE_MPI)
+endif()
 
 if(USE_CUDA)
     SET(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}")
     enable_language(CUDA)
     SET(USE_OPENMP ON CACHE BOOL "CUDA requires OpenMP" FORCE)
-endif(USE_CUDA)
+endif()
 
 if(USE_OPENMP)
     find_package(OpenMP REQUIRED)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-endif(USE_OPENMP)
+endif()
 
 if(USE_GPU)
     SET(BOOST_COMPUTE_HEADER_DIR ${PROJECT_SOURCE_DIR}/external_libs/compute/include)
@@ -152,7 +152,7 @@ if(USE_GPU)
     endif()
     include_directories(${Boost_INCLUDE_DIRS})
     ADD_DEFINITIONS(-DUSE_GPU)
-endif(USE_GPU)
+endif()
 
 if(__INTEGRATE_OPENCL)
     if(WIN32)
@@ -160,8 +160,8 @@ if(__INTEGRATE_OPENCL)
         ADD_DEFINITIONS(-DUSE_GPU)
     else()
         message(FATAL_ERROR "Integrated OpenCL build is available only for Windows")
-    endif(WIN32)
-endif(__INTEGRATE_OPENCL)
+    endif()
+endif()
 
 if(USE_CUDA)
     find_package(CUDA 9.0 REQUIRED)
@@ -236,7 +236,7 @@ if(USE_CUDA)
       add_histogram("${hsize}" "-fulldata_sp_const" "True" "1" "${FULLDATA_DEFINES}")
       add_histogram("${hsize}" "-fulldata_sp" "True" "0" "${FULLDATA_DEFINES}")
     endforeach()
-endif(USE_CUDA)
+endif()
 
 if(USE_HDFS)
     find_package(JNI REQUIRED)
@@ -245,7 +245,7 @@ if(USE_HDFS)
     include_directories(${HDFS_INCLUDE_DIR})
     ADD_DEFINITIONS(-DUSE_HDFS)
     SET(HDFS_CXX_LIBRARIES ${HDFS_LIB} ${JAVA_JVM_LIBRARY})
-endif(USE_HDFS)
+endif()
 
 include(CheckCXXSourceCompiles)
 check_cxx_source_compiles("
@@ -323,7 +323,7 @@ else()
     if(NOT USE_DEBUG)
       SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops")
     endif()
-endif(MSVC)
+endif()
 
 SET(LightGBM_HEADER_DIR ${PROJECT_SOURCE_DIR}/include)
 
@@ -338,11 +338,11 @@ if(APPLE)
   else()
     SET(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
   endif()
-endif(APPLE)
+endif()
 
 if(USE_MPI)
   include_directories(${MPI_CXX_INCLUDE_PATH})
-endif(USE_MPI)
+endif()
 
 file(GLOB SOURCES
     src/boosting/*.cpp
@@ -353,7 +353,7 @@ file(GLOB SOURCES
     src/treelearner/*.cpp
 if(USE_CUDA)
     src/treelearner/*.cu
-endif(USE_CUDA)
+endif()
 )
 
 add_library(lightgbm_objs OBJECT ${SOURCES})
@@ -366,7 +366,7 @@ set(API_SOURCES "src/c_api.cpp")
 # use with the R package
 if(__BUILD_FOR_R)
   list(APPEND API_SOURCES "src/lightgbm_R.cpp")
-endif(__BUILD_FOR_R)
+endif()
 
 add_library(lightgbm_capi_objs OBJECT ${API_SOURCES})
 
@@ -374,14 +374,14 @@ if(BUILD_STATIC_LIB)
   add_library(_lightgbm STATIC)
 else()
   add_library(_lightgbm SHARED)
-endif(BUILD_STATIC_LIB)
+endif()
 # LightGBM headers include openmp, cuda, R etc. headers, 
 # thus PUBLIC is required for building _lightgbm_swig target.
 target_link_libraries(_lightgbm PUBLIC lightgbm_capi_objs lightgbm_objs)
 
 if(MSVC)
   set_target_properties(_lightgbm PROPERTIES OUTPUT_NAME "lib_lightgbm")
-endif(MSVC)
+endif()
 
 if(USE_SWIG)
   set_property(SOURCE swig/lightgbmlib.i PROPERTY CPLUSPLUS ON)
@@ -418,11 +418,11 @@ if(USE_SWIG)
       COMMAND cp "${PROJECT_SOURCE_DIR}/*.so" com/microsoft/ml/lightgbm/linux/x86_64
       COMMAND "${Java_JAR_EXECUTABLE}" -cf lightgbmlib.jar com)
   endif()
-endif(USE_SWIG)
+endif()
 
 if(USE_MPI)
   target_link_libraries(lightgbm_objs PUBLIC ${MPI_CXX_LIBRARIES})
-endif(USE_MPI)
+endif()
 
 if(USE_OPENMP)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
@@ -435,11 +435,11 @@ if(USE_OPENMP)
     # https://cmake.org/cmake/help/v3.16/manual/cmake-buildsystem.7.html#transitive-usage-requirements
     target_link_libraries(lightgbm_capi_objs PUBLIC OpenMP::OpenMP_CXX)
   endif()
-endif(USE_OPENMP)
+endif()
 
 if(USE_GPU)
   target_link_libraries(lightgbm_objs PUBLIC ${OpenCL_LIBRARY} ${Boost_LIBRARIES})
-endif(USE_GPU)
+endif()
 
 if(__INTEGRATE_OPENCL)
   # targets OpenCL and Boost are added in IntegratedOpenCL.cmake
@@ -468,17 +468,17 @@ if(USE_CUDA)
   # used. Thus we have to call target_link_libraries on final targets here.
   target_link_libraries(lightgbm PRIVATE ${histograms})
   target_link_libraries(_lightgbm PRIVATE ${histograms})
-endif(USE_CUDA)
+endif()
 
 if(USE_HDFS)
   target_link_libraries(lightgbm_objs PUBLIC ${HDFS_CXX_LIBRARIES})
-endif(USE_HDFS)
+endif()
 
 if(WIN32)
     if(MINGW OR CYGWIN)
       target_link_libraries(lightgbm_objs PUBLIC Ws2_32 IPHLPAPI)
-    endif(MINGW OR CYGWIN)
-endif(WIN32)
+    endif()
+endif()
 
 if(__BUILD_FOR_R)
   # utils/log.h and capi uses R headers, thus both object libraries need to link
@@ -487,10 +487,10 @@ if(__BUILD_FOR_R)
     set(R_LIB ${LIBR_MSVC_CORE_LIBRARY})
   else()
     set(R_LIB ${LIBR_CORE_LIBRARY})
-  endif(MSVC)
+  endif()
   target_link_libraries(lightgbm_objs PUBLIC ${R_LIB})
   target_link_libraries(lightgbm_capi_objs PUBLIC ${R_LIB})
-endif(__BUILD_FOR_R)
+endif()
 
 #-- Google C++ tests
 if(BUILD_CPP_TEST)
@@ -520,7 +520,7 @@ if(BUILD_CPP_TEST)
     foreach(CompilerFlag ${CompilerFlags})
       string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
     endforeach()
-  endif(MSVC)
+  endif()
   add_executable(testlightgbm ${CPP_TEST_SOURCES})
   target_link_libraries(testlightgbm PRIVATE lightgbm_objs GTest::GTest)
 endif()

--- a/cmake/modules/FindLibR.cmake
+++ b/cmake/modules/FindLibR.cmake
@@ -66,7 +66,7 @@ function(create_rlib_for_msvc)
     "--input-def" "${CMAKE_CURRENT_BINARY_DIR}/R.def"
     "--output-lib" "${LIBR_MSVC_CORE_LIBRARY}"
   )
-endfunction(create_rlib_for_msvc)
+endfunction()
 
 # R version information is used to search for R's libraries in
 # the registry on Windows. Since this code is orchestrated by


### PR DESCRIPTION
Contributes to #4602.

Fix all
- `Expression repeated inside endif; better to use only endif() [readability/logic]`
- `Expression repeated inside endfunction; better to use only endfunction() [readability/logic]`

errors.