### PR TITLE
[R-package] remove semicolon in R code

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -719,8 +719,9 @@ Booster <- R6::R6Class(
         res <- feval(private$inner_predict(data_idx), data)
 
         if (is.null(res$name) || is.null(res$value) ||  is.null(res$higher_better)) {
-          stop("lgb.Booster.eval: custom eval function should return a
-            list with attribute (name, value, higher_better)");
+          stop(
+            "lgb.Booster.eval: custom eval function should return a list with attribute (name, value, higher_better)"
+          )
         }
 
         # Append names and evaluation


### PR DESCRIPTION
Contributes to #5228.

Fixes the following linting issue found by the upcoming v3.0.0 of `{lintr}`:

```text
LightGBM/R-package/R/lgb.Booster.R:723:63: style: Trailing semicolons are not needed.
            list with attribute (name, value, higher_better)");
                                                              ^
```