### PR TITLE
[ci] fix getting status of optional workflows in PRs with a lot of comments

### DIFF
--- a/.ci/get_workflow_status.py
+++ b/.ci/get_workflow_status.py
@@ -32,16 +32,27 @@ def get_runs(trigger_phrase):
     """
     pr_runs = []
     if environ.get("GITHUB_EVENT_NAME", "") == "pull_request":
-        pr_number = int(environ.get("GITHUB_REF").split('/')[-2])
-        req = request.Request(url="{}/repos/microsoft/LightGBM/issues/{}/comments".format(environ.get("GITHUB_API_URL"),
-                                                                                          pr_number),
-                              headers={"Accept": "application/vnd.github.v3+json"})
-        url = request.urlopen(req)
-        data = json.loads(url.read().decode('utf-8'))
-        url.close()
-        pr_runs = [i for i in data
-                   if i['author_association'].lower() in {'owner', 'member', 'collaborator'}
-                   and i['body'].startswith('/gha run {}'.format(trigger_phrase))]
+        while True:
+            pr_number = int(environ.get("GITHUB_REF").split('/')[-2])
+            page = 1
+            req = request.Request(
+                url="{}/repos/microsoft/LightGBM/issues/{}/comments?page={}&per_page=100".format(
+                    environ.get("GITHUB_API_URL"),
+                    pr_number,
+                    page
+                ),
+                headers={"Accept": "application/vnd.github.v3+json"}
+            )
+            url = request.urlopen(req)
+            data = json.loads(url.read().decode('utf-8'))
+            url.close()
+            if not data:
+                break
+            runs_on_page = [i for i in data
+                            if i['author_association'].lower() in {'owner', 'member', 'collaborator'}
+                            and i['body'].startswith('/gha run {}'.format(trigger_phrase))]
+            pr_runs.extend(runs_on_page)
+            page += 1
     return pr_runs[::-1]
 
 

--- a/.ci/get_workflow_status.py
+++ b/.ci/get_workflow_status.py
@@ -32,9 +32,9 @@ def get_runs(trigger_phrase):
     """
     pr_runs = []
     if environ.get("GITHUB_EVENT_NAME", "") == "pull_request":
+        pr_number = int(environ.get("GITHUB_REF").split('/')[-2])
+        page = 1
         while True:
-            pr_number = int(environ.get("GITHUB_REF").split('/')[-2])
-            page = 1
             req = request.Request(
                 url="{}/repos/microsoft/LightGBM/issues/{}/comments?page={}&per_page=100".format(
                     environ.get("GITHUB_API_URL"),


### PR DESCRIPTION
Refer to https://docs.github.com/en/rest/reference/issues#list-issue-comments.

In https://github.com/microsoft/LightGBM/pull/3234#issuecomment-970129705 script cannot update status for Solaris CI build because it doesn't receive the latest comments in that PR.