### PR TITLE
[R-package] remove support for '...' in predict()

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -764,6 +764,7 @@ Booster <- R6::R6Class(
 #'               \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html#predict-parameters}{
 #'               the "Predict Parameters" section of the documentation} for a list of parameters and
 #'               valid values.
+#' @param ... ignored
 #' @return For regression or binary classification, it returns a vector of length \code{nrows(data)}.
 #'         For multiclass classification, either a \code{num_class * nrows(data)} vector or
 #'         a \code{(nrows(data), num_class)} dimension matrix is returned, depending on
@@ -815,10 +816,20 @@ predict.lgb.Booster <- function(object,
                                 predcontrib = FALSE,
                                 header = FALSE,
                                 reshape = FALSE,
-                                params = list()) {
+                                params = list(),
+                                ...) {
 
   if (!lgb.is.Booster(x = object)) {
     stop("predict.lgb.Booster: object should be an ", sQuote("lgb.Booster"))
+  }
+
+  additional_params <- list(...)
+  if (length(additional_params) > 0L) {
+    warning(paste0(
+      "predict.lgb.Booster: Found the following passed through '...': "
+      , paste(names(additional_params), collapse = ", ")
+      , ". These are ignored. Use argument 'params' instead."
+    ))
   }
 
   return(

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -504,20 +504,9 @@ Booster <- R6::R6Class(
                        predcontrib = FALSE,
                        header = FALSE,
                        reshape = FALSE,
-                       params = list(),
-                       ...) {
+                       params = list()) {
 
       self$restore_handle()
-
-      additional_params <- list(...)
-      if (length(additional_params) > 0L) {
-        warning(paste0(
-          "Booster$predict(): Found the following passed through '...': "
-          , paste(names(additional_params), collapse = ", ")
-          , ". These will be used, but in future releases of lightgbm, this warning will become an error. "
-          , "Add these to 'params' instead. See ?predict.lgb.Booster for documentation on how to call this function."
-        ))
-      }
 
       if (is.null(num_iteration)) {
         num_iteration <- self$best_iter
@@ -528,7 +517,6 @@ Booster <- R6::R6Class(
       }
 
       # Predict on new data
-      params <- utils::modifyList(params, additional_params)
       predictor <- Predictor$new(
         modelfile = private$handle
         , params = params
@@ -776,7 +764,6 @@ Booster <- R6::R6Class(
 #'               \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html#predict-parameters}{
 #'               the "Predict Parameters" section of the documentation} for a list of parameters and
 #'               valid values.
-#' @param ... Additional prediction parameters. NOTE: deprecated as of v3.3.0. Use \code{params} instead.
 #' @return For regression or binary classification, it returns a vector of length \code{nrows(data)}.
 #'         For multiclass classification, either a \code{num_class * nrows(data)} vector or
 #'         a \code{(nrows(data), num_class)} dimension matrix is returned, depending on
@@ -828,21 +815,10 @@ predict.lgb.Booster <- function(object,
                                 predcontrib = FALSE,
                                 header = FALSE,
                                 reshape = FALSE,
-                                params = list(),
-                                ...) {
+                                params = list()) {
 
   if (!lgb.is.Booster(x = object)) {
     stop("predict.lgb.Booster: object should be an ", sQuote("lgb.Booster"))
-  }
-
-  additional_params <- list(...)
-  if (length(additional_params) > 0L) {
-    warning(paste0(
-      "predict.lgb.Booster: Found the following passed through '...': "
-      , paste(names(additional_params), collapse = ", ")
-      , ". These will be used, but in future releases of lightgbm, this warning will become an error. "
-      , "Add these to 'params' instead. See ?predict.lgb.Booster for documentation on how to call this function."
-    ))
   }
 
   return(
@@ -855,7 +831,7 @@ predict.lgb.Booster <- function(object,
       , predcontrib =  predcontrib
       , header = header
       , reshape = reshape
-      , params = utils::modifyList(params, additional_params)
+      , params = params
     )
   )
 }

--- a/R-package/man/predict.lgb.Booster.Rd
+++ b/R-package/man/predict.lgb.Booster.Rd
@@ -14,7 +14,8 @@
   predcontrib = FALSE,
   header = FALSE,
   reshape = FALSE,
-  params = list()
+  params = list(),
+  ...
 )
 }
 \arguments{
@@ -50,6 +51,8 @@ prediction outputs per case.}
 \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html#predict-parameters}{
 the "Predict Parameters" section of the documentation} for a list of parameters and
 valid values.}
+
+\item{...}{ignored}
 }
 \value{
 For regression or binary classification, it returns a vector of length \code{nrows(data)}.

--- a/R-package/man/predict.lgb.Booster.Rd
+++ b/R-package/man/predict.lgb.Booster.Rd
@@ -14,8 +14,7 @@
   predcontrib = FALSE,
   header = FALSE,
   reshape = FALSE,
-  params = list(),
-  ...
+  params = list()
 )
 }
 \arguments{
@@ -51,8 +50,6 @@ prediction outputs per case.}
 \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html#predict-parameters}{
 the "Predict Parameters" section of the documentation} for a list of parameters and
 valid values.}
-
-\item{...}{Additional prediction parameters. NOTE: deprecated as of v3.3.0. Use \code{params} instead.}
 }
 \value{
 For regression or binary classification, it returns a vector of length \code{nrows(data)}.


### PR DESCRIPTION
Contributes to #4226.

This PR removes support for passing anything through `...` in `predict.lgb.Booster()` and `Booster$predict()`.

### Notes for Reviewers

v3.3.0 and v3.3.1 contain a deprecation warning about this change.