### PR TITLE
[R-package] remove support for 'info' in Dataset

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -10,9 +10,6 @@
 #'              \code{group = c(10, 20, 40, 10, 10, 10)}, that means that you have 6 groups,
 #'              where the first 10 records are in the first group, records 11-30 are in the
 #'              second group, etc.
-#' @param info a list of information of the \code{lgb.Dataset} object. NOTE: use of \code{info}
-#'             is deprecated as of v3.3.0. Use keyword arguments (e.g. \code{init_score = init_score})
-#'             directly.
 #' @keywords internal
 NULL
 
@@ -52,7 +49,6 @@ Dataset <- R6::R6Class(
                           predictor = NULL,
                           free_raw_data = TRUE,
                           used_indices = NULL,
-                          info = list(),
                           label = NULL,
                           weight = NULL,
                           group = NULL,
@@ -66,14 +62,7 @@ Dataset <- R6::R6Class(
           stop("lgb.Dataset: If provided, predictor must be a ", sQuote("lgb.Predictor"))
       }
 
-      if (length(info) > 0L) {
-        warning(paste0(
-          "lgb.Dataset: found fields passed through 'info'. "
-          , "As of v3.3.0, this behavior is deprecated, and support for it will be removed in a future release. "
-          , "To suppress this warning, use keyword arguments 'label', 'weight', 'group', or 'init_score' directly"
-        ))
-      }
-
+      info <- list()
       if (!is.null(label)) {
         info[["label"]] <- label
       }
@@ -113,7 +102,6 @@ Dataset <- R6::R6Class(
     },
 
     create_valid = function(data,
-                            info = list(),
                             label = NULL,
                             weight = NULL,
                             group = NULL,
@@ -148,7 +136,6 @@ Dataset <- R6::R6Class(
         , predictor = private$predictor
         , free_raw_data = private$free_raw_data
         , used_indices = NULL
-        , info = info
         , label = label
         , weight = weight
         , group = group
@@ -611,7 +598,6 @@ Dataset <- R6::R6Class(
           , predictor = private$predictor
           , free_raw_data = private$free_raw_data
           , used_indices = sort(idxset, decreasing = FALSE)
-          , info = NULL
           , group = group
           , init_score = init_score
           , label = label
@@ -838,7 +824,6 @@ lgb.Dataset <- function(data,
                         colnames = NULL,
                         categorical_feature = NULL,
                         free_raw_data = TRUE,
-                        info = list(),
                         label = NULL,
                         weight = NULL,
                         group = NULL,
@@ -868,7 +853,6 @@ lgb.Dataset <- function(data,
       , predictor = NULL
       , free_raw_data = free_raw_data
       , used_indices = NULL
-      , info = info
       , label = label
       , weight = weight
       , group = group
@@ -944,7 +928,6 @@ lgb.Dataset <- function(data,
 #' @export
 lgb.Dataset.create.valid <- function(dataset,
                                      data,
-                                     info = list(),
                                      label = NULL,
                                      weight = NULL,
                                      group = NULL,
@@ -970,7 +953,6 @@ lgb.Dataset.create.valid <- function(dataset,
   return(invisible(
     dataset$create_valid(
       data = data
-      , info = info
       , label = label
       , weight = weight
       , group = group

--- a/R-package/man/lgb.Dataset.Rd
+++ b/R-package/man/lgb.Dataset.Rd
@@ -11,7 +11,6 @@ lgb.Dataset(
   colnames = NULL,
   categorical_feature = NULL,
   free_raw_data = TRUE,
-  info = list(),
   label = NULL,
   weight = NULL,
   group = NULL,
@@ -44,10 +43,6 @@ By default, that Dataset object on the R side does not keep a copy of the raw da
 This reduces LightGBM's memory consumption, but it means that the Dataset object
 cannot be changed after it has been constructed. If you'd prefer to be able to
 change the Dataset object after construction, set \code{free_raw_data = FALSE}.}
-
-\item{info}{a list of information of the \code{lgb.Dataset} object. NOTE: use of \code{info}
-is deprecated as of v3.3.0. Use keyword arguments (e.g. \code{init_score = init_score})
-directly.}
 
 \item{label}{vector of labels to use as the target variable}
 

--- a/R-package/man/lgb.Dataset.create.valid.Rd
+++ b/R-package/man/lgb.Dataset.create.valid.Rd
@@ -7,7 +7,6 @@
 lgb.Dataset.create.valid(
   dataset,
   data,
-  info = list(),
   label = NULL,
   weight = NULL,
   group = NULL,
@@ -22,10 +21,6 @@ lgb.Dataset.create.valid(
 \item{data}{a \code{matrix} object, a \code{dgCMatrix} object,
 a character representing a path to a text file (CSV, TSV, or LibSVM),
 or a character representing a path to a binary \code{Dataset} file}
-
-\item{info}{a list of information of the \code{lgb.Dataset} object. NOTE: use of \code{info}
-is deprecated as of v3.3.0. Use keyword arguments (e.g. \code{init_score = init_score})
-directly.}
 
 \item{label}{vector of labels to use as the target variable}
 

--- a/R-package/man/lgb_shared_dataset_params.Rd
+++ b/R-package/man/lgb_shared_dataset_params.Rd
@@ -16,10 +16,6 @@ to be ranked. For example, if you have a 100-document dataset with
 \code{group = c(10, 20, 40, 10, 10, 10)}, that means that you have 6 groups,
 where the first 10 records are in the first group, records 11-30 are in the
 second group, etc.}
-
-\item{info}{a list of information of the \code{lgb.Dataset} object. NOTE: use of \code{info}
-is deprecated as of v3.3.0. Use keyword arguments (e.g. \code{init_score = init_score})
-directly.}
 }
 \description{
 Parameter docs for fields used in \code{lgb.Dataset} construction


### PR DESCRIPTION
Contributes to #4543.

This PR proposes removing the keyword argument `info` from functions used for creating and manipulating `Dataset`s. After this PR, users of the R package will have to provide `init_score`, `label`, `weight`, and `group` via the keyword arguments added in #4573.

### Notes for Reviewers

v3.3.0 and v3.3.1 contain a deprecation warning about this change.

This PR is focused only on the *public* parts of the package's API. A future PR might propose replacing `Dataset$private$info` with e.g. `Dataset$private$init_score`, `Dataset$private$label`.