### PR TITLE
Build Windows artifacts in `windows-2019` image instead of `vs2017-win2016`

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -262,7 +262,7 @@ jobs:
 - job: Windows
 ###########################################
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   strategy:
     matrix:
       regular:


### PR DESCRIPTION
Closed #4748.

Refer to https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml and https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md.

I'm not sure but it looks like our new Windows artifacts won't be compatible with VC Redistributable 2015 and 2017.

> Visual Studio versions since Visual Studio 2015 share the same redistributable files. For example, any apps built by the Visual Studio 2015, 2017, 2019, or 2022 toolsets can use the latest Microsoft Visual C++ Redistributable. However, the version of the Microsoft Visual C++ redistributable installed on the machine must be the same or higher than the version of the Visual C++ toolset used to create your application. 
   https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#notes

> For example, Visual Studio 2019 redistributable files may be used by apps built by using the Visual Studio 2017 or 2015 toolset. While they may be compatible, we don't support using older redistributable files in apps built by using a newer toolset. For example, using the 2017 redistributable files in apps built by using the 2019 toolset isn't supported.
   https://docs.microsoft.com/en-us/cpp/windows/determining-which-dlls-to-redistribute?view=msvc-170

