### PR TITLE
[python] Drop Python 3.6 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,6 @@ install:
   - set CONDA_ENV="test-env"
   - ps: |
       switch ($env:PYTHON_VERSION) {
-          "3.6" {$env:MINICONDA = "C:\Miniconda36-x64"}
           "3.7" {$env:MINICONDA = "C:\Miniconda37-x64"}
           default {$env:MINICONDA = "C:\Miniconda37-x64"}
       }

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -114,14 +114,7 @@ if [[ $TASK == "swig" ]]; then
     exit 0
 fi
 
-# temporary fix for https://github.com/microsoft/LightGBM/issues/4769
-if [[ $PYTHON_VERSION == "3.6" ]]; then
-    DASK_DEPENDENCIES="dask distributed"
-else
-    DASK_DEPENDENCIES="dask=2021.9.1 distributed=2021.9.1"
-fi
-
-conda install -q -y -n $CONDA_ENV cloudpickle ${DASK_DEPENDENCIES} joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
+conda install -q -y -n $CONDA_ENV cloudpickle "dask=2021.9.1" "distributed=2021.9.1" joblib matplotlib numpy pandas psutil pytest scikit-learn scipy
 pip install graphviz  # python-graphviz from Anaconda is not allowed to be installed with Python 3.9
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           - os: macOS-latest
             task: regular
-            python_version: 3.6
+            python_version: 3.8
           - os: macOS-latest
             task: sdist
             python_version: 3.9
@@ -40,7 +40,7 @@ jobs:
           - os: macOS-latest
             task: mpi
             method: pip
-            python_version: 3.6
+            python_version: 3.9
           - os: macOS-latest
             task: mpi
             method: wheel

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -87,7 +87,6 @@ jobs:
     matrix:
       regular:
         TASK: regular
-        PYTHON_VERSION: 3.6
       sdist:
         TASK: sdist
       bdist:
@@ -112,7 +111,6 @@ jobs:
       gpu_pip:
         TASK: gpu
         METHOD: pip
-        PYTHON_VERSION: 3.6
       gpu_wheel:
         TASK: gpu
         METHOD: wheel
@@ -262,7 +260,6 @@ jobs:
     matrix:
       regular:
         TASK: regular
-        PYTHON_VERSION: 3.6
       sdist:
         TASK: sdist
         PYTHON_VERSION: 3.8

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -376,7 +376,6 @@ if __name__ == "__main__":
                        'Operating System :: POSIX',
                        'Operating System :: Unix',
                        'Programming Language :: Python :: 3',
-                       'Programming Language :: Python :: 3.6',
                        'Programming Language :: Python :: 3.7',
                        'Programming Language :: Python :: 3.8',
                        'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Python 3.6 is reaching its End of Life next week and no need to support it anymore.
https://devguide.python.org/#branchstatus