### PR TITLE
[ci] bump CUDA version from 11.4.2 to 11.5.0 at CI

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -26,7 +26,7 @@ jobs:
           - method: source
             compiler: gcc
             python_version: 3.7
-            cuda_version: "11.4.2"
+            cuda_version: "11.5.0"
           - method: pip
             compiler: clang
             python_version: 3.8


### PR DESCRIPTION
https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags

They have finally resolved internal problems with pipelines recently:

> Jesus Alvarez `@jesusa` · 2 months ago
Hey all, we are having some troubles with our test runner that should be resolved next week. Until then we have published the docker scripts for 11.5 images to here ...
   https://gitlab.com/nvidia/container-images/cuda/-/issues/142#note_718947207

> Jesus Alvarez `@jesusa` · 2 days ago
Hi all. Was on break last two weeks. We now have our internal pipelines fixed. Cuda images for 11.5.0, 11.5.1, and 11.4.3 will go out in the next few days.
   https://gitlab.com/nvidia/container-images/cuda/-/issues/142#note_803578322