### PR TITLE
[R-package] [docs] upgrade docs to roxygen2==7.2.0

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -63,4 +63,4 @@ Imports:
     utils
 SystemRequirements:
     C++11
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -12,7 +12,7 @@ dependencies:
   - r-matrix=1.4_0
   - r-pkgdown=1.6.1
   - r-rmarkdown=2.11
-  - r-roxygen2=7.1.2
+  - r-roxygen2=7.2.0
   - scikit-learn
   - sphinx
   - "sphinx_rtd_theme>=0.5"


### PR DESCRIPTION
Contributes to #3763.

`{roxygen2}` v 7.2.0 was released 16 days ago (https://cran.r-project.org/web/packages/roxygen2/index.html). This project currently uses v7.1.2.

This PR proposes updating the R package's documentation to use the newest version of `{roxygen2}`.

I regenerated the R package's documentation by running the following.

```shell
# install latest roxygen2 locally
Rscript -e "install.packages('roxygen2', repos = 'https://cran.r-project.org')"

# rebuild docs
sh build-cran-package.sh --no-build-vignettes
R CMD INSTALL --with-keep.source ./lightgbm_3.3.2.tar.gz
cd R-package/
Rscript -e "roxygen2::roxygenize(load = 'installed')"
```

### Notes for Reviewers

I didn't see this item listed in #3763, so I edited the description there today to include it.

@StrikerRUS could you temporarily enable readthedocs builds for this branch so we can check that this change will work there?