### PR TITLE
WIP: Load back parameters from saved model file (fixes #2613)

### DIFF
--- a/include/LightGBM/boosting.h
+++ b/include/LightGBM/boosting.h
@@ -316,6 +316,8 @@ class LIGHTGBM_EXPORT Boosting {
   virtual bool IsLinear() const { return false; }
 
   virtual std::string ParserConfigStr() const = 0;
+
+  std::string loaded_parameter_;
 };
 
 class GBDTBase : public Boosting {

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -484,6 +484,13 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterLoadModelFromString(const char* model_str,
                                                       int* out_num_iterations,
                                                       BoosterHandle* out);
 
+/*!
+ * \brief Load parameters of a booster as Json string.
+ * \param handle Handle to the booster.
+ * \param[out] buffer_len Size of pre-allocated strings for the output Json string.
+ * \param[out] out_str Output Json string.
+ * \return 0 when succeed, -1 when failure happens
+ */
 LIGHTGBM_C_EXPORT int LGBM_BoosterGetConfig(BoosterHandle handle,
   int64_t buffer_len,
   int64_t* out_len,

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -484,6 +484,11 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterLoadModelFromString(const char* model_str,
                                                       int* out_num_iterations,
                                                       BoosterHandle* out);
 
+LIGHTGBM_C_EXPORT int LGBM_BoosterGetConfig(BoosterHandle handle,
+  int64_t buffer_len,
+  int64_t* out_len,
+  char* out_str);
+
 /*!
  * \brief Free space for booster.
  * \param handle Handle of booster to be freed

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3311,7 +3311,7 @@ class Booster:
             ctypes.c_int(end_iteration)))
         return self
 
-    def _load_params(self):
+    def _load_params(self)-> Dict[str, Any]:
         """Loads model parameters by calling LGBM_BoosterGetConfig."""
         buffer_len = 2 << 20
         tmp_out_len = ctypes.c_int64(0)

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2620,10 +2620,10 @@ class Booster:
                 ctypes.byref(out_num_class)))
             self.__num_class = out_num_class.value
             self.pandas_categorical = _load_pandas_categorical(file_name=model_file)
-            self.params = self.loads_params()
+            self.params = self._load_params()
         elif model_str is not None:
             self.model_from_string(model_str)
-            self.params = self.loads_params()
+            self.params = self._load_params()
         else:
             raise TypeError('Need at least one training dataset or model file or model string '
                             'to create Booster instance')
@@ -3311,7 +3311,7 @@ class Booster:
             ctypes.c_int(end_iteration)))
         return self
 
-    def loads_params(self):
+    def _load_params(self):
         """Loads model parameters by calling LGBM_BoosterGetConfig."""
         buffer_len = 2 << 20
         tmp_out_len = ctypes.c_int64(0)

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3347,7 +3347,6 @@ class Booster:
             c_str(model_str),
             ctypes.byref(out_num_iterations),
             ctypes.byref(self.handle)))
-
         out_num_class = ctypes.c_int(0)
         _safe_call(_LIB.LGBM_BoosterGetNumClasses(
             self.handle,

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -531,7 +531,6 @@ class GBDT : public GBDTBase {
   bool average_output_;
   bool need_re_bagging_;
   bool balanced_bagging_;
-  std::string loaded_parameter_;
   std::vector<int8_t> monotone_constraints_;
   const int bagging_rand_block_ = 1024;
   std::vector<Random> bagging_rands_;

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1627,14 +1627,24 @@ int LGBM_BoosterGetConfig(
     while(std::getline(input_stream, line, '\n')){
       if (line.rfind("[boosting: ", 0) == 0) {
         obj["boosting"] = Json{extract_param("boosting", line)};
+      } else if (line.rfind("[boost_from_average: ", 0) == 0) {
+        obj["boost_from_average"] = Json{std::stod(extract_param("boost_from_average", line)) == 1 ? true : false};
+      } else if (line.rfind("[learning_rate: ", 0) == 0) {
+        obj["learning_rate"] = Json{std::stod(extract_param("learning_rate", line))};
+      } else if (line.rfind("[metric: ", 0) == 0) {
+        obj["metric"] = Json{extract_param("metric", line)};
+      } else if (line.rfind("[monotone_constraints: ", 0) == 0) {
+        obj["monotone_constraints"] = Json{LightGBM::Common::StringToArray<int8_t>(extract_param("monotone_constraints", line), ',')};
       } else if (line.rfind("[num_iterations: ", 0) == 0) {
         obj["num_iterations"] = Json{std::stoi(extract_param("num_iterations", line))};
       } else if (line.rfind("[num_leaves: ", 0) == 0) {
         obj["num_leaves"] = Json{std::stoi(extract_param("num_leaves", line))};
-      } else if (line.rfind("[learning_rate: ", 0) == 0) {
-        obj["learning_rate"] = Json{std::stod(extract_param("learning_rate", line))};
+      } else if (line.rfind("[objective: ", 0) == 0) {
+        obj["objective"] = Json{extract_param("objective", line)};
       } else if (line.rfind("[tree_learner: ", 0) == 0) {
         obj["tree_learner"] = Json{extract_param("tree_learner", line)};
+      } else if (line.rfind("[verbose: ", 0) == 0) {
+        obj["verbose"] = Json{std::stoi(extract_param("verbose", line))};
       }
       // TODO: more params to be extracted
     }

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1594,6 +1594,24 @@ int LGBM_BoosterLoadModelFromString(
   API_END();
 }
 
+int LGBM_BoosterGetConfig(
+  BoosterHandle handle,
+  int64_t buffer_len,
+  int64_t* out_len,
+  char* out_str
+) {
+  API_BEGIN();
+  Booster* ref_booster = reinterpret_cast<Booster*>(handle);
+  // GBDT* ref_gbdt = reinterpret_cast<GBDT*>(ref_booster);
+  std::string params = ref_booster->GetBoosting()->loaded_parameter_;
+  // std::string params = "abc";
+  *out_len = static_cast<int64_t>(params.size()) + 1;
+  if (*out_len <= buffer_len) {
+    std::memcpy(out_str, params.c_str(), *out_len);
+  }
+  API_END();
+}
+
 #ifdef _MSC_VER
   #pragma warning(disable : 4702)
 #endif

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -648,7 +648,7 @@ def _fake_model() -> lgb.Booster:
 
     return gbm
 
-def test_booster__load_param_when_passed_model_file(fake_model: lgb.Booster) -> None:
+def test_booster__load_param_when_passed_model_file(fake_model):
     with tempfile.TemporaryDirectory() as temp_dir:
         model_file = Path(temp_dir) / "model.txt"
         fake_model.save_model(model_file)
@@ -658,7 +658,7 @@ def test_booster__load_param_when_passed_model_file(fake_model: lgb.Booster) -> 
     # TODO: needs parse more params
     assert loaded.params['boosting'] == 'gbdt'
 
-def test_booster__load_param_when_passed_model_str(fake_model: lgb.Booster) -> None:
+def test_booster__load_param_when_passed_model_str(fake_model):
     model_str = fake_model.model_to_string()
 
     loaded = lgb.Booster(model_str=model_str)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -648,7 +648,7 @@ def _fake_model() -> lgb.Booster:
 
     return gbm
 
-def test_booster_load_params_when_passed_model_file(fake_model: lgb.Booster) -> None:
+def test_booster__load_param_when_passed_model_file(fake_model: lgb.Booster) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         model_file = Path(temp_dir) / "model.txt"
         fake_model.save_model(model_file)
@@ -658,7 +658,7 @@ def test_booster_load_params_when_passed_model_file(fake_model: lgb.Booster) -> 
     # TODO: needs parse more params
     assert loaded.params['boosting'] == 'gbdt'
 
-def test_booster_load_params_when_passed_model_str(fake_model: lgb.Booster) -> None:
+def test_booster__load_param_when_passed_model_str(fake_model: lgb.Booster) -> None:
     model_str = fake_model.model_to_string()
 
     loaded = lgb.Booster(model_str=model_str)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -652,7 +652,6 @@ def test_booster_load_params_when_passed_model_file(fake_model: lgb.Booster) -> 
     with tempfile.TemporaryDirectory() as temp_dir:
         model_file = Path(temp_dir) / "model.txt"
         fake_model.save_model(model_file)
-        # gbm.save_model('/Users/zhuyi/Projects/third-party/lightgbm/model.txt')
 
         loaded = lgb.Booster(model_file=model_file)
 

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -611,6 +611,7 @@ def test_custom_objective_safety():
     good_bst_multi.update(fobj=_good_gradients)
     with pytest.raises(ValueError, match=re.escape(f"number of models per one iteration ({nclass})")):
         bad_bst_multi.update(fobj=_bad_gradients)
+
 @pytest.fixture(name="fake_model")
 def _fake_model() -> lgb.Booster:
     # TODO: maybe removed deps on data_dir later
@@ -618,13 +619,6 @@ def _fake_model() -> lgb.Booster:
 
     df_train = pd.read_csv(data_dir / "binary.train", header=None, sep="\t")
     weights = pd.read_csv(data_dir / "binary.train.weight", header=None)[0]
-
-    # df_train = pd.DataFrame({
-    #     'feature_1': [0, 1, 2],
-    #     'feature_2': [0., 0.1, 0.2],
-    #     'feature_3': pd.Categorical(['a', 'b', 'b']),
-    #     'Target':
-    # })
 
     X_train = df_train.drop(0, axis=1)
     y_train = df_train[0]
@@ -663,7 +657,7 @@ def test_booster_load_params_when_passed_model_file(fake_model: lgb.Booster) -> 
         loaded = lgb.Booster(model_file=model_file)
 
     # TODO: needs parse more params
-    assert 'boosting' in loaded.params
+    assert loaded.params['boosting'] == 'gbdt'
 
 def test_booster_load_params_when_passed_model_str(fake_model: lgb.Booster) -> None:
     model_str = fake_model.model_to_string()
@@ -671,5 +665,4 @@ def test_booster_load_params_when_passed_model_str(fake_model: lgb.Booster) -> N
     loaded = lgb.Booster(model_str=model_str)
 
     # TODO: needs parse more params
-    assert 'boosting' in loaded.params
     assert loaded.params['boosting'] == 'gbdt'

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -618,7 +618,6 @@ def _fake_model() -> lgb.Booster:
     data_dir = Path(__file__).parent.parent.parent / "examples/binary_classification"
 
     df_train = pd.read_csv(data_dir / "binary.train", header=None, sep="\t")
-    weights = pd.read_csv(data_dir / "binary.train.weight", header=None)[0]
 
     X_train = df_train.drop(0, axis=1)
     y_train = df_train[0]
@@ -634,7 +633,7 @@ def _fake_model() -> lgb.Booster:
         "bagging_freq": 5,
         "verbose": 0,
     }
-    lgb_train = lgb.Dataset(X_train, y_train, weight=weights, free_raw_data=False)
+    lgb_train = lgb.Dataset(X_train, y_train, free_raw_data=False)
     feature_name = [f"feature_{col}" for col in X_train.columns]
 
     gbm = lgb.train(


### PR DESCRIPTION
This is still just an idea to collect feedbacks.

The approach in this PR:

1. made `loaded_parameter_` an attribute of `Boosting` instead of `GBDT` so it can be accessed in `c_api.cpp`.
1. implemented `LGBM_BoosterGetConfig` to return `loaded_parameter_` as a string.
1. `loaded_parameter_` can be parsed in Python code into proper types for the `params` dictionary.

test `test_booster_load_params_when_passed_model_str` passes

This PR is related to https://github.com/microsoft/LightGBM/issues/2613

A couple of questions:

* why isn't `loaded_parameter_` a parameter of `Boosting` instead of `GBDT` already? The other boosting types don't have parameters?
* Do I understand correctly that `c_api.cpp` can only deal with `gbdt` as I see it's hard-coded in https://github.com/microsoft/LightGBM/blob/874e6359241594a7fdfef59924532361c236cf7f/src/c_api.cpp#L109