### PR TITLE
[R-package] Fix custom objective detection in `print.lgb.Booster()`

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -861,7 +861,7 @@ print.lgb.Booster <- function(x, ...) {
 
   if (!handle_is_null) {
     obj <- x$params$objective
-    if (tolower(obj) == "none") {
+    if (obj == "none") {
       obj <- "custom"
     }
     num_class <- x$.__enclos_env__$private$num_class

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -861,15 +861,16 @@ print.lgb.Booster <- function(x, ...) {
 
   if (!handle_is_null) {
     obj <- x$params$objective
-    if (obj == "none") {
+    if (tolower(obj) == "none") {
       obj <- "custom"
     }
-    if (x$.__enclos_env__$private$num_class == 1L) {
+    num_class <- x$.__enclos_env__$private$num_class
+    if (num_class == 1L) {
       cat(sprintf("Objective: %s\n", obj))
     } else {
       cat(sprintf("Objective: %s (%d classes)\n"
           , obj
-          , x$.__enclos_env__$private$num_class))
+          , num_class))
     }
   } else {
     cat("(Booster handle is invalid)\n")

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -141,7 +141,7 @@ lgb.cv <- function(params = list()
   fobj <- NULL
   if (is.function(params$objective)) {
     fobj <- params$objective
-    params$objective <- "NONE"
+    params$objective <- "none"
   }
 
   # If eval is a single function, store it as a 1-element list

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -109,7 +109,7 @@ lgb.train <- function(params = list(),
   fobj <- NULL
   if (is.function(params$objective)) {
     fobj <- params$objective
-    params$objective <- "NONE"
+    params$objective <- "none"
   }
 
   # If eval is a single function, store it as a 1-element list


### PR DESCRIPTION
As the best of my knowledge, string comparison in R is case-sensitive. I think it's better to use lowercased `"none"` string value for objective parameter to avoid errors.
https://github.com/microsoft/LightGBM/blob/34f949782252d202097539124149e0d5f69000bd/R-package/R/lgb.Booster.R#L247-L250
https://github.com/microsoft/LightGBM/blob/34f949782252d202097539124149e0d5f69000bd/R-package/R/lgb.Booster.R#L864-L866