### PR TITLE
[python] enforce a floor of Python 3.6 (fixes #5004)

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -340,6 +340,7 @@ if __name__ == "__main__":
           version=version,
           description='LightGBM Python Package',
           long_description=readme,
+          python_requires='>=3.6',
           install_requires=[
               'wheel',
               'numpy',


### PR DESCRIPTION
Fixes #5004.
Replaces #5005.

Add python_requires='>=3.6' for setup().