### PR TITLE
[python][sklearn] do not replace empty dict with `None` for `evals_result_`

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -779,11 +779,7 @@ class LGBMModel(_LGBMModelBase):
             callbacks=callbacks
         )
 
-        if evals_result:
-            self._evals_result = evals_result
-        else:  # reset after previous call to fit()
-            self._evals_result = None
-
+        self._evals_result = evals_result
         self._best_iteration = self._Booster.best_iteration
         self._best_score = self._Booster.best_score
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -906,7 +906,7 @@ class LGBMModel(_LGBMModelBase):
 
     @property
     def evals_result_(self):
-        """:obj:`dict` or :obj:`None`: The evaluation results if validation sets have been specified."""
+        """:obj:`dict`: The evaluation results if validation sets have been specified."""
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError('No results found. Need to call fit with eval_set beforehand.')
         return self._evals_result

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -784,7 +784,7 @@ def test_metrics():
 
     # no metric
     gbm = lgb.LGBMRegressor(metric='None', **params).fit(**params_fit)
-    assert gbm.evals_result_ is None
+    assert gbm.evals_result_ == {}
 
     # non-default metric in eval_metric
     gbm = lgb.LGBMRegressor(**params).fit(eval_metric='mape', **params_fit)
@@ -833,7 +833,7 @@ def test_metrics():
     # no metric
     gbm = lgb.LGBMRegressor(objective='regression_l1', metric='None',
                             **params).fit(**params_fit)
-    assert gbm.evals_result_ is None
+    assert gbm.evals_result_ == {}
 
     # non-default metric in eval_metric for non-default objective
     gbm = lgb.LGBMRegressor(objective='regression_l1',
@@ -878,7 +878,7 @@ def test_metrics():
     # no metric
     gbm = lgb.LGBMRegressor(objective=custom_dummy_obj, metric='None',
                             **params).fit(**params_fit)
-    assert gbm.evals_result_ is None
+    assert gbm.evals_result_ == {}
 
     # default regression metric with non-default metric in eval_metric for custom objective
     gbm = lgb.LGBMRegressor(objective=custom_dummy_obj,


### PR DESCRIPTION
Simplify codebase and unify standard and sklearn interfaces.
Similarly to #4845.