### PR TITLE
[c++][fix] check nullable of bin mappers in dataset_loader.cpp (fix #5221)

### DIFF
--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -1472,7 +1472,7 @@ void DatasetLoader::CheckCategoricalFeatureNumBin(
   if (bin_mappers.size() < 1024) {
     for (size_t i = 0; i < bin_mappers.size(); ++i) {
       const int max_bin_for_this_feature = max_bin_by_feature.empty() ? max_bin : max_bin_by_feature[i];
-      if (bin_mappers[i]->bin_type() == BinType::CategoricalBin && bin_mappers[i]->num_bin() > max_bin_for_this_feature) {
+      if (bin_mappers[i] != nullptr && bin_mappers[i]->bin_type() == BinType::CategoricalBin && bin_mappers[i]->num_bin() > max_bin_for_this_feature) {
         need_warning = true;
         break;
       }


### PR DESCRIPTION
This is to fix #5221. Nullable of `bin_mappers[i]` should be checked. This is a bug introduced by PR #4448 amd was ignored by the fix #5145. Thanks @vollis for finding this out!