### PR TITLE
[python-package] Use scikit-learn interpretation of negative `n_jobs` and change default to number of cores

### DIFF
--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -179,7 +179,7 @@ except ImportError:
 try:
     from joblib import cpu_count
 
-    def _LGBMCpuCount(only_physical_cores: bool=True):
+    def _LGBMCpuCount(only_physical_cores: bool = True):
         return cpu_count(only_physical_cores=only_physical_cores)
 except ImportError:
     try:

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -174,3 +174,21 @@ except ImportError:
 
         def __init__(self, *args, **kwargs):
             pass
+
+"""cpu_count()"""
+try:
+    from joblib import cpu_count
+
+    def _LGBMCpuCount(only_physical_cores: bool=True):
+        return cpu_count(only_physical_cores=only_physical_cores)
+except ImportError:
+    try:
+        from psutil import cpu_count
+
+        def _LGBMCpuCount():
+            return cpu_count(logical=only_physical_cores)
+    except ImportError:
+        from multiprocessing import cpu_count
+
+        def _LGBMCpuCount():
+            return cpu_count()

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1111,7 +1111,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
         reg_alpha: float = 0.,
         reg_lambda: float = 0.,
         random_state: Optional[Union[int, np.random.RandomState]] = None,
-        n_jobs: int = -1,
+        n_jobs: Optional[int] = None,
         importance_type: str = 'split',
         client: Optional[Client] = None,
         **kwargs: Any
@@ -1283,7 +1283,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         reg_alpha: float = 0.,
         reg_lambda: float = 0.,
         random_state: Optional[Union[int, np.random.RandomState]] = None,
-        n_jobs: int = -1,
+        n_jobs: Optional[int] = None,
         importance_type: str = 'split',
         client: Optional[Client] = None,
         **kwargs: Any
@@ -1436,7 +1436,7 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
         reg_alpha: float = 0.,
         reg_lambda: float = 0.,
         random_state: Optional[Union[int, np.random.RandomState]] = None,
-        n_jobs: int = -1,
+        n_jobs: Optional[int] = None,
         importance_type: str = 'split',
         client: Optional[Client] = None,
         **kwargs: Any

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -443,8 +443,8 @@ class LGBMModel(_LGBMModelBase):
             For better performance, it is recommended to set this to the number of physical cores
             in the CPU.
 
-            Negative integers are interpreted as following joblib's formula, just like scikit-learn
-            (so e.g. -1 means using all threads). A value of zero corresponds the default number of
+            Negative integers are interpreted as following joblib's formula (n_cpus + 1 + n_jobs), just like
+            scikit-learn (so e.g. -1 means using all threads). A value of zero corresponds the default number of
             threads configured for OpenMP in the system. A value of ``None`` (the default) corresponds
             to using the number of physical cores in the system (its correct detection requires
             either the ``joblib`` or the ``psutil`` util libraries to be installed).

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -654,7 +654,7 @@ class LGBMModel(_LGBMModelBase):
         return params
 
     def _process_n_jobs(self, n_jobs: int):
-        """Convert special values of n_jobs to their actual values according to the formulas that apply
+        """Convert special values of n_jobs to their actual values according to the formulas that apply.
 
         Parameters
         ----------

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -852,8 +852,11 @@ class LGBMModel(_LGBMModelBase):
 
         # number of threads can have values with special meaning which is only applied
         # in the scikit-learn interface, these should not reach the c++ side as-is
-        predict_params = _choose_param_value("num_threads", predict_params, self.n_jobs)
-        predict_params["num_threads"] = self._process_n_jobs(predict_params["num_threads"])
+        num_threads_aliases = _ConfigAliases.get("num_threads")
+        for alias in num_threads_aliases:
+            if alias in predict_params:
+                n_jobs = predict_params.pop(alias)
+        predict_params["num_threads"] = self._process_n_jobs(n_jobs)
 
         return self._Booster.predict(X, raw_score=raw_score, start_iteration=start_iteration, num_iteration=num_iteration,
                                      pred_leaf=pred_leaf, pred_contrib=pred_contrib, **predict_params)

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -373,7 +373,7 @@ class LGBMModel(_LGBMModelBase):
         reg_alpha: float = 0.,
         reg_lambda: float = 0.,
         random_state: Optional[Union[int, np.random.RandomState]] = None,
-        n_jobs: Union[int, None] = None,
+        n_jobs: Optional[int] = None,
         importance_type: str = 'split',
         **kwargs
     ):

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -8,10 +8,23 @@ import numpy as np
 
 from .basic import Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _log_warning
 from .callback import record_evaluation
-from .compat import (SKLEARN_INSTALLED, LGBMNotFittedError, _LGBMAssertAllFinite, _LGBMCheckArray,
-                     _LGBMCheckClassificationTargets, _LGBMCheckSampleWeight, _LGBMCheckXY, _LGBMClassifierBase,
-                     _LGBMComputeSampleWeight, _LGBMCpuCount, _LGBMLabelEncoder, _LGBMModelBase,
-                     _LGBMRegressorBase, dt_DataTable, pd_DataFrame)
+from .compat import (
+    SKLEARN_INSTALLED,
+    LGBMNotFittedError,
+    _LGBMAssertAllFinite,
+    _LGBMCheckArray,
+    _LGBMCheckClassificationTargets,
+    _LGBMCheckSampleWeight,
+    _LGBMCheckXY,
+    _LGBMClassifierBase,
+    _LGBMComputeSampleWeight,
+    _LGBMCpuCount,
+    _LGBMLabelEncoder,
+    _LGBMModelBase,
+    _LGBMRegressorBase,
+    dt_DataTable,
+    pd_DataFrame,
+)
 from .engine import train
 
 _EvalResultType = Tuple[str, float, bool]

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -851,6 +851,7 @@ class LGBMModel(_LGBMModelBase):
 
         # number of threads can have values with special meaning which is only applied
         # in the scikit-learn interface, these should not reach the c++ side as-is
+        n_jobs = self.n_jobs
         num_threads_aliases = _ConfigAliases.get("num_threads")
         for alias in num_threads_aliases:
             if alias in predict_params:

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -654,8 +654,7 @@ class LGBMModel(_LGBMModelBase):
         return params
 
     def _process_n_jobs(self, n_jobs: int):
-        """
-        Convert special values of n_jobs to their actual values according to the formulas that apply
+        """Convert special values of n_jobs to their actual values according to the formulas that apply
 
         Parameters
         ----------

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -659,11 +659,12 @@ class LGBMModel(_LGBMModelBase):
         # use joblib conventions for negative n_jobs, just like scikit-learn
         n_jobs = self.n_jobs
         if stage == "fit":
-            params.pop("n_jobs")
+            params.remove("n_jobs")
         num_threads_aliases = _ConfigAliases.get("num_threads")
         for alias in num_threads_aliases:
             if alias in params:
-                n_jobs = params.pop(alias)
+                n_jobs = params[alias]
+                params.remove(alias)
         if n_jobs is None or n_jobs < 0:
             if n_jobs is None:
                 if cpu_count_lib == "joblib":

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -659,6 +659,7 @@ class LGBMModel(_LGBMModelBase):
         # use joblib conventions for negative n_jobs, just like scikit-learn
         if self.n_jobs is None or self.n_jobs < 0:
             num_threads_aliases = _ConfigAliases.get("num_threads")
+            num_threads_aliases = [alias for alias in num_threads_aliases if alias != "n_jobs"]
             if not any([k in num_threads_aliases for k in params.keys()]):
                 if self.n_jobs is None:
                     if cpu_count_lib == "joblib":

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 """Scikit-learn wrapper interface for LightGBM."""
 import copy
-import multiprocessing
 from inspect import signature
+from joblib import cpu_count
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -645,7 +645,7 @@ class LGBMModel(_LGBMModelBase):
         # use joblib conventions for negative n_jobs, just like scikit-learn
         num_threads_aliases = _ConfigAliases.get("num_threads")
         if self.n_jobs < 0 and not any([k in num_threads_aliases for k in params.keys()]):
-            params["num_threads"] = max(multiprocessing.cpu_count() + 1 + self.n_jobs, 1)
+            params["num_threads"] = max(cpu_count() + 1 + self.n_jobs, 1)
 
         return params
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -10,8 +10,8 @@ from .basic import Booster, Dataset, LightGBMError, _choose_param_value, _Config
 from .callback import record_evaluation
 from .compat import (SKLEARN_INSTALLED, LGBMNotFittedError, _LGBMAssertAllFinite, _LGBMCheckArray,
                      _LGBMCheckClassificationTargets, _LGBMCheckSampleWeight, _LGBMCheckXY, _LGBMClassifierBase,
-                     _LGBMComputeSampleWeight, _LGBMLabelEncoder, _LGBMModelBase, _LGBMRegressorBase, dt_DataTable,
-                     pd_DataFrame, _LGBMCpuCount)
+                     _LGBMComputeSampleWeight, _LGBMCpuCount, _LGBMLabelEncoder, _LGBMModelBase,
+                     _LGBMRegressorBase, dt_DataTable, pd_DataFrame)
 from .engine import train
 
 _EvalResultType = Tuple[str, float, bool]

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -645,7 +645,7 @@ class LGBMModel(_LGBMModelBase):
         # use joblib conventions for negative n_jobs, just like scikit-learn
         num_threads_aliases = _ConfigAliases.get("num_threads")
         if self.n_jobs < 0 and not any([k in num_threads_aliases for k in params.keys()]):
-            params["num_threads"] = multiprocessing.cpu_count() + 1 - self.n_jobs
+            params["num_threads"] = max(multiprocessing.cpu_count() + 1 + self.n_jobs, 1)
 
         return params
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -8,23 +8,10 @@ import numpy as np
 
 from .basic import Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _log_warning
 from .callback import record_evaluation
-from .compat import (
-    SKLEARN_INSTALLED,
-    LGBMNotFittedError,
-    _LGBMAssertAllFinite,
-    _LGBMCheckArray,
-    _LGBMCheckClassificationTargets,
-    _LGBMCheckSampleWeight,
-    _LGBMCheckXY,
-    _LGBMClassifierBase,
-    _LGBMComputeSampleWeight,
-    _LGBMCpuCount,
-    _LGBMLabelEncoder,
-    _LGBMModelBase,
-    _LGBMRegressorBase,
-    dt_DataTable,
-    pd_DataFrame,
-)
+from .compat import (SKLEARN_INSTALLED, LGBMNotFittedError, _LGBMAssertAllFinite, _LGBMCheckArray,
+                     _LGBMCheckClassificationTargets, _LGBMCheckSampleWeight, _LGBMCheckXY, _LGBMClassifierBase,
+                     _LGBMComputeSampleWeight, _LGBMCpuCount, _LGBMLabelEncoder, _LGBMModelBase, _LGBMRegressorBase,
+                     dt_DataTable, pd_DataFrame)
 from .engine import train
 
 _EvalResultType = Tuple[str, float, bool]

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -659,12 +659,11 @@ class LGBMModel(_LGBMModelBase):
         # use joblib conventions for negative n_jobs, just like scikit-learn
         n_jobs = self.n_jobs
         if stage == "fit":
-            params.remove("n_jobs")
+            del params["n_jobs"]
         num_threads_aliases = _ConfigAliases.get("num_threads")
         for alias in num_threads_aliases:
             if alias in params:
-                n_jobs = params[alias]
-                params.remove(alias)
+                n_jobs = params.pop(alias)
         if n_jobs is None or n_jobs < 0:
             if n_jobs is None:
                 if cpu_count_lib == "joblib":

--- a/tests/python_package_test/test_consistency.py
+++ b/tests/python_package_test/test_consistency.py
@@ -21,7 +21,7 @@ class FileLoader:
                 if line and not line.startswith('#'):
                     key, value = [token.strip() for token in line.split('=')]
                     if 'early_stopping' not in key:  # disable early_stopping
-                        self.params[key] = value if key != 'num_trees' else int(value)
+                        self.params[key] = value if key not in {'num_trees', 'num_threads'} else int(value)
 
     def load_dataset(self, suffix, is_sparse=False):
         filename = str(self.path(suffix))

--- a/tests/python_package_test/test_consistency.py
+++ b/tests/python_package_test/test_consistency.py
@@ -84,7 +84,7 @@ def test_binary_linear():
     X_test, _, X_test_fn = fd.load_dataset('.test')
     weight_train = fd.load_field('.train.weight')
     lgb_train = lgb.Dataset(X_train, y_train, params=fd.params, weight=weight_train)
-    gbm = lgb.LGBMClassifier(**fd.params)
+    gbm = lgb.LGBMClassifier(**fd.params, n_jobs=0)
     gbm.fit(X_train, y_train, sample_weight=weight_train)
     sk_pred = gbm.predict_proba(X_test)[:, 1]
     fd.train_predict_check(lgb_train, X_test, X_test_fn, sk_pred)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1314,7 +1314,7 @@ def test_negative_n_jobs():
     gbm.booster_.save_model("model.txt")
     with open("model.txt", "r") as f:
         model_txt = f.read()
-    assert bool(re.search(r"\[num_threads: %d\]" % val_minus_two, model_txt))
+    assert bool(re.search(rf"\[num_threads: {val_minus_two}\]", model_txt))
 
 
 def test_default_n_jobs():

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1308,6 +1308,7 @@ def test_negative_n_jobs():
     n_threads = joblib.cpu_count()
     if n_threads <= 1:
         return None
+    # 'val_minus_two' here is the expected number of threads for n_jobs=-2
     val_minus_two = n_threads - 1
     X, y = load_breast_cancer(return_X_y=True)
     # Note: according to joblib's formula, a value of n_jobs=-2 means

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1310,6 +1310,8 @@ def test_negative_n_jobs():
         return None
     val_minus_two = n_threads - 1
     X, y = load_breast_cancer(return_X_y=True)
+    # Note: according to joblib's formula, a value of n_jobs=-2 means
+    # "use all but one thread" (formula: n_cpus + 1 + n_jobs)
     gbm = lgb.LGBMClassifier(n_estimators=2, verbose=-1, n_jobs=-2).fit(X, y)
     gbm.booster_.save_model("model.txt")
     with open("model.txt", "r") as f:

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1320,11 +1320,11 @@ def test_negative_n_jobs(tmp_path):
     assert bool(re.search(rf"\[num_threads: {val_minus_two}\]", model_txt))
 
 
-def test_default_n_jobs():
+def test_default_n_jobs(tmp_path):
     n_cores = joblib.cpu_count(only_physical_cores=True)
     X, y = load_breast_cancer(return_X_y=True)
     gbm = lgb.LGBMClassifier(n_estimators=2, verbose=-1, n_jobs=None).fit(X, y)
-    gbm.booster_.save_model("model.txt")
-    with open("model.txt", "r") as f:
+    gbm.booster_.save_model(tmp_path / "model.txt")
+    with open(tmp_path / "model.txt", "r") as f:
         model_txt = f.read()
     assert bool(re.search(rf"\[num_threads: {n_cores}\]", model_txt))

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1304,7 +1304,7 @@ def test_multiclass_custom_objective():
     assert callable(custom_obj_model.objective_)
 
 
-def test_negative_n_jobs():
+def test_negative_n_jobs(tmp_path):
     n_threads = joblib.cpu_count()
     if n_threads <= 1:
         return None
@@ -1314,8 +1314,8 @@ def test_negative_n_jobs():
     # Note: according to joblib's formula, a value of n_jobs=-2 means
     # "use all but one thread" (formula: n_cpus + 1 + n_jobs)
     gbm = lgb.LGBMClassifier(n_estimators=2, verbose=-1, n_jobs=-2).fit(X, y)
-    gbm.booster_.save_model("model.txt")
-    with open("model.txt", "r") as f:
+    gbm.booster_.save_model(tmp_path / "model.txt")
+    with open(tmp_path / "model.txt", "r") as f:
         model_txt = f.read()
     assert bool(re.search(rf"\[num_threads: {val_minus_two}\]", model_txt))
 

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1324,4 +1324,4 @@ def test_default_n_jobs():
     gbm.booster_.save_model("model.txt")
     with open("model.txt", "r") as f:
         model_txt = f.read()
-    assert bool(re.search(r"\[num_threads: %d\]" % n_cores, model_txt))
+    assert bool(re.search(rf"\[num_threads: {n_cores}\]", model_txt))


### PR DESCRIPTION
The scikit-learn interface for lightgbm has a parameter `n_jobs` with a default value of `-1`, which is interpreted as using the default number of OMP threads.

According to the scikit-learn glossary, a negative `n_jobs` has a different meaning (uses joblib's formula), so `-1` means to use all available threads:
https://scikit-learn.org/stable/glossary.html#term-n_jobs

This PR changes the meaning of negative `n_jobs` to match that of scikit-learn, which I think is how most people would expect scikit-learn compatible libraries to behave.

I'm not sure what kind of requirements are there for the tests that are run on Python. This change *could* be tested, but it would imply fitting models using multiple threads per function call - not sure if there's any issue with that like in the R interface.