### PR TITLE
[python] reset storages in early stopping callback after finishing training

### DIFF
--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -221,6 +221,7 @@ def early_stopping(stopping_rounds: int, first_metric_only: bool = False, verbos
     best_score_list: list = []
     cmp_op = []
     enabled = True
+    inited = False
     first_metric = ''
 
     def _init(env: CallbackEnv) -> None:
@@ -229,6 +230,7 @@ def early_stopping(stopping_rounds: int, first_metric_only: bool = False, verbos
         nonlocal best_score_list
         nonlocal cmp_op
         nonlocal enabled
+        nonlocal inited
         nonlocal first_metric
         enabled = not any(env.params.get(boost_alias, "") == 'dart' for boost_alias
                           in _ConfigAliases.get("boosting"))
@@ -241,6 +243,14 @@ def early_stopping(stopping_rounds: int, first_metric_only: bool = False, verbos
 
         if verbose:
             _log_info(f"Training until validation scores don't improve for {stopping_rounds} rounds")
+
+        # reset storages
+        best_score = []
+        best_iter = []
+        best_score_list = []
+        cmp_op = []
+        inited = True
+        first_metric = ''
 
         n_metrics = len(set(m[1] for m in env.evaluation_result_list))
         n_datasets = len(env.evaluation_result_list) // n_metrics
@@ -283,6 +293,7 @@ def early_stopping(stopping_rounds: int, first_metric_only: bool = False, verbos
     def _final_iteration_check(env: CallbackEnv, eval_name_splitted: List[str], i: int) -> None:
         nonlocal best_iter
         nonlocal best_score_list
+        nonlocal inited
         if env.iteration == env.end_iteration - 1:
             if verbose:
                 best_score_str = '\t'.join([_format_eval_result(x) for x in best_score_list[i]])
@@ -290,6 +301,7 @@ def early_stopping(stopping_rounds: int, first_metric_only: bool = False, verbos
                           f'Best iteration is:\n[{best_iter[i] + 1}]\t{best_score_str}')
                 if first_metric_only:
                     _log_info(f"Evaluated only: {eval_name_splitted[-1]}")
+            inited = False
             raise EarlyStopException(best_iter[i], best_score_list[i])
 
     def _callback(env: CallbackEnv) -> None:
@@ -298,8 +310,9 @@ def early_stopping(stopping_rounds: int, first_metric_only: bool = False, verbos
         nonlocal best_score_list
         nonlocal cmp_op
         nonlocal enabled
+        nonlocal inited
         nonlocal first_metric
-        if not cmp_op:
+        if not inited:
             _init(env)
         if not enabled:
             return
@@ -323,6 +336,7 @@ def early_stopping(stopping_rounds: int, first_metric_only: bool = False, verbos
                     _log_info(f"Early stopping, best iteration is:\n[{best_iter[i] + 1}]\t{eval_result_str}")
                     if first_metric_only:
                         _log_info(f"Evaluated only: {eval_name_splitted[-1]}")
+                inited = False
                 raise EarlyStopException(best_iter[i], best_score_list[i])
             _final_iteration_check(env, eval_name_splitted, i)
     _callback.order = 30  # type: ignore

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -287,7 +287,7 @@ def test_grid_search():
                        reg_alpha=[0.01, 0.005])
     fit_params = dict(eval_set=[(X_val, y_val)],
                       eval_metric=constant_metric,
-                      early_stopping_rounds=2)
+                      callbacks=[lgb.early_stopping(2)])
     grid = GridSearchCV(estimator=lgb.LGBMClassifier(**params), param_grid=grid_params,
                         cv=2)
     grid.fit(X_train, y_train, **fit_params)


### PR DESCRIPTION
Right now `early_stopping()` callback cannot be used with scikit-learn's `GridSearchCV` tool due to that storages for metric results are not cleaned after early stopping occurs. This results in **comparing current results with the best iteration for the first grid iteration for the first fold**.

This was spotted by our `test_grid_search` test
https://github.com/microsoft/LightGBM/blob/fe535a0e9dfb251fcc85dd33fb0bf193d022fe90/tests/python_package_test/test_sklearn.py#L276
which fails with early stopping setup passed via callback with the following error
```
>       assert grid.best_estimator_.best_score_['valid_0']['multi_logloss'] < 0.25
E       assert 0.5915701709051111 < 0.25

../tests/python_package_test/test_sklearn.py:318: AssertionError
```

This PR proposes resetting all global variables in the `_init()` helper function and determining whether initialization is required by the special variable `inited` instead of checking `cmp_op` global variable for emptiness, which results right now in that `_init()` is called only once during the whole grid search routine.

Extracted from #4846.