### PR TITLE
[R-package] ensure boosting happens in tests on small datasets

### DIFF
--- a/R-package/tests/testthat/test_Predictor.R
+++ b/R-package/tests/testthat/test_Predictor.R
@@ -116,12 +116,20 @@ test_that("predictions for regression and binary classification are returned as 
     data(mtcars)
     X <- as.matrix(mtcars[, -1L])
     y <- as.numeric(mtcars[, 1L])
-    dtrain <- lgb.Dataset(X, label = y, params = list(max_bins = 5L))
+    dtrain <- lgb.Dataset(
+      X
+      , label = y
+      , params = list(
+        max_bins = 5L
+        , min_data_in_bin = 1L
+      )
+    )
     model <- lgb.train(
       data = dtrain
       , obj = "regression"
       , nrounds = 5L
       , verbose = VERBOSITY
+      , params = list(min_data_in_leaf = 1L)
     )
     pred <- predict(model, X)
     expect_true(is.vector(pred))

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -1718,7 +1718,8 @@ test_that("lgb.train() works with integer, double, and numeric data", {
       , label = y
       , params = list(
         objective = "regression"
-        , min_data = 1L
+        , min_data_in_bin = 1L
+        , min_data_in_leaf = 1L
         , learning_rate = 0.01
         , seed = 708L
       )
@@ -2984,7 +2985,11 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
     , weights = w
     , obj = "regression"
     , nrounds = 5L
-    , verbose = -1L
+    , verbose = VERBOSITY
+    , params = list(
+      min_data_in_bin = 1L
+      , min_data_in_leaf = 1L
+    )
   )
   expect_equal(model$.__enclos_env__$private$train_set$get_field("weight"), w)
 

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -1273,10 +1273,17 @@ test_that("Booster's print, show, and summary work correctly", {
 
     data("mtcars")
     model <- lgb.train(
-        params = list(objective = "regression")
+        params = list(
+          objective = "regression"
+          , min_data_in_leaf = 1L
+        )
         , data = lgb.Dataset(
             as.matrix(mtcars[, -1L])
-            , label = mtcars$mpg)
+            , label = mtcars$mpg
+            , params = list(
+              min_data_in_bin = 1L
+            )
+        )
         , verbose = VERBOSITY
         , nrounds = 5L
     )
@@ -1332,10 +1339,17 @@ test_that("Booster's print, show, and summary work correctly", {
 test_that("LGBM_BoosterGetNumFeature_R returns correct outputs", {
     data("mtcars")
     model <- lgb.train(
-        params = list(objective = "regression")
+        params = list(
+          objective = "regression"
+          , min_data_in_leaf = 1L
+        )
         , data = lgb.Dataset(
             as.matrix(mtcars[, -1L])
-            , label = mtcars$mpg)
+            , label = mtcars$mpg
+            , params = list(
+              min_data_in_bin = 1L
+            )
+        )
         , verbose = VERBOSITY
         , nrounds = 5L
     )


### PR DESCRIPTION
The R package contains a few tests using the `mtcars` dataset that comes built into R.

That dataset only has 32 observations in it. From `?mtcars`.

```r
data(mtcars)
dim(mtcars)
# [1] 32 11
```

As a result, the calls to `lightgbm()` and `lgb.train()` in tests using that dataset are not currently performing any boosting, for reasons described in #5081.

If setting `verbosity` to something low enough to allow `INFO` and `WARNING` level logs, those tests contain logs like the following:

```text
[LightGBM] [Warning] There are no meaningful features which satisfy the provided configuration. Decreasing Dataset parameters min_data_in_bin or min_data_in_leaf and re-constructing Dataset might resolve this warning.
[LightGBM] [Info] Total Bins 0
[LightGBM] [Info] Number of data points in the train set: 32, number of used features: 0
[LightGBM] [Info] Start training from score 20.090625
[LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
[LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
[LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
```

This PR proposes setting `min_data_in_bin = 1` and `min_data_in_leaf = 1` in those examples, to ensure that boosting occurs. I believe this will improve the test coverage LightGBM gets from these tests, by ensuring that the tests use models that actually generate trees with splits.