### PR TITLE
[R-package] remove support for '...' in `lgb.Dataset()`

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -776,7 +776,6 @@ Dataset <- R6::R6Class(
 #'                      This reduces LightGBM's memory consumption, but it means that the Dataset object
 #'                      cannot be changed after it has been constructed. If you'd prefer to be able to
 #'                      change the Dataset object after construction, set \code{free_raw_data = FALSE}.
-#' @param ... other parameters passed to \code{params}
 #'
 #' @return constructed dataset
 #'
@@ -800,22 +799,8 @@ lgb.Dataset <- function(data,
                         label = NULL,
                         weight = NULL,
                         group = NULL,
-                        init_score = NULL,
-                        ...) {
+                        init_score = NULL) {
 
-  additional_params <- list(...)
-  params <- modifyList(params, additional_params)
-
-  if (length(additional_params) > 0L) {
-    warning(paste0(
-      "lgb.Dataset: Found the following passed through '...': "
-      , paste(names(additional_params), collapse = ", ")
-      , ". These will be used, but in future releases of lightgbm, this warning will become an error. "
-      , "Add these to 'params' instead. See ?lgb.Dataset for documentation on how to call this function."
-    ))
-  }
-
-  # Create new dataset
   return(
     invisible(Dataset$new(
       data = data

--- a/R-package/man/lgb.Dataset.Rd
+++ b/R-package/man/lgb.Dataset.Rd
@@ -14,8 +14,7 @@ lgb.Dataset(
   label = NULL,
   weight = NULL,
   group = NULL,
-  init_score = NULL,
-  ...
+  init_score = NULL
 )
 }
 \arguments{
@@ -56,8 +55,6 @@ where the first 10 records are in the first group, records 11-30 are in the
 second group, etc.}
 
 \item{init_score}{initial score is the base prediction lightgbm will boost from}
-
-\item{...}{other parameters passed to \code{params}}
 }
 \value{
 constructed dataset

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -2075,7 +2075,9 @@ test_that("lgb.train() works with linear learners and data where a feature has o
     return(lgb.Dataset(
       data = X
       , label = 2L * X[, 1L] + runif(nrow(X), 0L, 0.1)
-      , feature_pre_filter = FALSE
+      , params = list(
+        feature_pre_filter = FALSE
+      )
     ))
   }
 


### PR DESCRIPTION
Contributes to #4226 and #4543.

This PR removes support for passing anything through ... in `lgb.Dataset()`.

### Notes for Reviewers

v3.3.0 and v3.3.1 contain a deprecation warning about this change.