### PR TITLE
WIP: [ci] show all leak types in valgrind logs

### DIFF
--- a/.ci/test_r_package_valgrind.sh
+++ b/.ci/test_r_package_valgrind.sh
@@ -14,7 +14,7 @@ VALGRIND_LOGS_FILE="valgrind-logs.log"
 RDvalgrind \
   --no-readline \
   --vanilla \
-  -d "valgrind --tool=memcheck --leak-check=full --track-origins=yes" \
+  -d "valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all" \
   -f testthat.R \
   > ${ALL_LOGS_FILE} 2>&1 || exit -1
 


### PR DESCRIPTION
This PR proposes a configuration change to see more verbose logs when the R valgrind CI job fails.

Also using it to test that that job would fail on the current state of `master` (as mentioned in https://github.com/microsoft/LightGBM/pull/4685#issuecomment-981241541).