### PR TITLE
[python-package] remove unused imports

### DIFF
--- a/helpers/parameter_generator.py
+++ b/helpers/parameter_generator.py
@@ -8,7 +8,7 @@ from the information in LightGBM/include/LightGBM/config.h file.
 """
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 
 def get_parameter_infos(

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import numpy as np
 
 from .basic import Booster, Dataset, LightGBMError, _ArrayLike, _choose_param_value, _ConfigAliases, _log_warning
-from .callback import log_evaluation, record_evaluation
+from .callback import record_evaluation
 from .compat import (SKLEARN_INSTALLED, LGBMNotFittedError, _LGBMAssertAllFinite, _LGBMCheckArray,
                      _LGBMCheckClassificationTargets, _LGBMCheckSampleWeight, _LGBMCheckXY, _LGBMClassifierBase,
                      _LGBMComputeSampleWeight, _LGBMLabelEncoder, _LGBMModelBase, _LGBMRegressorBase, dt_DataTable,


### PR DESCRIPTION
I checked the Python code in this project tonight with `flake8`, and found a few unused imports. This PR proposes removing them.

```shell
flake8 --ignore=E501,E2,E302,E713 ./helpers/
```

> ./helpers/parameter_generator.py:11:1: F401 'typing.Any' imported but unused
./helpers/parameter_generator.py:11:1: F401 'typing.Optional' imported but unused

```shell
flake8 --ignore=E501,E2,E302,E713 ./python-package/
```

> ./python-package/lightgbm/sklearn.py:10:1: F401 '.callback.log_evaluation' imported but unused