### PR TITLE
[R-package][tests] remove uses of `testthat::expect_is()`

### DIFF
--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -394,7 +394,7 @@ test_that("CVBooster$reset_parameter() works as expected", {
     , nrounds = 3L
     , nfold = n_folds
   )
-  expect_is(cv_bst, "lgb.CVBooster")
+  expect_true(methods::is(cv_bst, "lgb.CVBooster"))
   expect_length(cv_bst$boosters, n_folds)
   for (bst in cv_bst$boosters) {
     expect_equal(bst[["booster"]]$params[["num_leaves"]], 7L)
@@ -467,7 +467,7 @@ test_that("lightgbm.cv() gives the correct best_score and best_iter for a metric
       , num_leaves = 5L
     )
   )
-  expect_is(cv_bst, "lgb.CVBooster")
+  expect_true(methods::is(cv_bst, "lgb.CVBooster"))
   expect_named(
     cv_bst$record_evals
     , c("start_iter", "valid")
@@ -505,7 +505,7 @@ test_that("lgb.cv() fit on linearly-relatead data improves when using linear lea
     , params = params
     , nfold = 5L
   )
-  expect_is(cv_bst, "lgb.CVBooster")
+  expect_true(methods::is(cv_bst, "lgb.CVBooster"))
 
   dtrain <- .new_dataset()
   cv_bst_linear <- lgb.cv(
@@ -514,7 +514,7 @@ test_that("lgb.cv() fit on linearly-relatead data improves when using linear lea
     , params = utils::modifyList(params, list(linear_tree = TRUE))
     , nfold = 5L
   )
-  expect_is(cv_bst_linear, "lgb.CVBooster")
+  expect_true(methods::is(cv_bst_linear, "lgb.CVBooster"))
 
   expect_true(cv_bst_linear$best_score < cv_bst$best_score)
 })
@@ -549,7 +549,7 @@ test_that("lgb.cv() respects showsd argument", {
     evals_showsd[["eval"]]
     , evals_no_showsd[["eval"]]
   )
-  expect_is(evals_showsd[["eval_err"]], "list")
+  expect_true(methods::is(evals_showsd[["eval_err"]], "list"))
   expect_equal(length(evals_showsd[["eval_err"]]), nrounds)
   expect_identical(evals_no_showsd[["eval_err"]], list())
 })

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -148,7 +148,10 @@ test_that("Dataset$set_reference() updates categorical_feature, colnames, and pr
   dtest$set_reference(dtrain)
 
   # after setting reference to dtrain, those attributes should have dtrain's values
-  expect_is(dtest$.__enclos_env__$private$predictor, "lgb.Predictor")
+  expect_true(methods::is(
+    dtest$.__enclos_env__$private$predictor
+    , "lgb.Predictor"
+  ))
   expect_identical(
     dtest$.__enclos_env__$private$predictor$.__enclos_env__$private$handle
     , dtrain$.__enclos_env__$private$predictor$.__enclos_env__$private$handle
@@ -199,7 +202,7 @@ test_that("lgb.Dataset: Dataset should be able to construct from matrix and retu
     , lightgbm:::lgb.params2str(params = list())
     , ref_handle
   )
-  expect_is(handle, "externalptr")
+  expect_true(methods::is(handle, "externalptr"))
   expect_false(is.null(handle))
   .Call(LGBM_DatasetFree_R, handle)
   handle <- NULL
@@ -411,7 +414,7 @@ test_that("lgb.Dataset: should be able to run lgb.cv() immediately after using l
     , data = dtest_read_in
   )
 
-  expect_is(bst, "lgb.CVBooster")
+  expect_true(methods::is(bst, "lgb.CVBooster"))
 })
 
 test_that("lgb.Dataset: should be able to use and retrieve long feature names", {

--- a/R-package/tests/testthat/test_learning_to_rank.R
+++ b/R-package/tests/testthat/test_learning_to_rank.R
@@ -94,7 +94,7 @@ test_that("learning-to-rank with lgb.cv() works as expected", {
         , nrounds = nrounds
         , nfold = nfold
     )
-    expect_is(cv_bst, "lgb.CVBooster")
+    expect_true(methods::is(cv_bst, "lgb.CVBooster"))
     expect_equal(length(cv_bst$boosters), nfold)
 
     # "valid" should contain results for each metric

--- a/R-package/tests/testthat/test_lgb.convert_with_rules.R
+++ b/R-package/tests/testthat/test_lgb.convert_with_rules.R
@@ -37,7 +37,7 @@ test_that("lgb.convert_with_rules() should work correctly for a dataset with onl
         expect_identical(converted_dataset[["col2"]], c(1L, 1L, 2L))
         # rules should be returned and correct
         rules <- conversion_result$rules
-        expect_is(rules, "list")
+        expect_true(methods::is(rules, "list"))
         expect_length(rules, ncol(input_data))
         expect_identical(rules[["col1"]], c("a" = 1L, "b" = 2L, "c" = 3L))
         expect_identical(rules[["col2"]], c("green" = 1L, "red" = 2L))
@@ -62,7 +62,7 @@ test_that("lgb.convert_with_rules() should work correctly for a dataset with onl
         expect_identical(converted_dataset[["col2"]], c(1L, 1L, 2L))
         # rules should be returned and correct
         rules <- conversion_result$rules
-        expect_is(rules, "list")
+        expect_true(methods::is(rules, "list"))
         expect_length(rules, ncol(input_data))
         expect_identical(rules[["col1"]], c("a" = 1L, "b" = 2L, "c" = 3L))
         expect_identical(rules[["col2"]], c("green" = 1L, "red" = 2L))
@@ -106,7 +106,7 @@ test_that("lgb.convert_with_rules() should work correctly for a dataset with num
         expect_identical(converted_dataset[["factor_col"]], c(1L, 1L, 2L))
         # rules should be returned and correct
         rules <- conversion_result$rules
-        expect_is(rules, "list")
+        expect_true(methods::is(rules, "list"))
         expect_length(rules, 2L)
         expect_identical(rules[["character_col"]], c("a" = 1L, "b" = 2L, "c" = 3L))
         expect_identical(rules[["factor_col"]], c("n" = 1L, "y" = 2L))
@@ -164,7 +164,7 @@ test_that("lgb.convert_with_rules() should convert missing values to the expecte
 
         # rules should be returned and correct
         rules <- conversion_result$rules
-        expect_is(rules, "list")
+        expect_true(methods::is(rules, "list"))
         expect_length(rules, 3L)
         expect_identical(rules[["character_col"]], c("a" = 1L, "c" = 2L))
         expect_identical(rules[["factor_col"]], c("n" = 1L, "y" = 2L))


### PR DESCRIPTION
Similar to #4915, this PR proposes removing `{lightgbm}`'s use of a `{testthat}` function that is currently deprecated.

From the vignette describing `{testthat}` 3.x ([link](https://github.com/r-lib/testthat/blob/f8ccf033a74d89e2d1d3cb2ec3c6c4f63ca69055/vignettes/third-edition.Rmd#L78-L79)), which was first released in October 2020 ([link](https://cran.r-project.org/src/contrib/Archive/testthat/))

> `expect_is()` is deprecated in favour of the more specific `expect_type()`, `expect_s3_class()`, and `expect_s4_class()`.
    This ensures that you check the expected class along with the expected OO system.

This PR proposes removing uses of `expect_is()` in the R package's tests. It proposes replacing them with `expect_true(methods::is())` instead of the newest `{testthat}` because those 3 methods can't be used to test the class of an `R6` object.