### PR TITLE
[c-api][python-package][R-package] expose feature num bin

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -377,7 +377,7 @@ Dataset <- R6::R6Class(
     },
 
     # Get number of bins for feature
-    get_feature_num_bin = function(feature_idx) {
+    get_feature_num_bin = function(feature) {
       if (lgb.is.null.handle(x = private$handle)) {
         stop("Cannot get number of bins in feature before constructing Dataset.")
       }
@@ -385,7 +385,7 @@ Dataset <- R6::R6Class(
       .Call(
         LGBM_DatasetGetFeatureNumBin_R
         , private$handle
-        , feature_idx - 1L
+        , feature - 1L
         , num_bin
       )
       return(num_bin)

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -376,6 +376,21 @@ Dataset <- R6::R6Class(
 
     },
 
+    # Get number of bins for feature
+    get_feature_num_bin = function(feature_idx) {
+      if (lgb.is.null.handle(x = private$handle)) {
+        stop("Cannot perform Dataset$get_feature_num_bin() before constructing Dataset.")
+      }
+      num_bin <- integer(1)
+      .Call(
+        LGBM_DatasetGetFeatureNumBin_R
+        , private$handle
+        , feature_idx - 1
+        , num_bin
+      )
+      num_bin
+    },
+
     # Get column names
     get_colnames = function() {
 

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -379,13 +379,13 @@ Dataset <- R6::R6Class(
     # Get number of bins for feature
     get_feature_num_bin = function(feature_idx) {
       if (lgb.is.null.handle(x = private$handle)) {
-        stop("Cannot perform Dataset$get_feature_num_bin() before constructing Dataset.")
+        stop("Cannot get number of bins in feature before constructing Dataset.")
       }
       num_bin <- integer(1)
       .Call(
         LGBM_DatasetGetFeatureNumBin_R
         , private$handle
-        , feature_idx - 1
+        , feature_idx - 1L
         , num_bin
       )
       num_bin

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -388,7 +388,7 @@ Dataset <- R6::R6Class(
         , feature_idx - 1L
         , num_bin
       )
-      num_bin
+      return(num_bin)
     },
 
     # Get column names

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -381,7 +381,7 @@ Dataset <- R6::R6Class(
       if (lgb.is.null.handle(x = private$handle)) {
         stop("Cannot get number of bins in feature before constructing Dataset.")
       }
-      num_bin <- integer(1)
+      num_bin <- integer(1L)
       .Call(
         LGBM_DatasetGetFeatureNumBin_R
         , private$handle

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -950,6 +950,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"LGBM_DatasetUpdateParamChecking_R", (DL_FUNC) &LGBM_DatasetUpdateParamChecking_R, 2},
   {"LGBM_DatasetGetNumData_R"         , (DL_FUNC) &LGBM_DatasetGetNumData_R         , 2},
   {"LGBM_DatasetGetNumFeature_R"      , (DL_FUNC) &LGBM_DatasetGetNumFeature_R      , 2},
+  {"LGBM_DatasetGetFeatureNumBin_R"   , (DL_FUNC) &LGBM_DatasetGetFeatureNumBin_R   , 3},
   {"LGBM_BoosterCreate_R"             , (DL_FUNC) &LGBM_BoosterCreate_R             , 2},
   {"LGBM_BoosterFree_R"               , (DL_FUNC) &LGBM_BoosterFree_R               , 1},
   {"LGBM_BoosterCreateFromModelfile_R", (DL_FUNC) &LGBM_BoosterCreateFromModelfile_R, 1},

--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -428,6 +428,17 @@ SEXP LGBM_DatasetGetNumFeature_R(SEXP handle,
   R_API_END();
 }
 
+SEXP LGBM_DatasetGetFeatureNumBin_R(SEXP handle, SEXP feature_idx, SEXP out) {
+  R_API_BEGIN();
+  _AssertDatasetHandleNotNull(handle);
+  int feature = Rf_asInteger(feature_idx);
+  int nbins;
+  CHECK_CALL(LGBM_DatasetGetFeatureNumBin(R_ExternalPtrAddr(handle), feature, &nbins));
+  INTEGER(out)[0] = nbins;
+  return R_NilValue;
+  R_API_END();
+}
+
 // --- start Booster interfaces
 
 void _BoosterFinalizer(SEXP handle) {

--- a/R-package/src/lightgbm_R.h
+++ b/R-package/src/lightgbm_R.h
@@ -213,6 +213,19 @@ LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetNumFeature_R(
   SEXP out
 );
 
+/*!
+* \brief get number of bins for feature
+* \param handle the handle to the Dataset
+* \param feature the index of the feature
+* \param out The output of number of bins
+* \return R NULL value
+*/
+LIGHTGBM_C_EXPORT SEXP LGBM_DatasetGetFeatureNumBin_R(
+  SEXP handle,
+  SEXP feature,
+  SEXP out
+);
+
 // --- start Booster interfaces
 
 /*!

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -527,14 +527,16 @@ test_that("Dataset: method calls on a Dataset with a null handle should raise an
 })
 
 test_that("lgb.Dataset$get_feature_num_bin() works", {
-  data <- matrix(nrow = 100L, ncol = 5L)
-  data[, 1L] <- runif(100L)
-  data[, 2L] <- rep(1L:2L, 50L)
-  data[, 3L] <- c(rep(0L:2L, 33L), 0L)
-  data[, 4L] <- c(rep(1L:2L, 49L), rep(NA_real_, 2L))
-  data[, 5L] <- rep(0L, 100L)
+  raw_df <- data.frame(
+    all_random = runif(100L)
+    , two_vals = rep(c(1, 2), 50L)
+    , three_vals = c(rep(c(0, 1, 2), 33L), 0L)
+    , two_vals_plus_missing = c(rep(c(1, 2), 49L), NA_real_, NA_real_)
+    , all_zero = rep(0, 100L)
+  )
+  raw_mat <- data.matrix(raw_df)
   min_data_in_bin <- 2L
-  ds <- lgb.Dataset(data, params = list(min_data_in_bin = min_data_in_bin))
+  ds <- lgb.Dataset(raw_mat, params = list(min_data_in_bin = min_data_in_bin))
   ds$construct()
   expected_num_bins <- c(
     100L %/% min_data_in_bin + 1L  # extra bin for zero

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -537,10 +537,10 @@ test_that("lgb.Dataset$get_feature_num_bin() works", {
   ds <- lgb.Dataset(data, params = list(min_data_in_bin = min_data_in_bin))
   ds$construct()
   expected_num_bins <- c(
-    as.integer(ceiling(100L / min_data_in_bin) + 1L)  # extra bin for zero
+    100L %/% min_data_in_bin + 1L  # extra bin for zero
     , 3L  # 0, 1, 2
     , 3L  # 0, 1, 2
-    , 4L  # 0, 1, 2, + NA
+    , 4L  # 0, 1, 2 + NA
     , 0L  # unused
   )
   actual_num_bins <- sapply(1L:5L, ds$get_feature_num_bin)

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -500,7 +500,7 @@ test_that("Dataset: method calls on a Dataset with a null handle should raise an
   }, regexp = "cannot get column names before dataset has been constructed")
   expect_error({
     dtrain$get_feature_num_bin(1L)
-  }, regexp = "Cannot perform Dataset$get_feature_num_bin() before constructing Dataset.")
+  }, regexp = "Cannot get number of bins in feature before constructing Dataset.")
   expect_error({
     dtrain$save_binary(fname = tempfile(fileext = ".bin"))
   }, regexp = "Attempting to create a Dataset without any raw data")
@@ -527,23 +527,22 @@ test_that("Dataset: method calls on a Dataset with a null handle should raise an
 })
 
 test_that("lgb.Dataset$get_feature_num_bin() works", {
-  data <- cbind(
-    runif(100)
-    , rep(1:2, 50)
-    , c(rep(0:2, 33), 0)
-    , c(rep(1:2, 49), rep(NA_real_, 2))
-    , rep(0, 100)
-  )
-  min_data_in_bin = 2
+  data <- matrix(nrow = 100L, ncol = 5L)
+  data[, 1L] = runif(100L)
+  data[, 2L] = rep(1L:2L, 50L)
+  data[, 3L] = c(rep(0L:2L, 33L), 0L)
+  data[, 4L] = c(rep(1L:2L, 49L), rep(NA_real_, 2L))
+  data[, 5L] = rep(0L, 100L)
+  min_data_in_bin = 2L
   ds <- lgb.Dataset(data, params = list(min_data_in_bin = min_data_in_bin))
   ds$construct()
   expected_num_bins <- c(
-    as.integer(ceiling(100 / min_data_in_bin) + 1)  # extra bin for zero
+    as.integer(ceiling(100L / min_data_in_bin) + 1L)  # extra bin for zero
     , 3L  # 0, 1, 2
     , 3L  # 0, 1, 2
     , 4L  # 0, 1, 2, + NA
     , 0L  # unused
   )
-  actual_num_bins <- sapply(1:5, ds$get_feature_num_bin)
+  actual_num_bins <- sapply(1L:5L, ds$get_feature_num_bin)
   expect_identical(actual_num_bins, expected_num_bins)
 })

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -528,12 +528,12 @@ test_that("Dataset: method calls on a Dataset with a null handle should raise an
 
 test_that("lgb.Dataset$get_feature_num_bin() works", {
   data <- matrix(nrow = 100L, ncol = 5L)
-  data[, 1L] = runif(100L)
-  data[, 2L] = rep(1L:2L, 50L)
-  data[, 3L] = c(rep(0L:2L, 33L), 0L)
-  data[, 4L] = c(rep(1L:2L, 49L), rep(NA_real_, 2L))
-  data[, 5L] = rep(0L, 100L)
-  min_data_in_bin = 2L
+  data[, 1L] <- runif(100L)
+  data[, 2L] <- rep(1L:2L, 50L)
+  data[, 3L] <- c(rep(0L:2L, 33L), 0L)
+  data[, 4L] <- c(rep(1L:2L, 49L), rep(NA_real_, 2L))
+  data[, 5L] <- rep(0L, 100L)
+  min_data_in_bin <- 2L
   ds <- lgb.Dataset(data, params = list(min_data_in_bin = min_data_in_bin))
   ds$construct()
   expected_num_bins <- c(

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -529,10 +529,10 @@ test_that("Dataset: method calls on a Dataset with a null handle should raise an
 test_that("lgb.Dataset$get_feature_num_bin() works", {
   raw_df <- data.frame(
     all_random = runif(100L)
-    , two_vals = rep(c(1, 2), 50L)
-    , three_vals = c(rep(c(0, 1, 2), 33L), 0L)
-    , two_vals_plus_missing = c(rep(c(1, 2), 49L), NA_real_, NA_real_)
-    , all_zero = rep(0, 100L)
+    , two_vals = rep(c(1.0, 2.0), 50L)
+    , three_vals = c(rep(c(0.0, 1.0, 2.0), 33L), 0.0)
+    , two_vals_plus_missing = c(rep(c(1.0, 2.0), 49L), NA_real_, NA_real_)
+    , all_zero = rep(0.0, 100L)
   )
   raw_mat <- data.matrix(raw_df)
   min_data_in_bin <- 2L

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -433,6 +433,17 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetGetNumFeature(DatasetHandle handle,
                                                 int* out);
 
 /*!
+ * \brief Get number of bins for feature.
+ * \param handle Handle of dataset
+ * \param feature Index of the feature
+ * \param[out] out The address to hold number of bins
+ * \return 0 when succeed, -1 when failure happens
+ */
+LIGHTGBM_C_EXPORT int LGBM_DatasetGetFeatureNumBin(DatasetHandle handle,
+                                                   int feature,
+                                                   int* out);
+
+/*!
  * \brief Add features from ``source`` to ``target``.
  * \param target The handle of the dataset to add features to
  * \param source The handle of the dataset to take features from

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2371,6 +2371,29 @@ class Dataset:
         else:
             raise LightGBMError("Cannot get num_feature before construct dataset")
 
+    def feature_num_bin(self, feature_idx: int) -> int:
+        """Get the number of bins for a feature.
+
+        Parameters
+        ----------
+        feature_idx : int
+            Index of the feature.
+
+        Returns
+        -------
+        number_of_bins : int
+            The number of constructed bins for the feature in the Dataset.
+        """
+        if self.handle is not None:
+            ret = ctypes.c_int(0)
+            feature = ctypes.c_int(feature_idx)
+            _safe_call(_LIB.LGBM_DatasetGetFeatureNumBin(self.handle,
+                                                         feature,
+                                                         ctypes.byref(ret)))
+            return ret.value
+        else:
+            raise LightGBMError("Cannot get feature_num_bin before construct dataset")
+
     def get_ref_chain(self, ref_limit=100):
         """Get a chain of Dataset objects.
 

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2371,12 +2371,12 @@ class Dataset:
         else:
             raise LightGBMError("Cannot get num_feature before construct dataset")
 
-    def feature_num_bin(self, feature_idx: int) -> int:
+    def feature_num_bin(self, feature: int) -> int:
         """Get the number of bins for a feature.
 
         Parameters
         ----------
-        feature_idx : int
+        feature : int
             Index of the feature.
 
         Returns
@@ -2386,9 +2386,8 @@ class Dataset:
         """
         if self.handle is not None:
             ret = ctypes.c_int(0)
-            feature = ctypes.c_int(feature_idx)
             _safe_call(_LIB.LGBM_DatasetGetFeatureNumBin(self.handle,
-                                                         feature,
+                                                         ctypes.c_int(feature),
                                                          ctypes.byref(ret)))
             return ret.value
         else:

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1550,6 +1550,20 @@ int LGBM_DatasetGetNumFeature(DatasetHandle handle,
   API_END();
 }
 
+int LGBM_DatasetGetFeatureNumBin(DatasetHandle handle,
+                                 int feature,
+                                 int* out) {
+  API_BEGIN();
+  auto dataset = reinterpret_cast<Dataset*>(handle);
+  int inner_idx = dataset->InnerFeatureIndex(feature);
+  if (inner_idx >= 0) {
+    *out = dataset->FeatureNumBin(inner_idx);
+  } else {
+    *out = 0;
+  }
+  API_END();
+}
+
 int LGBM_DatasetAddFeaturesFrom(DatasetHandle target,
                                 DatasetHandle source) {
   API_BEGIN();

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -2,7 +2,6 @@
 import filecmp
 import numbers
 import re
-from math import ceil
 from pathlib import Path
 
 import numpy as np
@@ -635,7 +634,7 @@ def test_feature_num_bin(min_data_in_bin):
     ]).T
     ds = lgb.Dataset(X, params={'min_data_in_bin': min_data_in_bin}).construct()
     expected_num_bins = [
-        ceil(100 / min_data_in_bin) + 1,  # extra bin for zero
+        100 // min_data_in_bin + 1,  # extra bin for zero
         3,  # 0, 1, 2
         3,  # 0, 1, 2
         4,  # 0, 1, 2 + nan


### PR DESCRIPTION
This adds the `LGBM_DatasetGetFeatureNumBin` function to the C API to be able to get the number of constructed bins for a feature. I also added this to the Python API as the Dataset method `feature_num_bin` and added a test for it.

Closes #3406.