### PR TITLE
[docs] improve docs for sklearn wrapper

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -58,6 +58,8 @@ Note that this will not build the R documentation.
 Consider using common R utilities for documentation generation, if you need it.
 Or use the Docker-based approach described above to build the R documentation locally.
 
+Optionally, you may also install ``scikit-learn`` and get richer documentation for the classes in ``Scikit-learn API``.
+
 If you faced any problems with Doxygen installation or you simply do not need documentation for C code, it is possible to build the documentation without it:
 
 .. code:: sh

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,8 +103,11 @@ autodoc_mock_imports = [
     'pandas',
     'scipy',
     'scipy.sparse',
-    'sklearn'
 ]
+try:
+    import sklearn
+except ImportError:
+    autodoc_mock_imports.append('sklearn')
 # hide type hints in API docs
 autodoc_typehints = "none"
 

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -13,5 +13,6 @@ dependencies:
   - r-pkgdown=1.6.1
   - r-rmarkdown=2.11
   - r-roxygen2=7.1.2
+  - scikit-learn
   - sphinx
   - "sphinx_rtd_theme>=0.5"


### PR DESCRIPTION
Fixed #4479.

Generated docs for this branch: https://lightgbm.readthedocs.io/en/docs/Python-API.html#scikit-learn-api.



Please note key differences with docs for `master` branch or for b1efc1f5bcf2d85cafe6fad8d2068e7a28d99721 commit (docs for that commit was overwritten by newer version with installed scikit-learn):

![image](https://user-images.githubusercontent.com/25141164/155248372-b12518f0-ebd7-452f-99dd-40f569d941d9.png)


![image](https://user-images.githubusercontent.com/25141164/155248416-1c566eab-e8a6-438d-b876-de05cbb7a963.png)


