### PR TITLE
[docs] document that `pred_early_stop` can be used only in normal and raw scores prediction

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -923,6 +923,8 @@ Predict Parameters
 
    -  used only in ``classification`` and ``ranking`` applications
 
+   -  used only for predicting normal or raw scores
+
    -  if ``true``, will use early-stopping to speed up the prediction. May affect the accuracy
 
    -  **Note**: cannot be used with ``rf`` boosting type or custom objective function

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -776,6 +776,7 @@ struct Config {
   // [no-save]
   // desc = used only in ``prediction`` task
   // desc = used only in ``classification`` and ``ranking`` applications
+  // desc = used only for predicting normal or raw scores
   // desc = if ``true``, will use early-stopping to speed up the prediction. May affect the accuracy
   // desc = **Note**: cannot be used with ``rf`` boosting type or custom objective function
   bool pred_early_stop = false;


### PR DESCRIPTION
Note that `early_stop_` is used only in `PredictRaw()` and `Predict()` cases:
https://github.com/microsoft/LightGBM/blob/bfb346c13e6ea44f8b663a66bfc41e189d39a1fb/src/application/predictor.hpp#L71-L138