### PR TITLE
[ci] Run Linux OpenCL tests against POCL instead of the AMD App SDK

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -71,14 +71,21 @@ else  # Linux
         sudo apt-get install --no-install-recommends -y \
             libboost1.74-dev \
             ocl-icd-opencl-dev
-        cd $BUILD_DIRECTORY  # to avoid permission errors
-        curl -sL -o AMD-APP-SDKInstaller.tar.bz2 https://github.com/microsoft/LightGBM/releases/download/v2.0.12/AMD-APP-SDKInstaller-v3.0.130.136-GA-linux64.tar.bz2
-        tar -xjf AMD-APP-SDKInstaller.tar.bz2
-        mkdir -p $OPENCL_VENDOR_PATH
-        mkdir -p $AMDAPPSDK_PATH
-        sh AMD-APP-SDK*.sh --tar -xf -C $AMDAPPSDK_PATH
-        mv $AMDAPPSDK_PATH/lib/x86_64/sdk/* $AMDAPPSDK_PATH/lib/x86_64/
-        echo libamdocl64.so > $OPENCL_VENDOR_PATH/amdocl64.icd
+        if [[ $IN_UBUNTU_LATEST_CONTAINER == "true" ]]; then
+            sudo apt-get install --no-install-recommends -y \
+                pocl-opencl-icd
+        else
+            sudo apt-get install --no-install-recommends -y \
+                libhwloc-dev \
+                libtinfo-dev \
+                ocl-icd-dev \
+                pkg-config \
+                zlib1g-dev
+            git clone --depth 1 --branch v1.8 https://github.com/pocl/pocl.git
+            cmake -B pocl/build -S pocl -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-stdlib=libc++ -DPOCL_INSTALL_ICD_VENDORDIR=/etc/OpenCL/vendors -DPOCL_DEBUG_MESSAGES=OFF -DSTATIC_LLVM=ON -DINSTALL_OPENCL_HEADERS=OFF -DENABLE_SPIR=OFF -DENABLE_POCLCC=OFF -DENABLE_TESTS=OFF -DENABLE_EXAMPLES=OFF
+            cmake --build pocl/build -j 4
+            sudo cmake --install pocl/build
+        fi
     fi
     if [[ $TASK == "cuda" || $TASK == "cuda_exp" ]]; then
         echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -83,7 +83,7 @@ else  # Linux
                 zlib1g-dev
             git clone --depth 1 --branch v1.8 https://github.com/pocl/pocl.git
             cmake -B pocl/build -S pocl -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-stdlib=libc++ -DPOCL_INSTALL_ICD_VENDORDIR=/etc/OpenCL/vendors -DPOCL_DEBUG_MESSAGES=OFF -DSTATIC_LLVM=ON -DINSTALL_OPENCL_HEADERS=OFF -DENABLE_SPIR=OFF -DENABLE_POCLCC=OFF -DENABLE_TESTS=OFF -DENABLE_EXAMPLES=OFF
-            cmake --build pocl/build -j 4
+            cmake --build pocl/build -j4
             sudo cmake --install pocl/build
         fi
     fi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -179,16 +179,16 @@ if [[ $TASK == "gpu" ]]; then
     grep -q 'std::string device_type = "gpu"' $BUILD_DIRECTORY/include/LightGBM/config.h || exit -1  # make sure that changes were really done
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
-        pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--gpu --install-option="--opencl-include-dir=$AMDAPPSDK_PATH/include/" || exit -1
+        pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--gpu || exit -1
         pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
-        cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --gpu --opencl-include-dir="$AMDAPPSDK_PATH/include/" || exit -1
+        cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --gpu || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
         pytest $BUILD_DIRECTORY/tests || exit -1
         exit 0
     elif [[ $METHOD == "source" ]]; then
-        cmake -DUSE_GPU=ON -DOpenCL_INCLUDE_DIR=$AMDAPPSDK_PATH/include/ ..
+        cmake -DUSE_GPU=ON ..
     fi
 elif [[ $TASK == "cuda" || $TASK == "cuda_exp" ]]; then
     if [[ $TASK == "cuda" ]]; then

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -55,9 +55,7 @@ jobs:
       gpu_source:
         TASK: gpu
         METHOD: source
-        # on Ubuntu 14.04, gpu_source build segfaults with newer version of Python
-        # (and newer version of scipy as a consequence)
-        PYTHON_VERSION: '3.7'
+        PYTHON_VERSION: '3.9'
       swig:
         TASK: swig
   steps:
@@ -65,11 +63,6 @@ jobs:
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
       echo "##vso[task.setvariable variable=LGB_VER]$(head -n 1 VERSION.txt)"
       echo "##vso[task.prependpath]$CONDA/bin"
-      AMDAPPSDK_PATH=$BUILD_SOURCESDIRECTORY/AMDAPPSDK
-      echo "##vso[task.setvariable variable=AMDAPPSDK_PATH]$AMDAPPSDK_PATH"
-      LD_LIBRARY_PATH=$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH
-      echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$LD_LIBRARY_PATH"
-      echo "##vso[task.setvariable variable=OPENCL_VENDOR_PATH]$AMDAPPSDK_PATH/etc/OpenCL/vendors"
     displayName: 'Set variables'
   - script: |
       echo '$(Build.SourceVersion)' > '$(Build.ArtifactStagingDirectory)/commit.txt'
@@ -139,11 +132,6 @@ jobs:
       CONDA=$HOME/miniforge
       echo "##vso[task.setvariable variable=CONDA]$CONDA"
       echo "##vso[task.prependpath]$CONDA/bin"
-      AMDAPPSDK_PATH=$BUILD_SOURCESDIRECTORY/AMDAPPSDK
-      echo "##vso[task.setvariable variable=AMDAPPSDK_PATH]$AMDAPPSDK_PATH"
-      LD_LIBRARY_PATH=$AMDAPPSDK_PATH/lib/x86_64:$LD_LIBRARY_PATH
-      echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$LD_LIBRARY_PATH"
-      echo "##vso[task.setvariable variable=OPENCL_VENDOR_PATH]$AMDAPPSDK_PATH/etc/OpenCL/vendors"
     displayName: 'Set variables'
   # https://github.com/microsoft/azure-pipelines-agent/issues/2043#issuecomment-687983301
   - script: |

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -55,7 +55,6 @@ jobs:
       gpu_source:
         TASK: gpu
         METHOD: source
-        PYTHON_VERSION: '3.9'
       swig:
         TASK: swig
   steps:

--- a/docs/GPU-Targets.rst
+++ b/docs/GPU-Targets.rst
@@ -19,6 +19,8 @@ You can find below a table of correspondence:
 +---------------------------+-----------------+-----------------+-----------------+--------------+
 | AMD APP SDK \*            | Supported       | Not Supported   | Supported       | Not Supported|
 +---------------------------+-----------------+-----------------+-----------------+--------------+
+| `PoCL`_                   | Supported       | Not Supported   | Supported       | Not Supported|
++---------------------------+-----------------+-----------------+-----------------+--------------+
 | `NVIDIA CUDA Toolkit`_    | Not Supported   | Not Supported   | Not Supported   | Supported    |
 +---------------------------+-----------------+-----------------+-----------------+--------------+
 
@@ -168,3 +170,5 @@ Known issues:
 .. _clinfo: https://github.com/Oblomov/clinfo
 
 .. _GPUCapsViewer: http://www.ozone3d.net/gpu_caps_viewer/
+
+.. _PoCL: http://portablecl.org/


### PR DESCRIPTION
As discussed in https://github.com/microsoft/LightGBM/pull/5252#discussion_r892772322, I think that using [PoCL](http://portablecl.org) for the Linux `gpu` tests would make a lot of sense, as it is open source and actively maintained, as opposed to the AMD App SDK.

The `dask` tests are currently disabled for the `gpu` task, but they in my local testing the do succeed with PoCL. Should we maybe (re-)enable them?