### PR TITLE
[tests][python] Make test that checks original pandas data isn't modified more strict

### DIFF
--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -654,12 +654,11 @@ def test_no_copy_when_single_float_dtype_dataframe(dtype, feature_name):
     assert np.shares_memory(X, built_data)
 
 
-@pytest.mark.parametrize('feature_name', [[42], 'auto'])
+@pytest.mark.parametrize('feature_name', [['x1'], [42], 'auto'])
 def test_categorical_code_conversion_doesnt_modify_original_data(feature_name):
     pd = pytest.importorskip('pandas')
     X = np.random.choice(['a', 'b'], 100).reshape(-1, 1)
-    column_name = 42  # use int as name
-    assert [column_name] == feature_name or feature_name == 'auto'
+    column_name = 'a' if feature_name == 'auto' else feature_name[0]
     df = pd.DataFrame(X.copy(), columns=[column_name], dtype='category')
     data = lgb.basic._data_from_pandas(df, feature_name, None, None)[0]
     # check that the original data wasn't modified

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -654,16 +654,18 @@ def test_no_copy_when_single_float_dtype_dataframe(dtype, feature_name):
     assert np.shares_memory(X, built_data)
 
 
-@pytest.mark.parametrize('feature_name', [['x1'], 'auto'])
+@pytest.mark.parametrize('feature_name', [[42], 'auto'])
 def test_categorical_code_conversion_doesnt_modify_original_data(feature_name):
     pd = pytest.importorskip('pandas')
     X = np.random.choice(['a', 'b'], 100).reshape(-1, 1)
-    df = pd.DataFrame(X.copy(), columns=['x1'], dtype='category')
+    column_name = 42  # use int as name
+    assert [column_name] == feature_name or feature_name == 'auto'
+    df = pd.DataFrame(X.copy(), columns=[column_name], dtype='category')
     data = lgb.basic._data_from_pandas(df, feature_name, None, None)[0]
     # check that the original data wasn't modified
-    np.testing.assert_equal(df['x1'], X[:, 0])
+    np.testing.assert_equal(df[column_name], X[:, 0])
     # check that the built data has the codes
-    np.testing.assert_equal(df['x1'].cat.codes, data[:, 0])
+    np.testing.assert_equal(df[column_name].cat.codes, data[:, 0])
 
 
 @pytest.mark.parametrize('min_data_in_bin', [2, 10])


### PR DESCRIPTION
Sorry, should have proposed that in #5254.

Check that `_data_from_pandas()` doesn't modify column names (doesn't convert int to string) of original data.
Refer to https://github.com/microsoft/LightGBM/pull/5254#pullrequestreview-989794258.