### PR TITLE
[docs] use 'docker run --rm' in valgrind instructions

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -453,6 +453,7 @@ You can replicate these checks locally using Docker. Note that instrumented vers
 
 ```shell
 docker run \
+    --rm \
     -v $(pwd):/opt/LightGBM \
     -w /opt/LightGBM \
     -it \


### PR DESCRIPTION
Adding `--rm` to one more `docker run` instruction in the docs, per https://github.com/microsoft/LightGBM/pull/5125#issuecomment-1088154927.

I ran `git grep 'docker run'` to search for others, and didn't find any more uses in the project that should be updated.