### PR TITLE
[ci] use `latest` tag again for Ubuntu 14 CI Docker

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -14,7 +14,7 @@ variables:
 resources:
   containers:
   - container: ubuntu1404
-    image: lightgbm/vsts-agent:ubuntu-14.04-dev
+    image: lightgbm/vsts-agent:ubuntu-14.04
   - container: ubuntu-latest
     image: 'ubuntu:latest'
     options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"


### PR DESCRIPTION
According to https://github.com/guolinke/lightgbm-ci-docker/pull/22#issuecomment-1014778489.

![image](https://user-images.githubusercontent.com/25141164/153523326-4308f033-d885-486e-8797-ebb66007b677.png)
