### PR TITLE
[python-package] fix mypy errors in compat.py and setup.py

### DIFF
--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -27,7 +27,7 @@ except ImportError:
         def __init__(self, *args, **kwargs):
             pass
 
-    class pd_CategoricalDtype:
+    class pd_CategoricalDtype:  # type: ignore
         """Dummy class for pandas.CategoricalDtype."""
 
         def __init__(self, *args, **kwargs):

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -40,7 +40,7 @@ def find_lib() -> List[str]:
     libpath = {'__file__': libpath_py}
     exec(compile(libpath_py.read_bytes(), libpath_py, 'exec'), libpath, libpath)
 
-    LIB_PATH = libpath['find_lib_path']()
+    LIB_PATH = libpath['find_lib_path']()  # type: ignore
     logger.info(f"Installing lib_lightgbm from: {LIB_PATH}")
     return LIB_PATH
 


### PR DESCRIPTION
Contributes to #3867.

This PR adds `# type: ignore` comments to suppress two `mypy` warnings.

> python-package/lightgbm/compat.py:30: error: Name "pd_CategoricalDtype" already defined (possibly by an import)
python-package/setup.py:43: error: "Path" not callable

Confirmed that this suppresses these warnings by running the following.

```shell
mypy \
    --exclude='python-package/compile/|python-package/build' \
    --ignore-missing-imports \
    python-package/
```

### Notes for Reviewers

I think it's appropriate to use `# type: ignore` in these two cases since they are somewhat non-standard and the types of cases that type-checkers can struggle with. One is a use of `exec` and one is an import preceded by two other try-catched imports.