### PR TITLE
[python-package] support customizing Dataset creation in Booster.refit() (fixes #3038)

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3532,9 +3532,9 @@ class Booster:
             will use ``leaf_output = decay_rate * old_leaf_output + (1.0 - decay_rate) * new_leaf_output`` to refit trees.
         reference : Dataset or None, optional (default=None)
             reference for ``data``.
-            If this is Dataset for validation, training data should be used as reference.
         weight : list, numpy 1-D array, pandas Series or None, optional (default=None)
-            Weight for each ``data`` instance.
+            Weight for each ``data`` instance. Weight should be non-negative values because the Hessian
+            value multiplied by weight is supposed to be non-negative.
         group : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Group/query size for ``data``.
         init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3514,6 +3514,7 @@ class Booster:
         init_score=None,
         feature_name='auto',
         categorical_feature='auto',
+        dataset_params=None,
         free_raw_data=True,
         **kwargs
     ):
@@ -3550,7 +3551,9 @@ class Booster:
             Large values could be memory consuming. Consider using consecutive integers starting from zero.
             All negative values in categorical features will be treated as missing values.
             The output cannot be monotonically constrained with respect to a categorical feature.
-         free_raw_data : bool, optional (default=True)
+        dataset_params : dict or None, optional (default=None)
+            Other parameters for Dataset ``data``.
+        free_raw_data : bool, optional (default=True)
             If True, raw data is freed after constructing inner Dataset for ``data``.
         **kwargs
             Other parameters for refit.
@@ -3563,6 +3566,8 @@ class Booster:
         """
         if self.__set_objective_to_none:
             raise LightGBMError('Cannot refit due to null objective function.')
+        if dataset_params is None:
+            dataset_params = {}
         predictor = self._to_predictor(deepcopy(kwargs))
         leaf_preds = predictor.predict(data, -1, pred_leaf=True)
         nrow, ncol = leaf_preds.shape
@@ -3576,6 +3581,7 @@ class Booster:
             default_value=None
         )
         new_params["linear_tree"] = bool(out_is_linear.value)
+        new_params.update(dataset_params)
         train_set = Dataset(
             data=data,
             label=label,

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3531,21 +3531,25 @@ class Booster:
             Decay rate of refit,
             will use ``leaf_output = decay_rate * old_leaf_output + (1.0 - decay_rate) * new_leaf_output`` to refit trees.
         reference : Dataset or None, optional (default=None)
-            reference for ``data``.
+            Reference for ``data``.
         weight : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Weight for each ``data`` instance. Weight should be non-negative values because the Hessian
             value multiplied by weight is supposed to be non-negative.
         group : list, numpy 1-D array, pandas Series or None, optional (default=None)
             Group/query size for ``data``.
-        init_score : list, numpy 1-D array, pandas Series or None, optional (default=None)
+            Only used in the learning-to-rank task.
+            sum(group) = n_samples.
+            For example, if you have a 100-document dataset with ``group = [10, 20, 40, 10, 10, 10]``, that means that you have 6 groups,
+            where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the third group, etc.
+        init_score : list, list of lists (for multi-class task), numpy array, pandas Series, pandas DataFrame (for multi-class task), or None, optional (default=None)
             Init score for ``data``.
-        feature_name : list of strings or 'auto', optional (default="auto")
+        feature_name : list of str or 'auto', optional (default="auto")
             Feature names for ``data``.
             If 'auto' and data is pandas DataFrame, data columns names are used.
-        categorical_feature : list of strings or int, or 'auto', optional (default="auto")
+        categorical_feature : list of str or int, or 'auto', optional (default="auto")
             Categorical features for ``data``.
             If list of int, interpreted as indices.
-            If list of strings, interpreted as feature names (need to specify ``feature_name`` as well).
+            If list of str, interpreted as feature names (need to specify ``feature_name`` as well).
             If 'auto' and data is pandas DataFrame, pandas unordered categorical columns are used.
             All values in categorical features should be less than int32 max value (2147483647).
             Large values could be memory consuming. Consider using consecutive integers starting from zero.

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3503,7 +3503,7 @@ class Booster:
                                  raw_score, pred_leaf, pred_contrib,
                                  data_has_header, is_reshape)
 
-    def refit(self, data, label, decay_rate=0.9, **kwargs):
+    def refit(self, data, label, decay_rate=0.9, kwargs_for_predict=None, kwargs_for_dataset=None):
         """Refit the existing Booster by new data.
 
         Parameters
@@ -3516,9 +3516,10 @@ class Booster:
         decay_rate : float, optional (default=0.9)
             Decay rate of refit,
             will use ``leaf_output = decay_rate * old_leaf_output + (1.0 - decay_rate) * new_leaf_output`` to refit trees.
-        **kwargs
-            Other parameters for refit.
-            These parameters will be passed to ``predict`` method.
+        kwargs_for_predict: dict, optional (default=None)
+            parameters passed to ``predict`` method.
+        kwargs_for_dataset: dict, optional (default=None)
+            additional parameters passed to ``Dataset`` class. The keys data, label and params should not be contained.
 
         Returns
         -------
@@ -3527,7 +3528,9 @@ class Booster:
         """
         if self.__set_objective_to_none:
             raise LightGBMError('Cannot refit due to null objective function.')
-        predictor = self._to_predictor(deepcopy(kwargs))
+        kwargs_for_predict = {} if kwargs_for_predict is None else kwargs_for_predict
+        kwargs_for_dataset = {} if kwargs_for_dataset is None else kwargs_for_dataset
+        predictor = self._to_predictor(deepcopy(kwargs_for_predict))
         leaf_preds = predictor.predict(data, -1, pred_leaf=True)
         nrow, ncol = leaf_preds.shape
         out_is_linear = ctypes.c_int(0)
@@ -3540,7 +3543,7 @@ class Booster:
             default_value=None
         )
         new_params["linear_tree"] = bool(out_is_linear.value)
-        train_set = Dataset(data, label, params=new_params)
+        train_set = Dataset(data, label, params=new_params, **kwargs_for_dataset)
         new_params['refit_decay_rate'] = decay_rate
         new_booster = Booster(new_params, train_set)
         # Copy models

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3543,7 +3543,7 @@ class Booster:
             where the first 10 records are in the first group, records 11-30 are in the second group, records 31-70 are in the third group, etc.
         init_score : list, list of lists (for multi-class task), numpy array, pandas Series, pandas DataFrame (for multi-class task), or None, optional (default=None)
             Init score for ``data``.
-        feature_name : list of str or 'auto', optional (default="auto")
+        feature_name : list of str, or 'auto', optional (default="auto")
             Feature names for ``data``.
             If 'auto' and data is pandas DataFrame, data columns names are used.
         categorical_feature : list of str or int, or 'auto', optional (default="auto")

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3519,7 +3519,8 @@ class Booster:
         kwargs_for_predict: dict, optional (default=None)
             parameters passed to ``predict`` method.
         kwargs_for_dataset: dict, optional (default=None)
-            additional parameters passed to ``Dataset`` class. The keys data, label and params should not be contained.
+            additional parameters passed to ``Dataset`` class. If the parameters ``data, label, params`` are contained, they
+            are removed.
 
         Returns
         -------
@@ -3543,6 +3544,8 @@ class Booster:
             default_value=None
         )
         new_params["linear_tree"] = bool(out_is_linear.value)
+        for arg in ['data', 'label', 'params']:
+            kwargs_for_dataset.pop(arg, None)
         train_set = Dataset(data, label, params=new_params, **kwargs_for_dataset)
         new_params['refit_decay_rate'] = decay_rate
         new_booster = Booster(new_params, train_set)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1554,45 +1554,21 @@ def test_refit_dataset_params():
         'objective': 'binary',
         'metric': 'binary_logloss',
         'verbose': -1,
-        'min_data': 10
+        'min_data': 10,
+        'seed': 123
     }
     gbm = lgb.train(train_params, lgb_train, num_boost_round=20)
     non_weight_err_pred = log_loss(y_test, gbm.predict(X_test))
     dataset_params = {
-        'linear_tree': False,
-        'max_bin': 255,
-        'max_bin_by_feature': None,
-        'min_data_in_bin': 3,
-        'bin_construct_sample_cnt': 200000,
-        'data_random_seed': 1,
-        'is_enable_sparse': True,
-        'enable_bundle': True,
-        'use_missing': True,
-        'zero_as_missing': False,
-        'feature_pre_filter': True,
-        'pre_partition': False,
-        'two_round': False,
-        'header': False,
-        'label_column': "",
-        'weight_column': "",
-        'group_column': "",
-        'ignore_column': "",
-        'forcedbins_filename': "",
-        'save_binary': False,
-        'precise_float_parser': False,
-        'parser_config_file': "",
+        'max_bin': 260,
+        'min_data_in_bin': 5,
+        'data_random_seed': 123,
     }
     new_gbm = gbm.refit(
         data=X_train,
         label=y_train,
         weight=np.random.rand(y_train.shape[0]),
-        reference=None,
-        group=None,
-        init_score=None,
-        feature_name="auto",
-        categorical_feature="auto",
         dataset_params=dataset_params,
-        free_raw_data=True
     )
     weight_err_pred = log_loss(y_test, new_gbm.predict(X_test))
     assert weight_err_pred != non_weight_err_pred

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1548,7 +1548,7 @@ def test_refit():
 def test_refit_dataset_params():
     # check refit accepts dataset_params
     X, y = load_breast_cancer(return_X_y=True)
-    lgb_train = lgb.Dataset(X, y)
+    lgb_train = lgb.Dataset(X, y, init_score=np.zeros(y.size))
     train_params = {
         'objective': 'binary',
         'verbose': -1,
@@ -1567,6 +1567,7 @@ def test_refit_dataset_params():
         label=y,
         weight=refit_weight,
         dataset_params=dataset_params,
+        decay_rate=0.0,
     )
     weight_err_pred = log_loss(y, new_gbm.predict(X))
     train_set_params = new_gbm.train_set.get_params()

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1558,17 +1558,16 @@ def test_refit_dataset_params():
     }
     gbm = lgb.train(params, lgb_train, num_boost_round=20)
     non_weight_err_pred = log_loss(y_test, gbm.predict(X_test))
-    dataset_params = {
-        "weight": np.abs(np.random.normal(size=y_train.shape)),
-        "reference": None,
-        "group": None,
-        "init_score": None,
-        "feature_name": "auto",
-        "categorical_feature": "auto",
-        "free_raw_data": True
-    }
     new_gbm = gbm.refit(
-        X_train, y_train, dataset_params=dataset_params
+        data=X_train,
+        label=y_train,
+        weight=np.abs(np.random.normal(size=y_train.shape)),
+        reference=None,
+        group=None,
+        init_score=None,
+        feature_name="auto",
+        categorical_feature="auto",
+        free_raw_data=True
     )
     weight_err_pred = log_loss(y_test, new_gbm.predict(X_test))
     assert weight_err_pred != non_weight_err_pred

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -22,6 +22,7 @@ from .utils import load_boston, load_breast_cancer, load_digits, load_iris
 
 decreasing_generator = itertools.count(0, -1)
 
+
 def dummy_obj(preds, train_data):
     return np.ones(preds.shape), np.ones(preds.shape)
 

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1576,7 +1576,7 @@ def test_refit_dataset_params():
     assert train_set_params["max_bin"] == 260
     assert train_set_params["min_data_in_bin"] == 5
     assert train_set_params["data_random_seed"] == 123
-    np.testing.assert_allclose(stored_weights, refit_weight, verbose=True)
+    np.testing.assert_allclose(stored_weights, refit_weight)
 
 
 def test_mape_rf():

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1548,28 +1548,27 @@ def test_refit():
 def test_refit_dataset_params():
     # check refit accepts dataset_params
     X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
-    lgb_train = lgb.Dataset(X_train, y_train)
+    lgb_train = lgb.Dataset(X, y)
     train_params = {
         'objective': 'binary',
         'verbose': -1,
         'seed': 123
     }
     gbm = lgb.train(train_params, lgb_train, num_boost_round=10)
-    non_weight_err_pred = log_loss(y_test, gbm.predict(X_test))
-    refit_weight = np.random.rand(y_train.shape[0])
+    non_weight_err_pred = log_loss(y, gbm.predict(X))
+    refit_weight = np.random.rand(y.shape[0])
     dataset_params = {
         'max_bin': 260,
         'min_data_in_bin': 5,
         'data_random_seed': 123,
     }
     new_gbm = gbm.refit(
-        data=X_train,
-        label=y_train,
+        data=X,
+        label=y,
         weight=refit_weight,
         dataset_params=dataset_params,
     )
-    weight_err_pred = log_loss(y_test, new_gbm.predict(X_test))
+    weight_err_pred = log_loss(y, new_gbm.predict(X))
     train_set_params = new_gbm.train_set.get_params()
     stored_weights = new_gbm.train_set.get_weight()
     assert weight_err_pred != non_weight_err_pred

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1550,23 +1550,48 @@ def test_refit_dataset_params():
     X, y = load_breast_cancer(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
     lgb_train = lgb.Dataset(X_train, y_train)
-    params = {
+    train_params = {
         'objective': 'binary',
         'metric': 'binary_logloss',
         'verbose': -1,
         'min_data': 10
     }
-    gbm = lgb.train(params, lgb_train, num_boost_round=20)
+    gbm = lgb.train(train_params, lgb_train, num_boost_round=20)
     non_weight_err_pred = log_loss(y_test, gbm.predict(X_test))
+    dataset_params = {
+        'linear_tree': False,
+        'max_bin': 255,
+        'max_bin_by_feature': None,
+        'min_data_in_bin': 3,
+        'bin_construct_sample_cnt': 200000,
+        'data_random_seed': 1,
+        'is_enable_sparse': True,
+        'enable_bundle': True,
+        'use_missing': True,
+        'zero_as_missing': False,
+        'feature_pre_filter': True,
+        'pre_partition': False,
+        'two_round': False,
+        'header': False,
+        'label_column': "",
+        'weight_column': "",
+        'group_column': "",
+        'ignore_column': "",
+        'forcedbins_filename': "",
+        'save_binary': False,
+        'precise_float_parser': False,
+        'parser_config_file': "",
+    }
     new_gbm = gbm.refit(
         data=X_train,
         label=y_train,
-        weight=np.abs(np.random.normal(size=y_train.shape)),
+        weight=np.random.rand(y_train.shape[0]),
         reference=None,
         group=None,
         init_score=None,
         feature_name="auto",
         categorical_feature="auto",
+        dataset_params=dataset_params,
         free_raw_data=True
     )
     weight_err_pred = log_loss(y_test, new_gbm.predict(X_test))


### PR DESCRIPTION
**Context**:
This PR aims to close #3038 

**Changes**
* refit method accepts `kwargs_for_dataset` parameter to pass weight parameter to Dataset initialization inside `refit()`.
* refit method accepts `kwargs_for_predict` parameter to pass original params to `predict` method.

**Tests**:
Based on @jtilly example on issue #3038 test that `refit` method returns a valid prediction value when passing `kwargs_for_dataset` or `kwargs_for_predict`.
