### PR TITLE
[CUDA] Fix integer overflow in cuda row-wise data

### DIFF
--- a/src/io/cuda/cuda_row_data.cpp
+++ b/src/io/cuda/cuda_row_data.cpp
@@ -318,15 +318,15 @@ void CUDARowData::GetDenseDataPartitioned(const BIN_TYPE* row_wise_data, std::ve
     [this, num_total_columns, row_wise_data, out_data] (int /*thread_index*/, data_size_t start, data_size_t end) {
       for (size_t i = 0; i < feature_partition_column_index_offsets_.size() - 1; ++i) {
         const int num_prev_columns = static_cast<int>(feature_partition_column_index_offsets_[i]);
-        const data_size_t offset = num_data_ * num_prev_columns;
+        const size_t offset = static_cast<size_t>(num_data_) * static_cast<size_t>(num_prev_columns);
         const int partition_column_start = feature_partition_column_index_offsets_[i];
         const int partition_column_end = feature_partition_column_index_offsets_[i + 1];
         const int num_columns_in_cur_partition = partition_column_end - partition_column_start;
         for (data_size_t data_index = start; data_index < end; ++data_index) {
-          const data_size_t data_offset = offset + data_index * num_columns_in_cur_partition;
-          const data_size_t read_data_offset = data_index * num_total_columns;
+          const size_t data_offset = offset + data_index * num_columns_in_cur_partition;
+          const size_t read_data_offset = static_cast<size_t>(data_index) * num_total_columns;
           for (int column_index = 0; column_index < num_columns_in_cur_partition; ++column_index) {
-            const int true_column_index = read_data_offset + column_index + partition_column_start;
+            const size_t true_column_index = read_data_offset + column_index + partition_column_start;
             const BIN_TYPE bin = row_wise_data[true_column_index];
             out_data[data_offset + column_index] = bin;
           }


### PR DESCRIPTION
This is to fix integer overflow in `cuda_exp`. When data index is multiplied with the number of features, integer overflow can easily occur if 32-bit integers are used. In this PR, we cast the indices into 64-bit integers whenever necessary.