### PR TITLE
[python-package] fix mypy errors in engine.py

### DIFF
--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -25,7 +25,7 @@ class EarlyStopException(Exception):
         ----------
         best_iteration : int
             The best iteration stopped.
-        best_score : list of (eval_name, metric_name, eval_result, is_higher_better) tuples
+        best_score : list of (eval_name, metric_name, eval_result, is_higher_better) tuple
             Scores for each metric, on each validation set, as of the best iteration.
         """
         super().__init__()

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -2,7 +2,7 @@
 """Callbacks library."""
 import collections
 from functools import partial
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 from .basic import _ConfigAliases, _log_info, _log_warning
 
@@ -18,15 +18,15 @@ def _lt_delta(curr_score: float, best_score: float, delta: float) -> bool:
 class EarlyStopException(Exception):
     """Exception of early stopping."""
 
-    def __init__(self, best_iteration: int, best_score: float) -> None:
+    def __init__(self, best_iteration: int, best_score: List[Tuple[str, str, float, bool]]) -> None:
         """Create early stopping exception.
 
         Parameters
         ----------
         best_iteration : int
             The best iteration stopped.
-        best_score : float
-            The score of the best iteration.
+        best_score : list of (eval_name, metric_name, eval_result, is_higher_better) tuples
+            Scores for each metric, on each validation set, as of the best iteration.
         """
         super().__init__()
         self.best_iteration = best_iteration

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 
 from .basic import _ConfigAliases, _log_info, _log_warning
 
-
 _EvalResultTuple = Union[
     List[Tuple[str, str, float, bool]],
     List[Tuple[str, str, float, bool, float]]

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -7,6 +7,12 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 from .basic import _ConfigAliases, _log_info, _log_warning
 
 
+_EvalResultTuple = Union[
+    List[Tuple[str, str, float, bool]],
+    List[Tuple[str, str, float, bool, float]]
+]
+
+
 def _gt_delta(curr_score: float, best_score: float, delta: float) -> bool:
     return curr_score > best_score + delta
 
@@ -18,14 +24,14 @@ def _lt_delta(curr_score: float, best_score: float, delta: float) -> bool:
 class EarlyStopException(Exception):
     """Exception of early stopping."""
 
-    def __init__(self, best_iteration: int, best_score: List[Tuple[str, str, float, bool]]) -> None:
+    def __init__(self, best_iteration: int, best_score: _EvalResultTuple) -> None:
         """Create early stopping exception.
 
         Parameters
         ----------
         best_iteration : int
             The best iteration stopped.
-        best_score : list of (eval_name, metric_name, eval_result, is_higher_better) tuple
+        best_score : list of (eval_name, metric_name, eval_result, is_higher_better) tuple or (eval_name, metric_name, eval_result, is_higher_better, stdv) tuple
             Scores for each metric, on each validation set, as of the best iteration.
         """
         super().__init__()
@@ -44,7 +50,7 @@ CallbackEnv = collections.namedtuple(
      "evaluation_result_list"])
 
 
-def _format_eval_result(value: list, show_stdv: bool = True) -> str:
+def _format_eval_result(value: _EvalResultTuple, show_stdv: bool = True) -> str:
     """Format metric string."""
     if len(value) == 4:
         return f"{value[0]}'s {value[1]}: {value[2]:g}"

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -223,38 +223,38 @@ def train(
                 name_valid_sets.append(f'valid_{i}')
     # process callbacks
     if callbacks is None:
-        callbacks = set()
+        callbacks_set = set()
     else:
         for i, cb in enumerate(callbacks):
             cb.__dict__.setdefault('order', i - len(callbacks))
-        callbacks = set(callbacks)
+        callbacks_set = set(callbacks)
 
     # Most of legacy advanced options becomes callbacks
     if verbose_eval != "warn":
         _log_warning("'verbose_eval' argument is deprecated and will be removed in a future release of LightGBM. "
                      "Pass 'log_evaluation()' callback via 'callbacks' argument instead.")
     else:
-        if callbacks:  # assume user has already specified log_evaluation callback
+        if callbacks_set:  # assume user has already specified log_evaluation callback
             verbose_eval = False
         else:
             verbose_eval = True
     if verbose_eval is True:
-        callbacks.add(callback.log_evaluation())
+        callbacks_set.add(callback.log_evaluation())
     elif isinstance(verbose_eval, int):
-        callbacks.add(callback.log_evaluation(verbose_eval))
+        callbacks_set.add(callback.log_evaluation(verbose_eval))
 
     if early_stopping_rounds is not None and early_stopping_rounds > 0:
-        callbacks.add(callback.early_stopping(early_stopping_rounds, first_metric_only, verbose=bool(verbose_eval)))
+        callbacks_set.add(callback.early_stopping(early_stopping_rounds, first_metric_only, verbose=bool(verbose_eval)))
 
     if evals_result is not None:
         _log_warning("'evals_result' argument is deprecated and will be removed in a future release of LightGBM. "
                      "Pass 'record_evaluation()' callback via 'callbacks' argument instead.")
-        callbacks.add(callback.record_evaluation(evals_result))
+        callbacks_set.add(callback.record_evaluation(evals_result))
 
-    callbacks_before_iter = {cb for cb in callbacks if getattr(cb, 'before_iteration', False)}
-    callbacks_after_iter = callbacks - callbacks_before_iter
-    callbacks_before_iter = sorted(callbacks_before_iter, key=attrgetter('order'))
-    callbacks_after_iter = sorted(callbacks_after_iter, key=attrgetter('order'))
+    callbacks_before_iter_set = {cb for cb in callbacks_set if getattr(cb, 'before_iteration', False)}
+    callbacks_after_iter_set = callbacks_set - callbacks_before_iter_set
+    callbacks_before_iter = sorted(callbacks_before_iter_set, key=attrgetter('order'))
+    callbacks_after_iter = sorted(callbacks_after_iter_set, key=attrgetter('order'))
 
     # construct booster
     try:


### PR DESCRIPTION
Contributes to #3867.

This PR fixes `mypy` errors in `engine.py`

> python-package/lightgbm/engine.py:226: error: Incompatible types in assignment (expression has type "Set[<nothing>]", variable has type "Optional[List[Callable[..., Any]]]")
python-package/lightgbm/engine.py:230: error: Incompatible types in assignment (expression has type "Set[Callable[..., Any]]", variable has type "Optional[List[Callable[..., Any]]]")
python-package/lightgbm/engine.py:242: error: Item "List[Callable[..., Any]]" of "Optional[List[Callable[..., Any]]]" has no attribute "add"
python-package/lightgbm/engine.py:242: error: Item "None" of "Optional[List[Callable[..., Any]]]" has no attribute "add"
python-package/lightgbm/engine.py:244: error: Item "List[Callable[..., Any]]" of "Optional[List[Callable[..., Any]]]" has no attribute "add"
python-package/lightgbm/engine.py:244: error: Item "None" of "Optional[List[Callable[..., Any]]]" has no attribute "add"
python-package/lightgbm/engine.py:247: error: Item "List[Callable[..., Any]]" of "Optional[List[Callable[..., Any]]]" has no attribute "add"
python-package/lightgbm/engine.py:247: error: Item "None" of "Optional[List[Callable[..., Any]]]" has no attribute "add"
python-package/lightgbm/engine.py:252: error: Item "List[Callable[..., Any]]" of "Optional[List[Callable[..., Any]]]" has no attribute "add"
python-package/lightgbm/engine.py:252: error: Item "None" of "Optional[List[Callable[..., Any]]]" has no attribute "add"
python-package/lightgbm/engine.py:254: error: Item "None" of "Optional[List[Callable[..., Any]]]" has no attribute "__iter__" (not iterable)
python-package/lightgbm/engine.py:255: error: Unsupported left operand type for - ("List[Callable[..., Any]]")
python-package/lightgbm/engine.py:255: error: Unsupported left operand type for - ("None")
python-package/lightgbm/engine.py:255: note: Left operand is of type "Optional[List[Callable[..., Any]]]"
python-package/lightgbm/engine.py:256: error: Incompatible types in assignment (expression has type "List[Union[Callable[..., Any], Any]]", variable has type "Set[Union[Callable[..., Any], Any]]")
python-package/lightgbm/engine.py:300: error: Incompatible types in assignment (expression has type "float", variable has type "List[Any]")

Confirmed that this suppresses these warnings by running the following.

```shell
mypy \
    --exclude='python-package/compile/|python-package/build' \
    --ignore-missing-imports \
    python-package/
```

### Notes for Reviewers

Some of these errors caught an issue in the type hints for `callbacks.EarlyStopException`. That exception has a property `best_score` which seems like it should be a float, but in every place where one of those is created, `best_score` is populated with a list of eval results similar to this:

```python
[
    ('training', 'binary_logloss', 0.014361246252423975, False),
    ('training', 'mape', 0.013889796906138775, False),
    ('valid', 'binary_logloss', 0.0561150102648419, False),
    ('valid', 'mape', 0.042410104106485866, False)
]
```

https://github.com/microsoft/LightGBM/blob/67b4205c8043326553e294fa2c01ad1189784631/python-package/lightgbm/engine.py#L300

https://github.com/microsoft/LightGBM/blob/67b4205c8043326553e294fa2c01ad1189784631/python-package/lightgbm/callback.py#L280

https://github.com/microsoft/LightGBM/blob/67b4205c8043326553e294fa2c01ad1189784631/python-package/lightgbm/callback.py#L307