### PR TITLE
[ci] Prevent Python downgrading to pypy on Windows (2)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ configuration:  # a trick to construct a build matrix with multiple Python versi
 # commits to 'master'
 branches:
   only:
-    - master
+    - fix_ci
 
 environment:
   matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ configuration:  # a trick to construct a build matrix with multiple Python versi
 # commits to 'master'
 branches:
   only:
-    - fix_ci
+    - master
 
 environment:
   matrix:

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -51,8 +51,8 @@ if ($env:TASK -eq "swig") {
 }
 
 conda install -q -y -n $env:CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest python-graphviz scikit-learn scipy ; Check-Output $?
-# sometimes conda downgrades cpython to pypy
-conda remove -n $env:CONDA_ENV pypy$env:PYTHON_VERSION
+# python-graphviz has to be installed separately to prevent conda from downgrading to pypy
+conda install -q -y --no-update-deps -n $env:CONDA_ENV libxml2 python-graphviz ; Check-Output $?
 
 if ($env:TASK -eq "regular") {
   mkdir $env:BUILD_SOURCESDIRECTORY/build; cd $env:BUILD_SOURCESDIRECTORY/build

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -50,9 +50,9 @@ if ($env:TASK -eq "swig") {
   Exit 0
 }
 
-conda install -q -y -n $env:CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest scikit-learn scipy ; Check-Output $?
-# python-graphviz has to be installed separately to prevent conda from downgrading to pypy
-conda install -q -y -n $env:CONDA_ENV libxml2 python-graphviz ; Check-Output $?
+conda install -q -y -n $env:CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest python-graphviz scikit-learn scipy ; Check-Output $?
+# sometimes conda downgrades cpython to pypy
+conda remove -n $env:CONDA_ENV pypy
 
 if ($env:TASK -eq "regular") {
   mkdir $env:BUILD_SOURCESDIRECTORY/build; cd $env:BUILD_SOURCESDIRECTORY/build

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -50,7 +50,7 @@ if ($env:TASK -eq "swig") {
   Exit 0
 }
 
-conda install -q -y -n $env:CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest python-graphviz scikit-learn scipy ; Check-Output $?
+conda install -q -y -n $env:CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest scikit-learn scipy ; Check-Output $?
 # python-graphviz has to be installed separately to prevent conda from downgrading to pypy
 conda install -q -y --no-update-deps -n $env:CONDA_ENV libxml2 python-graphviz ; Check-Output $?
 

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -50,9 +50,9 @@ if ($env:TASK -eq "swig") {
   Exit 0
 }
 
-conda install -q -y --no-update-deps -n $env:CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest scikit-learn scipy ; Check-Output $?
-# python-graphviz has to be installed separately to prevent conda from downgrading to pypy
-conda install -q -y --no-update-deps -n $env:CONDA_ENV libxml2 python-graphviz ; Check-Output $?
+conda install -q -y -n $env:CONDA_ENV cloudpickle joblib numpy pandas psutil pytest scikit-learn scipy ; Check-Output $?
+# matplotlib and python-graphviz have to be installed separately to prevent conda from downgrading to pypy
+conda install -q -y -n $env:CONDA_ENV matplotlib python-graphviz ; Check-Output $?
 
 if ($env:TASK -eq "regular") {
   mkdir $env:BUILD_SOURCESDIRECTORY/build; cd $env:BUILD_SOURCESDIRECTORY/build

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -52,7 +52,7 @@ if ($env:TASK -eq "swig") {
 
 conda install -q -y -n $env:CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest python-graphviz scikit-learn scipy ; Check-Output $?
 # sometimes conda downgrades cpython to pypy
-conda remove -n $env:CONDA_ENV pypy
+conda remove -n $env:CONDA_ENV pypy$env:PYTHON_VERSION
 
 if ($env:TASK -eq "regular") {
   mkdir $env:BUILD_SOURCESDIRECTORY/build; cd $env:BUILD_SOURCESDIRECTORY/build

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -50,7 +50,7 @@ if ($env:TASK -eq "swig") {
   Exit 0
 }
 
-conda install -q -y -n $env:CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest scikit-learn scipy ; Check-Output $?
+conda install -q -y --no-update-deps -n $env:CONDA_ENV cloudpickle joblib matplotlib numpy pandas psutil pytest scikit-learn scipy ; Check-Output $?
 # python-graphviz has to be installed separately to prevent conda from downgrading to pypy
 conda install -q -y --no-update-deps -n $env:CONDA_ENV libxml2 python-graphviz ; Check-Output $?
 


### PR DESCRIPTION
Ah, `libxml2` isn't omnipotent as [we thought](https://github.com/microsoft/LightGBM/pull/5197#pullrequestreview-962369155) 🙁 

Appveyor at `master` fails again with the same error as yesterday in #5197 (but only MSVC job this time).
https://ci.appveyor.com/project/guolinke/lightgbm/builds/43451448