### PR TITLE
[ci] bump CUDA version from `11.5.1` to `11.6.2` at CI

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -26,7 +26,7 @@ jobs:
           - method: source
             compiler: gcc
             python_version: "3.8"
-            cuda_version: "11.5.1"
+            cuda_version: "11.6.2"
             tree_learner: cuda
           - method: pip
             compiler: clang
@@ -41,7 +41,7 @@ jobs:
           - method: source
             compiler: gcc
             python_version: "3.8"
-            cuda_version: "11.5.1"
+            cuda_version: "11.6.2"
             tree_learner: cuda_exp
           - method: pip
             compiler: clang


### PR DESCRIPTION
https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags

Linking #3763.