### PR TITLE
Load initial scores when use binary data files in CLI version

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -1259,6 +1259,8 @@ The initial score file corresponds with data file line by line, and has per scor
 And if the name of data file is ``train.txt``, the initial score file should be named as ``train.txt.init`` and placed in the same folder as the data file.
 In this case, LightGBM will auto load initial score file if it exists.
 
+If binary data files exist for raw data file ``train.txt``, for example in the name ``train.txt.bin``, then the initial score file should be named as ``train.txt.bin.init``.
+
 Weight Data
 ~~~~~~~~~~~
 

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -144,6 +144,9 @@ class Metadata {
     queries_[idx] = static_cast<data_size_t>(value);
   }
 
+  /*! \brief Load initial scores from file */
+  void LoadInitialScore(const std::string& data_filename);
+
   /*!
   * \brief Get weights, if not exists, will return nullptr
   * \return Pointer of weights
@@ -212,8 +215,6 @@ class Metadata {
   Metadata(const Metadata&) = delete;
 
  private:
-  /*! \brief Load initial scores from file */
-  void LoadInitialScore();
   /*! \brief Load wights from file */
   void LoadWeights();
   /*! \brief Load query boundaries from file */

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -270,6 +270,9 @@ Dataset* DatasetLoader::LoadFromFile(const char* filename, int rank, int num_mac
     is_load_from_binary = true;
     Log::Info("Load from binary file %s", bin_filename.c_str());
     dataset.reset(LoadFromBinFile(filename, bin_filename.c_str(), rank, num_machines, &num_global_data, &used_data_indices));
+    // checks whether there's a initial score file when loaded from binary data files
+    // the intial score file should with suffix ".bin.init"
+    dataset->metadata_.LoadInitialScore(bin_filename);
   }
   // check meta data
   dataset->metadata_.CheckOrPartition(num_global_data, used_data_indices);
@@ -326,6 +329,9 @@ Dataset* DatasetLoader::LoadFromFileAlignWithOtherDataset(const char* filename, 
   } else {
     // load data from binary file
     dataset.reset(LoadFromBinFile(filename, bin_filename.c_str(), 0, 1, &num_global_data, &used_data_indices));
+    // checks whether there's a initial score file when loaded from binary data files
+    // the intial score file should with suffix ".bin.init"
+    dataset->metadata_.LoadInitialScore(bin_filename);
   }
   // not need to check validation data
   // check meta data

--- a/src/io/metadata.cpp
+++ b/src/io/metadata.cpp
@@ -26,7 +26,7 @@ void Metadata::Init(const char* data_filename) {
   LoadQueryBoundaries();
   LoadWeights();
   LoadQueryWeights();
-  LoadInitialScore();
+  LoadInitialScore(data_filename_);
 }
 
 Metadata::~Metadata() {
@@ -390,10 +390,10 @@ void Metadata::LoadWeights() {
   weight_load_from_file_ = true;
 }
 
-void Metadata::LoadInitialScore() {
+void Metadata::LoadInitialScore(const std::string& data_filename) {
   num_init_score_ = 0;
-  std::string init_score_filename(data_filename_);
-  init_score_filename = std::string(data_filename_);
+  std::string init_score_filename(data_filename);
+  init_score_filename = std::string(data_filename);
   // default init_score file name
   init_score_filename.append(".init");
   TextReader<size_t> reader(init_score_filename.c_str(), false);


### PR DESCRIPTION
This is to fix #4786. Currently there's no way to load initial score when loading from binary data file in CLI version.

In `Metadata::LoadFromMemory` and `Metadata::SaveBinaryToFile`, other fields of `Metadata` is handled, except `init_score_`. The only way to set initial score when loading from binary data files is the call methods like `set_init_score` in Python, which is impossible for CLI version.

The implementation goes like this: after loading from binary data files, checks whether there are initial score files exists. If so, initial scores are loaded.

The corresponding documentation for continual training is also updated.