### PR TITLE
[R-package] Move R6 to Imports

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -28,7 +28,7 @@ Authors@R: c(
     person("IBM Corporation", role = c("ctb")),
     person("David", "Cortes", role = c("ctb"))
     )
-Description: Tree based algorithms can be improved by introducing boosting frameworks. 
+Description: Tree based algorithms can be improved by introducing boosting frameworks.
     'LightGBM' is one such framework, based on Ke, Guolin et al. (2017) <https://papers.nips.cc/paper/6907-lightgbm-a-highly-efficient-gradient-boosting-decision>.
     This package offers an R interface to work with it.
     It is designed to be distributed and efficient with the following advantages:
@@ -52,9 +52,9 @@ Suggests:
     rmarkdown,
     testthat
 Depends:
-    R (>= 3.5),
-    R6 (>= 2.0)
+    R (>= 3.6)
 Imports:
+    R6 (>= 2.0),
     data.table (>= 1.9.6),
     graphics,
     jsonlite (>= 1.0),

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -52,7 +52,7 @@ Suggests:
     rmarkdown,
     testthat
 Depends:
-    R (>= 3.6)
+    R (>= 3.5)
 Imports:
     R6 (>= 2.0),
     data.table (>= 1.9.6),


### PR DESCRIPTION
The R package has R6 as a 'Depends', which causes it to load it fully into the namespace when loading lightgbm. This is not actually required since only one function from this package is used in the R code, and this function is prefixed with `R6::`. This PR moves to 'Imports' instead so that it doesn't load its full namespace in user sessions.

Also it updates the dependency on R to 3.6, since after the latest PRs it won't compile with R 3.5 anymore due to headers not having all the function prototypes.