### PR TITLE
[R-package] add assertions to test on lightgbm() weights

### DIFF
--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -2941,6 +2941,7 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
     , nrounds = 5L
     , verbose = -1L
   )
+  expect_equal(model$.__enclos_env__$private$train_set$get_field("weight"), w)
 
   # Avoid a bad CRAN check due to partial argument matches
   lgb_args <- list(
@@ -2952,4 +2953,5 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
     , verbose = -1L
   )
   model <- do.call(lightgbm, lgb_args)
+  expect_equal(model$.__enclos_env__$private$train_set$get_field("weight"), w)
 })


### PR DESCRIPTION
I noticed the following today in the logs for the R package's tests.

```text
══ Skipped ════════════════════════════════════════════════════════════════════════════════════
1. lightgbm() accepts 'weight' and 'weights' (test_basic.R:2931:1) - Reason: empty test
```

This is coming from a test added recently (#4975). I guess that `{testthat}` skips tests that don't have any `expect_*` calls in them. It looks like this has been the behavior of that package since 2016 (https://github.com/r-lib/testthat/issues/413), I just never noticed it before.

This PR adds assertions to the relevant test, to ensure that it's run.

## Notes for Reviewers

You can check the `MSVC` R-package CI jobs to see the logs from tests, since for those the CI runs `Rscript testthat.R` instead of `R CMD check`.