### PR TITLE
[ci] have no-response bot post as github-actions user

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -20,4 +20,4 @@ jobs:
               Thank you for taking the time to improve LightGBM!
           daysUntilClose: 30
           responseRequiredLabel: awaiting response
-          token: ${{ secrets.WORKFLOW }}
+          token: ${{ github.token }}


### PR DESCRIPTION
Based on https://github.com/microsoft/LightGBM/issues/5060#issuecomment-1093470783.

Switches the no-response bot to the default GitHub Actions token, so its comments will be posted as the `github-actions` bot user.