### PR TITLE
[R-package] fix `--no-build-vignettes` option for `build-cran-package.sh`

### DIFF
--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -38,7 +38,7 @@ while [ $# -gt 0 ]; do
     --r-executable=*)
       LGB_R_EXECUTABLE="${1#*=}"
       ;;
-    --no-build-vignettes=*)
+    --no-build-vignettes*)
       BUILD_VIGNETTES=false
       ;;
     *)


### PR DESCRIPTION
Discovered tonight while testing things for #4813 that there was a small issue introduced in #4775.

```shell
sh build-cran-package.sh --no-build-vignettes
```

> invalid argument '--no-build-vignettes'

This PR fixes it. This project doesn't have any CI jobs that use that option, but I tested it locally.