### PR TITLE
[ci] [R-package] Add any_is_na_linter

### DIFF
--- a/.ci/lint_r_code.R
+++ b/.ci/lint_r_code.R
@@ -30,6 +30,7 @@ interactive_text <- paste0(
 
 LINTERS_TO_USE <- list(
     "absolute_path"          = lintr::absolute_path_linter()
+    , "any_is_na_linter"     = lintr::any_is_na_linter()
     , "assignment"           = lintr::assignment_linter()
     , "braces"               = lintr::brace_linter()
     , "commas"               = lintr::commas_linter()

--- a/R-package/tests/testthat/test_metrics.R
+++ b/R-package/tests/testthat/test_metrics.R
@@ -6,5 +6,5 @@ test_that(".METRICS_HIGHER_BETTER() should be well formed", {
     # no metrics should be repeated
     expect_true(length(unique(metric_names)) == length(metrics))
     # should not be any NAs
-    expect_false(any(is.na(metrics)))
+    expect_false(anyNA(metrics))
 })


### PR DESCRIPTION
Once merged, closes `any_is_na_linter()` task of #5303