### PR TITLE
CUDATreeLearner: free GPU memory in destructor if any allocated

### DIFF
--- a/src/objective/regression_objective.hpp
+++ b/src/objective/regression_objective.hpp
@@ -439,17 +439,20 @@ class RegressionPoissonLoss: public RegressionL2loss {
    */
   void GetGradients(const double* score, score_t* gradients,
                     score_t* hessians) const override {
+    double exp_max_delta_step_ = std::exp(max_delta_step_);
     if (weights_ == nullptr) {
       #pragma omp parallel for schedule(static)
       for (data_size_t i = 0; i < num_data_; ++i) {
-        gradients[i] = static_cast<score_t>(std::exp(score[i]) - label_[i]);
-        hessians[i] = static_cast<score_t>(std::exp(score[i] + max_delta_step_));
+        double exp_score = std::exp(score[i]);
+        gradients[i] = static_cast<score_t>(exp_score - label_[i]);
+        hessians[i] = static_cast<score_t>(exp_score * exp_max_delta_step_);
       }
     } else {
       #pragma omp parallel for schedule(static)
       for (data_size_t i = 0; i < num_data_; ++i) {
-        gradients[i] = static_cast<score_t>((std::exp(score[i]) - label_[i]) * weights_[i]);
-        hessians[i] = static_cast<score_t>(std::exp(score[i] + max_delta_step_) * weights_[i]);
+        double exp_score = std::exp(score[i]);
+        gradients[i] = static_cast<score_t>((exp_score - label_[i]) * weights_[i]);
+        hessians[i] = static_cast<score_t>(exp_score * exp_max_delta_step_ * weights_[i]);
       }
     }
   }
@@ -689,14 +692,16 @@ class RegressionGammaLoss : public RegressionPoissonLoss {
     if (weights_ == nullptr) {
       #pragma omp parallel for schedule(static)
       for (data_size_t i = 0; i < num_data_; ++i) {
-        gradients[i] = static_cast<score_t>(1.0 - label_[i] * std::exp(-score[i]));
-        hessians[i] = static_cast<score_t>(label_[i] * std::exp(-score[i]));
+        double exp_score = std::exp(-score[i]);
+        gradients[i] = static_cast<score_t>(1.0 - label_[i] * exp_score);
+        hessians[i] = static_cast<score_t>(label_[i] * exp_score);
       }
     } else {
       #pragma omp parallel for schedule(static)
       for (data_size_t i = 0; i < num_data_; ++i) {
-        gradients[i] = static_cast<score_t>((1.0 - label_[i] * std::exp(-score[i])) * weights_[i]);
-        hessians[i] = static_cast<score_t>(label_[i] * std::exp(-score[i]) * weights_[i]);
+        double exp_score = std::exp(-score[i]);
+        gradients[i] = static_cast<score_t>((1.0 - label_[i] * exp_score) * weights_[i]);
+        hessians[i] = static_cast<score_t>(label_[i] * exp_score * weights_[i]);
       }
     }
   }
@@ -725,16 +730,20 @@ class RegressionTweedieLoss: public RegressionPoissonLoss {
     if (weights_ == nullptr) {
       #pragma omp parallel for schedule(static)
       for (data_size_t i = 0; i < num_data_; ++i) {
-        gradients[i] = static_cast<score_t>(-label_[i] * std::exp((1 - rho_) * score[i]) + std::exp((2 - rho_) * score[i]));
-        hessians[i] = static_cast<score_t>(-label_[i] * (1 - rho_) * std::exp((1 - rho_) * score[i]) +
-          (2 - rho_) * std::exp((2 - rho_) * score[i]));
+        double exp_1_score = std::exp((1 - rho_) * score[i]);
+        double exp_2_score = std::exp((2 - rho_) * score[i]);
+        gradients[i] = static_cast<score_t>(-label_[i] * exp_1_score + exp_2_score);
+        hessians[i] = static_cast<score_t>(-label_[i] * (1 - rho_) * exp_1_score +
+          (2 - rho_) * exp_2_score);
       }
     } else {
       #pragma omp parallel for schedule(static)
       for (data_size_t i = 0; i < num_data_; ++i) {
-        gradients[i] = static_cast<score_t>((-label_[i] * std::exp((1 - rho_) * score[i]) + std::exp((2 - rho_) * score[i])) * weights_[i]);
-        hessians[i] = static_cast<score_t>((-label_[i] * (1 - rho_) * std::exp((1 - rho_) * score[i]) +
-          (2 - rho_) * std::exp((2 - rho_) * score[i])) * weights_[i]);
+        double exp_1_score = std::exp((1 - rho_) * score[i]);
+        double exp_2_score = std::exp((2 - rho_) * score[i]);
+        gradients[i] = static_cast<score_t>((-label_[i] * exp_1_score + exp_2_score) * weights_[i]);
+        hessians[i] = static_cast<score_t>((-label_[i] * (1 - rho_) * exp_1_score +
+          (2 - rho_) * exp_2_score) * weights_[i]);
       }
     }
   }

--- a/src/treelearner/cuda_tree_learner.cpp
+++ b/src/treelearner/cuda_tree_learner.cpp
@@ -63,6 +63,47 @@ CUDATreeLearner::CUDATreeLearner(const Config* config)
 }
 
 CUDATreeLearner::~CUDATreeLearner() {
+ #pragma omp parallel for schedule(static, num_gpu_)
+
+  for (int device_id = 0; device_id < num_gpu_; ++device_id) {
+    // do nothing it there is no gpu feature
+    int num_gpu_feature_groups = num_gpu_feature_groups_[device_id];
+    if (num_gpu_feature_groups) {
+      CUDASUCCESS_OR_FATAL(cudaSetDevice(device_id));
+
+      if (device_features_[device_id] != NULL) {
+        CUDASUCCESS_OR_FATAL(cudaFree(device_features_[device_id]));
+      }
+
+      if (device_gradients_[device_id] != NULL) {
+        CUDASUCCESS_OR_FATAL(cudaFree(device_gradients_[device_id]));
+      }
+
+      if (device_hessians_[device_id] != NULL) {
+        CUDASUCCESS_OR_FATAL(cudaFree(device_hessians_[device_id]));
+      }
+
+      if (device_feature_masks_[device_id] != NULL) {
+         CUDASUCCESS_OR_FATAL(cudaFree(device_feature_masks_[device_id]));
+      }
+
+      if (device_data_indices_[device_id] != NULL) {
+        CUDASUCCESS_OR_FATAL(cudaFree(device_data_indices_[device_id]));
+      }
+
+      if (sync_counters_[device_id] != NULL) {
+        CUDASUCCESS_OR_FATAL(cudaFree(sync_counters_[device_id]));
+      }
+
+      if (device_subhistograms_[device_id] != NULL) {
+        CUDASUCCESS_OR_FATAL(cudaFree(device_subhistograms_[device_id]));
+      }
+
+      if (device_histogram_outputs_[device_id] != NULL) {
+        CUDASUCCESS_OR_FATAL(cudaFree(device_histogram_outputs_[device_id]));
+      }
+    }
+  }
 }
 
 

--- a/src/treelearner/cuda_tree_learner.cpp
+++ b/src/treelearner/cuda_tree_learner.cpp
@@ -63,45 +63,41 @@ CUDATreeLearner::CUDATreeLearner(const Config* config)
 }
 
 CUDATreeLearner::~CUDATreeLearner() {
- #pragma omp parallel for schedule(static, num_gpu_)
+  #pragma omp parallel for schedule(static, num_gpu_)
 
   for (int device_id = 0; device_id < num_gpu_; ++device_id) {
-    // do nothing it there is no gpu feature
-    int num_gpu_feature_groups = num_gpu_feature_groups_[device_id];
-    if (num_gpu_feature_groups) {
-      CUDASUCCESS_OR_FATAL(cudaSetDevice(device_id));
+    CUDASUCCESS_OR_FATAL(cudaSetDevice(device_id));
 
-      if (device_features_[device_id] != NULL) {
-        CUDASUCCESS_OR_FATAL(cudaFree(device_features_[device_id]));
-      }
+    if (device_features_[device_id] != NULL) {
+      CUDASUCCESS_OR_FATAL(cudaFree(device_features_[device_id]));
+    }
 
-      if (device_gradients_[device_id] != NULL) {
-        CUDASUCCESS_OR_FATAL(cudaFree(device_gradients_[device_id]));
-      }
+    if (device_gradients_[device_id] != NULL) {
+      CUDASUCCESS_OR_FATAL(cudaFree(device_gradients_[device_id]));
+    }
 
-      if (device_hessians_[device_id] != NULL) {
-        CUDASUCCESS_OR_FATAL(cudaFree(device_hessians_[device_id]));
-      }
+    if (device_hessians_[device_id] != NULL) {
+      CUDASUCCESS_OR_FATAL(cudaFree(device_hessians_[device_id]));
+    }
 
-      if (device_feature_masks_[device_id] != NULL) {
-         CUDASUCCESS_OR_FATAL(cudaFree(device_feature_masks_[device_id]));
-      }
+    if (device_feature_masks_[device_id] != NULL) {
+      CUDASUCCESS_OR_FATAL(cudaFree(device_feature_masks_[device_id]));
+    }
 
-      if (device_data_indices_[device_id] != NULL) {
-        CUDASUCCESS_OR_FATAL(cudaFree(device_data_indices_[device_id]));
-      }
+    if (device_data_indices_[device_id] != NULL) {
+      CUDASUCCESS_OR_FATAL(cudaFree(device_data_indices_[device_id]));
+    }
 
-      if (sync_counters_[device_id] != NULL) {
-        CUDASUCCESS_OR_FATAL(cudaFree(sync_counters_[device_id]));
-      }
+    if (sync_counters_[device_id] != NULL) {
+      CUDASUCCESS_OR_FATAL(cudaFree(sync_counters_[device_id]));
+    }
 
-      if (device_subhistograms_[device_id] != NULL) {
-        CUDASUCCESS_OR_FATAL(cudaFree(device_subhistograms_[device_id]));
-      }
+    if (device_subhistograms_[device_id] != NULL) {
+      CUDASUCCESS_OR_FATAL(cudaFree(device_subhistograms_[device_id]));
+    }
 
-      if (device_histogram_outputs_[device_id] != NULL) {
-        CUDASUCCESS_OR_FATAL(cudaFree(device_histogram_outputs_[device_id]));
-      }
+    if (device_histogram_outputs_[device_id] != NULL) {
+      CUDASUCCESS_OR_FATAL(cudaFree(device_histogram_outputs_[device_id]));
     }
   }
 }


### PR DESCRIPTION
Fixes memory freeing issue described [here](https://github.com/microsoft/LightGBM/issues/4952): allocated GPU memory is not released after training cycle is complete, which leads to constant memory growth while using multiple train() invocations inside the same process (like hyperparameters search).