### PR TITLE
Pass train dataset parser config to valid dataset loading parser

### DIFF
--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -291,7 +291,7 @@ Dataset* DatasetLoader::LoadFromFileAlignWithOtherDataset(const char* filename, 
   auto bin_filename = CheckCanLoadFromBin(filename);
   if (bin_filename.size() == 0) {
     auto parser = std::unique_ptr<Parser>(Parser::CreateParser(filename, config_.header, 0, label_idx_,
-                                                               config_.precise_float_parser, dataset->parser_config_str_));
+                                                               config_.precise_float_parser, train_data->parser_config_str_));
     if (parser == nullptr) {
       Log::Fatal("Could not recognize data format of %s", filename);
     }


### PR DESCRIPTION
Issue: We received [an issue](https://github.com/microsoft/lightgbm-transform/issues/16) in [lightgbm-transform](https://github.com/microsoft/lightgbm-transform), in which user complained that custom parser can not take effect on valid dataset.

Solution: With some investigation, we find it is a bug and could be fixed by passing train dataset parser config to valid dataset loading parser.