### PR TITLE
Update versions of LightGBM dependencies

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -128,7 +128,7 @@ if [[ $TASK == "sdist" ]]; then
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
         cp $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz $BUILD_ARTIFACTSTAGINGDIRECTORY
     fi
-    pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
+    pytest $BUILD_DIRECTORY/tests/python_package_test -s -vvv || exit -1
     exit 0
 elif [[ $TASK == "bdist" ]]; then
     if [[ $OS_NAME == "macos" ]]; then
@@ -150,7 +150,7 @@ elif [[ $TASK == "bdist" ]]; then
         fi
     fi
     pip install --user $BUILD_DIRECTORY/python-package/dist/*.whl || exit -1
-    pytest $BUILD_DIRECTORY/tests || exit -1
+    pytest $BUILD_DIRECTORY/tests -s -vvv || exit -1
     exit 0
 fi
 
@@ -162,12 +162,12 @@ if [[ $TASK == "gpu" ]]; then
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--gpu --install-option="--opencl-include-dir=$AMDAPPSDK_PATH/include/" || exit -1
-        pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
+        pytest $BUILD_DIRECTORY/tests/python_package_test -s -vvv || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --gpu --opencl-include-dir="$AMDAPPSDK_PATH/include/" || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
-        pytest $BUILD_DIRECTORY/tests || exit -1
+        pytest $BUILD_DIRECTORY/tests -s -vvv || exit -1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         cmake -DUSE_GPU=ON -DOpenCL_INCLUDE_DIR=$AMDAPPSDK_PATH/include/ ..
@@ -178,12 +178,12 @@ elif [[ $TASK == "cuda" ]]; then
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--cuda || exit -1
-        pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
+        pytest $BUILD_DIRECTORY/tests/python_package_test -s -vvv || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --cuda || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
-        pytest $BUILD_DIRECTORY/tests || exit -1
+        pytest $BUILD_DIRECTORY/tests -s -vvv || exit -1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         cmake -DUSE_CUDA=ON ..
@@ -192,12 +192,12 @@ elif [[ $TASK == "mpi" ]]; then
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--mpi || exit -1
-        pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
+        pytest $BUILD_DIRECTORY/tests/python_package_test -s -vvv || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --mpi || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
-        pytest $BUILD_DIRECTORY/tests || exit -1
+        pytest $BUILD_DIRECTORY/tests -s -vvv || exit -1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         cmake -DUSE_MPI=ON -DUSE_DEBUG=ON ..

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -128,7 +128,7 @@ if [[ $TASK == "sdist" ]]; then
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
         cp $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz $BUILD_ARTIFACTSTAGINGDIRECTORY
     fi
-    pytest $BUILD_DIRECTORY/tests/python_package_test -s -vvv || exit -1
+    pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
     exit 0
 elif [[ $TASK == "bdist" ]]; then
     if [[ $OS_NAME == "macos" ]]; then
@@ -150,7 +150,7 @@ elif [[ $TASK == "bdist" ]]; then
         fi
     fi
     pip install --user $BUILD_DIRECTORY/python-package/dist/*.whl || exit -1
-    pytest $BUILD_DIRECTORY/tests -s -vvv || exit -1
+    pytest $BUILD_DIRECTORY/tests || exit -1
     exit 0
 fi
 
@@ -162,12 +162,12 @@ if [[ $TASK == "gpu" ]]; then
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--gpu --install-option="--opencl-include-dir=$AMDAPPSDK_PATH/include/" || exit -1
-        pytest $BUILD_DIRECTORY/tests/python_package_test -s -vvv || exit -1
+        pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --gpu --opencl-include-dir="$AMDAPPSDK_PATH/include/" || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
-        pytest $BUILD_DIRECTORY/tests -s -vvv || exit -1
+        pytest $BUILD_DIRECTORY/tests || exit -1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         cmake -DUSE_GPU=ON -DOpenCL_INCLUDE_DIR=$AMDAPPSDK_PATH/include/ ..
@@ -178,12 +178,12 @@ elif [[ $TASK == "cuda" ]]; then
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--cuda || exit -1
-        pytest $BUILD_DIRECTORY/tests/python_package_test -s -vvv || exit -1
+        pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --cuda || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
-        pytest $BUILD_DIRECTORY/tests -s -vvv || exit -1
+        pytest $BUILD_DIRECTORY/tests || exit -1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         cmake -DUSE_CUDA=ON ..
@@ -192,12 +192,12 @@ elif [[ $TASK == "mpi" ]]; then
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--mpi || exit -1
-        pytest $BUILD_DIRECTORY/tests/python_package_test -s -vvv || exit -1
+        pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --mpi || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
-        pytest $BUILD_DIRECTORY/tests -s -vvv || exit -1
+        pytest $BUILD_DIRECTORY/tests || exit -1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         cmake -DUSE_MPI=ON -DUSE_DEBUG=ON ..
@@ -209,7 +209,7 @@ fi
 make _lightgbm -j4 || exit -1
 
 cd $BUILD_DIRECTORY/python-package && python setup.py install --precompile --user || exit -1
-pytest $BUILD_DIRECTORY/tests -s -vvv || exit -1
+pytest $BUILD_DIRECTORY/tests || exit -1
 
 if [[ $TASK == "regular" ]]; then
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -209,7 +209,7 @@ fi
 make _lightgbm -j4 || exit -1
 
 cd $BUILD_DIRECTORY/python-package && python setup.py install --precompile --user || exit -1
-pytest $BUILD_DIRECTORY/tests || exit -1
+pytest $BUILD_DIRECTORY/tests -s -vvv || exit -1
 
 if [[ $TASK == "regular" ]]; then
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -24,15 +24,15 @@ jobs:
       matrix:
         include:
           - method: source
-            compiler: clang
+            compiler: gcc
             python_version: 3.7
             cuda_version: "11.5.1"
           - method: pip
-            compiler: gcc
+            compiler: clang
             python_version: 3.8
             cuda_version: "10.0"
           - method: wheel
-            compiler: clang
+            compiler: gcc
             python_version: 3.9
             cuda_version: "9.0"
     steps:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -24,15 +24,15 @@ jobs:
       matrix:
         include:
           - method: source
-            compiler: gcc
+            compiler: clang
             python_version: 3.7
             cuda_version: "11.5.1"
           - method: pip
-            compiler: clang
+            compiler: gcc
             python_version: 3.8
             cuda_version: "10.0"
           - method: wheel
-            compiler: gcc
+            compiler: clang
             python_version: 3.9
             cuda_version: "9.0"
     steps:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -58,10 +58,10 @@ jobs:
           export METHOD="${{ matrix.method }}"
           export PYTHON_VERSION="${{ matrix.python_version }}"
           if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
-              export COMPILER="gcc"
+              export COMPILER="clang"
               export OS_NAME="macos"
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-              export COMPILER="clang"
+              export COMPILER="gcc"
               export OS_NAME="linux"
           fi
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -58,10 +58,10 @@ jobs:
           export METHOD="${{ matrix.method }}"
           export PYTHON_VERSION="${{ matrix.python_version }}"
           if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
-              export COMPILER="clang"
+              export COMPILER="gcc"
               export OS_NAME="macos"
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-              export COMPILER="gcc"
+              export COMPILER="clang"
               export OS_NAME="linux"
           fi
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -25,7 +25,7 @@ jobs:
 - job: Linux
 ###########################################
   variables:
-    COMPILER: gcc
+    COMPILER: clang
     SETUP_CONDA: 'false'
     OS_NAME: 'linux'
     PRODUCES_ARTIFACTS: 'true'
@@ -79,7 +79,7 @@ jobs:
 - job: Linux_latest
 ###########################################
   variables:
-    COMPILER: clang
+    COMPILER: gcc
     DEBIAN_FRONTEND: 'noninteractive'
     IN_UBUNTU_LATEST_CONTAINER: 'true'
     OS_NAME: 'linux'
@@ -214,7 +214,7 @@ jobs:
 - job: macOS
 ###########################################
   variables:
-    COMPILER: clang
+    COMPILER: gcc
     OS_NAME: 'macos'
     PRODUCES_ARTIFACTS: 'true'
   pool:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -25,7 +25,7 @@ jobs:
 - job: Linux
 ###########################################
   variables:
-    COMPILER: clang
+    COMPILER: gcc
     SETUP_CONDA: 'false'
     OS_NAME: 'linux'
     PRODUCES_ARTIFACTS: 'true'
@@ -79,7 +79,7 @@ jobs:
 - job: Linux_latest
 ###########################################
   variables:
-    COMPILER: gcc
+    COMPILER: clang
     DEBIAN_FRONTEND: 'noninteractive'
     IN_UBUNTU_LATEST_CONTAINER: 'true'
     OS_NAME: 'linux'
@@ -214,7 +214,7 @@ jobs:
 - job: macOS
 ###########################################
   variables:
-    COMPILER: gcc
+    COMPILER: clang
     OS_NAME: 'macos'
     PRODUCES_ARTIFACTS: 'true'
   pool:

--- a/R-package/.Rbuildignore
+++ b/R-package/.Rbuildignore
@@ -38,6 +38,7 @@ src/external_libs/fmt/.*\.md
 src/external_libs/fmt/.travis.yml
 src/external_libs/fmt/doc
 src/external_libs/fmt/support/Android\.mk
+src/external_libs/fmt/support/bazel/.bazel.*
 src/external_libs/fmt/support/.*\.gradle
 src/external_libs/fmt/support/.*\.pro
 src/external_libs/fmt/support/.*\.py


### PR DESCRIPTION
Refer to #3763.

All dependencies were updated to the latest available stable version.

https://github.com/boostorg/compute/releases/tag/boost-1.78.0
https://gitlab.com/libeigen/eigen/-/releases/3.4.0
~https://github.com/lemire/fast_double_parser/releases/tag/v0.5.0~ see https://github.com/microsoft/LightGBM/pull/4935#issuecomment-1010122490
https://github.com/fmtlib/fmt/releases/tag/8.1.1