### PR TITLE
[R-package] added argument eval_train_metric to lgb.cv() (fixes #4911)

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -379,21 +379,20 @@ lgb.cv <- function(params = list()
       }
       return(out)
     })
-    
+
     # Prepare collection of evaluation results
     merged_msg <- lgb.merge.cv.result(
       msg = msg
       , showsd = showsd
     )
-    
+
     # Write evaluation result in environment
     env$eval_list <- merged_msg$eval_list
-    
+
     # Check for standard deviation requirement
     if (showsd) {
       env$eval_err_list <- merged_msg$eval_err_list
-    } 
-    
+    }
 
     # Loop through env
     for (f in cb$post_iter) {

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -31,7 +31,7 @@ CVBooster <- R6::R6Class(
 #' @param showsd \code{boolean}, whether to show standard deviation of cross validation.
 #'               This parameter defaults to \code{TRUE}. Setting it to \code{FALSE} can lead to a
 #'               slight speedup by avoiding unnecessary computation.
-#' @param eval_train_metric \code{boolean}, whether to add the cross validation results on the 
+#' @param eval_train_metric \code{boolean}, whether to add the cross validation results on the
 #'               training data. This parameter defaults to \code{FALSE}. Setting it to \code{TRUE}
 #'               will increase run time.
 #' @param stratified a \code{boolean} indicating whether sampling of folds should be stratified
@@ -341,7 +341,7 @@ lgb.cv <- function(params = list()
 
       booster <- Booster$new(params = params, train_set = dtrain)
       if (isTRUE(eval_train_metric)) {
-        booster$add_valid(data = dtrain, name = "train")  
+        booster$add_valid(data = dtrain, name = "train")
       }
       booster$add_valid(data = dtest, name = "valid")
       return(

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -31,9 +31,6 @@ CVBooster <- R6::R6Class(
 #' @param showsd \code{boolean}, whether to show standard deviation of cross validation.
 #'               This parameter defaults to \code{TRUE}. Setting it to \code{FALSE} can lead to a
 #'               slight speedup by avoiding unnecessary computation.
-#' @param eval_train_metric \code{boolean}, whether to add the cross validation results on the
-#'               training data. This parameter defaults to \code{FALSE}. Setting it to \code{TRUE}
-#'               will increase run time.
 #' @param stratified a \code{boolean} indicating whether sampling of folds should be stratified
 #'                   by the values of outcome labels.
 #' @param folds \code{list} provides a possibility to use a list of pre-defined CV folds
@@ -46,6 +43,9 @@ CVBooster <- R6::R6Class(
 #' @param callbacks List of callback functions that are applied at each iteration.
 #' @param reset_data Boolean, setting it to TRUE (not the default value) will transform the booster model
 #'                   into a predictor model which frees up memory and the original datasets
+#' @param eval_train_metric \code{boolean}, whether to add the cross validation results on the
+#'               training data. This parameter defaults to \code{FALSE}. Setting it to \code{TRUE}
+#'               will increase run time.
 #' @inheritSection lgb_shared_params Early Stopping
 #' @return a trained model \code{lgb.CVBooster}.
 #'
@@ -81,7 +81,6 @@ lgb.cv <- function(params = list()
                    , record = TRUE
                    , eval_freq = 1L
                    , showsd = TRUE
-                   , eval_train_metric = FALSE
                    , stratified = TRUE
                    , folds = NULL
                    , init_model = NULL
@@ -91,6 +90,7 @@ lgb.cv <- function(params = list()
                    , callbacks = list()
                    , reset_data = FALSE
                    , serializable = TRUE
+                   , eval_train_metric = FALSE
                    ) {
 
   if (nrounds <= 0L) {

--- a/R-package/man/lgb.cv.Rd
+++ b/R-package/man/lgb.cv.Rd
@@ -25,7 +25,8 @@ lgb.cv(
   early_stopping_rounds = NULL,
   callbacks = list(),
   reset_data = FALSE,
-  serializable = TRUE
+  serializable = TRUE,
+  eval_train_metric = FALSE
 )
 }
 \arguments{
@@ -120,6 +121,10 @@ into a predictor model which frees up memory and the original datasets}
 
 \item{serializable}{whether to make the resulting objects serializable through functions such as
 \code{save} or \code{saveRDS} (see section "Model serialization").}
+
+\item{eval_train_metric}{\code{boolean}, whether to add the cross validation results on the
+training data. This parameter defaults to \code{FALSE}. Setting it to \code{TRUE}
+will increase run time.}
 }
 \value{
 a trained model \code{lgb.CVBooster}.

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -586,7 +586,7 @@ test_that("lgb.cv() respects eval_train_metric argument", {
   )
   expect_true("train" %in% names(bst_train$record_evals))
   expect_false("train" %in% names(bst_no_train$record_evals))
-  expect_is(bst_train$record_evals[["train"]][["l2"]][["eval"]], "list")
+  expect_true(methods::is(bst_train$record_evals[["train"]][["l2"]][["eval"]], "list"))
   expect_equal(
     length(bst_train$record_evals[["train"]][["l2"]][["eval"]])
     , nrounds

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -554,6 +554,45 @@ test_that("lgb.cv() respects showsd argument", {
   expect_identical(evals_no_showsd[["eval_err"]], list())
 })
 
+test_that("lgb.cv() respects eval_train_metric argument", {
+  dtrain <- lgb.Dataset(train$data, label = train$label)
+  params <- list(
+    objective = "regression"
+    , metric = "l2"
+    , min_data = 1L
+  )
+  nrounds <- 5L
+  set.seed(708L)
+  bst_train <- lgb.cv(
+    params = params
+    , data = dtrain
+    , nrounds = nrounds
+    , nfold = 3L
+    , showsd = FALSE
+    , eval_train_metric = TRUE
+  )
+  set.seed(708L)
+  bst_no_train <- lgb.cv(
+    params = params
+    , data = dtrain
+    , nrounds = nrounds
+    , nfold = 3L
+    , showsd = FALSE
+    , eval_train_metric = FALSE
+  )
+  expect_equal(
+    bst_train$record_evals[["valid"]][["l2"]]
+    , bst_no_train$record_evals[["valid"]][["l2"]]
+  )
+  expect_true("train" %in% names(bst_train$record_evals))
+  expect_false("train" %in% names(bst_no_train$record_evals))
+  expect_is(bst_train$record_evals[["train"]][["l2"]][["eval"]], "list")
+  expect_equal(
+    length(bst_train$record_evals[["train"]][["l2"]][["eval"]])
+    , nrounds
+  )
+})
+
 context("lgb.train()")
 
 test_that("lgb.train() works as expected with multiple eval metrics", {


### PR DESCRIPTION
Attempt to solve https://github.com/microsoft/LightGBM/issues/4911 

If we set `eval_train_metric = TRUE` in `lgb.cv()`, then we get output like 

[1] "[50]:  train's binary_logloss:0.248276+0.00109575  valid's binary_logloss:0.248655+0.00448549"

The resulting object "cvm" contains the information in the `record_evals` slot and the average training performance of the best round could be found by something like `cvm$record_evals$train$binary_logloss$eval[[cvm$best_iter]]`.

There is no unit test yet, but that does not mean we shouldn't write one.