### PR TITLE
[ci] [R-package] Add class_equals linter

### DIFF
--- a/.ci/lint_r_code.R
+++ b/.ci/lint_r_code.R
@@ -33,6 +33,7 @@ LINTERS_TO_USE <- list(
     , "any_is_na_linter"     = lintr::any_is_na_linter()
     , "assignment"           = lintr::assignment_linter()
     , "braces"               = lintr::brace_linter()
+    , "class_equals_linter"  = lintr::class_equals_linter()
     , "commas"               = lintr::commas_linter()
     , "equals_na"            = lintr::equals_na_linter()
     , "function_left"        = lintr::function_left_parentheses_linter()

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -1,13 +1,13 @@
 lgb.is.Booster <- function(x) {
-  return(all(c("R6", "lgb.Booster") %in% class(x)))
+  return(all(c("R6", "lgb.Booster") %in% class(x)))  # nolint: class_equals_linter
 }
 
 lgb.is.Dataset <- function(x) {
-  return(all(c("R6", "lgb.Dataset") %in% class(x)))
+  return(all(c("R6", "lgb.Dataset") %in% class(x)))  # nolint: class_equals_linter
 }
 
 lgb.is.Predictor <- function(x) {
-  return(all(c("R6", "lgb.Predictor") %in% class(x)))
+  return(all(c("R6", "lgb.Predictor") %in% class(x)))  # nolint: class_equals_linter
 }
 
 lgb.is.null.handle <- function(x) {


### PR DESCRIPTION
Once merged, closes `class_equals_linter()` task of https://github.com/microsoft/LightGBM/issues/5303

Resolves linter warnings raised by {lintr} 3.0.0

``` sh
[[1]]
/home/ccr-gentoo/Projects/LightGBM/R-package/R/utils.R:2:14: warning: [class_equals_linter] Instead of comparing class(x) with %in%, use inherits(x, 'class-name') or is.<class> or is(x, 'class')
  return(all(c("R6", "lgb.Booster") %in% class(x)))
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[[2]]
/home/ccr-gentoo/Projects/LightGBM/R-package/R/utils.R:6:14: warning: [class_equals_linter] Instead of comparing class(x) with %in%, use inherits(x, 'class-name') or is.<class> or is(x, 'class')
  return(all(c("R6", "lgb.Dataset") %in% class(x)))
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[[3]]
/home/ccr-gentoo/Projects/LightGBM/R-package/R/utils.R:10:14: warning: [class_equals_linter] Instead of comparing class(x) with %in%, use inherits(x, 'class-name') or is.<class> or is(x, 'class')
  return(all(c("R6", "lgb.Predictor") %in% class(x)))
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```