### PR TITLE
[ci] temporarily remove R3.6 CRAN CI build

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -111,12 +111,6 @@ jobs:
           - os: windows-latest
             task: r-package
             compiler: MINGW
-            toolchain: MINGW
-            r_version: 3.6
-            build_type: cran
-          - os: windows-latest
-            task: r-package
-            compiler: MINGW
             toolchain: MSYS
             r_version: 4.1
             build_type: cran


### PR DESCRIPTION
CI has been blocked for 4 days, due to #5036.

I'm trying to investigate it in #5037, but it's going very slowly because:

1. testing it requires pushing to GitHub and waiting for CI logs (no way to interactively explore the GitHub Actions Windows runners)
2. I'm traveling with limited time to spend on LightGBM

This PR proposes temporarily removing the failing CI job, to unblock development in this repo.
I'll continue working on #5037 to try to restore this job, but I think it's ok to skip it for now.