### PR TITLE
[fix] fix duplicate added initial scores for single-leaf trees

### DIFF
--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -419,20 +419,15 @@ bool GBDT::TrainOneIter(const score_t* gradients, const score_t* hessians) {
     } else {
       // only add default score one-time
       if (models_.size() < static_cast<size_t>(num_tree_per_iteration_)) {
-        double output = 0.0;
-        if (!class_need_train_[cur_tree_id]) {
-          if (objective_function_ != nullptr) {
-            output = objective_function_->BoostFromScore(cur_tree_id);
+        if (objective_function_ != nullptr && !config_->boost_from_average && !train_score_updater_->has_init_score()) {
+          init_scores[cur_tree_id] = ObtainAutomaticInitialScore(objective_function_, cur_tree_id);
+          // updates scores
+          train_score_updater_->AddScore(init_scores[cur_tree_id], cur_tree_id);
+          for (auto& score_updater : valid_score_updater_) {
+            score_updater->AddScore(init_scores[cur_tree_id], cur_tree_id);
           }
-        } else {
-          output = init_scores[cur_tree_id];
         }
-        new_tree->AsConstantTree(output);
-        // updates scores
-        train_score_updater_->AddScore(output, cur_tree_id);
-        for (auto& score_updater : valid_score_updater_) {
-          score_updater->AddScore(output, cur_tree_id);
-        }
+        new_tree->AsConstantTree(init_scores[cur_tree_id]);
       }
     }
     // add model

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -3427,8 +3427,10 @@ def test_pandas_nullable_dtypes():
 
 
 def test_boost_from_average_with_single_leaf_trees():
-    X = np.array(
-        [[1021.0589, 1018.9578],
+    # test data are taken from bug report
+    # https://github.com/microsoft/LightGBM/issues/4708
+    X = np.array([
+        [1021.0589, 1018.9578],
         [1023.85754, 1018.7854],
         [1024.5468, 1018.88513],
         [1019.02954, 1018.88513],
@@ -3440,7 +3442,7 @@ def test_boost_from_average_with_single_leaf_trees():
         "min_data_in_bin": 1,
         "extra_seed": 7,
         "objective": "regression",
-        "verbose": -2,
+        "verbose": -1,
         "boost_from_average": True,
         "min_data_in_leaf": 1,
     }
@@ -3449,4 +3451,4 @@ def test_boost_from_average_with_single_leaf_trees():
 
     preds = model.predict(X)
     mean_preds = np.mean(preds)
-    assert mean_preds >= y.min() and mean_preds <= y.max()
+    assert y.min() <= mean_preds <= y.max()

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -18,7 +18,7 @@ from sklearn.model_selection import GroupKFold, TimeSeriesSplit, train_test_spli
 
 import lightgbm as lgb
 
-from utils import (load_boston, load_breast_cancer, load_digits, load_iris, make_synthetic_regression,
+from .utils import (load_boston, load_breast_cancer, load_digits, load_iris, make_synthetic_regression,
                     sklearn_multiclass_custom_objective, softmax)
 
 decreasing_generator = itertools.count(0, -1)


### PR DESCRIPTION
In example of #4708, the initial scores can be added twice when for single-leaf trees. This is to fix the duplicate addition.