### PR TITLE
[python-package] fix mypy errors in sklearn.py

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -2,11 +2,11 @@
 """Scikit-learn wrapper interface for LightGBM."""
 import copy
 from inspect import signature
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from .basic import Dataset, LightGBMError, _ArrayLike, _choose_param_value, _ConfigAliases, _log_warning
+from .basic import Booster, Dataset, LightGBMError, _ArrayLike, _choose_param_value, _ConfigAliases, _log_warning
 from .callback import log_evaluation, record_evaluation
 from .compat import (SKLEARN_INSTALLED, LGBMNotFittedError, _LGBMAssertAllFinite, _LGBMCheckArray,
                      _LGBMCheckClassificationTargets, _LGBMCheckSampleWeight, _LGBMCheckXY, _LGBMClassifierBase,
@@ -525,11 +525,11 @@ class LGBMModel(_LGBMModelBase):
         self.random_state = random_state
         self.n_jobs = n_jobs
         self.importance_type = importance_type
-        self._Booster = None
+        self._Booster: Optional[Booster] = None
         self._evals_result = None
         self._best_score = None
         self._best_iteration = None
-        self._other_params = {}
+        self._other_params: Dict[str, Any] = {}
         self._objective = objective
         self.class_weight = class_weight
         self._class_weight = None
@@ -874,7 +874,7 @@ class LGBMModel(_LGBMModelBase):
         This might be less than parameter ``n_estimators`` if early stopping was enabled or
         if boosting stopped early due to limits on complexity like ``min_gain_to_split``.
         """
-        if not self.__sklearn_is_fitted__():
+        if not self.__sklearn_is_fitted__() or self._Booster is None:
             raise LGBMNotFittedError('No n_estimators found. Need to call fit beforehand.')
         return self._Booster.current_iteration()
 
@@ -885,7 +885,7 @@ class LGBMModel(_LGBMModelBase):
         This might be less than parameter ``n_estimators`` if early stopping was enabled or
         if boosting stopped early due to limits on complexity like ``min_gain_to_split``.
         """
-        if not self.__sklearn_is_fitted__():
+        if not self.__sklearn_is_fitted__() or self._Booster is None:
             raise LGBMNotFittedError('No n_iter found. Need to call fit beforehand.')
         return self._Booster.current_iteration()
 
@@ -941,7 +941,7 @@ class LGBMRegressor(_LGBMRegressorBase, LGBMModel):
                     categorical_feature=categorical_feature, callbacks=callbacks, init_model=init_model)
         return self
 
-    _base_doc = LGBMModel.fit.__doc__.replace("self : LGBMModel", "self : LGBMRegressor")
+    _base_doc = LGBMModel.fit.__doc__.replace("self : LGBMModel", "self : LGBMRegressor")  # type: ignore
     _base_doc = (_base_doc[:_base_doc.find('group :')]  # type: ignore
                  + _base_doc[_base_doc.find('eval_set :'):])  # type: ignore
     _base_doc = (_base_doc[:_base_doc.find('eval_class_weight :')]
@@ -1008,7 +1008,7 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
                     callbacks=callbacks, init_model=init_model)
         return self
 
-    _base_doc = LGBMModel.fit.__doc__.replace("self : LGBMModel", "self : LGBMClassifier")
+    _base_doc = LGBMModel.fit.__doc__.replace("self : LGBMModel", "self : LGBMClassifier")  # type: ignore
     _base_doc = (_base_doc[:_base_doc.find('group :')]  # type: ignore
                  + _base_doc[_base_doc.find('eval_set :'):])  # type: ignore
     fit.__doc__ = (_base_doc[:_base_doc.find('eval_group :')]
@@ -1107,7 +1107,7 @@ class LGBMRanker(LGBMModel):
                     categorical_feature=categorical_feature, callbacks=callbacks, init_model=init_model)
         return self
 
-    _base_doc = LGBMModel.fit.__doc__.replace("self : LGBMModel", "self : LGBMRanker")
+    _base_doc = LGBMModel.fit.__doc__.replace("self : LGBMModel", "self : LGBMRanker")  # type: ignore
     fit.__doc__ = (_base_doc[:_base_doc.find('eval_class_weight :')]  # type: ignore
                    + _base_doc[_base_doc.find('eval_init_score :'):])  # type: ignore
     _base_doc = fit.__doc__

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -853,9 +853,9 @@ class LGBMModel(_LGBMModelBase):
         This might be less than parameter ``n_estimators`` if early stopping was enabled or
         if boosting stopped early due to limits on complexity like ``min_gain_to_split``.
         """
-        if not self.__sklearn_is_fitted__() or self._Booster is None:
+        if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError('No n_estimators found. Need to call fit beforehand.')
-        return self._Booster.current_iteration()
+        return self._Booster.current_iteration()  # type: ignore
 
     @property
     def n_iter_(self) -> int:
@@ -864,9 +864,9 @@ class LGBMModel(_LGBMModelBase):
         This might be less than parameter ``n_estimators`` if early stopping was enabled or
         if boosting stopped early due to limits on complexity like ``min_gain_to_split``.
         """
-        if not self.__sklearn_is_fitted__() or self._Booster is None:
+        if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError('No n_iter found. Need to call fit beforehand.')
-        return self._Booster.current_iteration()
+        return self._Booster.current_iteration()  # type: ignore
 
     @property
     def booster_(self):


### PR DESCRIPTION
Contributes to #3867.

This PR fixes `mypy` errors in `sklearn.py`.

> python-package/lightgbm/sklearn.py:532: error: Need type annotation for "_other_params" (hint: "_other_params: Dict[<type>, <type>] = ...")
python-package/lightgbm/sklearn.py:879: error: "None" has no attribute "current_iteration"
python-package/lightgbm/sklearn.py:890: error: "None" has no attribute "current_iteration"
python-package/lightgbm/sklearn.py:944: error: Item "None" of "Optional[str]" has no attribute "replace"
python-package/lightgbm/sklearn.py:1011: error: Item "None" of "Optional[str]" has no attribute "replace"
python-package/lightgbm/sklearn.py:1110: error: Item "None" of "Optional[str]" has no attribute "replace"

Confirmed that this suppresses these warnings by running the following.

```shell
mypy \
    --exclude='python-package/compile/|python-package/build' \
    --ignore-missing-imports \
    python-package/
```