### PR TITLE
[R-package] standardize style for placement of braces

### DIFF
--- a/R-package/R/lgb.convert_with_rules.R
+++ b/R-package/R/lgb.convert_with_rules.R
@@ -4,7 +4,9 @@
     return(
         vapply(
             X = df
-            , FUN = function(x) {paste0(class(x), collapse = ",")}
+            , FUN = function(x) {
+                paste0(class(x), collapse = ",")
+            }
             , FUN.VALUE = character(1L)
         )
     )
@@ -40,8 +42,12 @@
     return(invisible(NULL))
 }
 
-.LGB_CONVERT_DEFAULT_FOR_LOGICAL_NA <- function() {return(-1L)}
-.LGB_CONVERT_DEFAULT_FOR_NON_LOGICAL_NA <- function() {return(0L)}
+.LGB_CONVERT_DEFAULT_FOR_LOGICAL_NA <- function() {
+    return(-1L)
+}
+.LGB_CONVERT_DEFAULT_FOR_NON_LOGICAL_NA <- function() {
+    return(0L)
+}
 
 
 #' @name lgb.convert_with_rules

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -69,7 +69,13 @@ lgb.check_interaction_constraints <- function(interaction_constraints, column_na
     if (!methods::is(interaction_constraints, "list")) {
         stop("interaction_constraints must be a list")
     }
-    if (!all(sapply(interaction_constraints, function(x) {is.character(x) || is.numeric(x)}))) {
+    constraint_is_character_or_numeric <- sapply(
+        X = interaction_constraints
+        , FUN = function(x) {
+            return(is.character(x) || is.numeric(x))
+        }
+    )
+    if (!all(constraint_is_character_or_numeric)) {
         stop("every element in interaction_constraints must be a character vector or numeric vector")
     }
 

--- a/R-package/tests/testthat/test_learning_to_rank.R
+++ b/R-package/tests/testthat/test_learning_to_rank.R
@@ -49,7 +49,15 @@ test_that("learning-to-rank with lgb.train() works as expected", {
         expect_true(result[["higher_better"]])
         expect_identical(result[["data_name"]], "training")
     }
-    expect_identical(sapply(eval_results, function(x) {x$name}), eval_names)
+    expect_identical(
+        sapply(
+            X = eval_results
+            , FUN = function(x) {
+                x$name
+            }
+        )
+        , eval_names
+    )
     expect_equal(eval_results[[1L]][["value"]], 0.775)
     if (!ON_32_BIT_WINDOWS) {
         expect_true(abs(eval_results[[2L]][["value"]] - 0.745986) < TOLERANCE)

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -1203,7 +1203,9 @@ test_that("boosters with linear models at leaves work with saveRDS.lgb.Booster a
     rm(bst)
 
     # load the booster and make predictions...should be the same
-    expect_warning({bst2 <- readRDS.lgb.Booster(file = model_file)})
+    expect_warning({
+        bst2 <- readRDS.lgb.Booster(file = model_file)
+    })
     preds2 <- predict(bst2, X)
     expect_identical(preds, preds2)
 })


### PR DESCRIPTION
In preparation for the release of `{lintr}` 3.0.0 (#5228), this PR proposes changes to the placement of braces in the project's R code.

Without these changes, `{lintr}` 3.0.0 will return the following findings:

```text
LightGBM/R-package/R/lgb.convert_with_rules.R:7:33: style: Opening curly braces should never go on their own line and should always be followed by a new line.
            , FUN = function(x) {paste0(class(x), collapse = ",")}
                                ^
LightGBM/R-package/R/lgb.convert_with_rules.R:7:66: style: Closing curly-braces should always be on their own line, unless they are followed by an else.
            , FUN = function(x) {paste0(class(x), collapse = ",")}
                                                                 ^
LightGBM/R-package/R/lgb.convert_with_rules.R:43:51: style: Opening curly braces should never go on their own line and should always be followed by a new line.
.LGB_CONVERT_DEFAULT_FOR_LOGICAL_NA <- function() {return(-1L)}
                                                  ^
LightGBM/R-package/R/lgb.convert_with_rules.R:43:63: style: Closing curly-braces should always be on their own line, unless they are followed by an else.
.LGB_CONVERT_DEFAULT_FOR_LOGICAL_NA <- function() {return(-1L)}
                                                              ^
LightGBM/R-package/R/lgb.convert_with_rules.R:44:55: style: Opening curly braces should never go on their own line and should always be followed by a new line.
.LGB_CONVERT_DEFAULT_FOR_NON_LOGICAL_NA <- function() {return(0L)}
                                                      ^
LightGBM/R-package/R/lgb.convert_with_rules.R:44:66: style: Closing curly-braces should always be on their own line, unless they are followed by an else.
.LGB_CONVERT_DEFAULT_FOR_NON_LOGICAL_NA <- function() {return(0L)}
                                                                 ^
LightGBM/R-package/R/utils.R:72:58: style: Opening curly braces should never go on their own line and should always be followed by a new line.
    if (!all(sapply(interaction_constraints, function(x) {is.character(x) || is.numeric(x)}))) {
                                                         ^
LightGBM/R-package/tests/testthat/test_learning_to_rank.R:52:55: style: Opening curly braces should never go on their own line and should always be followed by a new line.
    expect_identical(sapply(eval_results, function(x) {x$name}), eval_names)
                                                      ^
LightGBM/R-package/tests/testthat/test_lgb.Booster.R:1206:20: style: Opening curly braces should never go on their own line and should always be followed by a new line.
    expect_warning({bst2 <- readRDS.lgb.Booster(file = model_file)})
```