### PR TITLE
[c-api] check number of features when retrieving number of bins

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1556,9 +1556,9 @@ int LGBM_DatasetGetFeatureNumBin(DatasetHandle handle,
   API_BEGIN();
   auto dataset = reinterpret_cast<Dataset*>(handle);
   int num_features = dataset->num_total_features();
-  if (feature >= num_features) {
+  if (feature < 0 || feature >= num_features) {
     Log::Fatal("Tried to retrieve number of bins for feature index %d, "
-               "but the total number of features is %d.", feature, num_features);
+               "but the valid feature indices are [0, %d].", feature, num_features - 1);
   }
   int inner_idx = dataset->InnerFeatureIndex(feature);
   if (inner_idx >= 0) {

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1555,6 +1555,11 @@ int LGBM_DatasetGetFeatureNumBin(DatasetHandle handle,
                                  int* out) {
   API_BEGIN();
   auto dataset = reinterpret_cast<Dataset*>(handle);
+  int num_features = dataset->num_total_features();
+  if (feature >= num_features) {
+    Log::Fatal("Tried to retrieve number of bins for feature index %d, "
+               "but the total number of features is %d.", feature, num_features);
+  }
   int inner_idx = dataset->InnerFeatureIndex(feature);
   if (inner_idx >= 0) {
     *out = dataset->FeatureNumBin(inner_idx);

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -680,7 +680,7 @@ def test_feature_num_bin(min_data_in_bin):
       lgb.basic.LightGBMError,
       match=(
         f'Tried to retrieve number of bins for feature index {num_features}, '
-        f'but the total number of features is {num_features}.'
+        f'but the valid feature indices are \\[0, {num_features - 1}\\].'
       )
     ):
       ds.feature_num_bin(num_features)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -674,6 +674,16 @@ def test_feature_num_bin(min_data_in_bin):
     ]
     actual_num_bins = [ds.feature_num_bin(i) for i in range(X.shape[1])]
     assert actual_num_bins == expected_num_bins
+    # check for feature indices outside of range
+    num_features = X.shape[1]
+    with pytest.raises(
+      lgb.basic.LightGBMError,
+      match=(
+        f'Tried to retrieve number of bins for feature index {num_features}, '
+        f'but the total number of features is {num_features}.'
+      )
+    ):
+      ds.feature_num_bin(num_features)
 
 
 def test_feature_num_bin_with_max_bin_by_feature():

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -677,13 +677,13 @@ def test_feature_num_bin(min_data_in_bin):
     # check for feature indices outside of range
     num_features = X.shape[1]
     with pytest.raises(
-      lgb.basic.LightGBMError,
-      match=(
-        f'Tried to retrieve number of bins for feature index {num_features}, '
-        f'but the valid feature indices are \\[0, {num_features - 1}\\].'
-      )
+        lgb.basic.LightGBMError,
+        match=(
+            f'Tried to retrieve number of bins for feature index {num_features}, '
+            f'but the valid feature indices are \\[0, {num_features - 1}\\].'
+        )
     ):
-      ds.feature_num_bin(num_features)
+        ds.feature_num_bin(num_features)
 
 
 def test_feature_num_bin_with_max_bin_by_feature():


### PR DESCRIPTION
When retrieving the number of bins for a given feature the input wasn't checked so if we input an invalid feature index (>= number of features) we could get garbage values or even a segfault, so this adds a check to see if we're in the valid range of feature indices.