### PR TITLE
[docs][R-package] Use direct link for the list of supported objectives

### DIFF
--- a/R-package/R/lightgbm.R
+++ b/R-package/R/lightgbm.R
@@ -94,8 +94,8 @@ NULL
 #' @param weight vector of response values. If not NULL, will set to dataset
 #' @param objective Optimization objective (e.g. `"regression"`, `"binary"`, etc.).
 #'                  For a list of accepted objectives, see
-#'                  \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html}{
-#'                  the "Parameters" section of the documentation}.
+#'                  \href{https://lightgbm.readthedocs.io/en/latest/Parameters.html#objective}{
+#'                  the "objective" item of the "Parameters" section of the documentation}.
 #' @param init_score initial score is the base prediction lightgbm will boost from
 #' @param ... Additional arguments passed to \code{\link{lgb.train}}. For example
 #'     \itemize{

--- a/R-package/man/lightgbm.Rd
+++ b/R-package/man/lightgbm.Rd
@@ -54,8 +54,8 @@ set to the iteration number of the best iteration.}
 
 \item{objective}{Optimization objective (e.g. `"regression"`, `"binary"`, etc.).
 For a list of accepted objectives, see
-\href{https://lightgbm.readthedocs.io/en/latest/Parameters.html}{
-the "Parameters" section of the documentation}.}
+\href{https://lightgbm.readthedocs.io/en/latest/Parameters.html#objective}{
+the "objective" item of the "Parameters" section of the documentation}.}
 
 \item{init_score}{initial score is the base prediction lightgbm will boost from}
 


### PR DESCRIPTION
Linking #4976.

We can provide a direct reference to any parameter name instead of making users to search for it through the huge "Parameters" web page.