### PR TITLE
[python] Use predefined constant in feature importance type comparison instead of raw int literal

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3760,7 +3760,7 @@ class Booster:
             ctypes.c_int(iteration),
             ctypes.c_int(importance_type_int),
             result.ctypes.data_as(ctypes.POINTER(ctypes.c_double))))
-        if importance_type_int == 0:
+        if importance_type_int == C_API_FEATURE_IMPORTANCE_SPLIT:
             return result.astype(np.int32)
         else:
             return result


### PR DESCRIPTION
https://github.com/microsoft/LightGBM/blob/b462d0a40f6978c0a66a47af4522c2ae12532316/python-package/lightgbm/basic.py#L453