### PR TITLE
[ci] fix git checkout for CI jobs (fixes #5151)

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -180,6 +180,9 @@ jobs:
           - r_customization: csan
             compiler: clang
     steps:
+      - name: Trust git cloning LightGBM
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
       - name: Checkout repository
         uses: actions/checkout@v2.4.0
         with:
@@ -210,6 +213,9 @@ jobs:
         run: |
           apt-get update --allow-releaseinfo-change
           apt-get install --no-install-recommends -y git
+      - name: Trust git cloning LightGBM
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
       - name: Checkout repository
         uses: actions/checkout@v2.4.0
         with:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -49,6 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     container: rocker/verse
     steps:
+      - name: Trust git cloning LightGBM
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
       - name: Checkout repository
         uses: actions/checkout@v2.4.0
         with:


### PR DESCRIPTION
Fixes #5151.

A security vulnerability was recently discovered in `git`, where the use of global git config files like `C:\.git\config`  could allow one user to run arbitrary code as another user. Detailed at https://github.blog/2022-04-12-git-security-vulnerability-announced/.

As reported in https://github.com/actions/checkout/issues/760, something in the combination of how the `checkout` GitHub Action works, how containerized GitHub Actions jobs work, and the security patches published to newer versions of `git` is causing LightGBM's containerized CI jobs on GitHub Actions to fail.

This PR proposes fixing that issue by explicitly telling `git` to trust the directory the `checkout` action clones into.

## Notes for Reviewers

I hope we'll be able to revert this in the future if/when there is a change to https://github.com/actions/checkout. Just putting up this PR for now to unblock development on the project.