### PR TITLE
[R-package] [tests] remove uses of testthat::context()

### DIFF
--- a/R-package/tests/testthat/test_Predictor.R
+++ b/R-package/tests/testthat/test_Predictor.R
@@ -2,8 +2,6 @@ VERBOSITY <- as.integer(
   Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-context("Predictor")
-
 test_that("Predictor$finalize() should not fail", {
     X <- as.matrix(as.integer(iris[, "Species"]), ncol = 1L)
     y <- iris[["Sepal.Length"]]

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -2,8 +2,6 @@ VERBOSITY <- as.integer(
   Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-context("lightgbm()")
-
 ON_WINDOWS <- .Platform$OS.type == "windows"
 
 UTF8_LOCALE <- all(grepl(
@@ -326,9 +324,6 @@ test_that("lightgbm() does not write model to disk if save_name=NULL", {
   expect_equal(files_before, files_after)
 })
 
-
-context("training continuation")
-
 test_that("training continuation works", {
   dtrain <- lgb.Dataset(
     train$data
@@ -359,8 +354,6 @@ test_that("training continuation works", {
   # iterations and the one trained in 5-then-5.
   expect_lt(abs(err_bst - err_bst2), 0.01)
 })
-
-context("lgb.cv()")
 
 test_that("cv works", {
   dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -553,8 +546,6 @@ test_that("lgb.cv() respects showsd argument", {
   expect_equal(length(evals_showsd[["eval_err"]]), nrounds)
   expect_identical(evals_no_showsd[["eval_err"]], list())
 })
-
-context("lgb.train()")
 
 test_that("lgb.train() works as expected with multiple eval metrics", {
   metrics <- c("binary_error", "auc", "binary_logloss")
@@ -2100,8 +2091,6 @@ test_that("lgb.cv() updates params based on keyword arguments", {
 
 })
 
-context("linear learner")
-
 test_that("lgb.train() fit on linearly-relatead data improves when using linear learners", {
   set.seed(708L)
   .new_dataset <- function() {
@@ -2341,8 +2330,6 @@ test_that("lgb.train() works with linear learners when Dataset has categorical f
   expect_true(bst_lin_last_mse <  bst_last_mse)
 })
 
-context("interaction constraints")
-
 test_that("lgb.train() throws an informative error if interaction_constraints is not a list", {
   dtrain <- lgb.Dataset(train$data, label = train$label)
   params <- list(objective = "regression", interaction_constraints = "[1,2],[3]")
@@ -2442,8 +2429,6 @@ test_that(paste0("lgb.train() gives same results when using interaction_constrai
   expect_equal(pred1, pred2)
 
 })
-
-context("monotone constraints")
 
 .generate_trainset_for_monotone_constraints_tests <- function(x3_to_categorical) {
   n_samples <- 3000L

--- a/R-package/tests/testthat/test_custom_objective.R
+++ b/R-package/tests/testthat/test_custom_objective.R
@@ -2,8 +2,6 @@ VERBOSITY <- as.integer(
   Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-context("Test models with custom objective")
-
 data(agaricus.train, package = "lightgbm")
 data(agaricus.test, package = "lightgbm")
 dtrain <- lgb.Dataset(agaricus.train$data, label = agaricus.train$label)

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -2,8 +2,6 @@ VERBOSITY <- as.integer(
   Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-context("testing lgb.Dataset functionality")
-
 data(agaricus.train, package = "lightgbm")
 train_data <- agaricus.train$data[seq_len(1000L), ]
 train_label <- agaricus.train$label[seq_len(1000L)]

--- a/R-package/tests/testthat/test_learning_to_rank.R
+++ b/R-package/tests/testthat/test_learning_to_rank.R
@@ -2,8 +2,6 @@ VERBOSITY <- as.integer(
   Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-context("Learning to rank")
-
 # numerical tolerance to use when checking metric values
 TOLERANCE <- 1e-06
 

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -2,8 +2,6 @@ VERBOSITY <- as.integer(
   Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-context("Booster")
-
 ON_WINDOWS <- .Platform$OS.type == "windows"
 TOLERANCE <- 1e-6
 
@@ -30,8 +28,6 @@ test_that("Booster$finalize() should not fail", {
     bst$finalize()
     expect_true(lgb.is.null.handle(bst$.__enclos_env__$private$handle))
 })
-
-context("lgb.get.eval.result")
 
 test_that("lgb.get.eval.result() should throw an informative error if booster is not an lgb.Booster", {
     bad_inputs <- list(
@@ -123,8 +119,6 @@ test_that("lgb.get.eval.result() should throw an informative error for incorrect
         )
     }, regexp = "Only the following eval_names exist for dataset.*\\: \\[l2\\]", fixed = FALSE)
 })
-
-context("lgb.load()")
 
 test_that("lgb.load() gives the expected error messages given different incorrect inputs", {
     set.seed(708L)
@@ -393,8 +387,6 @@ test_that("If a string and a file are both passed to lgb.load() the file is used
     pred2 <- predict(bst2, test$data)
     expect_identical(pred, pred2)
 })
-
-context("Booster")
 
 test_that("Creating a Booster from a Dataset should work", {
     set.seed(708L)
@@ -691,8 +683,6 @@ test_that("Booster$params should include dataset params, before and after Booste
     expect_identical(ret_bst$params, expected_params)
     expect_identical(bst$params, expected_params)
 })
-
-context("save_model")
 
 test_that("Saving a model with different feature importance types works", {
     set.seed(708L)
@@ -1032,8 +1022,6 @@ test_that("lgb.cv() correctly handles passing through params to the model file",
 
 })
 
-context("saveRDS.lgb.Booster() and readRDS.lgb.Booster()")
-
 test_that("params (including dataset params) should be stored in .rds file for Booster", {
     data(agaricus.train, package = "lightgbm")
     dtrain <- lgb.Dataset(
@@ -1068,8 +1056,6 @@ test_that("params (including dataset params) should be stored in .rds file for B
         )
     )
 })
-
-context("saveRDS and readRDS work on Booster")
 
 test_that("params (including dataset params) should be stored in .rds file for Booster", {
     data(agaricus.train, package = "lightgbm")

--- a/R-package/tests/testthat/test_lgb.convert_with_rules.R
+++ b/R-package/tests/testthat/test_lgb.convert_with_rules.R
@@ -1,5 +1,3 @@
-context("lgb.convert_with_rules()")
-
 test_that("lgb.convert_with_rules() rejects inputs that are not a data.table or data.frame", {
     bad_inputs <- list(
         matrix(1.0:10.0, 2L, 5L)

--- a/R-package/tests/testthat/test_lgb.importance.R
+++ b/R-package/tests/testthat/test_lgb.importance.R
@@ -1,5 +1,3 @@
-context("lgb.importance")
-
 test_that("lgb.importance() should reject bad inputs", {
     bad_inputs <- list(
         .Machine$integer.max

--- a/R-package/tests/testthat/test_lgb.interprete.R
+++ b/R-package/tests/testthat/test_lgb.interprete.R
@@ -2,8 +2,6 @@ VERBOSITY <- as.integer(
     Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-context("lgb.interpete")
-
 .sigmoid <- function(x) {
     1.0 / (1.0 + exp(-x))
 }

--- a/R-package/tests/testthat/test_lgb.plot.importance.R
+++ b/R-package/tests/testthat/test_lgb.plot.importance.R
@@ -2,8 +2,6 @@ VERBOSITY <- as.integer(
     Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-context("lgb.plot.importance()")
-
 test_that("lgb.plot.importance() should run without error for well-formed inputs", {
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train

--- a/R-package/tests/testthat/test_lgb.plot.interpretation.R
+++ b/R-package/tests/testthat/test_lgb.plot.interpretation.R
@@ -2,8 +2,6 @@ VERBOSITY <- as.integer(
     Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-context("lgb.plot.interpretation")
-
 .sigmoid <- function(x) {
     1.0 / (1.0 + exp(-x))
 }

--- a/R-package/tests/testthat/test_lgb.unloader.R
+++ b/R-package/tests/testthat/test_lgb.unloader.R
@@ -2,8 +2,6 @@ VERBOSITY <- as.integer(
     Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-context("lgb.unloader")
-
 test_that("lgb.unloader works as expected", {
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train

--- a/R-package/tests/testthat/test_metrics.R
+++ b/R-package/tests/testthat/test_metrics.R
@@ -1,5 +1,3 @@
-context(".METRICS_HIGHER_BETTER()")
-
 test_that(".METRICS_HIGHER_BETTER() should be well formed", {
     metrics <- .METRICS_HIGHER_BETTER()
     metric_names <- names(.METRICS_HIGHER_BETTER())

--- a/R-package/tests/testthat/test_parameters.R
+++ b/R-package/tests/testthat/test_parameters.R
@@ -1,6 +1,3 @@
-
-context("feature penalties")
-
 data(agaricus.train, package = "lightgbm")
 data(agaricus.test, package = "lightgbm")
 train <- agaricus.train
@@ -46,8 +43,6 @@ test_that("Feature penalties work properly", {
   # Ensure that feature is not used when feature_penalty = 0
   expect_length(var_gain[[length(var_gain)]], 0L)
 })
-
-context("parameter aliases")
 
 test_that(".PARAMETER_ALIASES() returns a named list of character vectors, where names are unique", {
   param_aliases <- .PARAMETER_ALIASES()

--- a/R-package/tests/testthat/test_utils.R
+++ b/R-package/tests/testthat/test_utils.R
@@ -1,5 +1,3 @@
-context("lgb.params2str")
-
 test_that("lgb.params2str() works as expected for empty lists", {
     out_str <- lgb.params2str(
         params = list()
@@ -25,8 +23,6 @@ test_that("lgb.params2str() works as expected for a key in params with multiple 
         , "objective=magic metric=a,ab,abc,abcdefg nrounds=10 learning_rate=0.0000001"
     )
 })
-
-context("lgb.check.eval")
 
 test_that("lgb.check.eval works as expected with no metric", {
     params <- lgb.check.eval(
@@ -72,8 +68,6 @@ test_that("lgb.check.eval drops duplicate metrics and preserves order", {
     expect_named(params, "metric")
     expect_identical(params[["metric"]], list("l1", "l2", "rmse"))
 })
-
-context("lgb.check.wrapper_param")
 
 test_that("lgb.check.wrapper_param() uses passed-in keyword arg if no alias found in params", {
     kwarg_val <- sample(seq_len(100L), size = 1L)

--- a/R-package/tests/testthat/test_weighted_loss.R
+++ b/R-package/tests/testthat/test_weighted_loss.R
@@ -2,8 +2,6 @@ VERBOSITY <- as.integer(
   Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-context("Case weights are respected")
-
 test_that("Gamma regression reacts on 'weight'", {
   n <- 100L
   set.seed(87L)


### PR DESCRIPTION
Older versions of `{testthat}` required the use of a function, `testthat::context()`, to separate tests in reporting output.

`{testthat}` has been moving away from requiring that, instead preferring to group tests results by test file name, the way `pytest` does.

From the testthat docs ([link](https://testthat.r-lib.org/reference/context.html))

> Use of `context()` is no longer recommended. Instead omit it, and messages will use the name of the file instead. This ensures that the context and test file name are always in sync.

And from the vignette describing `{testthat}` 3.x ([link](https://github.com/r-lib/testthat/blob/f8ccf033a74d89e2d1d3cb2ec3c6c4f63ca69055/vignettes/third-edition.Rmd#L75-L76)), which was first released in October 2020 ([link](https://cran.r-project.org/src/contrib/Archive/testthat/))

> `context()` is formally deprecated. testthat has been moving away from `context()` in favour of file names for quite some time, and now you'll be strongly encouraged remove these calls from your tests.

This PR proposes removing uses of `context()` in the R package's tests.

### Notes for Reviewers

Contributes to #4862. Check the logs in the `r-package MSVC` tests to see what the new test logs look like (since those tests don't run `R CMD check`).