### PR TITLE
[python][sklearn] unify values of `best_iteration` for sklearn and standard APIs

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -785,11 +785,7 @@ class LGBMModel(_LGBMModelBase):
         else:  # reset after previous call to fit()
             self._evals_result = None
 
-        if self._Booster.best_iteration != 0:
-            self._best_iteration = self._Booster.best_iteration
-        else:  # reset after previous call to fit()
-            self._best_iteration = None
-
+        self._best_iteration = self._Booster.best_iteration
         self._best_score = self._Booster.best_score
 
         self.fitted_ = True
@@ -872,7 +868,7 @@ class LGBMModel(_LGBMModelBase):
 
     @property
     def best_iteration_(self):
-        """:obj:`int` or :obj:`None`: The best iteration of fitted model if ``early_stopping()`` callback has been specified."""
+        """:obj:`int`: The best iteration of fitted model if ``early_stopping()`` callback has been specified."""
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError('No best_iteration found. Need to call fit with early_stopping callback beforehand.')
         return self._best_iteration

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -925,7 +925,7 @@ def test_eval_set_no_early_stopping(task, output, eval_sizes, eval_names_prefix,
 
             # check that early stopping was not applied.
             assert dask_model.booster_.num_trees() == model_trees
-            assert dask_model.best_iteration_ is None
+            assert dask_model.best_iteration_ == 0
 
             # checks that evals_result_ and best_score_ contain expected data and eval_set names.
             evals_result = dask_model.evals_result_


### PR DESCRIPTION
Do not replace default `0` with `None` in sklearn wrapper.
https://github.com/microsoft/LightGBM/blob/e048a6b409ff72cd2f563b05689ec082bd2e4635/python-package/lightgbm/engine.py#L270

Refer to https://github.com/microsoft/LightGBM/pull/4574#issuecomment-908810538.