### PR TITLE
[R-package] reduce cost of repeated parameter alias checks

### DIFF
--- a/R-package/R/aliases.R
+++ b/R-package/R/aliases.R
@@ -33,11 +33,18 @@
     )])
 }
 
+# [description] Non-exported environment, used for caching details that only need to be
+#               computed once per R session.
+.lgb_session_cache_env <- new.env()
+
 # [description] List of respected parameter aliases. Wrapped in a function to take advantage of
 #               lazy evaluation (so it doesn't matter what order R sources files during installation).
 # [return] A named list, where each key is a main LightGBM parameter and each value is a character
 #          vector of corresponding aliases.
 .PARAMETER_ALIASES <- function() {
+    if (exists("PARAMETER_ALIASES", where = .lgb_session_cache_env)) {
+        return(get("PARAMETER_ALIASES", envir = .lgb_session_cache_env))
+    }
     params_to_aliases <- jsonlite::fromJSON(
         .Call(
             LGBM_DumpParamAliases_R
@@ -47,6 +54,12 @@
         aliases_with_main_name <- c(main_name, unlist(params_to_aliases[[main_name]]))
         params_to_aliases[[main_name]] <- aliases_with_main_name
     }
+    # store in cache so the next call to `.PARAMETER_ALIASES()` doesn't need to recompute this
+    assign(
+        x = "PARAMETER_ALIASES"
+        , value = params_to_aliases
+        , envir = .lgb_session_cache_env
+    )
     return(params_to_aliases)
 }
 

--- a/R-package/tests/testthat/test_parameters.R
+++ b/R-package/tests/testthat/test_parameters.R
@@ -63,7 +63,7 @@ test_that(".PARAMETER_ALIASES() uses the internal session cache", {
   cache_key <- "PARAMETER_ALIASES"
 
   # clear cache, so this test isn't reliant on the order unit tests are run in
-  if (exists(cache_key, where = .lgb_session_cache_env)){
+  if (exists(cache_key, where = .lgb_session_cache_env)) {
     rm(list = cache_key, envir = .lgb_session_cache_env)
   }
   expect_false(exists(cache_key, where = .lgb_session_cache_env))
@@ -83,7 +83,7 @@ test_that(".PARAMETER_ALIASES() uses the internal session cache", {
   expect_equal(iter_aliases, c("test", "other_test"))
 
   # re-set cache so this doesn't interfere with other unit tests
-  if (exists(cache_key, where = .lgb_session_cache_env)){
+  if (exists(cache_key, where = .lgb_session_cache_env)) {
     rm(list = cache_key, envir = .lgb_session_cache_env)
   }
   expect_false(exists(cache_key, where = .lgb_session_cache_env))

--- a/R-package/tests/testthat/test_parameters.R
+++ b/R-package/tests/testthat/test_parameters.R
@@ -58,6 +58,37 @@ test_that(".PARAMETER_ALIASES() returns a named list of character vectors, where
   expect_equal(sort(param_aliases[["task"]]), c("task", "task_type"))
 })
 
+test_that(".PARAMETER_ALIASES() uses the internal session cache", {
+
+  cache_key <- "PARAMETER_ALIASES"
+
+  # clear cache, so this test isn't reliant on the order unit tests are run in
+  if (exists(cache_key, where = .lgb_session_cache_env)){
+    rm(list = cache_key, envir = .lgb_session_cache_env)
+  }
+  expect_false(exists(cache_key, where = .lgb_session_cache_env))
+
+  # check that result looks correct for at least one parameter
+  iter_aliases <- .PARAMETER_ALIASES()[["num_iterations"]]
+  expect_true(is.character(iter_aliases))
+  expect_true(all(c("num_round", "nrounds") %in% iter_aliases))
+
+  # patch the cache to check that .PARAMETER_ALIASES() checks it
+  assign(
+    x = cache_key
+    , value = list(num_iterations = c("test", "other_test"))
+    , envir = .lgb_session_cache_env
+  )
+  iter_aliases <- .PARAMETER_ALIASES()[["num_iterations"]]
+  expect_equal(iter_aliases, c("test", "other_test"))
+
+  # re-set cache so this doesn't interfere with other unit tests
+  if (exists(cache_key, where = .lgb_session_cache_env)){
+    rm(list = cache_key, envir = .lgb_session_cache_env)
+  }
+  expect_false(exists(cache_key, where = .lgb_session_cache_env))
+})
+
 test_that("training should warn if you use 'dart' boosting, specified with 'boosting' or aliases", {
   for (boosting_param in .PARAMETER_ALIASES()[["boosting"]]) {
     params <- list(


### PR DESCRIPTION
Created in response to https://github.com/microsoft/LightGBM/pull/5122#discussion_r846855854.

For many of LightGBM's supported  parameters (https://lightgbm.readthedocs.io/en/latest/Parameters.html), LightGBM respects multiple *aliases*. For example, `num_iterations=10`, `nrounds=10`, and `num_tree=10` all result in the same behavior.

As a result of this, the R package frequently needs to deal with the possibility that some relevant configuration might be provided via any of these aliases, and sometimes via special keyword arguments in the R package's public API.

Earlier versions of `{lightgbm}` included a hard-coded list of string literals with a mapping from select "main" parameter names to their aliases. To ensure that the package is always in sync with changes on the C++ side, #4829 replaced that list with a call to an entrypoint in LightGBM's C++ code which returns a JSON string containing all parameters and their aliases.

As noted in https://github.com/microsoft/LightGBM/pull/5122#discussion_r846818117, each of those calls results in re-generating that JSON string and deserializing it into an R list.

Since the parameter mapping will never change within an R session, it should only be necessary to fetch it once. This PR proposes introducing an internal cache in the R package and changing `.PARAMETER_ALIASES()` to check that cache before going to the C++ side to get parameter aliases.