### PR TITLE
[R-package] Remove `reshape` argument in `predict`

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -748,7 +748,12 @@ Booster <- R6::R6Class(
 #' @param predcontrib return per-feature contributions for each record.
 #' @param header only used for prediction for text file. True if text file has header
 #' @param reshape whether to reshape the vector of predictions to a matrix form when there are several
-#'                prediction outputs per case.
+#'                prediction outputs per case. If passing `reshape=TRUE` and the requested prediction is
+#'                a multi-output result, the output will be a matrix with number of rows matching to the
+#'                number of rows in the prediction data, and number of columns matching to the number of
+#'                prediction outputs. If passing `reshape=FALSE`, multi-output predictions will be returned
+#'                as a vector with this same matrix in row-major order (contrary to R matrices which use
+#'                column-major order).
 #' @param params a list of additional named parameters. See
 #'               \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html#predict-parameters}{
 #'               the "Predict Parameters" section of the documentation} for a list of parameters and
@@ -804,7 +809,7 @@ predict.lgb.Booster <- function(object,
                                 predleaf = FALSE,
                                 predcontrib = FALSE,
                                 header = FALSE,
-                                reshape = FALSE,
+                                reshape = TRUE,
                                 params = list(),
                                 ...) {
 

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -808,7 +808,7 @@ predict.lgb.Booster <- function(object,
   additional_params <- list(...)
   if (length(additional_params) > 0L) {
     if ("reshape" %in% names(additional_params)) {
-      warning("'reshape' argument is no longer supported.")
+      stop("'reshape' argument is no longer supported.")
     }
     warning(paste0(
       "predict.lgb.Booster: Found the following passed through '...': "

--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -492,7 +492,6 @@ Booster <- R6::R6Class(
                        predleaf = FALSE,
                        predcontrib = FALSE,
                        header = FALSE,
-                       reshape = FALSE,
                        params = list()) {
 
       self$restore_handle()
@@ -519,7 +518,6 @@ Booster <- R6::R6Class(
           , predleaf = predleaf
           , predcontrib = predcontrib
           , header = header
-          , reshape = reshape
         )
       )
 
@@ -747,25 +745,16 @@ Booster <- R6::R6Class(
 #' @param predleaf whether predict leaf index instead.
 #' @param predcontrib return per-feature contributions for each record.
 #' @param header only used for prediction for text file. True if text file has header
-#' @param reshape whether to reshape the vector of predictions to a matrix form when there are several
-#'                prediction outputs per case. If passing `reshape=TRUE` and the requested prediction is
-#'                a multi-output result, the output will be a matrix with number of rows matching to the
-#'                number of rows in the prediction data, and number of columns matching to the number of
-#'                prediction outputs. If passing `reshape=FALSE`, multi-output predictions will be returned
-#'                as a vector with this same matrix in row-major order (contrary to R matrices which use
-#'                column-major order).
 #' @param params a list of additional named parameters. See
 #'               \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html#predict-parameters}{
 #'               the "Predict Parameters" section of the documentation} for a list of parameters and
 #'               valid values.
 #' @param ... ignored
 #' @return For regression or binary classification, it returns a vector of length \code{nrows(data)}.
-#'         For multiclass classification, either a \code{num_class * nrows(data)} vector or
-#'         a \code{(nrows(data), num_class)} dimension matrix is returned, depending on
-#'         the \code{reshape} value.
+#'         For multiclass classification, it returns a matrix of dimensions \code{(nrows(data), num_class)}.
 #'
-#'         When \code{predleaf = TRUE}, the output is a matrix object with the
-#'         number of columns corresponding to the number of trees.
+#'         When passing \code{predleaf=TRUE} or \code{predcontrib=TRUE}, the output will always be
+#'         returned as a matrix.
 #'
 #' @examples
 #' \donttest{
@@ -809,7 +798,6 @@ predict.lgb.Booster <- function(object,
                                 predleaf = FALSE,
                                 predcontrib = FALSE,
                                 header = FALSE,
-                                reshape = TRUE,
                                 params = list(),
                                 ...) {
 
@@ -819,6 +807,9 @@ predict.lgb.Booster <- function(object,
 
   additional_params <- list(...)
   if (length(additional_params) > 0L) {
+    if ("reshape" %in% names(additional_params)) {
+      warning("'reshape' argument is no longer supported.")
+    }
     warning(paste0(
       "predict.lgb.Booster: Found the following passed through '...': "
       , paste(names(additional_params), collapse = ", ")
@@ -835,7 +826,6 @@ predict.lgb.Booster <- function(object,
       , predleaf =  predleaf
       , predcontrib =  predcontrib
       , header = header
-      , reshape = reshape
       , params = params
     )
   )

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -295,7 +295,6 @@ Dataset <- R6::R6Class(
         init_score <- private$predictor$predict(
           data = private$raw_data
           , rawscore = TRUE
-          , reshape = TRUE
         )
 
         # Not needed to transpose, for is col_marjor

--- a/R-package/R/lgb.Predictor.R
+++ b/R-package/R/lgb.Predictor.R
@@ -84,8 +84,7 @@ Predictor <- R6::R6Class(
                        rawscore = FALSE,
                        predleaf = FALSE,
                        predcontrib = FALSE,
-                       header = FALSE,
-                       reshape = FALSE) {
+                       header = FALSE) {
 
       # Check if number of iterations is existing - if not, then set it to -1 (use all)
       if (is.null(num_iteration)) {
@@ -215,23 +214,12 @@ Predictor <- R6::R6Class(
       # Get number of cases per row
       npred_per_case <- length(preds) / num_row
 
-
       # Data reshaping
-
-      if (predleaf | predcontrib) {
-
-        # Predict leaves only, reshaping is mandatory
+      if (npred_per_case > 1L || predleaf || predcontrib) {
         preds <- matrix(preds, ncol = npred_per_case, byrow = TRUE)
-
-      } else if (reshape && npred_per_case > 1L) {
-
-        # Predict with data reshaping
-        preds <- matrix(preds, ncol = npred_per_case, byrow = TRUE)
-
       }
 
       return(preds)
-
     }
 
   ),

--- a/R-package/demo/multiclass.R
+++ b/R-package/demo/multiclass.R
@@ -66,11 +66,5 @@ my_preds <- predict(model, test[, 1L:4L])
 # We can also get the predicted scores before the Sigmoid/Softmax application
 my_preds <- predict(model, test[, 1L:4L], rawscore = TRUE)
 
-# Raw score predictions as matrix instead of vector
-my_preds <- predict(model, test[, 1L:4L], rawscore = TRUE)
-
 # We can also get the leaf index
-my_preds <- predict(model, test[, 1L:4L], predleaf = TRUE)
-
-# Predict leaf index as matrix instead of vector
 my_preds <- predict(model, test[, 1L:4L], predleaf = TRUE)

--- a/R-package/demo/multiclass.R
+++ b/R-package/demo/multiclass.R
@@ -56,21 +56,21 @@ model <- lgb.train(
 # We can predict on test data, identical
 my_preds <- predict(model, test[, 1L:4L])
 
-# A (30x3) matrix with the predictions, use parameter reshape
+# A (30x3) matrix with the predictions
 # class1 class2 class3
 #   obs1   obs1   obs1
 #   obs2   obs2   obs2
 #   ....   ....   ....
-my_preds <- predict(model, test[, 1L:4L], reshape = TRUE)
+my_preds <- predict(model, test[, 1L:4L])
 
 # We can also get the predicted scores before the Sigmoid/Softmax application
 my_preds <- predict(model, test[, 1L:4L], rawscore = TRUE)
 
 # Raw score predictions as matrix instead of vector
-my_preds <- predict(model, test[, 1L:4L], rawscore = TRUE, reshape = TRUE)
+my_preds <- predict(model, test[, 1L:4L], rawscore = TRUE)
 
 # We can also get the leaf index
 my_preds <- predict(model, test[, 1L:4L], predleaf = TRUE)
 
 # Predict leaf index as matrix instead of vector
-my_preds <- predict(model, test[, 1L:4L], predleaf = TRUE, reshape = TRUE)
+my_preds <- predict(model, test[, 1L:4L], predleaf = TRUE)

--- a/R-package/demo/multiclass_custom_objective.R
+++ b/R-package/demo/multiclass_custom_objective.R
@@ -36,7 +36,7 @@ model_builtin <- lgb.train(
     , obj = "multiclass"
 )
 
-preds_builtin <- predict(model_builtin, test[, 1L:4L], rawscore = TRUE, reshape = TRUE)
+preds_builtin <- predict(model_builtin, test[, 1L:4L], rawscore = TRUE)
 probs_builtin <- exp(preds_builtin) / rowSums(exp(preds_builtin))
 
 # Method 2 of training with custom objective function
@@ -109,7 +109,7 @@ model_custom <- lgb.train(
     , eval = custom_multiclass_metric
 )
 
-preds_custom <- predict(model_custom, test[, 1L:4L], rawscore = TRUE, reshape = TRUE)
+preds_custom <- predict(model_custom, test[, 1L:4L], rawscore = TRUE)
 probs_custom <- exp(preds_custom) / rowSums(exp(preds_custom))
 
 # compare predictions

--- a/R-package/man/predict.lgb.Booster.Rd
+++ b/R-package/man/predict.lgb.Booster.Rd
@@ -13,7 +13,7 @@
   predleaf = FALSE,
   predcontrib = FALSE,
   header = FALSE,
-  reshape = FALSE,
+  reshape = TRUE,
   params = list(),
   ...
 )
@@ -45,7 +45,12 @@ for logistic regression would result in predictions for log-odds instead of prob
 \item{header}{only used for prediction for text file. True if text file has header}
 
 \item{reshape}{whether to reshape the vector of predictions to a matrix form when there are several
-prediction outputs per case.}
+prediction outputs per case. If passing `reshape=TRUE` and the requested prediction is
+a multi-output result, the output will be a matrix with number of rows matching to the
+number of rows in the prediction data, and number of columns matching to the number of
+prediction outputs. If passing `reshape=FALSE`, multi-output predictions will be returned
+as a vector with this same matrix in row-major order (contrary to R matrices which use
+column-major order).}
 
 \item{params}{a list of additional named parameters. See
 \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html#predict-parameters}{

--- a/R-package/man/predict.lgb.Booster.Rd
+++ b/R-package/man/predict.lgb.Booster.Rd
@@ -13,7 +13,6 @@
   predleaf = FALSE,
   predcontrib = FALSE,
   header = FALSE,
-  reshape = TRUE,
   params = list(),
   ...
 )
@@ -44,14 +43,6 @@ for logistic regression would result in predictions for log-odds instead of prob
 
 \item{header}{only used for prediction for text file. True if text file has header}
 
-\item{reshape}{whether to reshape the vector of predictions to a matrix form when there are several
-prediction outputs per case. If passing `reshape=TRUE` and the requested prediction is
-a multi-output result, the output will be a matrix with number of rows matching to the
-number of rows in the prediction data, and number of columns matching to the number of
-prediction outputs. If passing `reshape=FALSE`, multi-output predictions will be returned
-as a vector with this same matrix in row-major order (contrary to R matrices which use
-column-major order).}
-
 \item{params}{a list of additional named parameters. See
 \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html#predict-parameters}{
 the "Predict Parameters" section of the documentation} for a list of parameters and
@@ -61,12 +52,10 @@ valid values.}
 }
 \value{
 For regression or binary classification, it returns a vector of length \code{nrows(data)}.
-        For multiclass classification, either a \code{num_class * nrows(data)} vector or
-        a \code{(nrows(data), num_class)} dimension matrix is returned, depending on
-        the \code{reshape} value.
+        For multiclass classification, it returns a matrix of dimensions \code{(nrows(data), num_class)}.
 
-        When \code{predleaf = TRUE}, the output is a matrix object with the
-        number of columns corresponding to the number of trees.
+        When passing \code{predleaf=TRUE} or \code{predcontrib=TRUE}, the output will always be
+        returned as a matrix.
 }
 \description{
 Predicted values based on class \code{lgb.Booster}

--- a/R-package/tests/testthat/test_Predictor.R
+++ b/R-package/tests/testthat/test_Predictor.R
@@ -111,3 +111,61 @@ test_that("start_iteration works correctly", {
     pred_leaf2 <- predict(bst, test$data, start_iteration = 0L, num_iteration = end_iter + 1L, predleaf = TRUE)
     expect_equal(pred_leaf1, pred_leaf2)
 })
+
+test_that("predictions for regression and binary classification are returned as vectors", {
+    data(mtcars)
+    X <- as.matrix(mtcars[, -1L])
+    y <- as.numeric(mtcars[, 1L])
+    dtrain <- lgb.Dataset(X, label = y, params = list(max_bins = 5L))
+    model <- lgb.train(
+      data = dtrain
+      , obj = "regression"
+      , nrounds = 5L
+      , verbose = VERBOSITY
+    )
+    pred <- predict(model, X)
+    expect_true(is.vector(pred))
+    expect_equal(length(pred), nrow(X))
+    pred <- predict(model, X, rawscore = TRUE)
+    expect_true(is.vector(pred))
+    expect_equal(length(pred), nrow(X))
+
+    data(agaricus.train, package = "lightgbm")
+    X <- agaricus.train$data
+    y <- agaricus.train$label
+    dtrain <- lgb.Dataset(X, label = y)
+    model <- lgb.train(
+      data = dtrain
+      , obj = "binary"
+      , nrounds = 5L
+      , verbose = VERBOSITY
+    )
+    pred <- predict(model, X)
+    expect_true(is.vector(pred))
+    expect_equal(length(pred), nrow(X))
+    pred <- predict(model, X, rawscore = TRUE)
+    expect_true(is.vector(pred))
+    expect_equal(length(pred), nrow(X))
+})
+
+test_that("predictions for multiclass classification are returned as matrix", {
+    data(iris)
+    X <- as.matrix(iris[, -5L])
+    y <- as.numeric(iris$Species) - 1.0
+    dtrain <- lgb.Dataset(X, label = y)
+    model <- lgb.train(
+      data = dtrain
+      , obj = "multiclass"
+      , nrounds = 5L
+      , verbose = VERBOSITY
+      , params = list(num_class = 3L)
+    )
+    pred <- predict(model, X)
+    expect_true(is.matrix(pred))
+    expect_equal(nrow(pred), nrow(X))
+    expect_equal(ncol(pred), 3L)
+    pred <- predict(model, X, rawscore = TRUE)
+    expect_true(is.matrix(pred))
+    expect_equal(nrow(pred), nrow(X))
+    expect_equal(ncol(pred), 3L)
+})


### PR DESCRIPTION
ref #4968

When requesing a prediction type with several entries per row, the prediction function in the R package by default produces outputs as a 1-D vector in row-major order. This can be quite confusing and lead to user errors when used externally, especially since it is not documented that the output is row-major while R assumes that conversions to matrices are to be done assuming column-major order and uses vectors in column-major order in built-in operators such as `+`, `*`, `[`, or `[<-` and functions such as `sweep`.

What's more, base R's `stats` package and many core R packages for decision tree ensembles such as `ranger` or `randomForest` produce multi-output predictions as a matrix. Examples:

```r
library(ranger)
data(iris)
m <- ranger(Species ~ ., data = iris)
p <- predict(m, iris, type="terminalNodes")$predictions
dim(p)
```
```
[1] 150 500
```

```r
library(randomForest)
m <- randomForest(Species ~ ., data=iris)
p <- attr(predict(m, iris, nodes=TRUE), "nodes")
dim(p)
```
```
[1] 150 500
```

This PR changes the default towards `reshape=TRUE` and adds a note about the storage order in the documentation.