### PR TITLE
[python] reset storage in record evaluation callback each time before starting training

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -3,7 +3,7 @@ name: Python-package
 on:
   push:
     branches:
-    - master
+    - record_callback
   pull_request:
     branches:
     - master

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -3,7 +3,7 @@ name: Python-package
 on:
   push:
     branches:
-    - record_callback
+    - master
   pull_request:
     branches:
     - master

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -128,18 +128,24 @@ def record_evaluation(eval_result: Dict[str, Dict[str, List[Any]]]) -> Callable:
     """
     if not isinstance(eval_result, dict):
         raise TypeError('eval_result should be a dictionary')
-    eval_result.clear()
+    inited = False
 
     def _init(env: CallbackEnv) -> None:
+        nonlocal inited
+        eval_result.clear()
         for data_name, eval_name, _, _ in env.evaluation_result_list:
             eval_result.setdefault(data_name, collections.OrderedDict())
             eval_result[data_name].setdefault(eval_name, [])
+        inited = True
 
     def _callback(env: CallbackEnv) -> None:
-        if not eval_result:
+        nonlocal inited
+        if not inited:
             _init(env)
         for data_name, eval_name, result, _ in env.evaluation_result_list:
             eval_result[data_name][eval_name].append(result)
+        if env.iteration == env.end_iteration - 1:
+            inited = False
     _callback.order = 20  # type: ignore
     return _callback
 

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -294,20 +294,23 @@ def test_stacking_regressor():
 def test_grid_search():
     X, y = load_iris(return_X_y=True)
     y = y.astype(str)  # utilize label encoder at it's max power
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1,
-                                                        random_state=42)
-    X_train, X_val, y_train, y_val = train_test_split(X_train, y_train, test_size=0.1,
-                                                      random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+    X_train, X_val, y_train, y_val = train_test_split(X_train, y_train, test_size=0.1, random_state=42)
     params = dict(subsample=0.8,
                   subsample_freq=1)
     grid_params = dict(boosting_type=['rf', 'gbdt'],
                        n_estimators=[4, 6],
                        reg_alpha=[0.01, 0.005])
-    fit_params = dict(eval_set=[(X_val, y_val)],
-                      eval_metric=constant_metric,
-                      callbacks=[lgb.early_stopping(2)])
-    grid = GridSearchCV(estimator=lgb.LGBMClassifier(**params), param_grid=grid_params,
-                        cv=2)
+    evals_result = {}
+    fit_params = dict(
+        eval_set=[(X_val, y_val)],
+        eval_metric=constant_metric,
+        callbacks=[
+            lgb.early_stopping(2),
+            lgb.record_evaluation(evals_result)
+        ]
+    )
+    grid = GridSearchCV(estimator=lgb.LGBMClassifier(**params), param_grid=grid_params, cv=2)
     grid.fit(X_train, y_train, **fit_params)
     score = grid.score(X_test, y_test)  # utilizes GridSearchCV default refit=True
     assert grid.best_params_['boosting_type'] in ['rf', 'gbdt']
@@ -319,6 +322,7 @@ def test_grid_search():
     assert grid.best_estimator_.best_score_['valid_0']['error'] == 0
     assert score >= 0.2
     assert score <= 1.
+    assert evals_result == grid.best_estimator_.evals_result_
 
 
 def test_random_search():


### PR DESCRIPTION
Similarly to #4868.

Also, simplify early stopping callback by unconditionally reset all storages at the first iteration. This is much easier than tracking `inited` nonlocal flag (refer to https://github.com/microsoft/LightGBM/pull/4868#issuecomment-989456487).