### PR TITLE
[docs] clarify that custom eval functions are not only used on training data

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3151,7 +3151,7 @@ class Booster:
                     If ``fobj`` is specified, predicted values are returned before any transformation,
                     e.g. they are raw margin instead of probability of positive class for binary task in this case.
                 eval_data : Dataset
-                    The evaluation dataset.
+                    A ``Dataset`` to evaluate.
                 eval_name : str
                     The name of evaluation function (without whitespace).
                 eval_result : float

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -83,7 +83,7 @@ def train(
                 If ``fobj`` is specified, predicted values are returned before any transformation,
                 e.g. they are raw margin instead of probability of positive class for binary task in this case.
             eval_data : Dataset
-                The training dataset.
+                A ``Dataset`` to evaluate.
             eval_name : str
                 The name of evaluation function (without whitespaces).
             eval_result : float
@@ -429,15 +429,15 @@ def cv(params, train_set, num_boost_round=100,
 
     feval : callable, list of callable, or None, optional (default=None)
         Customized evaluation function.
-        Each evaluation function should accept two parameters: preds, train_data,
+        Each evaluation function should accept two parameters: preds, eval_data,
         and return (eval_name, eval_result, is_higher_better) or list of such tuples.
 
             preds : numpy 1-D array
                 The predicted values.
                 If ``fobj`` is specified, predicted values are returned before any transformation,
                 e.g. they are raw margin instead of probability of positive class for binary task in this case.
-            train_data : Dataset
-                The training dataset.
+            eval_data : Dataset
+                A ``Dataset`` to evaluate.
             eval_name : str
                 The name of evaluation function (without whitespace).
             eval_result : float


### PR DESCRIPTION
Continues #5002.
Fixes #4759.

The intent of changes proposed in #4759 was to clarify that in `lgb.train()` and `lgb.cv()`, the `Dataset` passed to custom evaluation functions isn't always "the training data", but that instead it can be either the training data or a validation set.

This PR clarifies that in a few additional places. I found those places like this:

```shell
git grep 'Customized evaluation function'
```

As of this PR, the documentation on custom evaluation functions would be identical and not say "the training data" for `cv()`, `train()`, and `Booster.eval()`.

I think that it's ok for `Booster.eval_train()` to say "the training dataset" and for `Booster.eval_valid()` to say "the validation dataset", since those are specific to those contexts.