### PR TITLE
[R-package] remove support for '...' in `dim.lgb.Dataset()`

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -949,7 +949,6 @@ lgb.Dataset.construct <- function(dataset) {
 #' @title Dimensions of an \code{lgb.Dataset}
 #' @description Returns a vector of numbers of rows and of columns in an \code{lgb.Dataset}.
 #' @param x Object of class \code{lgb.Dataset}
-#' @param ... ignored
 #'
 #' @return a vector of numbers of rows and of columns
 #'
@@ -969,7 +968,7 @@ lgb.Dataset.construct <- function(dataset) {
 #' }
 #' @rdname dim
 #' @export
-dim.lgb.Dataset <- function(x, ...) {
+dim.lgb.Dataset <- function(x) {
 
   if (!lgb.is.Dataset(x = x)) {
     stop("dim.lgb.Dataset: input data should be an lgb.Dataset object")

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -949,7 +949,7 @@ lgb.Dataset.construct <- function(dataset) {
 #' @title Dimensions of an \code{lgb.Dataset}
 #' @description Returns a vector of numbers of rows and of columns in an \code{lgb.Dataset}.
 #' @param x Object of class \code{lgb.Dataset}
-#' @param ... other parameters (ignored)
+#' @param ... ignored
 #'
 #' @return a vector of numbers of rows and of columns
 #'
@@ -970,16 +970,6 @@ lgb.Dataset.construct <- function(dataset) {
 #' @rdname dim
 #' @export
 dim.lgb.Dataset <- function(x, ...) {
-
-  additional_args <- list(...)
-  if (length(additional_args) > 0L) {
-    warning(paste0(
-      "dim.lgb.Dataset: Found the following passed through '...': "
-      , paste(names(additional_args), collapse = ", ")
-      , ". These are ignored. In future releases of lightgbm, this warning will become an error. "
-      , "See ?dim.lgb.Dataset for documentation on how to call this function."
-    ))
-  }
 
   if (!lgb.is.Dataset(x = x)) {
     stop("dim.lgb.Dataset: input data should be an lgb.Dataset object")

--- a/R-package/man/dim.Rd
+++ b/R-package/man/dim.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{x}{Object of class \code{lgb.Dataset}}
 
-\item{...}{other parameters (ignored)}
+\item{...}{ignored}
 }
 \value{
 a vector of numbers of rows and of columns

--- a/R-package/man/dim.Rd
+++ b/R-package/man/dim.Rd
@@ -4,12 +4,10 @@
 \alias{dim.lgb.Dataset}
 \title{Dimensions of an \code{lgb.Dataset}}
 \usage{
-\method{dim}{lgb.Dataset}(x, ...)
+\method{dim}{lgb.Dataset}(x)
 }
 \arguments{
 \item{x}{Object of class \code{lgb.Dataset}}
-
-\item{...}{ignored}
 }
 \value{
 a vector of numbers of rows and of columns


### PR DESCRIPTION
Contributes to #4226 and #4543.

This PR removes support for passing anything through ... in `dim.lgb.Booster()`.

### Notes for Reviewers

v3.3.0 and v3.3.1 contain a deprecation warning about this change.