### PR TITLE
[ci] [R-package] upgrade to lintr v3.0 (fixes #5228)

### DIFF
--- a/.ci/lint_r_code.R
+++ b/.ci/lint_r_code.R
@@ -29,28 +29,26 @@ interactive_text <- paste0(
 )
 
 LINTERS_TO_USE <- list(
-    "absolute_path"          = lintr::absolute_path_linter
-    , "assignment"           = lintr::assignment_linter
-    , "closed_curly"         = lintr::closed_curly_linter
-    , "commas"               = lintr::commas_linter
-    , "equals_na"            = lintr::equals_na_linter
-    , "function_left"        = lintr::function_left_parentheses_linter
-    , "implicit_integers"    = lintr::implicit_integer_linter
-    , "infix_spaces"         = lintr::infix_spaces_linter
+    "absolute_path"          = lintr::absolute_path_linter()
+    , "assignment"           = lintr::assignment_linter()
+    , "braces"               = lintr::brace_linter()
+    , "commas"               = lintr::commas_linter()
+    , "equals_na"            = lintr::equals_na_linter()
+    , "function_left"        = lintr::function_left_parentheses_linter()
+    , "implicit_integers"    = lintr::implicit_integer_linter()
+    , "infix_spaces"         = lintr::infix_spaces_linter()
     , "long_lines"           = lintr::line_length_linter(length = 120L)
-    , "no_tabs"              = lintr::no_tab_linter
-    , "non_portable_path"    = lintr::nonportable_path_linter
-    , "open_curly"           = lintr::open_curly_linter
-    , "paren_brace_linter"   = lintr::paren_brace_linter
-    , "semicolon"            = lintr::semicolon_terminator_linter
-    , "seq"                  = lintr::seq_linter
-    , "single_quotes"        = lintr::single_quotes_linter
-    , "spaces_inside"        = lintr::spaces_inside_linter
-    , "spaces_left_parens"   = lintr::spaces_left_parentheses_linter
+    , "no_tabs"              = lintr::no_tab_linter()
+    , "non_portable_path"    = lintr::nonportable_path_linter()
+    , "semicolon"            = lintr::semicolon_linter()
+    , "seq"                  = lintr::seq_linter()
+    , "single_quotes"        = lintr::single_quotes_linter()
+    , "spaces_inside"        = lintr::spaces_inside_linter()
+    , "spaces_left_parens"   = lintr::spaces_left_parentheses_linter()
     , "todo_comments"        = lintr::todo_comment_linter(c("todo", "fixme", "to-do"))
-    , "trailing_blank"       = lintr::trailing_blank_lines_linter
-    , "trailing_white"       = lintr::trailing_whitespace_linter
-    , "true_false"           = lintr::T_and_F_symbol_linter
+    , "trailing_blank"       = lintr::trailing_blank_lines_linter()
+    , "trailing_white"       = lintr::trailing_whitespace_linter()
+    , "true_false"           = lintr::T_and_F_symbol_linter()
     , "undesirable_function" = lintr::undesirable_function_linter(
         fun = c(
             "cat" = "CRAN forbids the use of cat() in packages except in special cases. Use message() or warning()."
@@ -58,8 +56,8 @@ LINTERS_TO_USE <- list(
                 "cbind is an unsafe way to build up a data frame. merge() or direct "
                 , "column assignment is preferred."
             )
-            , "dyn.load" = "Directly loading/unloading .dll/.so files in package code should not be necessary."
-            , "dyn.unload" = "Directly loading/unloading .dll/.so files in package code should not be necessary."
+            , "dyn.load" = "Directly loading or unloading .dll or .so files in package code should not be necessary."
+            , "dyn.unload" = "Directly loading or unloading .dll or .so files in package code should not be necessary."
             , "help" = interactive_text
             , "ifelse" = "The use of ifelse() is dangerous because it will silently allow mixing types."
             , "install.packages" = interactive_text
@@ -83,7 +81,7 @@ LINTERS_TO_USE <- list(
             , "??" = interactive_text
         )
     )
-    , "unneeded_concatenation" = lintr::unneeded_concatenation_linter
+    , "unneeded_concatenation" = lintr::unneeded_concatenation_linter()
 )
 
 noquote(paste0(length(FILES_TO_LINT), " R files need linting"))

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -75,7 +75,7 @@ if [[ $TASK == "lint" ]]; then
         mypy \
         pycodestyle \
         pydocstyle \
-        "r-lintr>=2.0,<3.0"
+        "r-lintr>=3.0"
     echo "Linting Python code"
     pycodestyle --ignore=E501,W503 --exclude=./.nuget,./external_libs . || exit -1
     pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^external_libs|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1

--- a/build_r.R
+++ b/build_r.R
@@ -24,7 +24,7 @@ TEMP_SOURCE_DIR <- file.path(TEMP_R_DIR, "src")
     , "make_args" = character(0L)
   )
   for (arg in args) {
-    if (any(grepl("^\\-j[0-9]+", arg))) {
+    if (any(grepl("^\\-j[0-9]+", arg))) {  # nolint: non_portable_path
         out_list[["make_args"]] <- arg
     } else if (any(grepl("=", arg))) {
       split_arg <- strsplit(arg, "=")[[1L]]


### PR DESCRIPTION
Fixes #5228.
Reverts #5290.

`{lintr}` v3.0.0 was released to CRAN a few days ago (https://cran.r-project.org/web/packages/lintr/index.html). This PR proposes updates to the `lint` CI job to make LightGBM's CI compatible with that new version.

### Changes in this PR

Converts linters to function calls instead of function references (see https://github.com/microsoft/LightGBM/issues/5228#issuecomment-1133823114 for background).

Replaces some linters to resolve the following warnings.

```text
Warning messages:
1: Linter closed_curly_linter was deprecated in lintr version 3.0.0. Use brace_linter instead.
2: Linter open_curly_linter was deprecated in lintr version 3.0.0. Use brace_linter instead.
3: Linter paren_brace_linter was deprecated in lintr version 3.0.0. Use brace_linter instead.
4: Linter semicolon_terminator_linter was deprecated in lintr version 3.0.0. Use semicolon_linter instead.
```

Makes minor changes to resolve the following linting errors.

```text
[[1]]
.ci/lint_r_code.R:59:29: warning: [non_portable_path] Use file.path() to construct portable file paths.
            , "dyn.load" = "Directly loading/unloading .dll/.so files in package code should not be necessary."
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[[2]]
.ci/lint_r_code.R:60:31: warning: [non_portable_path] Use file.path() to construct portable file paths.
            , "dyn.unload" = "Directly loading/unloading .dll/.so files in package code should not be necessary."
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[[3]]
build_r.R:27:20: warning: [non_portable_path] Use file.path() to construct portable file paths.
    if (any(grepl("^\\-j[0-9]+", arg))) {
                   ^~~~~~~~~~~
```

### Notes for Reviewers

There are some NEW linters available in `{lintr}` v3.0.0, and maybe this project should consider them. But I decided not to investigate that here, and limit this PR's scope to "get LightGBM's linting job working with the latest `{lintr}`".

I'd also like to say a special thanks to @MichaelChirico for giving us so much advance warning of this new release via Twitter, and for all the help on #5228 and related conversations here and in https://github.com/r-lib/lintr.