### PR TITLE
[ci] Pin lintr to <3.0

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -75,7 +75,7 @@ if [[ $TASK == "lint" ]]; then
         mypy \
         pycodestyle \
         pydocstyle \
-        "r-lintr>=2.0"
+        "r-lintr>=2.0,<3.0"
     echo "Linting Python code"
     pycodestyle --ignore=E501,W503 --exclude=./.nuget,./external_libs . || exit -1
     pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^external_libs|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1


### PR DESCRIPTION
Lint jobs started to fail in the CI because a new version of `r-lintr` was released. This PR pins the version to be 2.x.