### PR TITLE
[python-package] [dask] fix mypy error about worker_addresses

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -349,7 +349,7 @@ def _split_to_parts(data: _DaskCollection, is_matrix: bool) -> List[_DaskPart]:
     return parts
 
 
-def _machines_to_worker_map(machines: str, worker_addresses: List[str]) -> Dict[str, int]:
+def _machines_to_worker_map(machines: str, worker_addresses: Iterable[str]) -> Dict[str, int]:
     """Create a worker_map from machines list.
 
     Given ``machines`` and a list of Dask worker addresses, return a mapping where the keys are
@@ -360,7 +360,7 @@ def _machines_to_worker_map(machines: str, worker_addresses: List[str]) -> Dict[
     machines : str
         A comma-delimited list of workers, of the form ``ip1:port,ip2:port``.
     worker_addresses : list of str
-        A list of Dask worker addresses, of the form ``{protocol}{hostname}:{port}``, where ``port`` is the port Dask's scheduler uses to talk to that worker.
+        An iterable of Dask worker addresses, of the form ``{protocol}{hostname}:{port}``, where ``port`` is the port Dask's scheduler uses to talk to that worker.
 
     Returns
     -------


### PR DESCRIPTION
Contributes to #3867.

This PR fixes a `mypy` error in `dask.py`

> python-package/lightgbm/dask.py:726: error: Argument "worker_addresses" to "_machines_to_worker_map" has incompatible type "KeysView[Any]"; expected "List[str]"

Confirmed that this suppresses the error by running the following.

```shell
mypy \
    --exclude='python-package/compile/|python-package/build' \
    --ignore-missing-imports \
    python-package/
```
