### PR TITLE
fix typo in CEGB method name

### DIFF
--- a/src/treelearner/cost_effective_gradient_boosting.hpp
+++ b/src/treelearner/cost_effective_gradient_boosting.hpp
@@ -63,7 +63,7 @@ class CostEfficientGradientBoosting {
     }
     init_ = true;
   }
-  double DetlaGain(int feature_index, int real_fidx, int leaf_index,
+  double DeltaGain(int feature_index, int real_fidx, int leaf_index,
                    int num_data_in_leaf, SplitInfo split_info) {
     auto config = tree_learner_->config_;
     double delta =

--- a/src/treelearner/serial_tree_learner.cpp
+++ b/src/treelearner/serial_tree_learner.cpp
@@ -772,7 +772,7 @@ void SerialTreeLearner::ComputeBestSplitForFeature(
   new_split.feature = real_fidx;
   if (cegb_ != nullptr) {
     new_split.gain -=
-        cegb_->DetlaGain(feature_index, real_fidx, leaf_splits->leaf_index(),
+        cegb_->DeltaGain(feature_index, real_fidx, leaf_splits->leaf_index(),
                          num_data, new_split);
   }
   if (new_split.monotone_type != 0) {


### PR DESCRIPTION
Noticed while reviewing #5164.

I suspect that the method `CostEfficientGradientBoosting::DetlaGain()` was supposed to be called `DeltaGain()`. This PR proposes fixing that.

## Notes for Reviewers

This class isn't part of the library's public API, so this is not a user-facing breaking change.

I used the following to search for all such typos:

```shell
git grep -i detla
```