### PR TITLE
[R-package] prefer params to keyword argument in lgb.train()

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -127,7 +127,7 @@ lgb.cv <- function(params = list()
   params <- lgb.check.wrapper_param(
     main_param_name = "objective"
     , params = params
-    , alternative_kwarg_value = NULL
+    , alternative_kwarg_value = obj
   )
   params <- lgb.check.wrapper_param(
     main_param_name = "early_stopping_round"
@@ -137,7 +137,7 @@ lgb.cv <- function(params = list()
   early_stopping_rounds <- params[["early_stopping_round"]]
 
   # extract any function objects passed for objective or metric
-  params <- lgb.check.obj(params = params, obj = obj)
+  params <- lgb.check.obj(params = params)
   fobj <- NULL
   if (is.function(params$objective)) {
     fobj <- params$objective

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -95,7 +95,7 @@ lgb.train <- function(params = list(),
   params <- lgb.check.wrapper_param(
     main_param_name = "objective"
     , params = params
-    , alternative_kwarg_value = NULL
+    , alternative_kwarg_value = obj
   )
   params <- lgb.check.wrapper_param(
     main_param_name = "early_stopping_round"
@@ -105,7 +105,7 @@ lgb.train <- function(params = list(),
   early_stopping_rounds <- params[["early_stopping_round"]]
 
   # extract any function objects passed for objective or metric
-  params <- lgb.check.obj(params = params, obj = obj)
+  params <- lgb.check.obj(params = params)
   fobj <- NULL
   if (is.function(params$objective)) {
     fobj <- params$objective

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -117,7 +117,7 @@ lgb.check_interaction_constraints <- function(interaction_constraints, column_na
 
 }
 
-lgb.check.obj <- function(params, obj) {
+lgb.check.obj <- function(params) {
 
   # List known objectives in a vector
   OBJECTIVES <- c(
@@ -158,24 +158,17 @@ lgb.check.obj <- function(params, obj) {
     , "xendcg_mart"
   )
 
-  # Check whether the objective is empty or not, and take it from params if needed
-  if (!is.null(obj)) {
-    params$objective <- obj
+  if (is.null(params$objective)) {
+    stop("lgb.check.obj: objective should be a character or a function")
   }
 
-  # Check whether the objective is a character
   if (is.character(params$objective)) {
 
-    # If the objective is a character, check if it is a known objective
     if (!(params$objective %in% OBJECTIVES)) {
 
       stop("lgb.check.obj: objective name error should be one of (", paste0(OBJECTIVES, collapse = ", "), ")")
 
     }
-
-  } else if (!is.function(params$objective)) {
-
-    stop("lgb.check.obj: objective should be a character or a function")
 
   }
 

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -578,7 +578,7 @@ test_that("lgb.cv() prefers objective in params to keyword argument", {
     )
     , params = list(
       application = "regression_l1"
-      , verbosity = -1L
+      , verbosity = VERBOSITY
     )
     , nrounds = 5L
     , obj = "regression_l2"
@@ -721,7 +721,7 @@ test_that("lgb.train() prefers objective in params to keyword argument", {
     )
     , params = list(
         loss = "regression_l1"
-        , verbosity = -1L
+        , verbosity = VERBOSITY
     )
     , nrounds = 5L
     , obj = "regression_l2"

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -569,6 +569,23 @@ test_that("lgb.cv() respects parameter aliases for objective", {
   expect_length(cv_bst$boosters, nfold)
 })
 
+test_that("lgb.cv() prefers objective in params to keyword argument", {
+  data("EuStockMarkets")
+  bst <- lgb.train(
+    data = lgb.Dataset(
+      data = EuStockMarkets[, c("SMI", "CAC", "FTSE")]
+      , label = EuStockMarkets[, "DAX"]
+    )
+    , params = list(
+      objective = "regression_l2"
+      , verbosity = -1L
+    )
+    , nrounds = 5L
+    , obj = "regression_l1"
+  )
+  expect_equal(bst$params$objective, "regression_l2")
+})
+
 test_that("lgb.cv() respects parameter aliases for metric", {
   nrounds <- 3L
   nfold <- 4L
@@ -682,6 +699,23 @@ test_that("lgb.train() respects parameter aliases for objective", {
   expect_named(bst$record_evals[["the_training_data"]], "binary_logloss")
   expect_length(bst$record_evals[["the_training_data"]][["binary_logloss"]][["eval"]], nrounds)
   expect_equal(bst$params[["objective"]], "binary")
+})
+
+test_that("lgb.train() prefers objective in params to keyword argument", {
+  data("EuStockMarkets")
+  bst <- lgb.train(
+    data = lgb.Dataset(
+      data = EuStockMarkets[, c("SMI", "CAC", "FTSE")]
+      , label = EuStockMarkets[, "DAX"]
+    )
+    , params = list(
+        objective = "regression_l2"
+        , verbosity = -1L
+    )
+    , nrounds = 5L
+    , obj = "regression_l1"
+  )
+  expect_equal(bst$params$objective, "regression_l2")
 })
 
 test_that("lgb.train() respects parameter aliases for metric", {


### PR DESCRIPTION
From https://github.com/microsoft/LightGBM/pull/4976#discussion_r806384554.

Relates to #4913.

Today, when using `lightgbm::lgb.train()`, if you you pass different values to keyword argument `obj` and parameter `"objective"` in the `params` list, the value passed to the keyword argument will be preferred.

That is inconsistent with the way that the rest of the R package and the Python package works. Across LightGBM language-specific wrapper packages, it's expected that the values from `params` will take precedence over keyword arguments.

This PR proposes changing the R package to ensure that if `objective` or its aliases are passed through `params`, that value takes precedence over the keyword argument.

### Why make this breaking change now?

Normally I'd propose that a change like this go through a deprecation cycle. However, it's been almost 4 months since the previous release (v3.3.1, not counting v3.3.2 since that was just a small patch to satisfy CRAN), and given the current state of open large PRs like #3234, #4630, and #4827 I expect it will be at least 2 months until the next, 4.0.0 release.