### PR TITLE
[python] make `log_evaluation` callback pickleable

### DIFF
--- a/tests/python_package_test/test_callback.py
+++ b/tests/python_package_test/test_callback.py
@@ -20,3 +20,19 @@ def test_early_stopping_callback_is_picklable(serializer, tmp_path):
         serializer=serializer
     )
     assert callback.stopping_rounds == callback_from_disk.stopping_rounds
+
+
+@pytest.mark.parametrize('serializer', ["pickle", "joblib", "cloudpickle"])
+def test_log_evaluation_callback_is_picklable(serializer, tmp_path):
+    callback = lgb.log_evaluation(period=42)
+    tmp_file = tmp_path / "log_evaluation.pkl"
+    pickle_obj(
+        obj=callback,
+        filepath=tmp_file,
+        serializer=serializer
+    )
+    callback_from_disk = unpickle_obj(
+        filepath=tmp_file,
+        serializer=serializer
+    )
+    assert callback.period == callback_from_disk.period

--- a/tests/python_package_test/test_callback.py
+++ b/tests/python_package_test/test_callback.py
@@ -8,7 +8,8 @@ from .utils import pickle_obj, unpickle_obj
 
 @pytest.mark.parametrize('serializer', ["pickle", "joblib", "cloudpickle"])
 def test_early_stopping_callback_is_picklable(serializer, tmp_path):
-    callback = lgb.early_stopping(stopping_rounds=5)
+    rounds = 5
+    callback = lgb.early_stopping(stopping_rounds=rounds)
     tmp_file = tmp_path / "early_stopping.pkl"
     pickle_obj(
         obj=callback,
@@ -20,11 +21,13 @@ def test_early_stopping_callback_is_picklable(serializer, tmp_path):
         serializer=serializer
     )
     assert callback.stopping_rounds == callback_from_disk.stopping_rounds
+    assert callback.stopping_rounds == rounds
 
 
 @pytest.mark.parametrize('serializer', ["pickle", "joblib", "cloudpickle"])
 def test_log_evaluation_callback_is_picklable(serializer, tmp_path):
-    callback = lgb.log_evaluation(period=42)
+    periods = 42
+    callback = lgb.log_evaluation(period=periods)
     tmp_file = tmp_path / "log_evaluation.pkl"
     pickle_obj(
         obj=callback,
@@ -36,3 +39,4 @@ def test_log_evaluation_callback_is_picklable(serializer, tmp_path):
         serializer=serializer
     )
     assert callback.period == callback_from_disk.period
+    assert callback.period == periods


### PR DESCRIPTION
Contributes to #5080.

In `master`, `test_log_evaluation_callback_is_picklable()` test fails with
```
============================================================================== FAILURES ==============================================================================
_________________________________________________________ test_log_evaluation_callback_is_picklable[pickle] __________________________________________________________

serializer = 'pickle', tmp_path = WindowsPath('C:/Users/nekit/AppData/Local/Temp/pytest-of-nekit/pytest-26/test_log_evaluation_callback_i0')

    @pytest.mark.parametrize('serializer', ["pickle", "joblib", "cloudpickle"])
    def test_log_evaluation_callback_is_picklable(serializer, tmp_path):
        callback = lgb.log_evaluation(period=42)
        tmp_file = tmp_path / "log_evaluation.pkl"
>       pickle_obj(
            obj=callback,
            filepath=tmp_file,
            serializer=serializer
        )

test_callback.py:29:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

obj = <function log_evaluation.<locals>._callback at 0x000001E31C0E7C10>
filepath = WindowsPath('C:/Users/nekit/AppData/Local/Temp/pytest-of-nekit/pytest-26/test_log_evaluation_callback_i0/log_evaluation.pkl'), serializer = 'pickle'

    def pickle_obj(obj, filepath, serializer):
        if serializer == 'pickle':
            with open(filepath, 'wb') as f:
>               pickle.dump(obj, f)
E               AttributeError: Can't pickle local object 'log_evaluation.<locals>._callback'

utils.py:142: AttributeError
_________________________________________________________ test_log_evaluation_callback_is_picklable[joblib] __________________________________________________________

serializer = 'joblib', tmp_path = WindowsPath('C:/Users/nekit/AppData/Local/Temp/pytest-of-nekit/pytest-26/test_log_evaluation_callback_i1')

    @pytest.mark.parametrize('serializer', ["pickle", "joblib", "cloudpickle"])
    def test_log_evaluation_callback_is_picklable(serializer, tmp_path):
        callback = lgb.log_evaluation(period=42)
        tmp_file = tmp_path / "log_evaluation.pkl"
>       pickle_obj(
            obj=callback,
            filepath=tmp_file,
            serializer=serializer
        )

test_callback.py:29:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
utils.py:144: in pickle_obj
    joblib.dump(obj, filepath)
d:\miniconda3\lib\site-packages\joblib\numpy_pickle.py:480: in dump
    NumpyPickler(f, protocol=protocol).dump(value)
d:\miniconda3\lib\pickle.py:487: in dump
    self.save(obj)
d:\miniconda3\lib\site-packages\joblib\numpy_pickle.py:282: in save
    return Pickler.save(self, obj)
d:\miniconda3\lib\pickle.py:560: in save
    f(self, obj)  # Call unbound method with explicit self
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <joblib.numpy_pickle.NumpyPickler object at 0x000001E31C239490>, obj = <function log_evaluation.<locals>._callback at 0x000001E31C24E670>
name = 'log_evaluation.<locals>._callback'

    def save_global(self, obj, name=None):
        write = self.write
        memo = self.memo

        if name is None:
            name = getattr(obj, '__qualname__', None)
        if name is None:
            name = obj.__name__

        module_name = whichmodule(obj, name)
        try:
            __import__(module_name, level=0)
            module = sys.modules[module_name]
            obj2, parent = _getattribute(module, name)
        except (ImportError, KeyError, AttributeError):
>           raise PicklingError(
                "Can't pickle %r: it's not found as %s.%s" %
                (obj, module_name, name)) from None
E           _pickle.PicklingError: Can't pickle <function log_evaluation.<locals>._callback at 0x000001E31C24E670>: it's not found as lightgbm.callback.log_evaluation.<locals>._callback

d:\miniconda3\lib\pickle.py:1070: PicklingError
```