### PR TITLE
[ci] increase timeout on R Hub Solaris job to 4 hours

### DIFF
--- a/.github/workflows/r_solaris.yml
+++ b/.github/workflows/r_solaris.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: solaris-cran
-    timeout-minutes: 120
+    timeout-minutes: 240
     runs-on: ubuntu-latest
     container: wch1/r-debug
     env:


### PR DESCRIPTION
Proposes increasing the timeout on the R-package CI job testing on Solaris via R Hub, from 2 hours to 4 hours.

I recently observed a run that took 3h32m, which led to the GitHub Actions job being marked failed, blocking merging of a PR.

https://github.com/microsoft/LightGBM/pull/4827#issuecomment-1066184033