### PR TITLE
[ci] Prevent Python downgrading to pypy on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ configuration:  # a trick to construct a build matrix with multiple Python versi
 # commits to 'master'
 branches:
   only:
-    - master
+    - fix_ci
 
 environment:
   matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ configuration:  # a trick to construct a build matrix with multiple Python versi
 # commits to 'master'
 branches:
   only:
-    - fix_ci
+    - master
 
 environment:
   matrix:

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -52,7 +52,7 @@ if ($env:TASK -eq "swig") {
 
 conda install -q -y -n $env:CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest scikit-learn scipy ; Check-Output $?
 # python-graphviz has to be installed separately to prevent conda from downgrading to pypy
-conda install -q -y -n $env:CONDA_ENV python-graphviz ; Check-Output $?
+conda install -q -y -n $env:CONDA_ENV libxml2 python-graphviz ; Check-Output $?
 
 if ($env:TASK -eq "regular") {
   mkdir $env:BUILD_SOURCESDIRECTORY/build; cd $env:BUILD_SOURCESDIRECTORY/build


### PR DESCRIPTION
Fix current `master` failures at Appveyor that happen due to pytest uses `pypy3` as a Python interpreter.
```
The following packages will be DOWNGRADED:
  python                        3.7.12-h900ac77_100_cpython --> 3.7.12-0_73_pypy
  python_abi                                    3.7-2_cp37m --> 3.7-2_pypy37_pp73

...

============================= test session starts =============================
platform win32 -- Python 3.7.12[pypy-7.3.7-final], pytest-7.1.1, pluggy-1.0.0

...
_________________________________ test_basic __________________________________
self = <class 'ctypes.c_char_p'>, value = 1047415529008
    def from_param(self, value):
        if isinstance(value, self):
            return value
        try:
>           as_parameter = value._as_parameter_
E           AttributeError: 'int' object has no attribute '_as_parameter_'
C:\Miniconda3-x64\envs\test-env\lib_pypy\_ctypes\basics.py:56: AttributeError
```
https://ci.appveyor.com/project/guolinke/lightgbm/builds/43430960/job/smunq6b4pcq936b5?fullLog=true


Looks like `libxml2` installation is an universal workaround for any CI error 😄 
Related #4993, #5068, #5126.