### PR TITLE
[R-package] address linter warnings about portable paths

### DIFF
--- a/R-package/inst/make-r-def.R
+++ b/R-package/inst/make-r-def.R
@@ -71,7 +71,7 @@ invisible(file.remove(OBJDUMP_FILE))
 # see https://www.cs.colorado.edu/~main/cs1300/doc/mingwfaq.html
 start_index <- which(
     grepl(
-        pattern = "[Ordinal/Name Pointer] Table"
+        pattern = "[Ordinal/Name Pointer] Table"  # nolint
         , x = objdump_results
         , fixed = TRUE
     )

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -23,6 +23,11 @@ if (!(R_int_UUID == "0310d4b8-ccb1-4bb8-ba94-d36a55f60262"
   warning("Warning: unmatched R_INTERNALS_UUID, may not run normally.")
 }
 
+# Get some paths
+source_dir <- file.path(R_PACKAGE_SOURCE, "src", fsep = "/")
+build_dir <- file.path(source_dir, "build", fsep = "/")
+inst_dir <- file.path(R_PACKAGE_SOURCE, "inst", fsep = "/")
+
 # system() will not raise an R exception if the process called
 # fails. Wrapping it here to get that behavior.
 #
@@ -96,17 +101,13 @@ if (!(R_int_UUID == "0310d4b8-ccb1-4bb8-ba94-d36a55f60262"
 
 # Move in CMakeLists.txt
 write_succeeded <- file.copy(
-  "../inst/bin/CMakeLists.txt"
+  file.path(inst_dir, "bin", "CMakeLists.txt")
   , "CMakeLists.txt"
   , overwrite = TRUE
 )
 if (!write_succeeded) {
   stop("Copying CMakeLists.txt failed")
 }
-
-# Get some paths
-source_dir <- file.path(R_PACKAGE_SOURCE, "src", fsep = "/")
-build_dir <- file.path(source_dir, "build", fsep = "/")
 
 # Prepare building package
 dir.create(
@@ -122,7 +123,7 @@ use_visual_studio <- !(use_mingw || use_msys2)
 # to create R.def from R.dll
 if (WINDOWS && use_visual_studio) {
   write_succeeded <- file.copy(
-    "../../inst/make-r-def.R"
+    file.path(inst_dir, "make-r-def.R")
     , file.path(build_dir, "make-r-def.R")
     , overwrite = TRUE
   )

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -2425,7 +2425,7 @@ test_that("lgb.train() fit on linearly-relatead data improves when using linear 
 })
 
 
-test_that("lgb.train() w/ linear learner fails already-constructed dataset with linear=false", {
+test_that("lgb.train() with linear learner fails already-constructed dataset with linear=false", {
   set.seed(708L)
   params <- list(
     objective = "regression"


### PR DESCRIPTION
Contributes to #5228.

Resolves the remaining linter warnings that would be raised by `{lintr}` 3.0.0 once it's released (https://github.com/microsoft/LightGBM/issues/5228#issuecomment-1140355470).

```text
[1] Total linting issues found: 4
[[1]]
/Users/jlamb/repos/LightGBM/R-package/inst/make-r-def.R:74:20: warning: Use file.path() to construct portable file paths.
        pattern = "[Ordinal/Name Pointer] Table"
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~

[[2]]
/Users/jlamb/repos/LightGBM/R-package/src/install.libs.R:99:4: warning: Use file.path() to construct portable file paths.
  "../inst/bin/CMakeLists.txt"
   ^~~~~~~~~~~~~~~~~~~~~~~~~~

[[3]]
/Users/jlamb/repos/LightGBM/R-package/src/install.libs.R:125:6: warning: Use file.path() to construct portable file paths.
    "../../inst/make-r-def.R"
     ^~~~~~~~~~~~~~~~~~~~~~~

[[4]]
/Users/jlamb/repos/LightGBM/R-package/tests/testthat/test_basic.R:2428:12: warning: Use file.path() to construct portable file paths.
test_that("lgb.train() w/ linear learner fails already-constructed dataset with linear=false", {
           ^~
```