### PR TITLE
[ci] use `-1` for exit code in case of failure

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           cd R-package/tests
           exit_code=0
-          RDscript${{ matrix.r_customization }} testthat.R >> tests.log 2>&1 || exit_code=1
+          RDscript${{ matrix.r_customization }} testthat.R >> tests.log 2>&1 || exit_code=-1
           cat ./tests.log
           exit ${exit_code}
   test-r-debian-clang:


### PR DESCRIPTION
Just to keep the repository codebase consistent. We use either `0` or `-1` as exit code everywhere, see e.g.
https://github.com/microsoft/LightGBM/blob/master/.ci/test.sh
https://github.com/microsoft/LightGBM/blob/master/.github/workflows/cuda.yml
https://github.com/microsoft/LightGBM/blob/master/.github/workflows/r_package.yml