### PR TITLE
[R-package] [docs] document difference between lightgbm() and lgb.train() (fixes #5203)

### DIFF
--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -1,6 +1,8 @@
 #' @name lgb.train
 #' @title Main training logic for LightGBM
-#' @description Logic to train with LightGBM
+#' @description Low-level R interface to train a LightGBM model. Unlike \code{\link{lightgbm}},
+#'              this function is focused on performance (e.g. speed, memory efficiency). It is also
+#'              less likely to have breaking API changes in new releases than \code{\link{lightgbm}}.
 #' @inheritParams lgb_shared_params
 #' @param valids a list of \code{lgb.Dataset} objects, used for validation
 #' @param record Boolean, TRUE will record iteration message to \code{booster$record_evals}

--- a/R-package/R/lightgbm.R
+++ b/R-package/R/lightgbm.R
@@ -92,7 +92,7 @@ NULL
 #' @description High-level R interface to train a LightGBM model. Unlike \code{\link{lgb.train}}, this function
 #'              is focused on compatibility with other statistics and machine learning interfaces in R.
 #'              This focus on compatibility means that this interface may experience more frequent breaking API changes
-#'              than \code{link{lgb.train}}.
+#'              than \code{\link{lgb.train}}.
 #'              For efficiency-sensitive applications, or for applications where breaking API changes across releases
 #'              is very expensive, use \code{\link{lgb.train}}.
 #' @inheritParams lgb_shared_params

--- a/R-package/R/lightgbm.R
+++ b/R-package/R/lightgbm.R
@@ -89,7 +89,11 @@ NULL
 
 #' @name lightgbm
 #' @title Train a LightGBM model
-#' @description Simple interface for training a LightGBM model.
+#' @description High-level R interface to train a LightGBM model. Unlike \code{\link{lgb.train}}, this function
+#'              is focused on compatibility with other statistics and machine learning interfaces in R.
+#'              It is optimized for compatibility and usability, sometimes at the expense of efficiency or API stability.
+#'              For efficiency-sensitive applications, or for applications where breaking API changes across releases
+#'              is very expensive, use \code{\link{lgb.train}}.
 #' @inheritParams lgb_shared_params
 #' @param label Vector of labels, used if \code{data} is not an \code{\link{lgb.Dataset}}
 #' @param weights Sample / observation weights for rows in the input data. If \code{NULL}, will assume that all

--- a/R-package/R/lightgbm.R
+++ b/R-package/R/lightgbm.R
@@ -91,7 +91,8 @@ NULL
 #' @title Train a LightGBM model
 #' @description High-level R interface to train a LightGBM model. Unlike \code{\link{lgb.train}}, this function
 #'              is focused on compatibility with other statistics and machine learning interfaces in R.
-#'              It is optimized for compatibility and usability, sometimes at the expense of efficiency or API stability.
+#'              This focus on compatibility means that this interface may experience more frequent breaking API changes
+#'              than \code{link{lgb.train}}.
 #'              For efficiency-sensitive applications, or for applications where breaking API changes across releases
 #'              is very expensive, use \code{\link{lgb.train}}.
 #' @inheritParams lgb_shared_params

--- a/R-package/man/lgb.train.Rd
+++ b/R-package/man/lgb.train.Rd
@@ -107,7 +107,9 @@ original datasets}
 a trained booster model \code{lgb.Booster}.
 }
 \description{
-Logic to train with LightGBM
+Low-level R interface to train a LightGBM model. Unlike \code{\link{lightgbm}},
+             this function is focused on performance (e.g. speed, memory efficiency). It is also
+             less likely to have breaking API changes in new releases than \code{\link{lightgbm}}.
 }
 \section{Early Stopping}{
 

--- a/R-package/man/lightgbm.Rd
+++ b/R-package/man/lightgbm.Rd
@@ -102,7 +102,7 @@ a trained \code{lgb.Booster}
 High-level R interface to train a LightGBM model. Unlike \code{\link{lgb.train}}, this function
              is focused on compatibility with other statistics and machine learning interfaces in R.
              This focus on compatibility means that this interface may experience more frequent breaking API changes
-             than \code{link{lgb.train}}.
+             than \code{\link{lgb.train}}.
              For efficiency-sensitive applications, or for applications where breaking API changes across releases
              is very expensive, use \code{\link{lgb.train}}.
 }

--- a/R-package/man/lightgbm.Rd
+++ b/R-package/man/lightgbm.Rd
@@ -101,7 +101,8 @@ a trained \code{lgb.Booster}
 \description{
 High-level R interface to train a LightGBM model. Unlike \code{\link{lgb.train}}, this function
              is focused on compatibility with other statistics and machine learning interfaces in R.
-             It is optimized for compatibility and usability, sometimes at the expense of efficiency or API stability.
+             This focus on compatibility means that this interface may experience more frequent breaking API changes
+             than \code{link{lgb.train}}.
              For efficiency-sensitive applications, or for applications where breaking API changes across releases
              is very expensive, use \code{\link{lgb.train}}.
 }

--- a/R-package/man/lightgbm.Rd
+++ b/R-package/man/lightgbm.Rd
@@ -99,7 +99,11 @@ the "objective" item of the "Parameters" section of the documentation}.}
 a trained \code{lgb.Booster}
 }
 \description{
-Simple interface for training a LightGBM model.
+High-level R interface to train a LightGBM model. Unlike \code{\link{lgb.train}}, this function
+             is focused on compatibility with other statistics and machine learning interfaces in R.
+             It is optimized for compatibility and usability, sometimes at the expense of efficiency or API stability.
+             For efficiency-sensitive applications, or for applications where breaking API changes across releases
+             is very expensive, use \code{\link{lgb.train}}.
 }
 \section{Early Stopping}{
 


### PR DESCRIPTION
Fixes #5203.

This PR proposes making the explanation in https://github.com/microsoft/LightGBM/issues/5203#issuecomment-1124502018 explicit in the R package's documentation.

### Notes for Reviewers

The main *functional* change proposed in #5203 (decoupling `verbosity` and validation sets in `lightgbm::lightgbm()`) was implemented in #5209.