### PR TITLE
[docs] use 'docker run --rm' in autoconf instructions

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -335,6 +335,7 @@ At build time, `configure` will be run and used to create a file `Makevars`, usi
 
     ```shell
     docker run \
+        --rm \
         -v $(pwd):/opt/LightGBM \
         -w /opt/LightGBM \
         -t ubuntu:20.04 \


### PR DESCRIPTION
This PR proposes adding `--rm` to the `docker run` call in the R package's instructions for re-generating `configure` using `autoconf`.

Per the docs for `docker run` at https://docs.docker.com/engine/reference/run/#clean-up---rm

> By default a container’s file system persists even after the container exits. This makes debugging a lot easier (since you can inspect the final state) and you retain all your data by default. But if you are running short-term foreground processes, these container file systems can really pile up. If instead you’d like Docker to automatically clean up the container and remove the file system when the container exits, you can add the --rm flag

> If you set the `--rm` flag, Docker also removes the anonymous volumes associated with the container when the container is remove

## Notes for Reviewers

Noticed this because I saw the following on my laptop when running `docker container ls --all`.

```text
CONTAINER ID   IMAGE          COMMAND   CREATED         STATUS                       PORTS     NAMES
aa8772949750   ubuntu:20.04   "bash"    4 minutes ago   Exited (0) 3 minutes ago               magical_carver
cd0733a5ea46   ubuntu:20.04   "bash"    5 minutes ago   Exited (129) 4 minutes ago             objective_fermi
```

This is just a small thing that reduces the side effects on local developments of running the development steps mentioned in LightGBM's documentation.