### PR TITLE
[ci] bump CUDA version from `11.5.0` to `11.5.1` at CI

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -98,15 +98,9 @@ else  # Linux
                 clang \
                 libomp-dev
         fi
-        curl \
-            -s \
-            -L \
-            --insecure \
-            https://apt.kitware.com/keys/kitware-archive-latest.asc \
-        | apt-key add -
+        curl -sL https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add -
         apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" -y
-        apt-get --allow-unauthenticated upgrade -y
-        apt-get --allow-unauthenticated update -y
+        apt-get update
         apt-get install --no-install-recommends -y \
             cmake
     else

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -26,7 +26,7 @@ jobs:
           - method: source
             compiler: gcc
             python_version: 3.7
-            cuda_version: "11.5.0"
+            cuda_version: "11.5.1"
           - method: pip
             compiler: clang
             python_version: 3.8


### PR DESCRIPTION
https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags

Also, revert #4648 according to https://gitlab.com/nvidia/container-images/cuda/-/issues/140#note_806446655.