### PR TITLE
[ci] remove Visual Studio 2017 CI job for R-package

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -84,13 +84,6 @@ jobs:
             toolchain: MSYS
             r_version: 4.1
             build_type: cmake
-          # Visual Studio 2017
-          - os: windows-2016
-            task: r-package
-            compiler: MSVC
-            toolchain: MSVC
-            r_version: 3.6
-            build_type: cmake
           # Visual Studio 2019
           - os: windows-2019
             task: r-package

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -89,7 +89,7 @@ jobs:
             task: r-package
             compiler: MSVC
             toolchain: MSVC
-            r_version: 4.1
+            r_version: 3.6
             build_type: cmake
           # Visual Studio 2022
           - os: windows-2022


### PR DESCRIPTION
Closed #4748.

Related: #5059.

Sorry, I missed in #5059 the point that GitHub Actions shares the same environments with Azure Pipelines.
https://github.com/actions/virtual-environments/issues/4312
https://github.com/actions/virtual-environments/issues/5238