### PR TITLE
[R-package] update parameter 'verbosity' based on keyword arg 'verbose'

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -102,7 +102,6 @@ lgb.cv <- function(params = list()
   }
 
   # Setup temporary variables
-  params$verbose <- verbose
   params <- lgb.check.obj(params = params, obj = obj)
   params <- lgb.check.eval(params = params, eval = eval)
   fobj <- NULL
@@ -112,6 +111,11 @@ lgb.cv <- function(params = list()
   # in `params`.
   # this ensures that the model stored with Booster$save() correctly represents
   # what was passed in
+  params <- lgb.check.wrapper_param(
+    main_param_name = "verbosity"
+    , params = params
+    , alternative_kwarg_value = verbose
+  )
   params <- lgb.check.wrapper_param(
     main_param_name = "num_iterations"
     , params = params

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -74,7 +74,6 @@ lgb.train <- function(params = list(),
   }
 
   # Setup temporary variables
-  params$verbose <- verbose
   params <- lgb.check.obj(params = params, obj = obj)
   params <- lgb.check.eval(params = params, eval = eval)
   fobj <- NULL
@@ -84,6 +83,11 @@ lgb.train <- function(params = list(),
   # in `params`.
   # this ensures that the model stored with Booster$save() correctly represents
   # what was passed in
+  params <- lgb.check.wrapper_param(
+    main_param_name = "verbosity"
+    , params = params
+    , alternative_kwarg_value = verbose
+  )
   params <- lgb.check.wrapper_param(
     main_param_name = "num_iterations"
     , params = params

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -1534,6 +1534,60 @@ test_that("lgb.train() works with integer, double, and numeric data", {
   }
 })
 
+test_that("lgb.train() updates params based on keyword arguments", {
+  dtrain <- lgb.Dataset(
+    data = matrix(rnorm(400L), ncol =  4L)
+    , label = rnorm(100L)
+  )
+
+  # defaults from keyword arguments should be used if not specified in params
+  invisible(
+    capture.output({
+      bst <- lgb.train(
+        data = dtrain
+        , obj = "regression"
+        , params = list()
+      )
+    })
+  )
+  expect_equal(bst$params[["verbosity"]], 1L)
+  expect_equal(bst$params[["num_iterations"]], 100L)
+
+  # main param names should be preferred to keyword arguments
+  invisible(
+    capture.output({
+      bst <- lgb.train(
+        data = dtrain
+        , obj = "regression"
+        , params = list(
+          "verbosity" = 5L
+          , "num_iterations" = 2L
+        )
+      )
+    })
+  )
+  expect_equal(bst$params[["verbosity"]], 5L)
+  expect_equal(bst$params[["num_iterations"]], 2L)
+
+  # aliases should be preferred to keyword arguments, and converted to main parameter name
+  invisible(
+    capture.output({
+      bst <- lgb.train(
+        data = dtrain
+        , obj = "regression"
+        , params = list(
+          "verbose" = 5L
+          , "num_boost_round" = 2L
+        )
+      )
+    })
+  )
+  expect_equal(bst$params[["verbosity"]], 5L)
+  expect_false("verbose" %in% bst$params)
+  expect_equal(bst$params[["num_iterations"]], 2L)
+  expect_false("num_boost_round" %in% bst$params)
+})
+
 test_that("when early stopping is not activated, best_iter and best_score come from valids and not training data", {
   set.seed(708L)
   trainDF <- data.frame(
@@ -1951,6 +2005,74 @@ test_that("early stopping works with lgb.cv()", {
     length(bst$record_evals[["valid"]][["increasing_metric"]][["eval"]])
     , early_stopping_rounds + 1L
   )
+})
+
+test_that("lgb.cv() updates params based on keyword arguments", {
+  dtrain <- lgb.Dataset(
+    data = matrix(rnorm(400L), ncol =  4L)
+    , label = rnorm(100L)
+  )
+
+  # defaults from keyword arguments should be used if not specified in params
+  invisible(
+    capture.output({
+      cv_bst <- lgb.cv(
+        data = dtrain
+        , obj = "regression"
+        , params = list()
+        , nfold = 2L
+      )
+    })
+  )
+
+  for (bst in cv_bst$boosters) {
+    bst_params <- bst[["booster"]]$params
+    expect_equal(bst_params[["verbosity"]], 1L)
+    expect_equal(bst_params[["num_iterations"]], 100L)
+  }
+
+  # main param names should be preferred to keyword arguments
+  invisible(
+    capture.output({
+      cv_bst <- lgb.cv(
+        data = dtrain
+        , obj = "regression"
+        , params = list(
+          "verbosity" = 5L
+          , "num_iterations" = 2L
+        )
+        , nfold = 2L
+      )
+    })
+  )
+  for (bst in cv_bst$boosters) {
+    bst_params <- bst[["booster"]]$params
+    expect_equal(bst_params[["verbosity"]], 5L)
+    expect_equal(bst_params[["num_iterations"]], 2L)
+  }
+
+  # aliases should be preferred to keyword arguments, and converted to main parameter name
+  invisible(
+    capture.output({
+      cv_bst <- lgb.cv(
+        data = dtrain
+        , obj = "regression"
+        , params = list(
+          "verbose" = 5L
+          , "num_boost_round" = 2L
+        )
+        , nfold = 2L
+      )
+    })
+  )
+  for (bst in cv_bst$boosters) {
+    bst_params <- bst[["booster"]]$params
+    expect_equal(bst_params[["verbosity"]], 5L)
+    expect_false("verbose" %in% bst_params)
+    expect_equal(bst_params[["num_iterations"]], 2L)
+    expect_false("num_boost_round" %in% bst_params)
+  }
+
 })
 
 context("linear learner")


### PR DESCRIPTION
Related to #4667.
Related to #4862.

While investigating #4667, I noticed a small inconsistency in `lgb.train()` and `lgb.cv()`. Those functions have a keyword argument `verbose` and update the parameter `verbose` in parameters passed down to `LGBM_BoosterCreate`.

https://github.com/microsoft/LightGBM/blob/7b10baffb6e600862b087a4207343b0b58eed2b5/R-package/R/lgb.cv.R#L105

https://github.com/microsoft/LightGBM/blob/7b10baffb6e600862b087a4207343b0b58eed2b5/R-package/R/lgb.train.R#L77

As a result, if you pass different values for `verbosity` (in `params`) and `verbose` (via keyword arguments), then the Booster's parameters will contain both `verbosity` and `verbose`.

Consider this example:

```r
library(lightgbm)
data("agaricus.train")
dtrain <- lightgbm::lgb.Dataset(
    data = agaricus.train$data
    , label = agaricus.train$label
)
bst <- lightgbm::lgb.train(
    params = list(
        num_iterations = 2L
        , verbosity = 1L
    )
    , data = dtrain
    , obj = "binary"
    , verbose = -1L
)
bst$params
```

> $verbosity
[1] 1

> $verbose
[1] -1

Note that `verbosity` is the main parameter recognized by LightGBM (https://lightgbm.readthedocs.io/en/latest/Parameters.html#verbosity) and `verbose` is an alias for it.

This PR proposes two changes:

1. Update `params$verbosity` (the main parameter name, instead of an alias) based on the value of keyword argument `verbose`
2. Use internal function `lgb.check.wrapper_param()` to ensure consistent behavior when processing keyword arguments.