### PR TITLE
[docs] update categorical feature description in Advanced Topics

### DIFF
--- a/docs/Advanced-Topics.rst
+++ b/docs/Advanced-Topics.rst
@@ -23,7 +23,7 @@ Categorical Feature Support
 -  Use ``categorical_feature`` to specify the categorical features.
    Refer to the parameter ``categorical_feature`` in `Parameters <./Parameters.rst#categorical_feature>`__.
 
--  Categorical features will be cast to ``int32`` so they must be encoded as non-negative integers (negative values will be treated as missing)
+-  Categorical features will be cast to ``int32`` (integer codes will be extracted from pandas categoricals in the Python-package) so they must be encoded as non-negative integers (negative values will be treated as missing)
    less than ``Int32.MaxValue`` (2147483647).
    It is best to use a contiguous range of integers started from zero.
    Floating point numbers in categorical features will be rounded towards 0.


### PR DESCRIPTION
Fixed #4676.
Linking #4959.

Unify description with https://lightgbm.readthedocs.io/en/latest/Parameters.html#categorical_feature.