### PR TITLE
[R-package] respect aliases for objective and metric and lgb.train() and lgb.cv()

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -101,12 +101,6 @@ lgb.cv <- function(params = list()
     data <- lgb.Dataset(data = data, label = label)
   }
 
-  # Setup temporary variables
-  params <- lgb.check.obj(params = params, obj = obj)
-  params <- lgb.check.eval(params = params, eval = eval)
-  fobj <- NULL
-  eval_functions <- list(NULL)
-
   # set some parameters, resolving the way they were passed in with other parameters
   # in `params`.
   # this ensures that the model stored with Booster$save() correctly represents
@@ -122,13 +116,26 @@ lgb.cv <- function(params = list()
     , alternative_kwarg_value = nrounds
   )
   params <- lgb.check.wrapper_param(
+    main_param_name = "metric"
+    , params = params
+    , alternative_kwarg_value = NULL
+  )
+  params <- lgb.check.wrapper_param(
+    main_param_name = "objective"
+    , params = params
+    , alternative_kwarg_value = NULL
+  )
+  params <- lgb.check.wrapper_param(
     main_param_name = "early_stopping_round"
     , params = params
     , alternative_kwarg_value = early_stopping_rounds
   )
   early_stopping_rounds <- params[["early_stopping_round"]]
 
-  # Check for objective (function or not)
+  # extract any function objects passed for objective or metric
+  params <- lgb.check.obj(params = params, obj = obj)
+  params <- lgb.check.eval(params = params, eval = eval)
+  fobj <- NULL
   if (is.function(params$objective)) {
     fobj <- params$objective
     params$objective <- "NONE"
@@ -138,6 +145,7 @@ lgb.cv <- function(params = list()
   # (for backwards compatibility). If it is a list of functions, store
   # all of them. This makes it possible to pass any mix of strings like "auc"
   # and custom functions to eval
+  eval_functions <- list(NULL)
   if (is.function(eval)) {
     eval_functions <- list(eval)
   }

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -134,7 +134,6 @@ lgb.cv <- function(params = list()
 
   # extract any function objects passed for objective or metric
   params <- lgb.check.obj(params = params, obj = obj)
-  params <- lgb.check.eval(params = params, eval = eval)
   fobj <- NULL
   if (is.function(params$objective)) {
     fobj <- params$objective
@@ -145,6 +144,7 @@ lgb.cv <- function(params = list()
   # (for backwards compatibility). If it is a list of functions, store
   # all of them. This makes it possible to pass any mix of strings like "auc"
   # and custom functions to eval
+  params <- lgb.check.eval(params = params, eval = eval)
   eval_functions <- list(NULL)
   if (is.function(eval)) {
     eval_functions <- list(eval)

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -106,7 +106,6 @@ lgb.train <- function(params = list(),
 
   # extract any function objects passed for objective or metric
   params <- lgb.check.obj(params = params, obj = obj)
-  params <- lgb.check.eval(params = params, eval = eval)
   fobj <- NULL
   if (is.function(params$objective)) {
     fobj <- params$objective
@@ -117,6 +116,7 @@ lgb.train <- function(params = list(),
   # (for backwards compatibility). If it is a list of functions, store
   # all of them. This makes it possible to pass any mix of strings like "auc"
   # and custom functions to eval
+  params <- lgb.check.eval(params = params, eval = eval)
   eval_functions <- list(NULL)
   if (is.function(eval)) {
     eval_functions <- list(eval)

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -73,12 +73,6 @@ lgb.train <- function(params = list(),
     }
   }
 
-  # Setup temporary variables
-  params <- lgb.check.obj(params = params, obj = obj)
-  params <- lgb.check.eval(params = params, eval = eval)
-  fobj <- NULL
-  eval_functions <- list(NULL)
-
   # set some parameters, resolving the way they were passed in with other parameters
   # in `params`.
   # this ensures that the model stored with Booster$save() correctly represents
@@ -94,13 +88,26 @@ lgb.train <- function(params = list(),
     , alternative_kwarg_value = nrounds
   )
   params <- lgb.check.wrapper_param(
+    main_param_name = "metric"
+    , params = params
+    , alternative_kwarg_value = NULL
+  )
+  params <- lgb.check.wrapper_param(
+    main_param_name = "objective"
+    , params = params
+    , alternative_kwarg_value = NULL
+  )
+  params <- lgb.check.wrapper_param(
     main_param_name = "early_stopping_round"
     , params = params
     , alternative_kwarg_value = early_stopping_rounds
   )
   early_stopping_rounds <- params[["early_stopping_round"]]
 
-  # Check for objective (function or not)
+  # extract any function objects passed for objective or metric
+  params <- lgb.check.obj(params = params, obj = obj)
+  params <- lgb.check.eval(params = params, eval = eval)
+  fobj <- NULL
   if (is.function(params$objective)) {
     fobj <- params$objective
     params$objective <- "NONE"
@@ -110,6 +117,7 @@ lgb.train <- function(params = list(),
   # (for backwards compatibility). If it is a list of functions, store
   # all of them. This makes it possible to pass any mix of strings like "auc"
   # and custom functions to eval
+  eval_functions <- list(NULL)
   if (is.function(eval)) {
     eval_functions <- list(eval)
   }

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -127,6 +127,7 @@ test_that("train and predict softmax", {
   expect_equal(length(pred), nrow(iris) * 3L)
 })
 
+
 test_that("use of multiple eval metrics works", {
   metrics <- list("binary_error", "auc", "binary_logloss")
   bst <- lightgbm(

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -127,7 +127,6 @@ test_that("train and predict softmax", {
   expect_equal(length(pred), nrow(iris) * 3L)
 })
 
-
 test_that("use of multiple eval metrics works", {
   metrics <- list("binary_error", "auc", "binary_logloss")
   bst <- lightgbm(
@@ -554,6 +553,52 @@ test_that("lgb.cv() respects showsd argument", {
   expect_identical(evals_no_showsd[["eval_err"]], list())
 })
 
+test_that("lgb.cv() respects parameter aliases for objective", {
+  nrounds <- 3L
+  nfold <- 4L
+  dtrain <- lgb.Dataset(
+    data = train$data
+    , label = train$label
+  )
+  cv_bst <- lgb.cv(
+    data = dtrain
+    , params = list(
+      num_leaves = 5L
+      , application = "binary"
+      , num_iterations = nrounds
+    )
+    , nfold = nfold
+  )
+  expect_equal(cv_bst$best_iter, nrounds)
+  expect_named(cv_bst$record_evals[["valid"]], "binary_logloss")
+  expect_length(cv_bst$record_evals[["valid"]][["binary_logloss"]][["eval"]], nrounds)
+  expect_length(cv_bst$boosters, nfold)
+})
+
+test_that("lgb.cv() respects parameter aliases for metric", {
+  nrounds <- 3L
+  nfold <- 4L
+  dtrain <- lgb.Dataset(
+    data = train$data
+    , label = train$label
+  )
+  cv_bst <- lgb.cv(
+    data = dtrain
+    , params = list(
+      num_leaves = 5L
+      , objective = "binary"
+      , num_iterations = nrounds
+      , metric_types = c("auc", "binary_logloss")
+    )
+    , nfold = nfold
+  )
+  expect_equal(cv_bst$best_iter, nrounds)
+  expect_named(cv_bst$record_evals[["valid"]], c("auc", "binary_logloss"))
+  expect_length(cv_bst$record_evals[["valid"]][["binary_logloss"]][["eval"]], nrounds)
+  expect_length(cv_bst$record_evals[["valid"]][["auc"]][["eval"]], nrounds)
+  expect_length(cv_bst$boosters, nfold)
+})
+
 context("lgb.train()")
 
 test_that("lgb.train() works as expected with multiple eval metrics", {
@@ -584,6 +629,52 @@ test_that("lgb.train() works as expected with multiple eval metrics", {
     , ignore.order = FALSE
     , ignore.case = FALSE
   )
+})
+
+test_that("lgb.train() respects parameter aliases for objective", {
+  nrounds <- 3L
+  dtrain <- lgb.Dataset(
+    data = train$data
+    , label = train$label
+  )
+  bst <- lgb.train(
+    data = dtrain
+    , params = list(
+      num_leaves = 5L
+      , application = "binary"
+      , num_iterations = nrounds
+    )
+    , valids = list(
+      "the_training_data" = dtrain
+    )
+  )
+  expect_named(bst$record_evals[["the_training_data"]], "binary_logloss")
+  expect_length(bst$record_evals[["the_training_data"]][["binary_logloss"]][["eval"]], nrounds)
+})
+
+test_that("lgb.train() respects parameter aliases for metric", {
+  nrounds <- 3L
+  dtrain <- lgb.Dataset(
+    data = train$data
+    , label = train$label
+  )
+  bst <- lgb.train(
+    data = dtrain
+    , params = list(
+      num_leaves = 5L
+      , objective = "binary"
+      , num_iterations = nrounds
+      , metric_types = c("auc", "binary_logloss")
+    )
+    , valids = list(
+      "train" = dtrain
+    )
+  )
+  record_results <- bst$record_evals[["train"]]
+  expect_equal(sort(names(record_results)), c("auc", "binary_logloss"))
+  expect_length(record_results[["auc"]][["eval"]], nrounds)
+  expect_length(record_results[["binary_logloss"]][["eval"]], nrounds)
+  expect_equal(bst$params[["metric"]], list("auc", "binary_logloss"))
 })
 
 test_that("lgb.train() rejects negative or 0 value passed to nrounds", {

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -681,6 +681,7 @@ test_that("lgb.train() respects parameter aliases for objective", {
   )
   expect_named(bst$record_evals[["the_training_data"]], "binary_logloss")
   expect_length(bst$record_evals[["the_training_data"]][["binary_logloss"]][["eval"]], nrounds)
+  expect_equal(bst$params[["objective"]], "binary")
 })
 
 test_that("lgb.train() respects parameter aliases for metric", {


### PR DESCRIPTION
Similar to #4903, this PR proposes changes to ensure that parameter aliases in `lgb.train()` and `lgb.cv()` are handled correctly in the R package.

Currently, internal helper functions access `params$objective` and `params$metric` directly, without considering aliases.

https://github.com/microsoft/LightGBM/blob/ce486e5b45a6f5e67743e14765ed139ff8d532e5/R-package/R/utils.R#L168

https://github.com/microsoft/LightGBM/blob/ce486e5b45a6f5e67743e14765ed139ff8d532e5/R-package/R/utils.R#L194

As a result, it's not possible today to use any of [the aliases for `objective`](https://lightgbm.readthedocs.io/en/latest/Parameters.html#objective) with `lgb.train()` and `lgb.cv()`.

```r
library(lightgbm)
data("agaricus.train", package = "lightgbm")
train <- agaricus.train
dtrain <- lgb.Dataset(
    data = train$data
    , label = train$label
)
bst <- lgb.train(
    data = dtrain
    , params = list(
        num_leaves = 5L
        , application = "binary"
        , num_iterations = 5L
    )
)
```

>  Error in lgb.check.obj(params = params, obj = obj) : 
  lgb.check.obj: objective should be a character or a function

This PR proposes the following changes to address that:

* populate `params$objective` and `params$metric` using internal helper function `lgb.check.wrapper_param()`, which handles reconciling parameters passed by main parameter name and aliases
* move code for handling the possibility of custom objective and metrics (which are R function objects, not strings) down so it happens _after_ aliases have been handled in `params`