### PR TITLE
[ci] temporarily pin Azure Devops jobs to ubuntu 20.04

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -16,7 +16,7 @@ resources:
   - container: ubuntu1404
     image: lightgbm/vsts-agent:ubuntu-14.04
   - container: ubuntu-latest
-    image: 'ubuntu:latest'
+    image: 'ubuntu:20.04'
     options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
   - container: rbase
     image: wch1/r-debug


### PR DESCRIPTION
All `Linux_latest` jobs on Azure Devops started failing a few days ago, because the `ubuntu:latest` tag on DockerHub moved from Ubuntu 20.04 to 22.04.

https://github.com/microsoft/LightGBM/pull/5169#issuecomment-1106413298
https://github.com/microsoft/LightGBM/pull/5169#issuecomment-1107139143

While attempting to fix this on #5169, I ran into the issue from #5106 (https://github.com/microsoft/LightGBM/issues/5106#issuecomment-1107346250). I believe I've identified the root cause there, but I expect fixing it to require significant discussion and effort.

For now, to unblock other development in this project, this PR proposes **temporarily** pinning the `Linux_latest` jobs back to Ubuntu 20.04.