### PR TITLE
[ci] update to R 4.1.3 and use macOS-latest for R jobs (fixes #4990)

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -21,9 +21,9 @@ if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
     export R_LINUX_VERSION="3.6.3-1bionic"
     export R_APT_REPO="bionic-cran35/"
 elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
-    export R_MAC_VERSION=4.1.2
+    export R_MAC_VERSION=4.1.3
     export R_MAC_PKG_URL=https://cran.r-project.org/bin/macosx/base/R-${R_MAC_VERSION}.pkg
-    export R_LINUX_VERSION="4.1.2-1.2004.0"
+    export R_LINUX_VERSION="4.1.3-1.2004.0"
     export R_APT_REPO="focal-cran40/"
 else
     echo "Unrecognized R version: ${R_VERSION}"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -78,7 +78,7 @@ if ($env:R_MAJOR_VERSION -eq "3") {
   $env:RTOOLS_BIN = "$RTOOLS_INSTALL_PATH\usr\bin"
   $env:RTOOLS_MINGW_BIN = "$RTOOLS_INSTALL_PATH\mingw64\bin"
   $env:RTOOLS_EXE_FILE = "rtools40v2-x86_64.exe"
-  $env:R_WINDOWS_VERSION = "4.1.2"
+  $env:R_WINDOWS_VERSION = "4.1.3"
 } else {
   Write-Output "[ERROR] Unrecognized R version: $env:R_VERSION"
   Check-Output $false

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -57,7 +57,7 @@ jobs:
             compiler: gcc
             r_version: 3.6
             build_type: cmake
-          - os: macOS-10.15
+          - os: macOS-latest
             task: r-package
             compiler: gcc
             r_version: 4.1
@@ -67,7 +67,7 @@ jobs:
             compiler: clang
             r_version: 3.6
             build_type: cmake
-          - os: macOS-10.15
+          - os: macOS-latest
             task: r-package
             compiler: clang
             r_version: 4.1
@@ -112,7 +112,7 @@ jobs:
             compiler: gcc
             r_version: 4.1
             build_type: cran
-          - os: macOS-10.15
+          - os: macOS-latest
             task: r-package
             compiler: clang
             r_version: 4.1

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -138,13 +138,13 @@ jobs:
       - name: Install pandoc
         uses: r-lib/actions/setup-pandoc@v1
       - name: Setup and run tests on Linux and macOS
-        if: startsWith(matrix.os, 'macOS') || matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'macOS-latest' || matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
           export TASK="${{ matrix.task }}"
           export COMPILER="${{ matrix.compiler }}"
           export GITHUB_ACTIONS="true"
-          if [[ $(echo "${{ matrix.os }}" | head -c5) == "macOS" ]]; then
+          if [[ "${{ matrix.os }}" == "macOS-latest" ]]; then
               export OS_NAME="macos"
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
               export OS_NAME="linux"

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - breathe
   - python=3.9
-  - r-base=4.1.2
+  - r-base=4.1.3
   - r-data.table=1.14.2
   - r-jsonlite=1.7.2
   - r-knitr=1.37


### PR DESCRIPTION
Fixes #4990.
Contributes to #3763.
Based on https://github.com/microsoft/LightGBM/pull/5129#issuecomment-1089299960.

Updates R r.x CI jobs to R 4.1.2 ([released last month](https://cran.r-project.org/bin/windows/base/old/)).

Changes R 4.1 Mac CI jobs back to `macOS-latest` environment (reverting a workaround from #4989).