### PR TITLE
clarify no-meaningful-features warning in Dataset construction (fixes #5081)

### DIFF
--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -333,8 +333,9 @@ void Dataset::Construct(std::vector<std::unique_ptr<BinMapper>>* bin_mappers,
   }
   if (used_features.empty()) {
     Log::Warning(
-        "There are no meaningful features, as all feature values are "
-        "constant.");
+        "There are no meaningful features which satisfy the provided configuration. "
+        "Decreasing Dataset parameters min_data_in_bin or min_data_in_leaf and re-constructing "
+        "Dataset might resolve this warning.");
   }
   auto features_in_group = NoGroup(used_features);
 

--- a/tests/python_package_test/test_utilities.py
+++ b/tests/python_package_test/test_utilities.py
@@ -43,7 +43,7 @@ def test_register_logger(tmp_path):
     lgb.plot_metric(eval_records)
 
     expected_log = r"""
-INFO | [LightGBM] [Warning] There are no meaningful features, as all feature values are constant.
+INFO | [LightGBM] [Warning] There are no meaningful features which satisfy the provided configuration. Decreasing Dataset parameters min_data_in_bin or min_data_in_leaf and re-constructing Dataset might resolve this warning.
 INFO | [LightGBM] [Info] Number of positive: 2, number of negative: 2
 INFO | [LightGBM] [Info] Total Bins 0
 INFO | [LightGBM] [Info] Number of data points in the train set: 4, number of used features: 0


### PR DESCRIPTION
Fixes #5081.

During `Dataset` construction, LightGBM may drop features for the following reasons:

* all data would end up in one bin (e.g. all missing or otherwise constant)
* not possible to create any bins the satisfy `min_data_in_bin`
* not possible to create any bins that satisfy `min_data_in_leaf`

https://github.com/microsoft/LightGBM/blob/d4cdbcfe1b1db2d48e95665a8b358028c496cdb2/src/io/bin.cpp#L493-L502

If all features in the raw data are dropped for these reasons, the following warning is issued

> [LightGBM] [Warning] There are no meaningful features, as all feature values are constant.

Note that that warning only cites one of the possible reasons a feature is excluded (all values are constant). As a result, sometimes this warning can be confusing or misleading. See the example in the description of #5081, where for a very small dataset (<40 rows), LightGBM excludes all features and issues this warning unless `min_data_in_bin=1, min_data_in_leaf=1` are set.

This PR proposes clarifying the language in this warning.

## Notes for Reviewers

@StrikerRUS @shiyu1994 @guolinke why is this a warning and not a fatal error? What is the purpose for allowing a `Dataset` to be constructed which has 0 features? Is it related to distributed training, or maybe to the ability to use `forced_splits`?