### PR TITLE
[ci] skip auto-injected tasks at Azure Pipelines

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - skip
+    - master
   tags:
     include:
     - v*

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - master
+    - skip
   tags:
     include:
     - v*
@@ -11,6 +11,10 @@ variables:
   AZURE: 'true'
   PYTHON_VERSION: '3.10'
   CONDA_ENV: test-env
+  runCodesignValidationInjection: false
+  skipComponentGovernanceDetection: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 resources:
   containers:
   - container: ubuntu1404


### PR DESCRIPTION
I have no idea what is it, but we haven't requested these checks. 😕 
They just increase our overall CI time and are potential places for project-unrelated CI failures.

Taken from here:
https://github.com/achu152/Industrial-IoT/blob/df614129f257dc719369309185b65721906d51ad/tools/templates/ci.yml#L10-L13

Compare:

#### `master`:

https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=12641&view=results

![image](https://user-images.githubusercontent.com/25141164/164951773-df6ecc71-706f-4f48-8dd4-15596bd4438d.png)

![image](https://user-images.githubusercontent.com/25141164/164951794-e164695a-086e-4630-a051-acc461172a57.png)



#### this PR:

https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=12644&view=results

![image](https://user-images.githubusercontent.com/25141164/164951807-7c1af710-a4fa-4111-ae35-287c0b993df3.png)

![image](https://user-images.githubusercontent.com/25141164/164951816-f8bf189f-8c13-41e6-b558-7aa7dc4f5f73.png)

