### PR TITLE
[python-package][dask] handle failures parsing worker host names

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -95,6 +95,8 @@ def _group_workers_by_host(worker_addresses: Iterable[str]) -> Dict[str, _HostWo
     host_to_workers: Dict[str, _HostWorkers] = {}
     for address in worker_addresses:
         hostname = urlparse(address).hostname
+        if not hostname:
+            raise ValueError(f"Could not parse host name from worker address '{address}'")
         if hostname not in host_to_workers:
             host_to_workers[hostname] = _HostWorkers(default=address, all=[address])
         else:
@@ -380,6 +382,8 @@ def _machines_to_worker_map(machines: str, worker_addresses: List[str]) -> Dict[
     out = {}
     for address in worker_addresses:
         worker_host = urlparse(address).hostname
+        if not worker_host:
+            raise ValueError(f"Could not parse host name from worker address '{address}'")
         out[address] = machine_to_port[worker_host].pop()
 
     return out

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -15,8 +15,8 @@ import pytest
 
 import lightgbm as lgb
 
-if not platform.startswith('linux'):
-    pytest.skip('lightgbm.dask is currently supported in Linux environments', allow_module_level=True)
+#if not platform.startswith('linux'):
+#    pytest.skip('lightgbm.dask is currently supported in Linux environments', allow_module_level=True)
 if machine() != 'x86_64':
     pytest.skip('lightgbm.dask tests are currently skipped on some architectures like arm64', allow_module_level=True)
 if not lgb.compat.DASK_INSTALLED:
@@ -467,6 +467,19 @@ def test_group_workers_by_host():
     }
     host_to_workers = lgb.dask._group_workers_by_host(workers)
     assert host_to_workers == expected
+
+
+def test_group_workers_by_host_unparseable_host_names():
+    workers_without_protocol = ['0.0.0.1:80', '0.0.0.2:80']
+    with pytest.raises(ValueError, match="Could not parse host name from worker address '0.0.0.1:80'"):
+        lgb.dask._group_workers_by_host(workers_without_protocol)
+
+
+def test_machines_to_worker_map_unparseable_host_names():
+    workers = {'0.0.0.1:80': {}, '0.0.0.2:80': {}}
+    machines = "0.0.0.1:80,0.0.0.2:80"
+    with pytest.raises(ValueError, match="Could not parse host name from worker address '0.0.0.1:80'"):
+        lgb.dask._machines_to_worker_map(machines=machines, worker_addresses=workers.keys())
 
 
 def test_assign_open_ports_to_workers(cluster):

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -15,8 +15,8 @@ import pytest
 
 import lightgbm as lgb
 
-#if not platform.startswith('linux'):
-#    pytest.skip('lightgbm.dask is currently supported in Linux environments', allow_module_level=True)
+if not platform.startswith('linux'):
+    pytest.skip('lightgbm.dask is currently supported in Linux environments', allow_module_level=True)
 if machine() != 'x86_64':
     pytest.skip('lightgbm.dask tests are currently skipped on some architectures like arm64', allow_module_level=True)
 if not lgb.compat.DASK_INSTALLED:


### PR DESCRIPTION
Contributes to #3867.

This PR fixes `mypy` errors in `dask.py`

> python-package/lightgbm/dask.py:99: error: Invalid index type "Optional[str]" for "Dict[str, _HostWorkers]"; expected type "str"
python-package/lightgbm/dask.py:383: error: Invalid index type "Optional[str]" for "defaultdict[str, Set[int]]"; expected type "str"

This is `mypy` correctly pointing out the `urlparse(something).hostname` can be `None`, but `lightgbm.dask` treats as if it is guaranteed to be non-None.

```python
from urllib.parse import urlparse

print(urlparse("https://127.0.0.1:123").hostname)
# 127.0.0.1

print(urlparse("127.0.0.1:123").hostname)
# None
```

The changes in this PR add explicit handling for that case, so that if it happens `lightgbm` will raise a more specific and helpful error.

Confirmed that this suppresses the error by running the following.

```shell
mypy \
    --exclude='python-package/compile/|python-package/build' \
    --ignore-missing-imports \
    python-package/
```
