### PR TITLE
[R-package] remove unnecessary comments and fix typos in comments

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -236,7 +236,7 @@ Dataset <- R6::R6Class(
           if (length(private$raw_data@p) > 2147483647L) {
             stop("Cannot support large CSC matrix")
           }
-          # Are we using a dgCMatrix (sparsed matrix column compressed)
+          # Are we using a dgCMatrix (sparse matrix column compressed)
           handle <- .Call(
             LGBM_DatasetCreateFromCSC_R
             , private$raw_data@p
@@ -462,15 +462,14 @@ Dataset <- R6::R6Class(
           , info_len
         )
 
-        # Check if info is not empty
         if (info_len > 0L) {
 
           # Get back fields
           ret <- NULL
           ret <- if (field_name == "group") {
-            integer(info_len) # Integer
+            integer(info_len)
           } else {
-            numeric(info_len) # Numeric
+            numeric(info_len)
           }
 
           .Call(
@@ -501,9 +500,9 @@ Dataset <- R6::R6Class(
 
       # Check for type of information
       data <- if (field_name == "group") {
-        as.integer(data) # Integer
+        as.integer(data)
       } else {
-        as.numeric(data) # Numeric
+        as.numeric(data)
       }
 
       # Store information privately
@@ -531,10 +530,8 @@ Dataset <- R6::R6Class(
 
     },
 
-    # Slice dataset
     slice = function(idxset) {
 
-      # Perform slicing
       return(
         Dataset$new(
           data = NULL
@@ -617,7 +614,6 @@ Dataset <- R6::R6Class(
 
     },
 
-    # Set reference
     set_reference = function(reference) {
 
       # setting reference to this same Dataset object doesn't require any changes
@@ -677,7 +673,6 @@ Dataset <- R6::R6Class(
     info = NULL,
     version = 0L,
 
-    # Get handle
     get_handle = function() {
 
       # Get handle and construct if needed
@@ -688,7 +683,6 @@ Dataset <- R6::R6Class(
 
     },
 
-    # Set predictor
     set_predictor = function(predictor) {
 
       if (identical(private$predictor, predictor)) {

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -550,7 +550,7 @@ lgb.stratified.folds <- function(y, k) {
 
       ## Create a vector of integers from 1:k as many times as possible without
       ## going over the number of samples in the class. Note that if the number
-      ## of samples in a class is less than k, nothing is producd here.
+      ## of samples in a class is less than k, nothing is produced here.
       seqVector <- rep(seq_len(k), numInClass[i] %/% k)
 
       ## Add enough random integers to get length(seqVector) == numInClass[i]

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -268,7 +268,7 @@ lgb.check.wrapper_param <- function(main_param_name, params, alternative_kwarg_v
     return(params)
   }
 
-  # if the main parameter wasn't proovided, prefer the first alias
+  # if the main parameter wasn't provided, prefer the first alias
   if (length(aliases_provided) > 0L) {
     first_param <- aliases_provided[1L]
     params[[main_param_name]] <- params[[first_param]]


### PR DESCRIPTION
I've been looking more closely at the R package recently, and noticed a few comments that are either uninformative or provide typos. This PR proposes cleaning them up.