### PR TITLE
[python-package] [R-package] propagate the best iteration of cvbooster into the individual boosters

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -434,6 +434,10 @@ lgb.cv <- function(params = list()
     )
     cv_booster$best_score <- cv_booster$record_evals[["valid"]][[first_metric]][[.EVAL_KEY()]][[cv_booster$best_iter]]
   }
+  # Propagate the best_iter attribute from the cv_booster to the individual boosters
+  for (bst in cv_booster$boosters) {
+    bst$booster$best_iter <- cv_booster$best_iter
+  }
 
   if (reset_data) {
     lapply(cv_booster$boosters, function(fd) {

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -2207,6 +2207,16 @@ test_that("early stopping works with lgb.cv()", {
     length(bst$record_evals[["valid"]][["increasing_metric"]][["eval"]])
     , early_stopping_rounds + 1L
   )
+
+  # every booster's predict method should use best_iter as num_iteration in predict
+  random_data <- as.matrix(rnorm(10L), ncol = 1L, drop = FALSE)
+  for (x in bst$boosters) {
+    expect_equal(x$booster$best_iter, bst$best_iter)
+    expect_gt(x$booster$current_iter(), bst$best_iter)
+    preds_iter <- predict(x$booster, random_data, num_iteration = bst$best_iter)
+    preds_no_iter <- predict(x$booster, random_data)
+    expect_equal(preds_iter, preds_no_iter)
+  }
 })
 
 test_that("lgb.cv() respects changes to logging verbosity", {

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -581,6 +581,8 @@ def cv(params, train_set, num_boost_round=100,
                                         evaluation_result_list=res))
         except callback.EarlyStopException as earlyStopException:
             cvfolds.best_iteration = earlyStopException.best_iteration + 1
+            for bst in cvfolds.boosters:
+                bst.best_iteration = cvfolds.best_iteration
             for k in results:
                 results[k] = results[k][:cvfolds.best_iteration]
             break


### PR DESCRIPTION
This propagates the `best_iteration` attribute in the Python package and the `best_iter` attribute in the R package from the CV Booster to each individual booster in the boosters list. In the Python package this ensures that calling `CVBooster.predict` uses the best iteration in all boosters (closes #4777).