### PR TITLE
[R-package] [ci] silence more logs in tests (fixes #4862)

### DIFF
--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -561,13 +561,15 @@ test_that("lgb.cv() raises an informative error for unrecognized objectives", {
     , label = train$label
   )
   expect_error({
-    bst <- lgb.cv(
-      data = dtrain
-      , params = list(
-        objective_type = "not_a_real_objective"
-        , verbosity = VERBOSITY
+    capture.output({
+      bst <- lgb.cv(
+        data = dtrain
+        , params = list(
+          objective_type = "not_a_real_objective"
+          , verbosity = VERBOSITY
+        )
       )
-    )
+    }, type = "message")
   }, regexp = "Unknown objective type name: not_a_real_objective")
 })
 
@@ -723,13 +725,15 @@ test_that("lgb.train() raises an informative error for unrecognized objectives",
     , label = train$label
   )
   expect_error({
-    bst <- lgb.train(
-      data = dtrain
-      , params = list(
-        objective_type = "not_a_real_objective"
-        , verbosity = VERBOSITY
+    capture.output({
+      bst <- lgb.train(
+        data = dtrain
+        , params = list(
+          objective_type = "not_a_real_objective"
+          , verbosity = VERBOSITY
+        )
       )
-    )
+    }, type = "message")
   }, regexp = "Unknown objective type name: not_a_real_objective")
 })
 
@@ -2441,11 +2445,13 @@ test_that("lgb.train() w/ linear learner fails already-constructed dataset with 
   )
   dtrain$construct()
   expect_error({
-    bst_linear <- lgb.train(
-      data = dtrain
-      , nrounds = 10L
-      , params = utils::modifyList(params, list(linear_tree = TRUE))
-    )
+    capture.output({
+      bst_linear <- lgb.train(
+        data = dtrain
+        , nrounds = 10L
+        , params = utils::modifyList(params, list(linear_tree = TRUE))
+      )
+    }, type = "message")
   }, regexp = "Cannot change linear_tree after constructed Dataset handle")
 })
 

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -226,7 +226,9 @@ test_that("cpp errors should be raised as proper R errors", {
     , init_score = seq_len(10L)
   )
   expect_error({
-    dtrain$construct()
+    capture.output({
+      dtrain$construct()
+    }, type = "message")
   }, regexp = "Initial score size doesn't match data size")
 })
 

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -749,7 +749,11 @@ test_that("Saving a model with unknown importance type fails", {
 
     UNSUPPORTED_IMPORTANCE <- 2L
     expect_error({
-        model_string <- bst$save_model_to_string(feature_importance_type = UNSUPPORTED_IMPORTANCE)
+        capture.output({
+          model_string <- bst$save_model_to_string(
+            feature_importance_type = UNSUPPORTED_IMPORTANCE
+          )
+        }, type = "message")
     }, "Unknown importance type")
 })
 
@@ -964,10 +968,12 @@ test_that("Booster$new() raises informative errors for malformed inputs", {
 
   # unrecognized objective
   expect_error({
-    Booster$new(
-      params = list(objective = "not_a_real_objective")
-      , train_set = dtrain
-    )
+    capture.output({
+      Booster$new(
+        params = list(objective = "not_a_real_objective")
+        , train_set = dtrain
+      )
+    }, type = "message")
   }, regexp = "Unknown objective type name: not_a_real_objective")
 
   # train_set is not a Dataset
@@ -986,10 +992,12 @@ test_that("Booster$new() raises informative errors for malformed inputs", {
 
   # model file doesn't exist
   expect_error({
-    Booster$new(
-      params = list()
-      , modelfile = "file-that-does-not-exist.model"
-    )
+    capture.output({
+      Booster$new(
+        params = list()
+        , modelfile = "file-that-does-not-exist.model"
+      )
+    }, type = "message")
   }, regexp = "Could not open file-that-does-not-exist.model")
 
   # model file doesn't contain a valid LightGBM model
@@ -999,18 +1007,22 @@ test_that("Booster$new() raises informative errors for malformed inputs", {
     , con = model_file
   )
   expect_error({
-    Booster$new(
-      params = list()
-      , modelfile = model_file
-    )
+    capture.output({
+      Booster$new(
+        params = list()
+        , modelfile = model_file
+      )
+    }, type = "message")
   }, regexp = "Unknown model format or submodel type in model file")
 
   # malformed model string
   expect_error({
-    Booster$new(
-      params = list()
-      , model_str = "a\nb\n"
-    )
+    capture.output({
+      Booster$new(
+        params = list()
+        , model_str = "a\nb\n"
+      )
+    }, type = "message")
   }, regexp = "Model file doesn't specify the number of classes")
 
   # model string isn't character or raw


### PR DESCRIPTION
Fixes #4862.

This removes the last remaining log lines from the R tests (other than dots for test statuses).

As described in https://github.com/microsoft/LightGBM/pull/5237#issuecomment-1136142589, when LightGBM's C++ code calls `Log::Fatal()`, the same log message comes through stderr twice:

1. as a log message printed with `REprintf()`
2. as an R exception

<img width="856" alt="image" src="https://user-images.githubusercontent.com/7608904/170850123-26ea4a8e-e59b-4151-935d-3f5c3fec9e73.png">

I think it makes sense to have both, so that if user code try-catches `{lightgbm}` stuff, suppressing those exceptions, they'll still at least see a log message indicating that the exception happened.

This PR proposes just using `capture.output()` in the R package's tests to keep those logs out of the test output.