### PR TITLE
[R-package] small simplifications in Booster and Predictor

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -497,7 +497,7 @@ Booster <- R6::R6Class(
 
     # Predict on new data
     predict = function(data,
-                       start_iteration = NULL,
+                       start_iteration = 0L,
                        num_iteration = NULL,
                        rawscore = FALSE,
                        predleaf = FALSE,
@@ -521,10 +521,6 @@ Booster <- R6::R6Class(
 
       if (is.null(num_iteration)) {
         num_iteration <- self$best_iter
-      }
-
-      if (is.null(start_iteration)) {
-        start_iteration <- 0L
       }
 
       # Predict on new data

--- a/R-package/R/lgb.Predictor.R
+++ b/R-package/R/lgb.Predictor.R
@@ -79,22 +79,13 @@ Predictor <- R6::R6Class(
 
     # Predict from data
     predict = function(data,
-                       start_iteration = NULL,
-                       num_iteration = NULL,
+                       start_iteration = 0L,
+                       num_iteration = -1L,
                        rawscore = FALSE,
                        predleaf = FALSE,
                        predcontrib = FALSE,
                        header = FALSE,
                        reshape = FALSE) {
-
-      # Check if number of iterations is existing - if not, then set it to -1 (use all)
-      if (is.null(num_iteration)) {
-        num_iteration <- -1L
-      }
-      # Check if start iterations is existing - if not, then set it to 0 (start from the first iteration)
-      if (is.null(start_iteration)) {
-        start_iteration <- 0L
-      }
 
       num_row <- 0L
 


### PR DESCRIPTION
Working through #4857, I noticed a few functions in the R package doing something like this:

```r
some_function <- function(x = NULL) {
    if (is.null(x)) {
        x <- -1L
    }
}
```

This PR proposes simplifying that code by just changing the default values in function signatures.

```r
some_function <- function(x = -1L){
}
```

### Notes for Reviewers

Function defaults are lazily evaluated in R, so no memory is saved by using `NULL` instead of an integer.

```r
# this does not fail until the function is called
do_something <- function(m = stop("hey")){
     return TRUE
}
```

Function defaults are not stored in the global environment, so it isn't necessary to worry about side effects [like you have to with using mutable types as function defaults in Python](https://stackoverflow.com/a/26320938/3986677).

```r
do_something <- function(x = 10L) {
    x <- x + 1L
    print(x)
}

do_something()
# 11

do_something()
# 11

do_something()
# 11
```