### PR TITLE
[R-package] [docs] fix calculation of R test coverage (fixes #4919)

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -48,7 +48,6 @@ NeedsCompilation: yes
 Biarch: true
 VignetteBuilder: knitr
 Suggests:
-    covr,
     knitr,
     processx,
     rmarkdown,

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -48,6 +48,7 @@ NeedsCompilation: yes
 Biarch: true
 VignetteBuilder: knitr
 Suggests:
+    covr,
     knitr,
     processx,
     rmarkdown,

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -269,7 +269,6 @@ sh build-cran-package.sh \
     --no-build-vignettes
 
 # Get coverage
-LIGHTGBM_TEST_COVERAGE="true" \
 Rscript -e " \
     library(covr);
     coverage  <- covr::package_coverage('./lightgbm_r', type = 'tests', quiet = FALSE);

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -269,7 +269,7 @@ sh build-cran-package.sh \
     --no-build-vignettes
 
 # Get coverage
-LIGHTGBM_TEST_COVERAGE=true \
+LIGHTGBM_TEST_COVERAGE="true" \
 Rscript -e " \
     library(covr);
     coverage  <- covr::package_coverage('./lightgbm_r', type = 'tests', quiet = FALSE);

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -265,10 +265,13 @@ The example below shows how to generate code coverage for the R package on a mac
 
 ```shell
 # Install
-sh build-cran-package.sh
+sh build-cran-package.sh \
+    --no-build-vignettes
 
 # Get coverage
+LIGHTGBM_TEST_COVERAGE=true \
 Rscript -e " \
+    library(covr);
     coverage  <- covr::package_coverage('./lightgbm_r', type = 'tests', quiet = FALSE);
     print(coverage);
     covr::report(coverage, file = file.path(getwd(), 'coverage.html'), browse = TRUE);

--- a/R-package/tests/testthat/test_lgb.unloader.R
+++ b/R-package/tests/testthat/test_lgb.unloader.R
@@ -2,7 +2,13 @@ VERBOSITY <- as.integer(
     Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
+CALCULATING_TEST_COVERAGE <- Sys.getenv("LIGHTGBM_TEST_COVERAGE") == "true"
+
 test_that("lgb.unloader works as expected", {
+    testthat::skip_if(
+        condition = CALCULATING_TEST_COVERAGE
+        , message = "lgb.unloader() tests are skipped when calculating test coverage"
+    )
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -24,6 +30,10 @@ test_that("lgb.unloader works as expected", {
 })
 
 test_that("lgb.unloader finds all boosters and removes them", {
+    testthat::skip_if(
+        condition = CALCULATING_TEST_COVERAGE
+        , message = "lgb.unloader() tests are skipped when calculating test coverage"
+    )
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)

--- a/R-package/tests/testthat/test_lgb.unloader.R
+++ b/R-package/tests/testthat/test_lgb.unloader.R
@@ -2,13 +2,13 @@ VERBOSITY <- as.integer(
     Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
+CALCULATING_TEST_COVERAGE <- Sys.getenv("R_COVR") == "true"
+
 test_that("lgb.unloader works as expected", {
-    if (require(covr)) {  # nolint
-        testthat::skip_if(
-            condition = covr::in_covr()
-            , message = "lgb.unloader() tests are skipped when calculating test coverage"
-        )
-    }
+    testthat::skip_if(
+        condition = CALCULATING_TEST_COVERAGE
+        , message = "lgb.unloader() tests are skipped when calculating test coverage"
+    )
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -30,12 +30,10 @@ test_that("lgb.unloader works as expected", {
 })
 
 test_that("lgb.unloader finds all boosters and removes them", {
-    if (require(covr)) {  # nolint
-        testthat::skip_if(
-            condition = covr::in_covr()
-            , message = "lgb.unloader() tests are skipped when calculating test coverage"
-        )
-    }
+    testthat::skip_if(
+        condition = CALCULATING_TEST_COVERAGE
+        , message = "lgb.unloader() tests are skipped when calculating test coverage"
+    )
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)

--- a/R-package/tests/testthat/test_lgb.unloader.R
+++ b/R-package/tests/testthat/test_lgb.unloader.R
@@ -2,7 +2,7 @@ VERBOSITY <- as.integer(
     Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-CALCULATING_TEST_COVERAGE <- Sys.getenv("R_COVR") == "true"
+CALCULATING_TEST_COVERAGE <- Sys.getenv("R_COVR", unset = "unset") != "unset"
 
 test_that("lgb.unloader works as expected", {
     testthat::skip_if(

--- a/R-package/tests/testthat/test_lgb.unloader.R
+++ b/R-package/tests/testthat/test_lgb.unloader.R
@@ -3,10 +3,12 @@ VERBOSITY <- as.integer(
 )
 
 test_that("lgb.unloader works as expected", {
-    testthat::skip_if(
-        condition = covr::in_covr()
-        , message = "lgb.unloader() tests are skipped when calculating test coverage"
-    )
+    if (require(covr)) {  # nolint
+        testthat::skip_if(
+            condition = covr::in_covr()
+            , message = "lgb.unloader() tests are skipped when calculating test coverage"
+        )
+    }
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)
@@ -28,10 +30,12 @@ test_that("lgb.unloader works as expected", {
 })
 
 test_that("lgb.unloader finds all boosters and removes them", {
-    testthat::skip_if(
-        condition = covr::in_covr()
-        , message = "lgb.unloader() tests are skipped when calculating test coverage"
-    )
+    if (require(covr)) {  # nolint
+        testthat::skip_if(
+            condition = covr::in_covr()
+            , message = "lgb.unloader() tests are skipped when calculating test coverage"
+        )
+    }
     data(agaricus.train, package = "lightgbm")
     train <- agaricus.train
     dtrain <- lgb.Dataset(train$data, label = train$label)

--- a/R-package/tests/testthat/test_lgb.unloader.R
+++ b/R-package/tests/testthat/test_lgb.unloader.R
@@ -2,11 +2,9 @@ VERBOSITY <- as.integer(
     Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
-CALCULATING_TEST_COVERAGE <- Sys.getenv("LIGHTGBM_TEST_COVERAGE") == "true"
-
 test_that("lgb.unloader works as expected", {
     testthat::skip_if(
-        condition = CALCULATING_TEST_COVERAGE
+        condition = covr::in_covr()
         , message = "lgb.unloader() tests are skipped when calculating test coverage"
     )
     data(agaricus.train, package = "lightgbm")
@@ -31,7 +29,7 @@ test_that("lgb.unloader works as expected", {
 
 test_that("lgb.unloader finds all boosters and removes them", {
     testthat::skip_if(
-        condition = CALCULATING_TEST_COVERAGE
+        condition = covr::in_covr()
         , message = "lgb.unloader() tests are skipped when calculating test coverage"
     )
     data(agaricus.train, package = "lightgbm")


### PR DESCRIPTION
Fixes #4919.

See the discussion in #4919, especially https://github.com/microsoft/LightGBM/issues/4919#issuecomment-1003267201, for an explanation of the changes in this PR.

Running the instructions in the R package README as of this branch, I found that the test results from `{covr}` match my expectations and seem correct.

<details><summary>lightgbm coverage - 55.65% (click me)</summary>

```text
lightgbm Coverage: 55.65%
R/lgb.drop_serialized.R: 0.00%
R/lgb.unloader.R: 0.00%
src/boosting/goss.hpp: 0.00%
src/boosting/rf.hpp: 0.00%
src/include/Eigen/src/Core/Map.h: 0.00%
src/include/Eigen/src/Core/products/GeneralMatrixVector.h: 0.00%
src/include/Eigen/src/Core/products/Parallelizer.h: 0.00%
src/include/Eigen/src/Core/Stride.h: 0.00%
src/include/Eigen/src/Core/Transpose.h: 0.00%
src/include/Eigen/src/plugins/MatrixCwiseBinaryOps.h: 0.00%
src/metric/map_metric.hpp: 0.00%
src/metric/xentropy_metric.hpp: 0.00%
src/network/linkers_socket.cpp: 0.00%
src/network/linkers.h: 0.00%
src/network/socket_wrapper.hpp: 0.00%
src/objective/xentropy_objective.hpp: 0.00%
src/treelearner/cuda_tree_learner.h: 0.00%
src/treelearner/data_parallel_tree_learner.cpp: 0.00%
src/treelearner/feature_parallel_tree_learner.cpp: 0.00%
src/treelearner/gpu_tree_learner.h: 0.00%
src/treelearner/parallel_tree_learner.h: 0.00%
src/treelearner/voting_parallel_tree_learner.cpp: 0.00%
src/network/network.cpp: 3.17%
src/include/LightGBM/network.h: 3.39%
src/io/json11.cpp: 4.33%
src/treelearner/cost_effective_gradient_boosting.hpp: 4.81%
src/network/linker_topo.cpp: 4.96%
src/include/Eigen/src/Core/GeneralProduct.h: 6.25%
src/include/Eigen/src/Core/products/GeneralBlockPanelKernel.h: 10.50%
src/boosting/prediction_early_stop.cpp: 14.29%
src/include/LightGBM/utils/array_args.h: 16.53%
src/treelearner/tree_learner.cpp: 18.75%
src/include/Eigen/src/Core/products/GeneralMatrixMatrix.h: 18.90%
src/treelearner/split_info.hpp: 18.99%
src/objective/regression_objective.hpp: 24.93%
src/metric/multiclass_metric.hpp: 25.00%
src/io/parser.hpp: 30.14%
src/include/LightGBM/fmt/format.h: 36.22%
src/include/LightGBM/utils/text_reader.h: 36.65%
src/io/metadata.cpp: 36.73%
src/boosting/gbdt_prediction.cpp: 37.50%
src/objective/multiclass_objective.hpp: 39.29%
src/include/LightGBM/utils/json11.h: 40.00%
src/io/dataset_loader.cpp: 40.87%
src/include/Eigen/src/Core/util/Memory.h: 40.93%
src/application/predictor.hpp: 40.98%
src/io/parser.cpp: 41.32%
src/metric/regression_metric.hpp: 42.03%
src/metric/binary_metric.hpp: 43.72%
src/c_api.cpp: 44.37%
src/boosting/dart.hpp: 45.54%
src/treelearner/col_sampler.hpp: 45.86%
src/objective/objective_function.cpp: 47.37%
src/include/Eigen/src/Core/arch/SSE/PacketMath.h: 47.83%
src/include/LightGBM/fmt/format-inl.h: 48.49%
src/io/multi_val_dense_bin.hpp: 51.30%
src/io/tree.cpp: 51.98%
src/include/Eigen/src/Core/Inverse.h: 53.33%
src/include/LightGBM/utils/random.h: 54.35%
src/include/Eigen/src/Core/util/BlasUtil.h: 54.55%
src/boosting/gbdt.h: 55.10%
src/io/config.cpp: 56.68%
src/include/LightGBM/objective_function.h: 57.14%
src/boosting/gbdt_model_text.cpp: 57.42%
src/io/multi_val_sparse_bin.hpp: 57.73%
src/io/sparse_bin.hpp: 58.24%
src/treelearner/feature_histogram.hpp: 58.81%
src/include/Eigen/src/Core/GenericPacketMath.h: 60.00%
src/include/Eigen/src/Core/MathFunctions.h: 60.00%
src/io/train_share_states.cpp: 60.42%
src/boosting/gbdt.cpp: 60.48%
src/include/LightGBM/fmt/core.h: 61.80%
src/treelearner/serial_tree_learner.cpp: 63.27%
src/include/LightGBM/feature_group.h: 63.72%
src/include/Eigen/src/Core/Redux.h: 64.58%
src/include/Eigen/src/Core/MapBase.h: 65.38%
src/include/Eigen/src/Core/ProductEvaluators.h: 65.85%
src/include/LightGBM/tree.h: 66.42%
src/include/Eigen/src/Core/util/Meta.h: 66.67%
src/include/LightGBM/tree_learner.h: 66.67%
src/objective/rank_objective.hpp: 67.68%
src/include/LightGBM/utils/openmp_wrapper.h: 68.00%
src/objective/binary_objective.hpp: 69.23%
src/io/bin.cpp: 69.40%
src/boosting/boosting.cpp: 69.77%
src/include/Eigen/src/plugins/BlockMethods.h: 70.00%
src/include/LightGBM/dataset.h: 70.30%
src/metric/rank_metric.hpp: 70.65%
src/include/Eigen/src/Core/CwiseNullaryOp.h: 71.43%
R/lgb.Predictor.R: 73.77%
R/lgb.make_serializable.R: 75.00%
R/lgb.restore_handle.R: 75.00%
src/include/Eigen/src/Core/util/IntegralConstant.h: 75.00%
src/include/LightGBM/boosting.h: 75.00%
src/metric/metric.cpp: 75.00%
src/io/dataset.cpp: 76.47%
src/include/LightGBM/bin.h: 76.62%
src/include/Eigen/src/Core/DenseBase.h: 76.92%
src/include/Eigen/src/Core/CoreEvaluators.h: 77.68%
src/io/dense_bin.hpp: 77.73%
src/include/Eigen/src/Core/functors/BinaryFunctors.h: 77.78%
src/include/Eigen/src/Core/functors/UnaryFunctors.h: 77.78%
src/include/LightGBM/utils/common.h: 78.09%
src/treelearner/serial_tree_learner.h: 78.95%
src/include/Eigen/src/Core/AssignEvaluator.h: 79.25%
src/lightgbm_R.cpp: 79.32%
src/treelearner/data_partition.hpp: 80.30%
R/lgb.convert_with_rules.R: 80.65%
src/include/Eigen/src/Core/products/TriangularSolverMatrix.h: 80.70%
src/include/Eigen/src/Core/DenseCoeffsBase.h: 83.33%
src/include/Eigen/src/Core/functors/AssignmentFunctors.h: 83.33%
R/lgb.cv.R: 83.39%
src/boosting/score_updater.hpp: 83.67%
src/include/LightGBM/fast_double_parser.h: 83.83%
src/include/LightGBM/train_share_states.h: 84.27%
src/metric/dcg_calculator.cpp: 86.36%
src/treelearner/linear_tree_learner.cpp: 86.43%
src/include/LightGBM/config.h: 86.83%
R/lgb.Dataset.R: 87.59%
src/include/Eigen/src/LU/FullPivLU.h: 90.10%
R/lgb.Booster.R: 90.32%
R/lgb.train.R: 91.33%
src/include/Eigen/src/Core/DenseStorage.h: 91.53%
src/include/LightGBM/utils/yamc/alternate_shared_mutex.hpp: 91.67%
src/io/file_io.cpp: 91.67%
src/include/Eigen/src/Core/CwiseBinaryOp.h: 92.31%
src/include/LightGBM/utils/threading.h: 92.63%
R/saveRDS.lgb.Booster.R: 92.86%
src/include/Eigen/src/Core/SolveTriangular.h: 92.86%
src/include/LightGBM/utils/log.h: 93.33%
R/callback.R: 93.49%
src/treelearner/leaf_splits.hpp: 93.65%
src/include/LightGBM/utils/file_io.h: 93.75%
src/include/Eigen/src/Core/Block.h: 93.88%
src/include/Eigen/src/Core/PlainObjectBase.h: 94.34%
R/utils.R: 94.74%
src/include/Eigen/src/Core/Visitor.h: 97.06%
src/treelearner/monotone_constraints.hpp: 97.96%
src/io/config_auto.cpp: 98.41%
R/aliases.R: 100.00%
R/lgb.importance.R: 100.00%
R/lgb.interprete.R: 100.00%
R/lgb.model.dt.tree.R: 100.00%
R/lgb.plot.importance.R: 100.00%
R/lgb.plot.interpretation.R: 100.00%
R/lightgbm.R: 100.00%
R/metrics.R: 100.00%
R/readRDS.lgb.Booster.R: 100.00%
src/include/Eigen/src/Core/Assign.h: 100.00%
src/include/Eigen/src/Core/CwiseUnaryOp.h: 100.00%
src/include/Eigen/src/Core/EigenBase.h: 100.00%
src/include/Eigen/src/Core/functors/NullaryFunctors.h: 100.00%
src/include/Eigen/src/Core/Matrix.h: 100.00%
src/include/Eigen/src/Core/MatrixBase.h: 100.00%
src/include/Eigen/src/Core/NoAlias.h: 100.00%
src/include/Eigen/src/Core/NumTraits.h: 100.00%
src/include/Eigen/src/Core/PartialReduxEvaluator.h: 100.00%
src/include/Eigen/src/Core/PermutationMatrix.h: 100.00%
src/include/Eigen/src/Core/Product.h: 100.00%
src/include/Eigen/src/Core/SelfCwiseBinaryOp.h: 100.00%
src/include/Eigen/src/Core/Solve.h: 100.00%
src/include/Eigen/src/Core/SolverBase.h: 100.00%
src/include/Eigen/src/Core/Swap.h: 100.00%
src/include/Eigen/src/Core/TriangularMatrix.h: 100.00%
src/include/Eigen/src/Core/util/ForwardDeclarations.h: 100.00%
src/include/Eigen/src/Core/util/IndexedViewHelper.h: 100.00%
src/include/Eigen/src/Core/util/Macros.h: 100.00%
src/include/Eigen/src/Core/util/SymbolicIndex.h: 100.00%
src/include/Eigen/src/Core/util/XprHelper.h: 100.00%
src/include/Eigen/src/Core/VectorBlock.h: 100.00%
src/include/Eigen/src/Core/VectorwiseOp.h: 100.00%
src/include/Eigen/src/plugins/CommonCwiseBinaryOps.h: 100.00%
src/include/Eigen/src/plugins/CommonCwiseUnaryOps.h: 100.00%
src/include/Eigen/src/plugins/MatrixCwiseUnaryOps.h: 100.00%
src/include/LightGBM/c_api.h: 100.00%
src/include/LightGBM/dataset_loader.h: 100.00%
src/include/LightGBM/metric.h: 100.00%
src/include/LightGBM/prediction_early_stop.h: 100.00%
src/include/LightGBM/utils/pipeline_reader.h: 100.00%
src/include/LightGBM/utils/yamc/yamc_rwlock_sched.hpp: 100.00%
src/include/LightGBM/utils/yamc/yamc_shared_lock.hpp: 100.00%
src/treelearner/linear_tree_learner.h: 100.00%
```

</details>