### PR TITLE
[R-package] remove Solaris reference in test message

### DIFF
--- a/R-package/tests/testthat/test_learning_to_rank.R
+++ b/R-package/tests/testthat/test_learning_to_rank.R
@@ -60,7 +60,7 @@ test_that("learning-to-rank with lgb.train() works as expected", {
 test_that("learning-to-rank with lgb.cv() works as expected", {
     testthat::skip_if(
         ON_32_BIT_WINDOWS
-        , message = "Skipping on Solaris and 32-bit Windows"
+        , message = "Skipping on 32-bit Windows"
     )
     set.seed(708L)
     data(agaricus.train, package = "lightgbm")


### PR DESCRIPTION
Implements the proposed change from https://github.com/microsoft/LightGBM/pull/5226#discussion_r878774239, removing a reference to Solaris in a message about why a test in the R package is being skipped.

### Notes for Reviewers

The CI for this may fail until #5230 is merged.