### PR TITLE
fix gcc11 compatibility

### DIFF
--- a/src/io/dense_bin.hpp
+++ b/src/io/dense_bin.hpp
@@ -470,7 +470,7 @@ class DenseBin : public Bin {
 #endif
   std::vector<uint8_t> buf_;
 
-  DenseBin<VAL_T, IS_4BIT>(const DenseBin<VAL_T, IS_4BIT>& other)
+  DenseBin(const DenseBin<VAL_T, IS_4BIT>& other)
       : num_data_(other.num_data_), data_(other.data_) {}
 };
 

--- a/src/io/multi_val_dense_bin.hpp
+++ b/src/io/multi_val_dense_bin.hpp
@@ -217,7 +217,7 @@ class MultiValDenseBin : public MultiValBin {
   std::vector<uint32_t> offsets_;
   std::vector<VAL_T, Common::AlignmentAllocator<VAL_T, 32>> data_;
 
-  MultiValDenseBin<VAL_T>(const MultiValDenseBin<VAL_T>& other)
+  MultiValDenseBin(const MultiValDenseBin<VAL_T>& other)
     : num_data_(other.num_data_), num_bin_(other.num_bin_), num_feature_(other.num_feature_),
       offsets_(other.offsets_), data_(other.data_) {
   }

--- a/src/io/multi_val_sparse_bin.hpp
+++ b/src/io/multi_val_sparse_bin.hpp
@@ -302,7 +302,7 @@ class MultiValSparseBin : public MultiValBin {
   std::vector<INDEX_T> t_size_;
   std::vector<uint32_t> offsets_;
 
-  MultiValSparseBin<INDEX_T, VAL_T>(
+  MultiValSparseBin(
       const MultiValSparseBin<INDEX_T, VAL_T>& other)
       : num_data_(other.num_data_),
         num_bin_(other.num_bin_),

--- a/src/io/sparse_bin.hpp
+++ b/src/io/sparse_bin.hpp
@@ -598,7 +598,7 @@ class SparseBin : public Bin {
 
   SparseBin<VAL_T>* Clone() override;
 
-  SparseBin<VAL_T>(const SparseBin<VAL_T>& other)
+  SparseBin(const SparseBin<VAL_T>& other)
       : num_data_(other.num_data_),
         deltas_(other.deltas_),
         vals_(other.vals_),


### PR DESCRIPTION
Hey,

I recently switched from gcc 10 to gcc 11 (in the project using the c++20 standard) and discovered lightgbm sources no longer compiled for me. This PR fixes the issue for me. No logic is affected, and I checked build compaitbility against gcc 10/11 and clang 12 before submitting.

Alex