### PR TITLE
[R-package] remove support for '...' in `slice()`

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -532,49 +532,19 @@ Dataset <- R6::R6Class(
     },
 
     # Slice dataset
-    slice = function(idxset, ...) {
-
-      additional_keyword_args <- list(...)
-
-      if (length(additional_keyword_args) > 0L) {
-        warning(paste0(
-          "Dataset$slice(): Found the following passed through '...': "
-          , paste(names(additional_keyword_args), collapse = ", ")
-          , ". These are ignored and should be removed. "
-          , "To change the parameters of a Dataset produced by Dataset$slice(), use Dataset$set_params(). "
-          , "To modify attributes like 'init_score', use Dataset$set_field(). "
-          , "In future releases of lightgbm, this warning will become an error."
-        ))
-      }
-
-      # extract Dataset attributes passed through '...'
-      #
-      # NOTE: takes advantage of the fact that list[["non-existent-key"]] returns NULL
-      group <- additional_keyword_args[["group"]]
-      init_score <- additional_keyword_args[["init_score"]]
-      label <- additional_keyword_args[["label"]]
-      weight <- additional_keyword_args[["weight"]]
-
-      # remove attributes from '...', so only params are left
-      for (info_key in .INFO_KEYS()) {
-        additional_keyword_args[[info_key]] <- NULL
-      }
+    slice = function(idxset) {
 
       # Perform slicing
       return(
         Dataset$new(
           data = NULL
-          , params = utils::modifyList(self$get_params(), additional_keyword_args)
+          , params = self$get_params()
           , reference = self
           , colnames = private$colnames
           , categorical_feature = private$categorical_feature
           , predictor = private$predictor
           , free_raw_data = private$free_raw_data
           , used_indices = sort(idxset, decreasing = FALSE)
-          , group = group
-          , init_score = init_score
-          , label = label
-          , weight = weight
         )
       )
 
@@ -1068,7 +1038,9 @@ dimnames.lgb.Dataset <- function(x) {
 #'              original \code{lgb.Dataset} object
 #' @param dataset Object of class \code{lgb.Dataset}
 #' @param idxset an integer vector of indices of rows needed
-#' @param ... other parameters (currently not used)
+#' @param ... ignored. To change the parameters of a \code{lgb.Dataset} produced by this function,
+#'            use \code{Dataset$set_params()}. To modify fields like "init_score",
+#'            use \code{Dataset$set_field()} or \code{set_field()}.
 #' @return constructed sub dataset
 #'
 #' @examples
@@ -1094,7 +1066,17 @@ slice.lgb.Dataset <- function(dataset, idxset, ...) {
     stop("slice.lgb.Dataset: input dataset should be an lgb.Dataset object")
   }
 
-  return(invisible(dataset$slice(idxset = idxset, ...)))
+  additional_args <- list(...)
+  if (length(additional_args) > 0L) {
+    warning(paste0(
+      "slice.lgb.Dataset: Found the following passed through '...': "
+      , paste(names(additional_args), collapse = ", ")
+      , ". These are ignored. Use method Dataset$set_params() to change parameters "
+      , "or method Dataset$set_field() to modify fields like 'init_score'."
+    ))
+  }
+
+  return(invisible(dataset$slice(idxset = idxset)))
 
 }
 

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -1038,9 +1038,6 @@ dimnames.lgb.Dataset <- function(x) {
 #'              original \code{lgb.Dataset} object
 #' @param dataset Object of class \code{lgb.Dataset}
 #' @param idxset an integer vector of indices of rows needed
-#' @param ... ignored. To change the parameters of a \code{lgb.Dataset} produced by this function,
-#'            use \code{Dataset$set_params()}. To modify fields like "init_score",
-#'            use \code{Dataset$set_field()} or \code{set_field()}.
 #' @return constructed sub dataset
 #'
 #' @examples
@@ -1054,7 +1051,7 @@ dimnames.lgb.Dataset <- function(x) {
 #' labels <- lightgbm::get_field(dsub, "label")
 #' }
 #' @export
-slice <- function(dataset, ...) {
+slice <- function(dataset, idxset) {
   UseMethod("slice")
 }
 

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -1060,20 +1060,10 @@ slice <- function(dataset, ...) {
 
 #' @rdname slice
 #' @export
-slice.lgb.Dataset <- function(dataset, idxset, ...) {
+slice.lgb.Dataset <- function(dataset, idxset) {
 
   if (!lgb.is.Dataset(x = dataset)) {
     stop("slice.lgb.Dataset: input dataset should be an lgb.Dataset object")
-  }
-
-  additional_args <- list(...)
-  if (length(additional_args) > 0L) {
-    warning(paste0(
-      "slice.lgb.Dataset: Found the following passed through '...': "
-      , paste(names(additional_args), collapse = ", ")
-      , ". These are ignored. Use method Dataset$set_params() to change parameters "
-      , "or method Dataset$set_field() to modify fields like 'init_score'."
-    ))
   }
 
   return(invisible(dataset$slice(idxset = idxset)))

--- a/R-package/man/slice.Rd
+++ b/R-package/man/slice.Rd
@@ -12,7 +12,9 @@ slice(dataset, ...)
 \arguments{
 \item{dataset}{Object of class \code{lgb.Dataset}}
 
-\item{...}{other parameters (currently not used)}
+\item{...}{ignored. To change the parameters of a \code{lgb.Dataset} produced by this function,
+use \code{Dataset$set_params()}. To modify fields like "init_score",
+use \code{Dataset$set_field()} or \code{set_field()}.}
 
 \item{idxset}{an integer vector of indices of rows needed}
 }

--- a/R-package/man/slice.Rd
+++ b/R-package/man/slice.Rd
@@ -7,7 +7,7 @@
 \usage{
 slice(dataset, ...)
 
-\method{slice}{lgb.Dataset}(dataset, idxset, ...)
+\method{slice}{lgb.Dataset}(dataset, idxset)
 }
 \arguments{
 \item{dataset}{Object of class \code{lgb.Dataset}}

--- a/R-package/man/slice.Rd
+++ b/R-package/man/slice.Rd
@@ -5,16 +5,12 @@
 \alias{slice.lgb.Dataset}
 \title{Slice a dataset}
 \usage{
-slice(dataset, ...)
+slice(dataset, idxset)
 
 \method{slice}{lgb.Dataset}(dataset, idxset)
 }
 \arguments{
 \item{dataset}{Object of class \code{lgb.Dataset}}
-
-\item{...}{ignored. To change the parameters of a \code{lgb.Dataset} produced by this function,
-use \code{Dataset$set_params()}. To modify fields like "init_score",
-use \code{Dataset$set_field()} or \code{set_field()}.}
 
 \item{idxset}{an integer vector of indices of rows needed}
 }

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -50,32 +50,36 @@ test_that("lgb.Dataset: slice, dim", {
   expect_equal(ncol(dsub1), ncol(test_data))
 })
 
-test_that("Dataset$slice() supports passing additional parameters through '...'", {
+test_that("Dataset$slice() warns when passing params '...'", {
   dtest <- lgb.Dataset(test_data, label = test_label)
   dtest$construct()
-  dsub1 <- slice(
-    dataset = dtest
-    , idxset = seq_len(42L)
-    , feature_pre_filter = FALSE
-  )
+  expect_warning({
+      dsub1 <- slice(
+        dataset = dtest
+        , idxset = seq_len(42L)
+        , feature_pre_filter = FALSE
+      )
+  }, regexp = "Use method Dataset$set_params()", fixed = TRUE)
   dsub1$construct()
   expect_identical(dtest$get_params(), list())
-  expect_identical(dsub1$get_params(), list(feature_pre_filter = FALSE))
+  expect_identical(dsub1$get_params(), list())
 })
 
-test_that("Dataset$slice() supports passing Dataset attributes through '...'", {
+test_that("Dataset$slice() warns when passing Dataset attributes through '...'", {
   dtest <- lgb.Dataset(test_data, label = test_label)
   dtest$construct()
   num_subset_rows <- 51L
   init_score <- rnorm(n = num_subset_rows)
-  dsub1 <- slice(
-    dataset = dtest
-    , idxset = seq_len(num_subset_rows)
-    , init_score = init_score
-  )
+  expect_warning({
+      dsub1 <- slice(
+        dataset = dtest
+        , idxset = seq_len(num_subset_rows)
+        , init_score = init_score
+      )
+  }, regexp = "method Dataset$set_field() to modify fields", fixed = TRUE)
   dsub1$construct()
   expect_null(dtest$get_field("init_score"), NULL)
-  expect_identical(dsub1$get_field("init_score"), init_score)
+  expect_identical(dsub1$get_field("init_score"), NULL)
 })
 
 test_that("Dataset$set_reference() on a constructed Dataset fails if raw data has been freed", {

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -50,38 +50,6 @@ test_that("lgb.Dataset: slice, dim", {
   expect_equal(ncol(dsub1), ncol(test_data))
 })
 
-test_that("Dataset$slice() warns when passing params '...'", {
-  dtest <- lgb.Dataset(test_data, label = test_label)
-  dtest$construct()
-  expect_warning({
-      dsub1 <- slice(
-        dataset = dtest
-        , idxset = seq_len(42L)
-        , feature_pre_filter = FALSE
-      )
-  }, regexp = "Use method Dataset$set_params()", fixed = TRUE)
-  dsub1$construct()
-  expect_identical(dtest$get_params(), list())
-  expect_identical(dsub1$get_params(), list())
-})
-
-test_that("Dataset$slice() warns when passing Dataset attributes through '...'", {
-  dtest <- lgb.Dataset(test_data, label = test_label)
-  dtest$construct()
-  num_subset_rows <- 51L
-  init_score <- rnorm(n = num_subset_rows)
-  expect_warning({
-      dsub1 <- slice(
-        dataset = dtest
-        , idxset = seq_len(num_subset_rows)
-        , init_score = init_score
-      )
-  }, regexp = "method Dataset$set_field() to modify fields", fixed = TRUE)
-  dsub1$construct()
-  expect_null(dtest$get_field("init_score"), NULL)
-  expect_identical(dsub1$get_field("init_score"), NULL)
-})
-
 test_that("Dataset$set_reference() on a constructed Dataset fails if raw data has been freed", {
   dtrain <- lgb.Dataset(train_data, label = train_label)
   dtrain$construct()


### PR DESCRIPTION
Contributes to #4226 and #4543.

This PR removes support for passing anything through `...` in `lgb.Dataset.slice()` and `Dataset$slice()`.

### Notes for Reviewers

v3.3.0 and v3.3.1 contain a deprecation warning about this change.