### PR TITLE
[R-package] Promote objective and init_score to top-level arguments in `lightgbm()`

### DIFF
--- a/R-package/R/lightgbm.R
+++ b/R-package/R/lightgbm.R
@@ -92,6 +92,13 @@ NULL
 #' @inheritParams lgb_shared_params
 #' @param label Vector of labels, used if \code{data} is not an \code{\link{lgb.Dataset}}
 #' @param weight vector of response values. If not NULL, will set to dataset
+#' @param init_score Initial values for each observation from which the boosting process will
+#'                   be started (e.g. as the result of some previous model). If not passing it (the default),
+#'                   will start from a blank state.
+#' @param objective Optimization objective (e.g. `"regression"`, `"binary"`, etc.).
+#'                  For a list of accepted objectives, see
+#'                  \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html}{
+#'                  the "Parameters" section of the documentation}.
 #' @param save_name File name to use when writing the trained model to disk. Should end in ".model".
 #'                  If passing `NULL`, will not save the trained model to disk.
 #' @param ... Additional arguments passed to \code{\link{lgb.train}}. For example
@@ -115,6 +122,8 @@ NULL
 lightgbm <- function(data,
                      label = NULL,
                      weight = NULL,
+                     init_score = NULL,
+                     objective = "regression",
                      params = list(),
                      nrounds = 100L,
                      verbose = 1L,
@@ -136,13 +145,14 @@ lightgbm <- function(data,
 
   # Check whether data is lgb.Dataset, if not then create lgb.Dataset manually
   if (!lgb.is.Dataset(x = dtrain)) {
-    dtrain <- lgb.Dataset(data = data, label = label, weight = weight)
+    dtrain <- lgb.Dataset(data = data, label = label, weight = weight, init_score = init_score)
   }
 
   train_args <- list(
     "params" = params
     , "data" = dtrain
     , "nrounds" = nrounds
+    , "obj" = objective
     , "verbose" = verbose
     , "eval_freq" = eval_freq
     , "early_stopping_rounds" = early_stopping_rounds

--- a/R-package/man/lightgbm.Rd
+++ b/R-package/man/lightgbm.Rd
@@ -8,6 +8,8 @@ lightgbm(
   data,
   label = NULL,
   weight = NULL,
+  init_score = NULL,
+  objective = "regression",
   params = list(),
   nrounds = 100L,
   verbose = 1L,
@@ -28,6 +30,15 @@ may allow you to pass other types of data like \code{matrix} and then separately
 \item{label}{Vector of labels, used if \code{data} is not an \code{\link{lgb.Dataset}}}
 
 \item{weight}{vector of response values. If not NULL, will set to dataset}
+
+\item{init_score}{Initial values for each observation from which the boosting process will
+be started (e.g. as the result of some previous model). If not passing it (the default),
+will start from a blank state.}
+
+\item{objective}{Optimization objective (e.g. `"regression"`, `"binary"`, etc.).
+For a list of accepted objectives, see
+\href{https://lightgbm.readthedocs.io/en/latest/Parameters.html}{
+the "Parameters" section of the documentation}.}
 
 \item{params}{a list of parameters. See \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html}{
 the "Parameters" section of the documentation} for a list of parameters and valid values.}

--- a/R-package/tests/testthat/test_Predictor.R
+++ b/R-package/tests/testthat/test_Predictor.R
@@ -68,10 +68,10 @@ test_that("start_iteration works correctly", {
     bst <- lightgbm(
         data = as.matrix(train$data)
         , label = train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 4L
             , learning_rate = 0.6
-            , objective = "binary"
             , verbosity = VERBOSITY
         )
         , nrounds = 50L

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -74,9 +74,9 @@ test_that("train and predict binary classification", {
   bst <- lightgbm(
     data = train$data
     , label = train$label
+    , objective = "binary"
     , params = list(
         num_leaves = 5L
-        , objective = "binary"
         , metric = "binary_error"
     )
     , nrounds = nrounds
@@ -104,12 +104,12 @@ test_that("train and predict softmax", {
   bst <- lightgbm(
     data = as.matrix(iris[, -5L])
     , label = lb
+    , objective = "multiclass"
     , params = list(
         num_leaves = 4L
         , learning_rate = 0.05
         , min_data = 20L
         , min_hessian = 10.0
-        , objective = "multiclass"
         , metric = "multi_error"
         , num_class = 3L
     )
@@ -131,10 +131,10 @@ test_that("use of multiple eval metrics works", {
   bst <- lightgbm(
     data = train$data
     , label = train$label
+    , objective = "binary"
     , params = list(
         num_leaves = 4L
         , learning_rate = 1.0
-        , objective = "binary"
         , metric = metrics
     )
     , nrounds = 10L
@@ -155,9 +155,9 @@ test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expec
   bst <- lightgbm(
     data = train$data
     , label = train$label
+    , objective = "binary"
     , params = list(
         num_leaves = 5L
-        , objective = "binary"
         , metric = "binary_error"
     )
     , nrounds = nrounds
@@ -173,9 +173,9 @@ test_that("lgb.Booster.upper_bound() and lgb.Booster.lower_bound() work as expec
   bst <- lightgbm(
     data = train$data
     , label = train$label
+    , objective = "regression"
     , params = list(
         num_leaves = 5L
-        , objective = "regression"
         , metric = "l2"
     )
     , nrounds = nrounds
@@ -192,6 +192,7 @@ test_that("lightgbm() rejects negative or 0 value passed to nrounds", {
     expect_error({
       bst <- lightgbm(
         data = dtrain
+        , objective = "regression"
         , params = params
         , nrounds = nround_value
         , save_name = tempfile(fileext = ".model")
@@ -207,10 +208,10 @@ test_that("lightgbm() accepts nrounds as either a top-level argument or paramete
   top_level_bst <- lightgbm(
     data = train$data
     , label = train$label
+    , objective = "regression"
     , nrounds = nrounds
     , params = list(
-      objective = "regression"
-      , metric = "l2"
+      metric = "l2"
       , num_leaves = 5L
     )
     , save_name = tempfile(fileext = ".model")
@@ -220,9 +221,9 @@ test_that("lightgbm() accepts nrounds as either a top-level argument or paramete
   param_bst <- lightgbm(
     data = train$data
     , label = train$label
+    , objective = "regression"
     , params = list(
-      objective = "regression"
-      , metric = "l2"
+      metric = "l2"
       , num_leaves = 5L
       , nrounds = nrounds
     )
@@ -233,10 +234,10 @@ test_that("lightgbm() accepts nrounds as either a top-level argument or paramete
   both_customized <- lightgbm(
     data = train$data
     , label = train$label
+    , objective = "regression"
     , nrounds = 20L
     , params = list(
-      objective = "regression"
-      , metric = "l2"
+      metric = "l2"
       , num_leaves = 5L
       , nrounds = nrounds
     )
@@ -276,9 +277,9 @@ test_that("lightgbm() performs evaluation on validation sets if they are provide
   bst <- lightgbm(
     data = train$data
     , label = train$label
+    , objective = "binary"
     , params = list(
         num_leaves = 5L
-        , objective = "binary"
         , metric = c(
             "binary_error"
             , "auc"
@@ -313,8 +314,8 @@ test_that("lightgbm() does not write model to disk if save_name=NULL", {
   model <- lightgbm(
     data = train$data
     , label = train$label
+    , objective = "binary"
     , nrounds = 5L
-    , params = list(objective = "binary")
     , verbose = 0L
     , save_name = NULL
   )
@@ -1661,9 +1662,9 @@ test_that("lgb.train() works with integer, double, and numeric data", {
     bst <- lightgbm(
       data = X
       , label = y
+      , objective = "regression"
       , params = list(
-        objective = "regression"
-        , min_data = 1L
+        min_data = 1L
         , learning_rate = 0.01
         , seed = 708L
       )
@@ -1969,14 +1970,14 @@ test_that("using lightgbm() without early stopping, best_iter and best_score com
   bst <- lightgbm(
     data = dtrain
     , nrounds = nrounds
+    , objective = "binary"
     , valids = list(
       "valid1" = dvalid1
       , "something-random-we-would-not-hardcode" = dtrain
       , "valid2" = dvalid2
     )
     , params = list(
-      objective = "binary"
-      , metric = "auc"
+      metric = "auc"
       , learning_rate = 1.5
       , num_leaves = 5L
     )
@@ -2514,10 +2515,11 @@ test_that("lgb.train() works with linear learners when Dataset has categorical f
 
 test_that("lgb.train() throws an informative error if interaction_constraints is not a list", {
   dtrain <- lgb.Dataset(train$data, label = train$label)
-  params <- list(objective = "regression", interaction_constraints = "[1,2],[3]")
+  params <- list(interaction_constraints = "[1,2],[3]")
     expect_error({
       bst <- lightgbm(
         data = dtrain
+        , objective = "regression"
         , params = params
         , nrounds = 2L
       )
@@ -2527,10 +2529,11 @@ test_that("lgb.train() throws an informative error if interaction_constraints is
 test_that(paste0("lgb.train() throws an informative error if the members of interaction_constraints ",
                  "are not character or numeric vectors"), {
   dtrain <- lgb.Dataset(train$data, label = train$label)
-  params <- list(objective = "regression", interaction_constraints = list(list(1L, 2L), list(3L)))
+  params <- list(interaction_constraints = list(list(1L, 2L), list(3L)))
     expect_error({
       bst <- lightgbm(
         data = dtrain
+        , objective = "regression"
         , params = params
         , nrounds = 2L
       )
@@ -2539,11 +2542,11 @@ test_that(paste0("lgb.train() throws an informative error if the members of inte
 
 test_that("lgb.train() throws an informative error if interaction_constraints contains a too large index", {
   dtrain <- lgb.Dataset(train$data, label = train$label)
-  params <- list(objective = "regression",
-                 interaction_constraints = list(c(1L, length(colnames(train$data)) + 1L), 3L))
+  params <- list(interaction_constraints = list(c(1L, length(colnames(train$data)) + 1L), 3L))
     expect_error({
       bst <- lightgbm(
         data = dtrain
+        , objective = "regression"
         , params = params
         , nrounds = 2L
       )
@@ -2555,26 +2558,29 @@ test_that(paste0("lgb.train() gives same result when interaction_constraints is 
   set.seed(1L)
   dtrain <- lgb.Dataset(train$data, label = train$label)
 
-  params <- list(objective = "regression", interaction_constraints = list(c(1L, 2L), 3L))
+  params <- list(interaction_constraints = list(c(1L, 2L), 3L))
   bst <- lightgbm(
     data = dtrain
+    , objective = "regression"
     , params = params
     , nrounds = 2L
   )
   pred1 <- bst$predict(test$data)
 
   cnames <- colnames(train$data)
-  params <- list(objective = "regression", interaction_constraints = list(c(cnames[[1L]], cnames[[2L]]), cnames[[3L]]))
+  params <- list(interaction_constraints = list(c(cnames[[1L]], cnames[[2L]]), cnames[[3L]]))
   bst <- lightgbm(
     data = dtrain
+    , objective = "regression"
     , params = params
     , nrounds = 2L
   )
   pred2 <- bst$predict(test$data)
 
-  params <- list(objective = "regression", interaction_constraints = list(c(cnames[[1L]], cnames[[2L]]), 3L))
+  params <- list(interaction_constraints = list(c(cnames[[1L]], cnames[[2L]]), 3L))
   bst <- lightgbm(
     data = dtrain
+    , objective = "regression"
     , params = params
     , nrounds = 2L
   )
@@ -2589,19 +2595,20 @@ test_that(paste0("lgb.train() gives same results when using interaction_constrai
   set.seed(1L)
   dtrain <- lgb.Dataset(train$data, label = train$label)
 
-  params <- list(objective = "regression", interaction_constraints = list(c(1L, 2L), 3L))
+  params <- list(interaction_constraints = list(c(1L, 2L), 3L))
   bst <- lightgbm(
     data = dtrain
+    , objective = "regression"
     , params = params
     , nrounds = 2L
   )
   pred1 <- bst$predict(test$data)
 
   new_colnames <- paste0(colnames(train$data), "_x")
-  params <- list(objective = "regression"
-                 , interaction_constraints = list(c(new_colnames[1L], new_colnames[2L]), new_colnames[3L]))
+  params <- list(interaction_constraints = list(c(new_colnames[1L], new_colnames[2L]), new_colnames[3L]))
   bst <- lightgbm(
     data = dtrain
+    , objective = "regression"
     , params = params
     , nrounds = 2L
     , colnames = new_colnames

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -129,9 +129,9 @@ test_that("lgb.load() gives the expected error messages given different incorrec
     bst <- lightgbm(
         data = as.matrix(train$data)
         , label = train$label
+        , objective = "binary"
         , params = list(
-            objective = "binary"
-            , num_leaves = 4L
+            num_leaves = 4L
             , learning_rate = 1.0
             , verbose = VERBOSITY
         )
@@ -176,10 +176,10 @@ test_that("Loading a Booster from a text file works", {
     bst <- lightgbm(
         data = as.matrix(train$data)
         , label = train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 4L
             , learning_rate = 1.0
-            , objective = "binary"
             , verbose = VERBOSITY
         )
         , nrounds = 2L
@@ -253,10 +253,10 @@ test_that("Loading a Booster from a string works", {
     bst <- lightgbm(
         data = as.matrix(train$data)
         , label = train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 4L
             , learning_rate = 1.0
-            , objective = "binary"
             , verbose = VERBOSITY
         )
         , nrounds = 2L
@@ -286,10 +286,10 @@ test_that("Saving a large model to string should work", {
     bst <- lightgbm(
         data = as.matrix(train$data)
         , label = train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 100L
             , learning_rate = 0.01
-            , objective = "binary"
         )
         , nrounds = 500L
         , save_name = tempfile(fileext = ".model")
@@ -330,10 +330,10 @@ test_that("Saving a large model to JSON should work", {
     bst <- lightgbm(
         data = as.matrix(train$data)
         , label = train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 100L
             , learning_rate = 0.01
-            , objective = "binary"
         )
         , nrounds = 200L
         , save_name = tempfile(fileext = ".model")
@@ -360,10 +360,10 @@ test_that("If a string and a file are both passed to lgb.load() the file is used
     bst <- lightgbm(
         data = as.matrix(train$data)
         , label = train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 4L
             , learning_rate = 1.0
-            , objective = "binary"
             , verbose = VERBOSITY
         )
         , nrounds = 2L
@@ -416,10 +416,10 @@ test_that("Creating a Booster from a Dataset with an existing predictor should w
     bst <- lightgbm(
         data = as.matrix(agaricus.train$data)
         , label = agaricus.train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 4L
             , learning_rate = 1.0
-            , objective = "binary"
             , verbose = VERBOSITY
         )
         , nrounds = nrounds
@@ -510,10 +510,10 @@ test_that("Booster$rollback_one_iter() should work as expected", {
     bst <- lightgbm(
         data = as.matrix(train$data)
         , label = train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 4L
             , learning_rate = 1.0
-            , objective = "binary"
             , verbose = VERBOSITY
         )
         , nrounds = nrounds
@@ -545,10 +545,10 @@ test_that("Booster$update() passing a train_set works as expected", {
     bst <- lightgbm(
         data = as.matrix(agaricus.train$data)
         , label = agaricus.train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 4L
             , learning_rate = 1.0
-            , objective = "binary"
             , verbose = VERBOSITY
         )
         , nrounds = nrounds
@@ -569,10 +569,10 @@ test_that("Booster$update() passing a train_set works as expected", {
     bst2 <- lightgbm(
         data = as.matrix(agaricus.train$data)
         , label = agaricus.train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 4L
             , learning_rate = 1.0
-            , objective = "binary"
             , verbose = VERBOSITY
         )
         , nrounds = nrounds +  1L
@@ -595,10 +595,10 @@ test_that("Booster$update() throws an informative error if you provide a non-Dat
     bst <- lightgbm(
         data = as.matrix(agaricus.train$data)
         , label = agaricus.train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 4L
             , learning_rate = 1.0
-            , objective = "binary"
             , verbose = VERBOSITY
         )
         , nrounds = nrounds
@@ -691,10 +691,10 @@ test_that("Saving a model with different feature importance types works", {
     bst <- lightgbm(
         data = as.matrix(train$data)
         , label = train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 4L
             , learning_rate = 1.0
-            , objective = "binary"
             , verbose = VERBOSITY
         )
         , nrounds = 2L
@@ -747,10 +747,10 @@ test_that("Saving a model with unknown importance type fails", {
     bst <- lightgbm(
         data = as.matrix(train$data)
         , label = train$label
+        , objective = "binary"
         , params = list(
             num_leaves = 4L
             , learning_rate = 1.0
-            , objective = "binary"
             , verbose = VERBOSITY
         )
         , nrounds = 2L

--- a/R-package/tests/testthat/test_parameters.R
+++ b/R-package/tests/testthat/test_parameters.R
@@ -14,10 +14,10 @@ test_that("Feature penalties work properly", {
     lightgbm(
       data = train$data
       , label = train$label
+      , objective = "binary"
       , params = list(
         num_leaves = 5L
         , learning_rate = 0.05
-        , objective = "binary"
         , feature_penalty = paste0(feature_penalties, collapse = ",")
         , metric = "binary_error"
       )
@@ -64,7 +64,6 @@ test_that("training should warn if you use 'dart' boosting, specified with 'boos
     params <- list(
         num_leaves = 5L
         , learning_rate = 0.05
-        , objective = "binary"
         , metric = "binary_error"
     )
     params[[boosting_param]] <- "dart"
@@ -72,6 +71,7 @@ test_that("training should warn if you use 'dart' boosting, specified with 'boos
       result <- lightgbm(
         data = train$data
         , label = train$label
+        , objective = "binary"
         , params = params
         , nrounds = 5L
         , verbose = -1L

--- a/R-package/vignettes/basic_walkthrough.Rmd
+++ b/R-package/vignettes/basic_walkthrough.Rmd
@@ -62,10 +62,10 @@ X <- data.matrix(bank[, c("age", "balance")])
 fit <- lightgbm(
   data = X
   , label = y
+  , objective = "binary"
   , params = list(
     num_leaves = 4L
     , learning_rate = 1.0
-    , objective = "binary"
   )
   , nrounds = 10L
   , verbose = -1L


### PR DESCRIPTION
ref #4968

This PR promotes `objective` and `init_score` to top-level parameters in `lightgbm()`. This is for 3 reasons:
* `objective` is probably one of the most common parameters to want to change. It's also accepted as a top-level parameter in the `lgb.train` interface and in the scikit-learn interface.
* Having `objective` as a top-level parameter will allow an option `"auto"` in the future (as part of #4968) to adjust it automatically for binary and multi-class classification depending on the input.
* Having `init_score` as a top-level parameter will allow to take it as a column from the input data in the future (as part of #4968), even if it right now looks out of place.