### PR TITLE
[R-package] remove internal function lgb.check.obj()

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -127,7 +127,7 @@ lgb.cv <- function(params = list()
   params <- lgb.check.wrapper_param(
     main_param_name = "objective"
     , params = params
-    , alternative_kwarg_value = NULL
+    , alternative_kwarg_value = obj
   )
   params <- lgb.check.wrapper_param(
     main_param_name = "early_stopping_round"
@@ -137,7 +137,6 @@ lgb.cv <- function(params = list()
   early_stopping_rounds <- params[["early_stopping_round"]]
 
   # extract any function objects passed for objective or metric
-  params <- lgb.check.obj(params = params, obj = obj)
   fobj <- NULL
   if (is.function(params$objective)) {
     fobj <- params$objective

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -95,7 +95,7 @@ lgb.train <- function(params = list(),
   params <- lgb.check.wrapper_param(
     main_param_name = "objective"
     , params = params
-    , alternative_kwarg_value = NULL
+    , alternative_kwarg_value = obj
   )
   params <- lgb.check.wrapper_param(
     main_param_name = "early_stopping_round"
@@ -105,7 +105,6 @@ lgb.train <- function(params = list(),
   early_stopping_rounds <- params[["early_stopping_round"]]
 
   # extract any function objects passed for objective or metric
-  params <- lgb.check.obj(params = params, obj = obj)
   fobj <- NULL
   if (is.function(params$objective)) {
     fobj <- params$objective

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -117,64 +117,6 @@ lgb.check_interaction_constraints <- function(interaction_constraints, column_na
 
 }
 
-lgb.check.obj <- function(params) {
-
-  # List known objectives in a vector
-  OBJECTIVES <- c(
-    "regression"
-    , "regression_l1"
-    , "regression_l2"
-    , "mean_squared_error"
-    , "mse"
-    , "l2_root"
-    , "root_mean_squared_error"
-    , "rmse"
-    , "mean_absolute_error"
-    , "mae"
-    , "quantile"
-    , "huber"
-    , "fair"
-    , "poisson"
-    , "binary"
-    , "lambdarank"
-    , "multiclass"
-    , "softmax"
-    , "multiclassova"
-    , "multiclass_ova"
-    , "ova"
-    , "ovr"
-    , "xentropy"
-    , "cross_entropy"
-    , "xentlambda"
-    , "cross_entropy_lambda"
-    , "mean_absolute_percentage_error"
-    , "mape"
-    , "gamma"
-    , "tweedie"
-    , "rank_xendcg"
-    , "xendcg"
-    , "xe_ndcg"
-    , "xe_ndcg_mart"
-    , "xendcg_mart"
-  )
-
-  if (is.null(params$objective)) {
-    stop("lgb.check.obj: objective should be a character or a function")
-  }
-
-  if (is.character(params$objective)) {
-
-    if (!(params$objective %in% OBJECTIVES)) {
-
-      stop("lgb.check.obj: objective name error should be one of (", paste0(OBJECTIVES, collapse = ", "), ")")
-
-    }
-
-  }
-
-  return(params)
-
-}
 
 # [description]
 #     Take any character values from eval and store them in params$metric.

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -635,6 +635,24 @@ test_that("lgb.train() works as expected with multiple eval metrics", {
   )
 })
 
+test_that("lgb.train() raises an informative error for unrecognized objectives", {
+  dtrain <- lgb.Dataset(
+    data = train$data
+    , label = train$label
+  )
+  expect_error({
+    expect_warning({
+      bst <- lgb.train(
+        data = dtrain
+        , params = list(
+          objective_type = "not_a_real_objective"
+          , verbosity = VERBOSITY
+        )
+      )
+    }, regexp = "[LightGBM] [Fatal] Unknown objective type name: not_a_real_objective")
+  }, regexp = "lgb.Booster: cannot create Booster handle")
+})
+
 test_that("lgb.train() respects parameter aliases for objective", {
   nrounds <- 3L
   dtrain <- lgb.Dataset(

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -520,6 +520,22 @@ test_that("lgb.cv() respects showsd argument", {
   expect_identical(evals_no_showsd[["eval_err"]], list())
 })
 
+test_that("lgb.cv() raises an informative error for unrecognized objectives", {
+  dtrain <- lgb.Dataset(
+    data = train$data
+    , label = train$label
+  )
+  expect_error({
+    bst <- lgb.cv(
+      data = dtrain
+      , params = list(
+        objective_type = "not_a_real_objective"
+        , verbosity = VERBOSITY
+      )
+    )
+  }, regexp = "Unknown objective type name: not_a_real_objective")
+})
+
 test_that("lgb.cv() respects parameter aliases for objective", {
   nrounds <- 3L
   nfold <- 4L
@@ -669,16 +685,14 @@ test_that("lgb.train() raises an informative error for unrecognized objectives",
     , label = train$label
   )
   expect_error({
-    expect_warning({
-      bst <- lgb.train(
-        data = dtrain
-        , params = list(
-          objective_type = "not_a_real_objective"
-          , verbosity = VERBOSITY
-        )
+    bst <- lgb.train(
+      data = dtrain
+      , params = list(
+        objective_type = "not_a_real_objective"
+        , verbosity = VERBOSITY
       )
-    }, regexp = "[LightGBM] [Fatal] Unknown objective type name: not_a_real_objective")
-  }, regexp = "lgb.Booster: cannot create Booster handle")
+    )
+  }, regexp = "Unknown objective type name: not_a_real_objective")
 })
 
 test_that("lgb.train() respects parameter aliases for objective", {


### PR DESCRIPTION
Based on https://github.com/microsoft/LightGBM/pull/5007#discussion_r808401098. The R package has an internal function, `lgb.check.obj()`, that has been there since the very beginning of the R package (#168).

All of the things it does or once did are already handled by other parts of the code base.

1. resolve parameter aliases for `objective` and keyword argument
    - https://github.com/microsoft/LightGBM/blob/820ae7e65e90860061ec89cc4a1ad0a39b96e051/R-package/R/lgb.train.R#L95-L99
    - #4913, #5007
2. extract custom objective functions written in R
    - https://github.com/microsoft/LightGBM/blob/820ae7e65e90860061ec89cc4a1ad0a39b96e051/R-package/R/lgb.train.R#L109-L113
3. raise an informative error for unrecognized objectives
    - https://github.com/microsoft/LightGBM/blob/d517ba12f2e7862ac533908304dddbd770655d2b/src/objective/objective_function.cpp#L51

This PR proposes removing `lgb.check.obj()` from the R package, to reduce maintenance burden for the package and remove the risk of bugs caused by that code.

### Notes for Reviewers

Should be merged prior to #4976.
