### PR TITLE
[R-package] Apply patch for R4.2 on Windows

### DIFF
--- a/src/network/socket_wrapper.hpp
+++ b/src/network/socket_wrapper.hpp
@@ -60,6 +60,9 @@ const int INVALID_SOCKET = -1;
 #endif
 
 #ifdef _WIN32
+#ifndef _UCRT
+// Recent MinGW has inet_pton, which then causes compiler error in
+// combination with this replacement.
 #ifndef _MSC_VER
 // not using visual studio in windows
 inline int inet_pton(int af, const char *src, void *dst) {
@@ -84,6 +87,7 @@ inline int inet_pton(int af, const char *src, void *dst) {
   }
   return 0;
 }
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Recently I've got an email from CRAN. LightGBM needs a small fix to work for updated R-devel/R 4.2 on Windows. I've applied the patch provided by CRAN in this PR.

Maybe we need a minor version update for this patch to update our CRAN package.
