### PR TITLE
Cleanup codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,18 +11,18 @@
 
 # other catch-alls that will get matched if specific rules below are not matched
 *.R    @jameslamb @jmoralez
-*.py    @StrikerRUS @jmoralez @jameslamb @shiyu1994 @hzy46 @tongwu-msft
-*.cpp    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
-*.h    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
+*.py    @StrikerRUS @jmoralez @jameslamb @shiyu1994 @tongwu-msft
+*.cpp    @guolinke @btrotta @shiyu1994 @tongwu-msft
+*.h    @guolinke @btrotta @shiyu1994 @tongwu-msft
 
 # main C++ code
-include/    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
-src/    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
-CMakeLists.txt    @guolinke @jameslamb @StrikerRUS @huanzhang12 @btrotta @shiyu1994 @hzy46 @tongwu-msft
-tests/c_api_test/    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
-tests/cpp_tests/    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
-tests/data/    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
-windows/    @guolinke @btrotta @StrikerRUS @shiyu1994 @hzy46 @tongwu-msft
+include/    @guolinke @btrotta @shiyu1994 @tongwu-msft
+src/    @guolinke @btrotta @shiyu1994 @tongwu-msft
+CMakeLists.txt    @guolinke @jameslamb @StrikerRUS @huanzhang12 @btrotta @shiyu1994 @tongwu-msft
+tests/c_api_test/    @guolinke @btrotta @shiyu1994 @tongwu-msft
+tests/cpp_tests/    @guolinke @btrotta @shiyu1994 @tongwu-msft
+tests/data/    @guolinke @btrotta @shiyu1994 @tongwu-msft
+windows/    @guolinke @btrotta @StrikerRUS @shiyu1994 @tongwu-msft
 
 # R code
 build_r.R    @jameslamb @StrikerRUS @jmoralez
@@ -30,7 +30,7 @@ build-cran-package.sh    @jameslamb @StrikerRUS @jmoralez
 R-package/    @jameslamb @jmoralez
 
 # Python code
-python-package/    @StrikerRUS @shiyu1994 @jameslamb @hzy46 @tongwu-msft @jmoralez
+python-package/    @StrikerRUS @shiyu1994 @jameslamb @tongwu-msft @jmoralez
 
 # Dask integration
 python-package/lightgbm/dask.py    @jameslamb @jmoralez

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,17 +12,17 @@
 # other catch-alls that will get matched if specific rules below are not matched
 *.R    @jameslamb @jmoralez
 *.py    @StrikerRUS @jmoralez @jameslamb @shiyu1994
-*.cpp    @guolinke @btrotta @shiyu1994
-*.h    @guolinke @btrotta @shiyu1994
+*.cpp    @guolinke @shiyu1994
+*.h    @guolinke @shiyu1994
 
 # main C++ code
-include/    @guolinke @btrotta @shiyu1994
-src/    @guolinke @btrotta @shiyu1994
-CMakeLists.txt    @guolinke @jameslamb @StrikerRUS @huanzhang12 @btrotta @shiyu1994
-tests/c_api_test/    @guolinke @btrotta @shiyu1994
-tests/cpp_tests/    @guolinke @btrotta @shiyu1994
-tests/data/    @guolinke @btrotta @shiyu1994
-windows/    @guolinke @btrotta @StrikerRUS @shiyu1994
+include/    @guolinke @shiyu1994
+src/    @guolinke @shiyu1994
+CMakeLists.txt    @guolinke @jameslamb @StrikerRUS @huanzhang12 @shiyu1994
+tests/c_api_test/    @guolinke @shiyu1994
+tests/cpp_tests/    @guolinke @shiyu1994
+tests/data/    @guolinke @shiyu1994
+windows/    @guolinke @StrikerRUS @shiyu1994
 
 # R code
 build_r.R    @jameslamb @StrikerRUS @jmoralez

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,18 +11,18 @@
 
 # other catch-alls that will get matched if specific rules below are not matched
 *.R    @jameslamb @jmoralez
-*.py    @StrikerRUS @jmoralez @jameslamb @shiyu1994 @tongwu-msft
-*.cpp    @guolinke @btrotta @shiyu1994 @tongwu-msft
-*.h    @guolinke @btrotta @shiyu1994 @tongwu-msft
+*.py    @StrikerRUS @jmoralez @jameslamb @shiyu1994
+*.cpp    @guolinke @btrotta @shiyu1994
+*.h    @guolinke @btrotta @shiyu1994
 
 # main C++ code
-include/    @guolinke @btrotta @shiyu1994 @tongwu-msft
-src/    @guolinke @btrotta @shiyu1994 @tongwu-msft
-CMakeLists.txt    @guolinke @jameslamb @StrikerRUS @huanzhang12 @btrotta @shiyu1994 @tongwu-msft
-tests/c_api_test/    @guolinke @btrotta @shiyu1994 @tongwu-msft
-tests/cpp_tests/    @guolinke @btrotta @shiyu1994 @tongwu-msft
-tests/data/    @guolinke @btrotta @shiyu1994 @tongwu-msft
-windows/    @guolinke @btrotta @StrikerRUS @shiyu1994 @tongwu-msft
+include/    @guolinke @btrotta @shiyu1994
+src/    @guolinke @btrotta @shiyu1994
+CMakeLists.txt    @guolinke @jameslamb @StrikerRUS @huanzhang12 @btrotta @shiyu1994
+tests/c_api_test/    @guolinke @btrotta @shiyu1994
+tests/cpp_tests/    @guolinke @btrotta @shiyu1994
+tests/data/    @guolinke @btrotta @shiyu1994
+windows/    @guolinke @btrotta @StrikerRUS @shiyu1994
 
 # R code
 build_r.R    @jameslamb @StrikerRUS @jmoralez
@@ -30,7 +30,7 @@ build-cran-package.sh    @jameslamb @StrikerRUS @jmoralez
 R-package/    @jameslamb @jmoralez
 
 # Python code
-python-package/    @StrikerRUS @shiyu1994 @jameslamb @tongwu-msft @jmoralez
+python-package/    @StrikerRUS @shiyu1994 @jameslamb @jmoralez
 
 # Dask integration
 python-package/lightgbm/dask.py    @jameslamb @jmoralez

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 *    @guolinke @StrikerRUS @jameslamb @shiyu1994
 
 # other catch-alls that will get matched if specific rules below are not matched
-*.R    @Laurae2 @jameslamb @jmoralez
+*.R    @jameslamb @jmoralez
 *.py    @StrikerRUS @jmoralez @jameslamb @shiyu1994 @hzy46 @tongwu-msft
 *.cpp    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
 *.h    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
@@ -18,7 +18,7 @@
 # main C++ code
 include/    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
 src/    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
-CMakeLists.txt    @guolinke @Laurae2 @jameslamb @StrikerRUS @huanzhang12 @btrotta @shiyu1994 @hzy46 @tongwu-msft
+CMakeLists.txt    @guolinke @jameslamb @StrikerRUS @huanzhang12 @btrotta @shiyu1994 @hzy46 @tongwu-msft
 tests/c_api_test/    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
 tests/cpp_tests/    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
 tests/data/    @guolinke @btrotta @shiyu1994 @hzy46 @tongwu-msft
@@ -27,7 +27,7 @@ windows/    @guolinke @btrotta @StrikerRUS @shiyu1994 @hzy46 @tongwu-msft
 # R code
 build_r.R    @jameslamb @StrikerRUS @jmoralez
 build-cran-package.sh    @jameslamb @StrikerRUS @jmoralez
-R-package/    @Laurae2 @jameslamb @jmoralez
+R-package/    @jameslamb @jmoralez
 
 # Python code
 python-package/    @StrikerRUS @shiyu1994 @jameslamb @hzy46 @tongwu-msft @jmoralez
@@ -51,7 +51,7 @@ docker/    @StrikerRUS @jameslamb
 docker/dockerfile-cli    @guolinke @shiyu1994 @StrikerRUS @jameslamb
 docker/gpu/    @huanzhang12 @StrikerRUS @jameslamb
 docker/dockerfile-python    @StrikerRUS @shiyu1994 @jameslamb @jmoralez
-docker/dockerfile-r    @Laurae2 @jameslamb @jmoralez
+docker/dockerfile-r    @jameslamb @jmoralez
 
 # GPU code
 docs/GPU-*.rst    @huanzhang12 @shiyu1994 @guolinke

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 # main C++ code
 include/    @guolinke @shiyu1994
 src/    @guolinke @shiyu1994
-CMakeLists.txt    @guolinke @jameslamb @StrikerRUS @huanzhang12 @shiyu1994
+CMakeLists.txt    @guolinke @jameslamb @StrikerRUS @shiyu1994
 tests/c_api_test/    @guolinke @shiyu1994
 tests/cpp_tests/    @guolinke @shiyu1994
 tests/data/    @guolinke @shiyu1994
@@ -49,14 +49,14 @@ examples/     @StrikerRUS @jameslamb @guolinke @jmoralez
 # docker setup
 docker/    @StrikerRUS @jameslamb
 docker/dockerfile-cli    @guolinke @shiyu1994 @StrikerRUS @jameslamb
-docker/gpu/    @huanzhang12 @StrikerRUS @jameslamb
+docker/gpu/    @StrikerRUS @jameslamb
 docker/dockerfile-python    @StrikerRUS @shiyu1994 @jameslamb @jmoralez
 docker/dockerfile-r    @jameslamb @jmoralez
 
 # GPU code
-docs/GPU-*.rst    @huanzhang12 @shiyu1994 @guolinke
-src/treelearner/gpu_tree_learner.cpp    @huanzhang12 @guolinke @shiyu1994
-src/treelearner/tree_learner.cpp    @huanzhang12 @guolinke @shiyu1994
+docs/GPU-*.rst    @shiyu1994 @guolinke
+src/treelearner/gpu_tree_learner.cpp    @guolinke @shiyu1994
+src/treelearner/tree_learner.cpp    @guolinke @shiyu1994
 
 # JAVA code
 swig/    @guolinke @shiyu1994


### PR DESCRIPTION
Remove inactive persons from the CODEOWNERS file.

Removed persons have been inactive for a long time (or simply never reviewed any PR) and unlikely will return to review new PRs.
CODEOWNERS file is used to automatically assign reviewers for PRs. Keeping this file clean and actual might be important for two reasons:
* outside contributors will be more patient for long delays in reviews when they understand the actual number of persons who are able to give a review;
* active maintainers will be more motivated to provide their reviews and feel greater responsibility for in time replies when they see only a couple of persons among assigned reviewers for a particular PR or that there is no "backup" reviewer for that code changes at all.

However, active maintainers can still ping these removed from the file persons manually in special cases according to this ["person - code area" mapping](https://lightgbm.readthedocs.io/en/latest/FAQ.html#critical-issues).