### PR TITLE
[R-package] ensure that callbacks respect verbosity from params

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -288,7 +288,7 @@ lgb.cv <- function(params = list()
       , cb = cb_early_stop(
         stopping_rounds = early_stopping_rounds
         , first_metric_only = isTRUE(params[["first_metric_only"]])
-        , verbose = params[["verbosity"]]
+        , verbose = params[["verbosity"]] > 0L
       )
     )
   }

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -245,7 +245,7 @@ lgb.cv <- function(params = list()
   }
 
   # Add printing log callback
-  if (verbose > 0L && eval_freq > 0L) {
+  if (params[["verbosity"]] > 0L && eval_freq > 0L) {
     callbacks <- add.cb(cb_list = callbacks, cb = cb_print_evaluation(period = eval_freq))
   }
 
@@ -288,7 +288,7 @@ lgb.cv <- function(params = list()
       , cb = cb_early_stop(
         stopping_rounds = early_stopping_rounds
         , first_metric_only = isTRUE(params[["first_metric_only"]])
-        , verbose = verbose
+        , verbose = params[["verbosity"]]
       )
     )
   }

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -253,7 +253,7 @@ lgb.train <- function(params = list(),
       , cb = cb_early_stop(
         stopping_rounds = early_stopping_rounds
         , first_metric_only = isTRUE(params[["first_metric_only"]])
-        , verbose = params[["verbosity"]]
+        , verbose = params[["verbosity"]] > 0L
       )
     )
   }

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -210,7 +210,7 @@ lgb.train <- function(params = list(),
   }
 
   # Add printing log callback
-  if (verbose > 0L && eval_freq > 0L) {
+  if (params[["verbosity"]] > 0L && eval_freq > 0L) {
     callbacks <- add.cb(cb_list = callbacks, cb = cb_print_evaluation(period = eval_freq))
   }
 
@@ -253,7 +253,7 @@ lgb.train <- function(params = list(),
       , cb = cb_early_stop(
         stopping_rounds = early_stopping_rounds
         , first_metric_only = isTRUE(params[["first_metric_only"]])
-        , verbose = verbose
+        , verbose = params[["verbosity"]]
       )
     )
   }

--- a/R-package/R/lightgbm.R
+++ b/R-package/R/lightgbm.R
@@ -161,6 +161,11 @@ lightgbm <- function(data,
     , params = params
     , alternative_kwarg_value = num_threads
   )
+  params <- lgb.check.wrapper_param(
+    main_param_name = "verbosity"
+    , params = params
+    , alternative_kwarg_value = verbose
+  )
 
   # Set data to a temporary variable
   dtrain <- data
@@ -175,7 +180,7 @@ lightgbm <- function(data,
     , "data" = dtrain
     , "nrounds" = nrounds
     , "obj" = objective
-    , "verbose" = verbose
+    , "verbose" = params[["verbosity"]]
     , "eval_freq" = eval_freq
     , "early_stopping_rounds" = early_stopping_rounds
     , "init_model" = init_model
@@ -189,7 +194,7 @@ lightgbm <- function(data,
   }
 
   # Set validation as oneself
-  if (verbose > 0L) {
+  if (params[["verbosity"]] > 0L) {
     train_args[["valids"]][["train"]] <- dtrain
   }
 

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3006,7 +3006,7 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
   expect_equal(model$.__enclos_env__$private$train_set$get_field("weight"), w)
 })
 
-.assert_has_expected_logs <- function(log_txt, lgb_info, lgb_warn, early_stopping, valid1_eval_msg, train_eval_msg) {
+.assert_has_expected_logs <- function(log_txt, lgb_info, lgb_warn, early_stopping, valid_eval_msg, train_eval_msg) {
   expect_identical(
     object = any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt))
     , expected = lgb_info
@@ -3024,8 +3024,8 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
     , expected = early_stopping
   )
   expect_identical(
-    object = any(grepl("valid1's auc\\:[0-9]+", log_txt))
-    , expected = valid1_eval_msg
+    object = any(grepl("valid's auc\\:[0-9]+", log_txt))
+    , expected = valid_eval_msg
   )
   expect_identical(
     object = any(grepl("train's auc\\:[0-9]+", log_txt))
@@ -3037,12 +3037,12 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
   record_evals <- fitted_model$record_evals
   expect_equal(record_evals$start_iter, 1L)
   expect_equal(
-    object = unlist(record_evals[["valid1"]][["auc"]][["eval"]])
+    object = unlist(record_evals[["valid"]][["auc"]][["eval"]])
     , expected = c(0.9805752, 0.9805752, 0.9934957, 0.9934957, 0.9949372)
     , tolerance = TOLERANCE
   )
   if (isTRUE(valids_should_include_train_set)) {
-    expect_named(record_evals, c("start_iter", "valid1", "train"), ignore.order = TRUE, ignore.case = FALSE)
+    expect_named(record_evals, c("start_iter", "valid", "train"), ignore.order = TRUE, ignore.case = FALSE)
     expect_equal(
       object = unlist(record_evals[["train"]][["auc"]][["eval"]])
       , expected = c(0.9817835, 0.9817835, 0.9929513, 0.9929513, 0.9947141)
@@ -3050,9 +3050,9 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
     )
     expect_equal(record_evals[["train"]][["auc"]][["eval_err"]], list())
   } else {
-    expect_named(record_evals, c("start_iter", "valid1"), ignore.order = TRUE, ignore.case = FALSE)
+    expect_named(record_evals, c("start_iter", "valid"), ignore.order = TRUE, ignore.case = FALSE)
   }
-  expect_equal(record_evals[["valid1"]][["auc"]][["eval_err"]], list())
+  expect_equal(record_evals[["valid"]][["auc"]][["eval_err"]], list())
 }
 
 .train_for_verbosity_test <- function(train_function, verbose_kwarg, verbose_param){
@@ -3070,7 +3070,7 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
     params = params
     , nrounds = nrounds
     , valids = list(
-      "valid1" = lgb.Dataset(data = test$data, label = test$label)
+      "valid" = lgb.Dataset(data = test$data, label = test$label)
     )
   )
   if (!is.null(verbose_kwarg)) {
@@ -3111,7 +3111,7 @@ test_that("lgb.train() only prints eval metrics when expected to", {
       , lgb_info = FALSE
       , lgb_warn = FALSE
       , early_stopping = FALSE
-      , valid1_eval_msg = FALSE
+      , valid_eval_msg = FALSE
       , train_eval_msg = FALSE
     )
     .assert_has_expected_record_evals(
@@ -3130,7 +3130,7 @@ test_that("lgb.train() only prints eval metrics when expected to", {
       , lgb_info = FALSE
       , lgb_warn = TRUE
       , early_stopping = FALSE
-      , valid1_eval_msg = FALSE
+      , valid_eval_msg = FALSE
       , train_eval_msg = FALSE
     )
     .assert_has_expected_record_evals(
@@ -3149,7 +3149,7 @@ test_that("lgb.train() only prints eval metrics when expected to", {
       , lgb_info = TRUE
       , lgb_warn = TRUE
       , early_stopping = TRUE
-      , valid1_eval_msg = TRUE
+      , valid_eval_msg = TRUE
       , train_eval_msg = FALSE
     )
     .assert_has_expected_record_evals(
@@ -3172,7 +3172,7 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     , lgb_info = FALSE
     , lgb_warn = FALSE
     , early_stopping = FALSE
-    , valid1_eval_msg = FALSE
+    , valid_eval_msg = FALSE
     , train_eval_msg = FALSE
   )
   .assert_has_expected_record_evals(
@@ -3191,7 +3191,7 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     , lgb_info = FALSE
     , lgb_warn = TRUE
     , early_stopping = FALSE
-    , valid1_eval_msg = FALSE
+    , valid_eval_msg = FALSE
     , train_eval_msg = FALSE
   )
   .assert_has_expected_record_evals(
@@ -3210,7 +3210,7 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     , lgb_info = TRUE
     , lgb_warn = TRUE
     , early_stopping = TRUE
-    , valid1_eval_msg = TRUE
+    , valid_eval_msg = TRUE
     , train_eval_msg = FALSE
   )
   .assert_has_expected_record_evals(
@@ -3236,7 +3236,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
       , lgb_info = FALSE
       , lgb_warn = FALSE
       , early_stopping = FALSE
-      , valid1_eval_msg = FALSE
+      , valid_eval_msg = FALSE
       , train_eval_msg = FALSE
     )
     .assert_has_expected_record_evals(
@@ -3255,7 +3255,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
       , lgb_info = FALSE
       , lgb_warn = TRUE
       , early_stopping = FALSE
-      , valid1_eval_msg = FALSE
+      , valid_eval_msg = FALSE
       , train_eval_msg = FALSE
     )
     .assert_has_expected_record_evals(
@@ -3275,7 +3275,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
       , lgb_info = TRUE
       , lgb_warn = TRUE
       , early_stopping = TRUE
-      , valid1_eval_msg = TRUE
+      , valid_eval_msg = TRUE
       , train_eval_msg = TRUE
     )
     .assert_has_expected_record_evals(
@@ -3298,7 +3298,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
     , lgb_info = FALSE
     , lgb_warn = FALSE
     , early_stopping = FALSE
-    , valid1_eval_msg = FALSE
+    , valid_eval_msg = FALSE
     , train_eval_msg = FALSE
   )
   .assert_has_expected_record_evals(
@@ -3317,7 +3317,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
     , lgb_info = FALSE
     , lgb_warn = TRUE
     , early_stopping = FALSE
-    , valid1_eval_msg = FALSE
+    , valid_eval_msg = FALSE
     , train_eval_msg = FALSE
   )
   .assert_has_expected_record_evals(
@@ -3337,7 +3337,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
     , lgb_info = TRUE
     , lgb_warn = TRUE
     , early_stopping = TRUE
-    , valid1_eval_msg = TRUE
+    , valid_eval_msg = TRUE
     , train_eval_msg = TRUE
   )
   .assert_has_expected_record_evals(
@@ -3383,18 +3383,22 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
           num_leaves = 5L
           , objective = "binary"
           , metric =  "auc"
-          , verbose = -1L
           , early_stopping_round = nrounds
+          , verbose = -1L
         )
         , nrounds = nrounds
         , nfold = nfolds
         , verbose = verbose_keyword_arg
       )
     })
-    expect_false(any(grepl("\\[LightGBM\\]", log_txt)))
-    expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
-    expect_false(any(grepl("Did not meet early stopping", log_txt)))
-    expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
+    .assert_has_expected_logs(
+      log_txt = log_txt
+      , lgb_info = FALSE
+      , lgb_warn = FALSE
+      , early_stopping = FALSE
+      , valid_eval_msg = FALSE
+      , train_eval_msg = FALSE
+    )
     .assert_has_expected_record_evals(cv_bst)
 
     # (verbose = 0) should be only WARN-level LightGBM logs
@@ -3406,19 +3410,22 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
           num_leaves = 5L
           , objective = "binary"
           , metric =  "auc"
-          , verbose = 0L
           , early_stopping_round = nrounds
+          , verbose = 0L
         )
         , nrounds = nrounds
         , nfold = nfolds
         , verbose = verbose_keyword_arg
       )
     })
-    expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
-    expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-    expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
-    expect_false(any(grepl("Did not meet early stopping", log_txt)))
-    expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
+    .assert_has_expected_logs(
+      log_txt = log_txt
+      , lgb_info = FALSE
+      , lgb_warn = TRUE
+      , early_stopping = FALSE
+      , valid_eval_msg = FALSE
+      , train_eval_msg = FALSE
+    )
     .assert_has_expected_record_evals(cv_bst)
 
     # (verbose > 0) should be INFO- and WARN-level LightGBM logs, and record eval messages
@@ -3430,6 +3437,7 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
           num_leaves = 5L
           , objective = "binary"
           , metric =  "auc"
+          , early_stopping_round = nrounds
           , verbose = 2L
         )
         , nrounds = nrounds
@@ -3437,9 +3445,14 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
         , verbose = verbose_keyword_arg
       )
     })
-    expect_true(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
-    expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-    expect_equal(sum(grepl("valid's auc\\:[0-9]+", log_txt)), nrounds)
+    .assert_has_expected_logs(
+      log_txt = log_txt
+      , lgb_info = TRUE
+      , lgb_warn = TRUE
+      , early_stopping = TRUE
+      , valid_eval_msg = TRUE
+      , train_eval_msg = FALSE
+    )
     .assert_has_expected_record_evals(cv_bst)
   }
 
@@ -3455,14 +3468,21 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
         num_leaves = 5L
         , objective = "binary"
         , metric =  "auc"
+        , early_stopping_round = nrounds
       )
       , nrounds = nrounds
       , nfold = nfolds
       , verbose = -1L
     )
   })
-  expect_false(any(grepl("\\[LightGBM\\]", log_txt)))
-  expect_false(any(grepl("valid's auc\\:[0-9]+", log_txt)))
+  .assert_has_expected_logs(
+    log_txt = log_txt
+    , lgb_info = FALSE
+    , lgb_warn = FALSE
+    , early_stopping = FALSE
+    , valid_eval_msg = FALSE
+    , train_eval_msg = FALSE
+  )
   .assert_has_expected_record_evals(cv_bst)
 
   # (verbose = 0) should be only WARN-level LightGBM logs
@@ -3474,17 +3494,21 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
         num_leaves = 5L
         , objective = "binary"
         , metric =  "auc"
+        , early_stopping_round = nrounds
       )
       , nrounds = nrounds
       , nfold = nfolds
       , verbose = 0L
     )
   })
-  expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
-  expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-  expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
-  expect_false(any(grepl("Did not meet early stopping", log_txt)))
-  expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
+  .assert_has_expected_logs(
+    log_txt = log_txt
+    , lgb_info = FALSE
+    , lgb_warn = TRUE
+    , early_stopping = FALSE
+    , valid_eval_msg = FALSE
+    , train_eval_msg = FALSE
+  )
   .assert_has_expected_record_evals(cv_bst)
 
   # (verbose > 0) should be INFO- and WARN-level LightGBM logs, and record eval messages
@@ -3496,14 +3520,20 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
         num_leaves = 5L
         , objective = "binary"
         , metric =  "auc"
+        , early_stopping_round = nrounds
       )
       , nrounds = nrounds
       , nfold = nfolds
       , verbose = 1L
     )
   })
-  expect_true(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
-  expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-  expect_equal(sum(grepl("valid's auc\\:[0-9]+", log_txt)), nrounds)
+  .assert_has_expected_logs(
+    log_txt = log_txt
+    , lgb_info = TRUE
+    , lgb_warn = TRUE
+    , early_stopping = TRUE
+    , valid_eval_msg = TRUE
+    , train_eval_msg = FALSE
+  )
   .assert_has_expected_record_evals(cv_bst)
 })

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3143,11 +3143,14 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     , verbose_param = NULL
     , nrounds = nrounds
   )
-  log_txt <- out[["logs"]]
-  expect_false(any(grepl("\\[LightGBM\\]", log_txt)))
-  expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
-  expect_false(any(grepl("Did not meet early stopping", log_txt)))
-  expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
+  .assert_has_expected_logs(
+    log_txt = out[["logs"]]
+    , lgb_info = FALSE
+    , lgb_warn = FALSE
+    , early_stopping = FALSE
+    , valid1_eval_msg = FALSE
+    , train_eval_msg = FALSE
+  )
   .assert_has_expected_record_evals(out[["booster"]])
 
   # (verbose = 0) should be only WARN-level LightGBM logs
@@ -3156,12 +3159,14 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     , verbose_param = NULL
     , nrounds = nrounds
   )
-  log_txt <- out[["logs"]]
-  expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
-  expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-  expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
-  expect_false(any(grepl("Did not meet early stopping", log_txt)))
-  expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
+  .assert_has_expected_logs(
+    log_txt = out[["logs"]]
+    , lgb_info = FALSE
+    , lgb_warn = TRUE
+    , early_stopping = FALSE
+    , valid1_eval_msg = FALSE
+    , train_eval_msg = FALSE
+  )
   .assert_has_expected_record_evals(out[["booster"]])
 
   # (verbose > 0) should be INFO- and WARN-level LightGBM logs, and record eval messages
@@ -3170,13 +3175,14 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     , verbose_param = NULL
     , nrounds = nrounds
   )
-  log_txt <- out[["logs"]]
-  expect_true(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
-  expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-  expect_equal(sum(grepl("Will train until there is no improvement in 5 rounds", log_txt)), 1L)
-  expect_equal(sum(grepl("Did not meet early stopping", log_txt)), 1L)
-  # NOTE: one of the messages like "valid1's auc:0.123" is re-printed by the "Did not meet early stopping" message
-  expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds + 1L)
+  .assert_has_expected_logs(
+    log_txt = out[["logs"]]
+    , lgb_info = TRUE
+    , lgb_warn = TRUE
+    , early_stopping = TRUE
+    , valid1_eval_msg = TRUE
+    , train_eval_msg = FALSE
+  )
   .assert_has_expected_record_evals(out[["booster"]])
 })
 

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3165,6 +3165,204 @@ test_that("lgb.train() only prints eval metrics when expected to", {
   .assert_has_expected_record_evals(bst)
 })
 
+test_that("lightgbm() only prints eval metrics when expected to", {
+  dvalid <- lgb.Dataset(
+    data = test$data
+    , label = test$label
+    , free_raw_data = FALSE
+  )
+  nrounds <- 5L
+
+  .assert_has_expected_record_evals <- function(fitted_model, valids_should_include_train_set) {
+    record_evals <- fitted_model$record_evals
+    expect_equal(record_evals$start_iter, 1L)
+    expect_equal(
+      object = unlist(record_evals[["valid1"]][["auc"]][["eval"]])
+      , expected = c(0.9805752, 0.9805752, 0.9934957, 0.9934957, 0.9949372)
+      , tolerance = TOLERANCE
+    )
+    if (isTRUE(valids_should_include_train_set)) {
+      expect_named(record_evals, c("start_iter", "valid1", "train"), ignore.order = TRUE, ignore.case = FALSE)
+      expect_equal(
+        object = unlist(record_evals[["train"]][["auc"]][["eval"]])
+        , expected = c(0.9817835, 0.9817835, 0.9929513, 0.9929513, 0.9947141)
+        , tolerance = TOLERANCE
+      )
+      expect_equal(record_evals[["train"]][["auc"]][["eval_err"]], list())
+    } else {
+      expect_named(record_evals, c("start_iter", "valid1"), ignore.order = TRUE, ignore.case = FALSE)
+    }
+    expect_equal(record_evals[["valid1"]][["auc"]][["eval_err"]], list())
+  }
+
+  # regardless of value passed to keyword argument 'verbose', value in params
+  # should take precedence
+  for (verbose_keyword_arg in c(-5L, -1L, 0L, 1L, 5L)) {
+
+    # (verbose = -1) should not be any logs, should be record evals only for valid1
+    log_txt <- capture.output({
+      bst <- lightgbm(
+        data = train$data
+        , label = train$label
+        , params = list(
+          num_leaves = 5L
+          , objective = "binary"
+          , metric =  "auc"
+          , verbose = -1L
+        )
+        , nrounds = nrounds
+        , valids = list(
+          "valid1" = dvalid
+        )
+        , verbose = verbose_keyword_arg
+      )
+    })
+    expect_false(any(grepl("\\[LightGBM\\]", log_txt)))
+    expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
+    expect_false(any(grepl("train's auc\\:[0-9]+", log_txt)))
+    .assert_has_expected_record_evals(
+      fitted_model = bst
+      , valids_should_include_train_set = FALSE
+    )
+
+    # (verbose = 0) should be only WARN-level LightGBM logs, record evals only for valid1
+    log_txt <- capture.output({
+      bst <- lightgbm(
+        data = train$data
+        , label = train$label
+        , params = list(
+          num_leaves = 5L
+          , objective = "binary"
+          , metric =  "auc"
+          , verbose = 0L
+        )
+        , nrounds = nrounds
+        , valids = list(
+          "valid1" = dvalid
+        )
+        , verbose = verbose_keyword_arg
+      )
+    })
+    expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
+    expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
+    expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
+    expect_false(any(grepl("train's auc\\:[0-9]+", log_txt)))
+    .assert_has_expected_record_evals(
+      fitted_model = bst
+      , valids_should_include_train_set = FALSE
+    )
+
+    # (verbose > 0) should be INFO- and WARN-level LightGBM logs, record eval messages,
+    #               and record evals for both valid1 and train
+    log_txt <- capture.output({
+      bst <- lightgbm(
+        data = train$data
+        , label = train$label
+        , params = list(
+          num_leaves = 5L
+          , objective = "binary"
+          , metric =  "auc"
+          , verbose = 2L
+        )
+        , nrounds = nrounds
+        , valids = list(
+          "valid1" = dvalid
+        )
+        , verbose = verbose_keyword_arg
+      )
+    })
+    expect_true(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
+    expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
+    expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds)
+    expect_equal(sum(grepl("train's auc\\:[0-9]+", log_txt)), nrounds)
+    .assert_has_expected_record_evals(
+      fitted_model = bst
+      , valids_should_include_train_set = TRUE
+    )
+  }
+
+  # if verbosity isn't specified in `params`, changing keyword argument `verbose` should
+  # alter what messages are printed
+
+  # (verbose = -1) should not be any logs, should be record evals only for valid1
+  log_txt <- capture.output({
+    bst <- lightgbm(
+      data = train$data
+      , label = train$label
+      , params = list(
+        num_leaves = 5L
+        , objective = "binary"
+        , metric =  "auc"
+      )
+      , nrounds = nrounds
+      , valids = list(
+        "valid1" = dvalid
+      )
+      , verbose = -1L
+    )
+  })
+  expect_false(any(grepl("\\[LightGBM\\]", log_txt)))
+  expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
+  expect_false(any(grepl("train's auc\\:[0-9]+", log_txt)))
+  .assert_has_expected_record_evals(
+    fitted_model = bst
+    , valids_should_include_train_set = FALSE
+  )
+
+  # (verbose = 0) should be only WARN-level LightGBM logs, record evals only for valid1
+  log_txt <- capture.output({
+    bst <- lightgbm(
+      data = train$data
+      , label = train$label
+      , params = list(
+        num_leaves = 5L
+        , objective = "binary"
+        , metric =  "auc"
+      )
+      , nrounds = nrounds
+      , valids = list(
+        "valid1" = dvalid
+      )
+      , verbose = 0L
+    )
+  })
+  expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
+  expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
+  expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
+  expect_false(any(grepl("train's auc\\:[0-9]+", log_txt)))
+  .assert_has_expected_record_evals(
+    fitted_model = bst
+    , valids_should_include_train_set = FALSE
+  )
+
+  # (verbose > 0) should be INFO- and WARN-level LightGBM logs, record eval messages,
+  #               and record evals for both valid1 and train
+  log_txt <- capture.output({
+    bst <- lightgbm(
+      data = train$data
+      , label = train$label
+      , params = list(
+        num_leaves = 5L
+        , objective = "binary"
+        , metric =  "auc"
+      )
+      , nrounds = nrounds
+      , valids = list(
+        "valid1" = dvalid
+      )
+      , verbose = 2L
+    )
+  })
+  expect_true(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
+  expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
+  expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds)
+  expect_equal(sum(grepl("train's auc\\:[0-9]+", log_txt)), nrounds)
+  .assert_has_expected_record_evals(
+    fitted_model = bst
+    , valids_should_include_train_set = TRUE
+  )
+})
+
 test_that("lgb.cv() only prints eval metrics when expected to", {
   dtrain <- lgb.Dataset(
     data = train$data

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3239,11 +3239,14 @@ test_that("lightgbm() only prints eval metrics when expected to", {
         , verbose = verbose_keyword_arg
       )
     })
-    expect_false(any(grepl("\\[LightGBM\\]", log_txt)))
-    expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
-    expect_false(any(grepl("Did not meet early stopping", log_txt)))
-    expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
-    expect_false(any(grepl("train's auc\\:[0-9]+", log_txt)))
+    .assert_has_expected_logs(
+      log_txt = log_txt
+      , lgb_info = FALSE
+      , lgb_warn = FALSE
+      , early_stopping = FALSE
+      , valid1_eval_msg = FALSE
+      , train_eval_msg = FALSE
+    )
     .assert_has_expected_record_evals(
       fitted_model = bst
       , valids_should_include_train_set = FALSE
@@ -3268,12 +3271,14 @@ test_that("lightgbm() only prints eval metrics when expected to", {
         , verbose = verbose_keyword_arg
       )
     })
-    expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
-    expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-    expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
-    expect_false(any(grepl("Did not meet early stopping", log_txt)))
-    expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
-    expect_false(any(grepl("train's auc\\:[0-9]+", log_txt)))
+    .assert_has_expected_logs(
+      log_txt = log_txt
+      , lgb_info = FALSE
+      , lgb_warn = TRUE
+      , early_stopping = FALSE
+      , valid1_eval_msg = FALSE
+      , train_eval_msg = FALSE
+    )
     .assert_has_expected_record_evals(
       fitted_model = bst
       , valids_should_include_train_set = FALSE
@@ -3299,13 +3304,14 @@ test_that("lightgbm() only prints eval metrics when expected to", {
         , verbose = verbose_keyword_arg
       )
     })
-    expect_true(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
-    expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-    expect_equal(sum(grepl("Will train until there is no improvement in 5 rounds", log_txt)), 1L)
-    expect_equal(sum(grepl("Did not meet early stopping", log_txt)), 1L)
-    # NOTE: one of the messages like "valid1's auc:0.123" is re-printed by the "Did not meet early stopping" message
-    expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds + 1L)
-    expect_equal(sum(grepl("train's auc\\:[0-9]+", log_txt)), nrounds + 1L)
+    .assert_has_expected_logs(
+      log_txt = log_txt
+      , lgb_info = TRUE
+      , lgb_warn = TRUE
+      , early_stopping = TRUE
+      , valid1_eval_msg = TRUE
+      , train_eval_msg = TRUE
+    )
     .assert_has_expected_record_evals(
       fitted_model = bst
       , valids_should_include_train_set = TRUE
@@ -3333,11 +3339,14 @@ test_that("lightgbm() only prints eval metrics when expected to", {
       , verbose = -1L
     )
   })
-  expect_false(any(grepl("\\[LightGBM\\]", log_txt)))
-  expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
-  expect_false(any(grepl("Did not meet early stopping", log_txt)))
-  expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
-  expect_false(any(grepl("train's auc\\:[0-9]+", log_txt)))
+  .assert_has_expected_logs(
+    log_txt = log_txt
+    , lgb_info = FALSE
+    , lgb_warn = FALSE
+    , early_stopping = FALSE
+    , valid1_eval_msg = FALSE
+    , train_eval_msg = FALSE
+  )
   .assert_has_expected_record_evals(
     fitted_model = bst
     , valids_should_include_train_set = FALSE
@@ -3361,12 +3370,14 @@ test_that("lightgbm() only prints eval metrics when expected to", {
       , verbose = 0L
     )
   })
-  expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
-  expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-  expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
-  expect_false(any(grepl("Did not meet early stopping", log_txt)))
-  expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
-  expect_false(any(grepl("train's auc\\:[0-9]+", log_txt)))
+  .assert_has_expected_logs(
+    log_txt = log_txt
+    , lgb_info = FALSE
+    , lgb_warn = TRUE
+    , early_stopping = FALSE
+    , valid1_eval_msg = FALSE
+    , train_eval_msg = FALSE
+  )
   .assert_has_expected_record_evals(
     fitted_model = bst
     , valids_should_include_train_set = FALSE
@@ -3391,13 +3402,14 @@ test_that("lightgbm() only prints eval metrics when expected to", {
       , verbose = 2L
     )
   })
-  expect_true(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
-  expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-  expect_equal(sum(grepl("Will train until there is no improvement in 5 rounds", log_txt)), 1L)
-  expect_equal(sum(grepl("Did not meet early stopping", log_txt)), 1L)
-  # NOTE: one of the messages like "valid1's auc:0.123" is re-printed by the "Did not meet early stopping" message
-  expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds + 1L)
-  expect_equal(sum(grepl("train's auc\\:[0-9]+", log_txt)), nrounds + 1L)
+  .assert_has_expected_logs(
+    log_txt = log_txt
+    , lgb_info = TRUE
+    , lgb_warn = TRUE
+    , early_stopping = TRUE
+    , valid1_eval_msg = TRUE
+    , train_eval_msg = TRUE
+  )
   .assert_has_expected_record_evals(
     fitted_model = bst
     , valids_should_include_train_set = TRUE

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3348,6 +3348,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
 
 test_that("lgb.cv() only prints eval metrics when expected to", {
   .cv_for_verbosity_test <- function(verbose_kwarg, verbose_param) {
+    set.seed(708L)
     nrounds <- 5L
     dtrain <- lgb.Dataset(
       data = train$data
@@ -3395,18 +3396,12 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
       , tolerance = TOLERANCE
     )
   }
-  nrounds = 5
-  nfolds = 3
-  dtrain <- lgb.Dataset(
-    data = train$data
-    , label = train$label
-  )
+
   # regardless of value passed to keyword argument 'verbose', value in params
   # should take precedence
   for (verbose_keyword_arg in c(-5L, -1L, 0L, 1L, 5L)) {
 
     # (verbose = -1) should not be any logs, should be record evals
-    set.seed(708L)
     out <- .cv_for_verbosity_test(
       verbose_kwarg = verbose_keyword_arg
       , verbose_param = -1L
@@ -3422,138 +3417,81 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
     .assert_has_expected_record_evals(out[["cv_booster"]])
 
     # (verbose = 0) should be only WARN-level LightGBM logs
-    set.seed(708L)
-    log_txt <- capture.output({
-      cv_bst <- lgb.cv(
-        data = dtrain
-        , params = list(
-          num_leaves = 5L
-          , objective = "binary"
-          , metric =  "auc"
-          , early_stopping_round = nrounds
-          , verbose = 0L
-        )
-        , nrounds = nrounds
-        , nfold = nfolds
-        , verbose = verbose_keyword_arg
-      )
-    })
+    out <- .cv_for_verbosity_test(
+      verbose_kwarg = verbose_keyword_arg
+      , verbose_param = 0L
+    )
     .assert_has_expected_logs(
-      log_txt = log_txt
+      log_txt = out[["logs"]]
       , lgb_info = FALSE
       , lgb_warn = TRUE
       , early_stopping = FALSE
       , valid_eval_msg = FALSE
       , train_eval_msg = FALSE
     )
-    .assert_has_expected_record_evals(cv_bst)
+    .assert_has_expected_record_evals(out[["cv_booster"]])
 
     # (verbose > 0) should be INFO- and WARN-level LightGBM logs, and record eval messages
-    set.seed(708L)
-    log_txt <- capture.output({
-      cv_bst <- lgb.cv(
-        data = dtrain
-        , params = list(
-          num_leaves = 5L
-          , objective = "binary"
-          , metric =  "auc"
-          , early_stopping_round = nrounds
-          , verbose = 2L
-        )
-        , nrounds = nrounds
-        , nfold = nfolds
-        , verbose = verbose_keyword_arg
-      )
-    })
+    out <- .cv_for_verbosity_test(
+      verbose_kwarg = verbose_keyword_arg
+      , verbose_param = 1L
+    )
     .assert_has_expected_logs(
-      log_txt = log_txt
+      log_txt = out[["logs"]]
       , lgb_info = TRUE
       , lgb_warn = TRUE
       , early_stopping = TRUE
       , valid_eval_msg = TRUE
       , train_eval_msg = FALSE
     )
-    .assert_has_expected_record_evals(cv_bst)
+    .assert_has_expected_record_evals(out[["cv_booster"]])
   }
 
   # if verbosity isn't specified in `params`, changing keyword argument `verbose` should
   # alter what messages are printed
 
   # (verbose = -1) should not be any logs, should be record evals
-  set.seed(708L)
-  log_txt <- capture.output({
-    cv_bst <- lgb.cv(
-      data = dtrain
-      , params = list(
-        num_leaves = 5L
-        , objective = "binary"
-        , metric =  "auc"
-        , early_stopping_round = nrounds
-      )
-      , nrounds = nrounds
-      , nfold = nfolds
-      , verbose = -1L
-    )
-  })
+  out <- .cv_for_verbosity_test(
+    verbose_kwarg = -1L
+    , verbose_param = NULL
+  )
   .assert_has_expected_logs(
-    log_txt = log_txt
+    log_txt = out[["logs"]]
     , lgb_info = FALSE
     , lgb_warn = FALSE
     , early_stopping = FALSE
     , valid_eval_msg = FALSE
     , train_eval_msg = FALSE
   )
-  .assert_has_expected_record_evals(cv_bst)
+  .assert_has_expected_record_evals(out[["cv_booster"]])
 
   # (verbose = 0) should be only WARN-level LightGBM logs
-  set.seed(708L)
-  log_txt <- capture.output({
-    cv_bst <- lgb.cv(
-      data = dtrain
-      , params = list(
-        num_leaves = 5L
-        , objective = "binary"
-        , metric =  "auc"
-        , early_stopping_round = nrounds
-      )
-      , nrounds = nrounds
-      , nfold = nfolds
-      , verbose = 0L
-    )
-  })
+  out <- .cv_for_verbosity_test(
+    verbose_kwarg = 0L
+    , verbose_param = NULL
+  )
   .assert_has_expected_logs(
-    log_txt = log_txt
+    log_txt = out[["logs"]]
     , lgb_info = FALSE
     , lgb_warn = TRUE
     , early_stopping = FALSE
     , valid_eval_msg = FALSE
     , train_eval_msg = FALSE
   )
-  .assert_has_expected_record_evals(cv_bst)
+  .assert_has_expected_record_evals(out[["cv_booster"]])
 
   # (verbose > 0) should be INFO- and WARN-level LightGBM logs, and record eval messages
-  set.seed(708L)
-  log_txt <- capture.output({
-    cv_bst <- lgb.cv(
-      data = dtrain
-      , params = list(
-        num_leaves = 5L
-        , objective = "binary"
-        , metric =  "auc"
-        , early_stopping_round = nrounds
-      )
-      , nrounds = nrounds
-      , nfold = nfolds
-      , verbose = 1L
-    )
-  })
+  out <- .cv_for_verbosity_test(
+    verbose_kwarg = 1L
+    , verbose_param = NULL
+  )
   .assert_has_expected_logs(
-    log_txt = log_txt
+    log_txt = out[["logs"]]
     , lgb_info = TRUE
     , lgb_warn = TRUE
     , early_stopping = TRUE
     , valid_eval_msg = TRUE
     , train_eval_msg = FALSE
   )
-  .assert_has_expected_record_evals(cv_bst)
+  .assert_has_expected_record_evals(out[["cv_booster"]])
 })

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3033,6 +3033,28 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
   )
 }
 
+.assert_has_expected_record_evals <- function(fitted_model, valids_should_include_train_set) {
+  record_evals <- fitted_model$record_evals
+  expect_equal(record_evals$start_iter, 1L)
+  expect_equal(
+    object = unlist(record_evals[["valid1"]][["auc"]][["eval"]])
+    , expected = c(0.9805752, 0.9805752, 0.9934957, 0.9934957, 0.9949372)
+    , tolerance = TOLERANCE
+  )
+  if (isTRUE(valids_should_include_train_set)) {
+    expect_named(record_evals, c("start_iter", "valid1", "train"), ignore.order = TRUE, ignore.case = FALSE)
+    expect_equal(
+      object = unlist(record_evals[["train"]][["auc"]][["eval"]])
+      , expected = c(0.9817835, 0.9817835, 0.9929513, 0.9929513, 0.9947141)
+      , tolerance = TOLERANCE
+    )
+    expect_equal(record_evals[["train"]][["auc"]][["eval_err"]], list())
+  } else {
+    expect_named(record_evals, c("start_iter", "valid1"), ignore.order = TRUE, ignore.case = FALSE)
+  }
+  expect_equal(record_evals[["valid1"]][["auc"]][["eval_err"]], list())
+}
+
 test_that("lgb.train() only prints eval metrics when expected to", {
   nrounds <- 5L
 
@@ -3069,18 +3091,6 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     ))
   }
 
-  .assert_has_expected_record_evals <- function(fitted_model) {
-    record_evals <- fitted_model$record_evals
-    expect_named(record_evals, c("start_iter", "valid1"), ignore.order = TRUE, ignore.case = FALSE)
-    expect_equal(record_evals$start_iter, 1L)
-    expect_equal(
-      object = unlist(record_evals[["valid1"]][["auc"]][["eval"]])
-      , expected = c(0.9805752, 0.9805752, 0.9934957, 0.9934957, 0.9949372)
-      , tolerance = TOLERANCE
-    )
-    expect_equal(fitted_model$record_evals[["valid1"]][["auc"]][["eval_err"]], list())
-  }
-
   # regardless of value passed to keyword argument 'verbose', value in params
   # should take precedence
   for (verbose_keyword_arg in c(-5L, -1L, 0L, 1L, 5L)) {
@@ -3099,7 +3109,10 @@ test_that("lgb.train() only prints eval metrics when expected to", {
       , valid1_eval_msg = FALSE
       , train_eval_msg = FALSE
     )
-    .assert_has_expected_record_evals(out[["booster"]])
+    .assert_has_expected_record_evals(
+      fitted_model = out[["booster"]]
+      , valids_should_include_train_set = FALSE
+    )
 
     # (verbose = 0) should be only WARN-level LightGBM logs
     out <- .train(
@@ -3115,7 +3128,10 @@ test_that("lgb.train() only prints eval metrics when expected to", {
       , valid1_eval_msg = FALSE
       , train_eval_msg = FALSE
     )
-    .assert_has_expected_record_evals(out[["booster"]])
+    .assert_has_expected_record_evals(
+      fitted_model = out[["booster"]]
+      , valids_should_include_train_set = FALSE
+    )
 
     # (verbose > 0) should be INFO- and WARN-level LightGBM logs, and record eval messages
     out <- .train(
@@ -3131,7 +3147,10 @@ test_that("lgb.train() only prints eval metrics when expected to", {
       , valid1_eval_msg = TRUE
       , train_eval_msg = FALSE
     )
-    .assert_has_expected_record_evals(out[["booster"]])
+    .assert_has_expected_record_evals(
+      fitted_model = out[["booster"]]
+      , valids_should_include_train_set = FALSE
+    )
   }
 
   # if verbosity isn't specified in `params`, changing keyword argument `verbose` should
@@ -3151,7 +3170,10 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     , valid1_eval_msg = FALSE
     , train_eval_msg = FALSE
   )
-  .assert_has_expected_record_evals(out[["booster"]])
+  .assert_has_expected_record_evals(
+    fitted_model = out[["booster"]]
+    , valids_should_include_train_set = FALSE
+  )
 
   # (verbose = 0) should be only WARN-level LightGBM logs
   out <- .train(
@@ -3167,7 +3189,10 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     , valid1_eval_msg = FALSE
     , train_eval_msg = FALSE
   )
-  .assert_has_expected_record_evals(out[["booster"]])
+  .assert_has_expected_record_evals(
+    fitted_model = out[["booster"]]
+    , valids_should_include_train_set = FALSE
+  )
 
   # (verbose > 0) should be INFO- and WARN-level LightGBM logs, and record eval messages
   out <- .train(
@@ -3183,7 +3208,10 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     , valid1_eval_msg = TRUE
     , train_eval_msg = FALSE
   )
-  .assert_has_expected_record_evals(out[["booster"]])
+  .assert_has_expected_record_evals(
+    fitted_model = out[["booster"]]
+    , valids_should_include_train_set = FALSE
+  )
 })
 
 test_that("lightgbm() only prints eval metrics when expected to", {
@@ -3193,28 +3221,6 @@ test_that("lightgbm() only prints eval metrics when expected to", {
     , free_raw_data = FALSE
   )
   nrounds <- 5L
-
-  .assert_has_expected_record_evals <- function(fitted_model, valids_should_include_train_set) {
-    record_evals <- fitted_model$record_evals
-    expect_equal(record_evals$start_iter, 1L)
-    expect_equal(
-      object = unlist(record_evals[["valid1"]][["auc"]][["eval"]])
-      , expected = c(0.9805752, 0.9805752, 0.9934957, 0.9934957, 0.9949372)
-      , tolerance = TOLERANCE
-    )
-    if (isTRUE(valids_should_include_train_set)) {
-      expect_named(record_evals, c("start_iter", "valid1", "train"), ignore.order = TRUE, ignore.case = FALSE)
-      expect_equal(
-        object = unlist(record_evals[["train"]][["auc"]][["eval"]])
-        , expected = c(0.9817835, 0.9817835, 0.9929513, 0.9929513, 0.9947141)
-        , tolerance = TOLERANCE
-      )
-      expect_equal(record_evals[["train"]][["auc"]][["eval_err"]], list())
-    } else {
-      expect_named(record_evals, c("start_iter", "valid1"), ignore.order = TRUE, ignore.case = FALSE)
-    }
-    expect_equal(record_evals[["valid1"]][["auc"]][["eval_err"]], list())
-  }
 
   # regardless of value passed to keyword argument 'verbose', value in params
   # should take precedence

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3036,9 +3036,14 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
 .assert_has_expected_record_evals <- function(fitted_model, valids_should_include_train_set) {
   record_evals <- fitted_model$record_evals
   expect_equal(record_evals$start_iter, 1L)
+  if (inherits(fitted_model, "lgb.CVBooster")) {
+    expected_valid_auc <- c(0.979056, 0.9844697, 0.9900813, 0.9908026, 0.9935588)
+  } else {
+    expected_valid_auc <-  c(0.9805752, 0.9805752, 0.9934957, 0.9934957, 0.9949372)
+  }
   expect_equal(
     object = unlist(record_evals[["valid"]][["auc"]][["eval"]])
-    , expected = c(0.9805752, 0.9805752, 0.9934957, 0.9934957, 0.9949372)
+    , expected = expected_valid_auc
     , tolerance = TOLERANCE
   )
   if (isTRUE(valids_should_include_train_set)) {
@@ -3055,7 +3060,7 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
   expect_equal(record_evals[["valid"]][["auc"]][["eval_err"]], list())
 }
 
-.train_for_verbosity_test <- function(train_function, verbose_kwarg, verbose_param){
+.train_for_verbosity_test <- function(train_function, verbose_kwarg, verbose_param) {
   set.seed(708L)
   nrounds <- 5L
   params <- list(
@@ -3095,6 +3100,7 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
       , label = train$label
     )
     train_kwargs[["nfold"]] <- 3L
+    train_kwargs[["showsd"]] <- FALSE
   }
   log_txt <- capture.output({
     bst <- do.call(
@@ -3359,22 +3365,6 @@ test_that("lightgbm() only prints eval metrics when expected to", {
 
 test_that("lgb.cv() only prints eval metrics when expected to", {
 
-  .assert_has_expected_record_evals <- function(fitted_model) {
-    record_evals <- fitted_model$record_evals
-    expect_named(record_evals, c("start_iter", "valid"), ignore.order = TRUE, ignore.case = FALSE)
-    expect_equal(record_evals$start_iter, 1L)
-    expect_equal(
-      object = unlist(record_evals[["valid"]][["auc"]][["eval"]])
-      , expected = c(0.979056, 0.9844697, 0.9900813, 0.9908026, 0.9935588)
-      , tolerance = TOLERANCE
-    )
-    expect_equal(
-      object = unlist(fitted_model$record_evals[["valid"]][["auc"]][["eval_err"]])
-      , expected = c(0.0009148442, 0.0067418719, 0.0045669616, 0.0049976408, 0.00131507)
-      , tolerance = TOLERANCE
-    )
-  }
-
   # regardless of value passed to keyword argument 'verbose', value in params
   # should take precedence
   for (verbose_keyword_arg in c(-5L, -1L, 0L, 1L, 5L)) {
@@ -3393,7 +3383,10 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
       , valid_eval_msg = FALSE
       , train_eval_msg = FALSE
     )
-    .assert_has_expected_record_evals(out[["booster"]])
+    .assert_has_expected_record_evals(
+      fitted_model = out[["booster"]]
+      , valids_should_include_train_set = FALSE
+    )
 
     # (verbose = 0) should be only WARN-level LightGBM logs
     out <- .train_for_verbosity_test(
@@ -3409,7 +3402,10 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
       , valid_eval_msg = FALSE
       , train_eval_msg = FALSE
     )
-    .assert_has_expected_record_evals(out[["booster"]])
+    .assert_has_expected_record_evals(
+      fitted_model = out[["booster"]]
+      , valids_should_include_train_set = FALSE
+    )
 
     # (verbose > 0) should be INFO- and WARN-level LightGBM logs, and record eval messages
     out <- .train_for_verbosity_test(
@@ -3425,7 +3421,10 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
       , valid_eval_msg = TRUE
       , train_eval_msg = FALSE
     )
-    .assert_has_expected_record_evals(out[["booster"]])
+    .assert_has_expected_record_evals(
+      fitted_model = out[["booster"]]
+      , valids_should_include_train_set = FALSE
+    )
   }
 
   # if verbosity isn't specified in `params`, changing keyword argument `verbose` should
@@ -3445,7 +3444,10 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
     , valid_eval_msg = FALSE
     , train_eval_msg = FALSE
   )
-  .assert_has_expected_record_evals(out[["booster"]])
+  .assert_has_expected_record_evals(
+    fitted_model = out[["booster"]]
+    , valids_should_include_train_set = FALSE
+  )
 
   # (verbose = 0) should be only WARN-level LightGBM logs
   out <- .train_for_verbosity_test(
@@ -3461,7 +3463,10 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
     , valid_eval_msg = FALSE
     , train_eval_msg = FALSE
   )
-  .assert_has_expected_record_evals(out[["booster"]])
+  .assert_has_expected_record_evals(
+    fitted_model = out[["booster"]]
+    , valids_should_include_train_set = FALSE
+  )
 
   # (verbose > 0) should be INFO- and WARN-level LightGBM logs, and record eval messages
   out <- .train_for_verbosity_test(
@@ -3477,5 +3482,8 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
     , valid_eval_msg = TRUE
     , train_eval_msg = FALSE
   )
-  .assert_has_expected_record_evals(out[["booster"]])
+  .assert_has_expected_record_evals(
+    fitted_model = out[["booster"]]
+    , valids_should_include_train_set = FALSE
+  )
 })

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3042,6 +3042,7 @@ test_that("lgb.train() only prints eval metrics when expected to", {
           , objective = "binary"
           , metric =  "auc"
           , verbose = -1L
+          , early_stopping_round = nrounds
         )
         , nrounds = nrounds
         , valids = list(
@@ -3051,6 +3052,8 @@ test_that("lgb.train() only prints eval metrics when expected to", {
       )
     })
     expect_false(any(grepl("\\[LightGBM\\]", log_txt)))
+    expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
+    expect_false(any(grepl("Did not meet early stopping", log_txt)))
     expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
     .assert_has_expected_record_evals(bst)
 
@@ -3063,6 +3066,7 @@ test_that("lgb.train() only prints eval metrics when expected to", {
           , objective = "binary"
           , metric =  "auc"
           , verbose = 0L
+          , early_stopping_round = nrounds
         )
         , nrounds = nrounds
         , valids = list(
@@ -3073,6 +3077,8 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     })
     expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
     expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
+    expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
+    expect_false(any(grepl("Did not meet early stopping", log_txt)))
     expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
     .assert_has_expected_record_evals(bst)
 
@@ -3085,6 +3091,7 @@ test_that("lgb.train() only prints eval metrics when expected to", {
           , objective = "binary"
           , metric =  "auc"
           , verbose = 2L
+          , early_stopping_round = nrounds
         )
         , nrounds = nrounds
         , valids = list(
@@ -3095,7 +3102,10 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     })
     expect_true(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
     expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-    expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds)
+    expect_equal(sum(grepl("Will train until there is no improvement in 5 rounds", log_txt)), 1L)
+    expect_equal(sum(grepl("Did not meet early stopping", log_txt)), 1L)
+    # NOTE: one of the messages like "valid1's auc:0.123" is re-printed by the "Did not meet early stopping" message
+    expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds + 1L)
     .assert_has_expected_record_evals(bst)
   }
 
@@ -3110,6 +3120,7 @@ test_that("lgb.train() only prints eval metrics when expected to", {
         num_leaves = 5L
         , objective = "binary"
         , metric =  "auc"
+        , early_stopping_round = nrounds
       )
       , nrounds = nrounds
       , valids = list(
@@ -3119,6 +3130,8 @@ test_that("lgb.train() only prints eval metrics when expected to", {
     )
   })
   expect_false(any(grepl("\\[LightGBM\\]", log_txt)))
+  expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
+  expect_false(any(grepl("Did not meet early stopping", log_txt)))
   expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
   .assert_has_expected_record_evals(bst)
 
@@ -3130,6 +3143,7 @@ test_that("lgb.train() only prints eval metrics when expected to", {
         num_leaves = 5L
         , objective = "binary"
         , metric =  "auc"
+        , early_stopping_round = nrounds
       )
       , nrounds = nrounds
       , valids = list(
@@ -3140,6 +3154,8 @@ test_that("lgb.train() only prints eval metrics when expected to", {
   })
   expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
   expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
+  expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
+  expect_false(any(grepl("Did not meet early stopping", log_txt)))
   expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
   .assert_has_expected_record_evals(bst)
 
@@ -3151,6 +3167,7 @@ test_that("lgb.train() only prints eval metrics when expected to", {
         num_leaves = 5L
         , objective = "binary"
         , metric =  "auc"
+        , early_stopping_round = nrounds
       )
       , nrounds = nrounds
       , valids = list(
@@ -3161,7 +3178,10 @@ test_that("lgb.train() only prints eval metrics when expected to", {
   })
   expect_true(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
   expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-  expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds)
+  expect_equal(sum(grepl("Will train until there is no improvement in 5 rounds", log_txt)), 1L)
+  expect_equal(sum(grepl("Did not meet early stopping", log_txt)), 1L)
+  # NOTE: one of the messages like "valid1's auc:0.123" is re-printed by the "Did not meet early stopping" message
+  expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds + 1L)
   .assert_has_expected_record_evals(bst)
 })
 
@@ -3209,6 +3229,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
           , objective = "binary"
           , metric =  "auc"
           , verbose = -1L
+          , early_stopping_round = nrounds
         )
         , nrounds = nrounds
         , valids = list(
@@ -3218,6 +3239,8 @@ test_that("lightgbm() only prints eval metrics when expected to", {
       )
     })
     expect_false(any(grepl("\\[LightGBM\\]", log_txt)))
+    expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
+    expect_false(any(grepl("Did not meet early stopping", log_txt)))
     expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
     expect_false(any(grepl("train's auc\\:[0-9]+", log_txt)))
     .assert_has_expected_record_evals(
@@ -3235,6 +3258,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
           , objective = "binary"
           , metric =  "auc"
           , verbose = 0L
+          , early_stopping_round = nrounds
         )
         , nrounds = nrounds
         , valids = list(
@@ -3245,6 +3269,8 @@ test_that("lightgbm() only prints eval metrics when expected to", {
     })
     expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
     expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
+    expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
+    expect_false(any(grepl("Did not meet early stopping", log_txt)))
     expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
     expect_false(any(grepl("train's auc\\:[0-9]+", log_txt)))
     .assert_has_expected_record_evals(
@@ -3263,6 +3289,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
           , objective = "binary"
           , metric =  "auc"
           , verbose = 2L
+          , early_stopping_round = nrounds
         )
         , nrounds = nrounds
         , valids = list(
@@ -3273,8 +3300,11 @@ test_that("lightgbm() only prints eval metrics when expected to", {
     })
     expect_true(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
     expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-    expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds)
-    expect_equal(sum(grepl("train's auc\\:[0-9]+", log_txt)), nrounds)
+    expect_equal(sum(grepl("Will train until there is no improvement in 5 rounds", log_txt)), 1L)
+    expect_equal(sum(grepl("Did not meet early stopping", log_txt)), 1L)
+    # NOTE: one of the messages like "valid1's auc:0.123" is re-printed by the "Did not meet early stopping" message
+    expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds + 1L)
+    expect_equal(sum(grepl("train's auc\\:[0-9]+", log_txt)), nrounds + 1L)
     .assert_has_expected_record_evals(
       fitted_model = bst
       , valids_should_include_train_set = TRUE
@@ -3293,6 +3323,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
         num_leaves = 5L
         , objective = "binary"
         , metric =  "auc"
+        , early_stopping_round = nrounds
       )
       , nrounds = nrounds
       , valids = list(
@@ -3302,6 +3333,8 @@ test_that("lightgbm() only prints eval metrics when expected to", {
     )
   })
   expect_false(any(grepl("\\[LightGBM\\]", log_txt)))
+  expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
+  expect_false(any(grepl("Did not meet early stopping", log_txt)))
   expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
   expect_false(any(grepl("train's auc\\:[0-9]+", log_txt)))
   .assert_has_expected_record_evals(
@@ -3318,6 +3351,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
         num_leaves = 5L
         , objective = "binary"
         , metric =  "auc"
+        , early_stopping_round = nrounds
       )
       , nrounds = nrounds
       , valids = list(
@@ -3328,6 +3362,8 @@ test_that("lightgbm() only prints eval metrics when expected to", {
   })
   expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
   expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
+  expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
+  expect_false(any(grepl("Did not meet early stopping", log_txt)))
   expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
   expect_false(any(grepl("train's auc\\:[0-9]+", log_txt)))
   .assert_has_expected_record_evals(
@@ -3345,6 +3381,7 @@ test_that("lightgbm() only prints eval metrics when expected to", {
         num_leaves = 5L
         , objective = "binary"
         , metric =  "auc"
+        , early_stopping_round = nrounds
       )
       , nrounds = nrounds
       , valids = list(
@@ -3355,8 +3392,11 @@ test_that("lightgbm() only prints eval metrics when expected to", {
   })
   expect_true(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
   expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-  expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds)
-  expect_equal(sum(grepl("train's auc\\:[0-9]+", log_txt)), nrounds)
+  expect_equal(sum(grepl("Will train until there is no improvement in 5 rounds", log_txt)), 1L)
+  expect_equal(sum(grepl("Did not meet early stopping", log_txt)), 1L)
+  # NOTE: one of the messages like "valid1's auc:0.123" is re-printed by the "Did not meet early stopping" message
+  expect_equal(sum(grepl("valid1's auc\\:[0-9]+", log_txt)), nrounds + 1L)
+  expect_equal(sum(grepl("train's auc\\:[0-9]+", log_txt)), nrounds + 1L)
   .assert_has_expected_record_evals(
     fitted_model = bst
     , valids_should_include_train_set = TRUE
@@ -3401,6 +3441,7 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
           , objective = "binary"
           , metric =  "auc"
           , verbose = -1L
+          , early_stopping_round = nrounds
         )
         , nrounds = nrounds
         , nfold = nfolds
@@ -3408,7 +3449,9 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
       )
     })
     expect_false(any(grepl("\\[LightGBM\\]", log_txt)))
-    expect_false(any(grepl("valid's auc\\:[0-9]+", log_txt)))
+    expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
+    expect_false(any(grepl("Did not meet early stopping", log_txt)))
+    expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
     .assert_has_expected_record_evals(cv_bst)
 
     # (verbose = 0) should be only WARN-level LightGBM logs
@@ -3421,6 +3464,7 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
           , objective = "binary"
           , metric =  "auc"
           , verbose = 0L
+          , early_stopping_round = nrounds
         )
         , nrounds = nrounds
         , nfold = nfolds
@@ -3429,7 +3473,9 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
     })
     expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
     expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-    expect_false(any(grepl("valid's auc\\:[0-9]+", log_txt)))
+    expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
+    expect_false(any(grepl("Did not meet early stopping", log_txt)))
+    expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
     .assert_has_expected_record_evals(cv_bst)
 
     # (verbose > 0) should be INFO- and WARN-level LightGBM logs, and record eval messages
@@ -3493,7 +3539,9 @@ test_that("lgb.cv() only prints eval metrics when expected to", {
   })
   expect_false(any(grepl("\\[LightGBM\\] \\[Info\\]", log_txt)))
   expect_true(any(grepl("\\[LightGBM\\] \\[Warning\\]", log_txt)))
-  expect_false(any(grepl("valid's auc\\:[0-9]+", log_txt)))
+  expect_false(any(grepl("Will train until there is no improvement in 5 rounds", log_txt)))
+  expect_false(any(grepl("Did not meet early stopping", log_txt)))
+  expect_false(any(grepl("valid1's auc\\:[0-9]+", log_txt)))
   .assert_has_expected_record_evals(cv_bst)
 
   # (verbose > 0) should be INFO- and WARN-level LightGBM logs, and record eval messages


### PR DESCRIPTION
Contributes to #4862.
Fixes an issue introduced by #4899 .

In the R package, `lightgbm()`, `lgb.train()`, and `lgb.cv()` have a keyword argument `verbose`. #4899 added changes to ensure that that verbosity parameters passed through `params` took precedence over that keyword argument.

However, evaluation and and early stopping callbacks still reference that keyword argument, which can lead to inconsistent behavior where some printed messages' verbosity can only be controlled by the keyword argument.

While working on this, I also discovered another closely-related bug...parameter `verbose` in calls to `cb_early_stop()` is being passed an integer, but that value is then checked with `isTRUE()`...which means that no messages are ever printed from that callback.

https://github.com/microsoft/LightGBM/blob/dad391574137958402bec4b417bc594fa1c5fbed/R-package/R/callback.R#L207

This PR proposes changes to ensure that it's possible to silence early stopping messages and evaluation messages using `params`.

### Notes for Reviewers

This PR reduces the number of logs printed by the R package's tests from 2095 lines to 1616 lines.

```shell
sh build-cran-package --no-build-vignettes
R CMD INSTALL --with-keep.source ./lightgbm_3.3.1.99.tar.gz
cd R-package/tests
Rscript testthat.R > ../../out.log 2>&1
echo "log lines from tests: $(cat ../../out.log | wc -l)"
```