### PR TITLE
WIP: [ci] switch to r-devel in Solaris builds (fixes #5216)

### DIFF
--- a/.ci/test_r_package_solaris.sh
+++ b/.ci/test_r_package_solaris.sh
@@ -7,9 +7,11 @@ apt-get install --no-install-recommends -y \
 
 # installation of dependencies needs to happen before building the package,
 # since `R CMD build` needs to install the package to build vignettes
-Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'Matrix', 'RhpcBLASctl', 'rmarkdown', 'rhub', 'testthat'), dependencies = c('Depends', 'Imports', 'LinkingTo'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())" || exit -1
+RDscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'Matrix', 'RhpcBLASctl', 'rmarkdown', 'rhub', 'testthat'), dependencies = c('Depends', 'Imports', 'LinkingTo'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())" || exit -1
 
-sh build-cran-package.sh || exit -1
+sh build-cran-package.sh \
+    --r-executable=RDvalgrind \
+    || exit -1
 
 log_file="rhub_logs.txt"
-Rscript ./.ci/run_rhub_solaris_checks.R lightgbm_*.tar.gz $log_file || exit -1
+RDscript ./.ci/run_rhub_solaris_checks.R lightgbm_*.tar.gz $log_file || exit -1

--- a/.ci/test_r_package_solaris.sh
+++ b/.ci/test_r_package_solaris.sh
@@ -10,7 +10,7 @@ apt-get install --no-install-recommends -y \
 RDscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'Matrix', 'RhpcBLASctl', 'rmarkdown', 'rhub', 'testthat'), dependencies = c('Depends', 'Imports', 'LinkingTo'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())" || exit -1
 
 sh build-cran-package.sh \
-    --r-executable=RDvalgrind \
+    --r-executable=RD \
     || exit -1
 
 log_file="rhub_logs.txt"


### PR DESCRIPTION
Fixes #5216.

Proposes using `RDscript` instead of `Rscript` when building the R package prior to uploading it to R Hub.

### Notes for Reviewers

As mentioned in https://github.com/microsoft/LightGBM/issues/5216#issuecomment-1127158605, I've opened an issue in https://github.com/wch/r-debug asking about the choice of `RDscript` vs. `Rscript` in that image. At least for now, though, I think this PR should be merged if if fixes the Solaris CI builds, to unblock development on #5159 (and the rest of the repo).