### PR TITLE
[docs] Update broken links in docs

### DIFF
--- a/docs/GPU-Windows.rst
+++ b/docs/GPU-Windows.rst
@@ -598,13 +598,13 @@ And open an issue in GitHub `here`_ with that log.
 
 .. _Khronos official OpenCL headers: https://github.com/KhronosGroup/OpenCL-Headers
 
-.. _this: http://iweb.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe
+.. _this: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe/download
 
 .. _Boost: https://www.boost.org/users/history/
 
-.. _Prebuilt Boost x86_64: https://mirror.linux-ia64.org/fedora/linux/releases/32/Everything/x86_64/os/Packages/m/mingw64-boost-static-1.66.0-6.fc32.noarch.rpm
+.. _Prebuilt Boost x86_64: https://www.rpmfind.net/linux/fedora/linux/development/rawhide/Everything/x86_64/os/Packages/m/mingw64-boost-static-1.75.0-7.fc37.noarch.rpm
 
-.. _Prebuilt Boost i686: https://mirror.linux-ia64.org/fedora/linux/releases/32/Everything/x86_64/os/Packages/m/mingw32-boost-static-1.66.0-6.fc32.noarch.rpm
+.. _Prebuilt Boost i686: https://www.rpmfind.net/linux/fedora/linux/development/rawhide/Everything/x86_64/os/Packages/m/mingw32-boost-static-1.75.0-7.fc37.noarch.rpm
 
 .. _7zip: https://www.7-zip.org/download.html
 


### PR DESCRIPTION
https://github.com/microsoft/LightGBM/runs/6736962389?check_suite_focus=true
```
URL        `http://iweb.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe'
Name       `this'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/GPU-Windows.html, line 149, col 47
Real URL   http://iweb.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe
Check time 120.214 seconds
Result     Error: ConnectionError: HTTPConnectionPool(host='iweb.dl.sourceforge.net', port=80): Max retries exceeded with url: /project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe (Caused by NewCon...
URL        `https://mirror.linux-ia64.org/fedora/linux/releases/32/Everything/x86_64/os/Packages/m/mingw64-boost-static-1.66.0-6.fc32.noarch.rpm'
Name       `Prebuilt Boost x86_64'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/GPU-Windows.html, line 175, col 14
Real URL   https://mirror.linux-ia64.org/fedora/linux/releases/32/Everything/x86_64/os/Packages/m/mingw64-boost-static-1.66.0-6.fc32.noarch.rpm
Check time 1.325 seconds
Result     Error: 404 Not Found
URL        `https://mirror.linux-ia64.org/fedora/linux/releases/32/Everything/x86_64/os/Packages/m/mingw32-boost-static-1.66.0-6.fc32.noarch.rpm'
Name       `Prebuilt Boost i686'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/GPU-Windows.html, line 175, col 213
Real URL   https://mirror.linux-ia64.org/fedora/linux/releases/32/Everything/x86_64/os/Packages/m/mingw32-boost-static-1.66.0-6.fc32.noarch.rpm
Check time 2.091 seconds
Result     Error: 404 Not Found
```