### PR TITLE
[CUDA] Fix row-wise histogram construction with dense data matrix

### DIFF
--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -342,7 +342,7 @@ void Dataset::Construct(std::vector<std::unique_ptr<BinMapper>>* bin_mappers,
   auto is_sparse = io_config.is_enable_sparse;
   if (io_config.device_type == std::string("cuda") || io_config.device_type == std::string("cuda_exp")) {
       LGBM_config_::current_device = lgbm_device_cuda;
-      if (io_config.device_type == std::string("cuda") && is_sparse) {
+      if ((io_config.device_type == std::string("cuda") || io_config.device_type == std::string("cuda_exp")) && is_sparse) {
         Log::Warning("Using sparse features with CUDA is currently not supported.");
         is_sparse = false;
       }

--- a/src/treelearner/cuda/cuda_histogram_constructor.cu
+++ b/src/treelearner/cuda/cuda_histogram_constructor.cu
@@ -284,7 +284,11 @@ void CUDAHistogramConstructor::LaunchConstructHistogramKernelInner0(
   } else if (cuda_row_data_->row_ptr_bit_type() == 64) {
     LaunchConstructHistogramKernelInner1<HIST_TYPE, SHARED_HIST_SIZE, BIN_TYPE, uint64_t>(cuda_smaller_leaf_splits, num_data_in_smaller_leaf);
   } else {
-    Log::Fatal("Unknown row_ptr_bit_type = %d", cuda_row_data_->row_ptr_bit_type());
+    if (!cuda_row_data_->is_sparse()) {
+      LaunchConstructHistogramKernelInner1<HIST_TYPE, SHARED_HIST_SIZE, BIN_TYPE, uint16_t>(cuda_smaller_leaf_splits, num_data_in_smaller_leaf);
+    } else {
+      Log::Fatal("Unknown row_ptr_bit_type = %d", cuda_row_data_->row_ptr_bit_type());
+    }
   }
 }
 


### PR DESCRIPTION
Currently row-wise histogram construction cannot run successfully with dense data matrix. The check `row_ptr_bit_type` should be skipped here for dense data matrix,
https://github.com/microsoft/LightGBM/blob/60e72d5f4ec5ec2a4d30a53633e1e2d59c81309b/src/treelearner/cuda/cuda_histogram_constructor.cu#L280-L288

In addition, we disable the use of multi-value feature group in `cuda_exp` for now in this PR. Because we don't have an implementation of sparse bin currently, thus using multi-value feature group can be too costly for GPU memory. We force the feature groups to be single-value.