### PR TITLE
[R-package] fix handling of duplicate parameters (fixes #4521)

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -25,6 +25,7 @@ lgb.params2str <- function(params) {
     stop("params must be a list")
   }
 
+  names(params) <- gsub("\\.", "_", names(params))
   param_names <- names(params)
   ret <- list()
 

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -25,20 +25,18 @@ lgb.params2str <- function(params) {
     stop("params must be a list")
   }
 
-  # Split parameter names
-  names(params) <- gsub("\\.", "_", names(params))
-
+  param_names <- names(params)
   ret <- list()
 
   # Perform key value join
-  for (key in names(params)) {
+  for (i in seq_along(params)) {
 
     # If a parameter has multiple values, join those values together with commas.
     # trimws() is necessary because format() will pad to make strings the same width
     val <- paste0(
       trimws(
         format(
-          x = params[[key]]
+          x = unname(params[[i]])
           , scientific = FALSE
         )
       )
@@ -47,7 +45,7 @@ lgb.params2str <- function(params) {
     if (nchar(val) <= 0L) next # Skip join
 
     # Join key value
-    pair <- paste0(c(key, val), collapse = "=")
+    pair <- paste0(c(param_names[[i]], val), collapse = "=")
     ret <- c(ret, pair)
 
   }

--- a/R-package/tests/testthat/test_utils.R
+++ b/R-package/tests/testthat/test_utils.R
@@ -26,6 +26,17 @@ test_that("lgb.params2str() works as expected for a key in params with multiple 
     )
 })
 
+test_that("lgb.params2str() passes through duplicated params", {
+    out_str <- lgb.params2str(
+        params = list(
+            objective = "regression"
+            , bagging_fraction = 0.8
+            , bagging_fraction = 0.5
+        )
+    )
+    expect_equal(out_str, "objective=regression bagging_fraction=0.8 bagging_fraction=0.5")
+})
+
 context("lgb.check.eval")
 
 test_that("lgb.check.eval works as expected with no metric", {


### PR DESCRIPTION
Fixes #4521.

When LightGBM's core library finds duplicates provided in params, it emits a warning-level log message and uses the value from the first instance of that parameter encountered while parsing parameters.

The R package doesn't enforce uniqueness of parameter names either, but due to a bug in how it converts an R list of parameters to a string, the warning message generated when duplicate parameters are passed is currently incorrect.

This PR proposes fixing that.