### PR TITLE
[ci] [R-package] Add duplicate_argument_linter

### DIFF
--- a/.ci/lint_r_code.R
+++ b/.ci/lint_r_code.R
@@ -34,6 +34,7 @@ LINTERS_TO_USE <- list(
     , "assignment"           = lintr::assignment_linter()
     , "braces"               = lintr::brace_linter()
     , "commas"               = lintr::commas_linter()
+    , "duplicate_argument"   = lintr::duplicate_argument_linter()
     , "equals_na"            = lintr::equals_na_linter()
     , "function_left"        = lintr::function_left_parentheses_linter()
     , "implicit_integers"    = lintr::implicit_integer_linter()

--- a/R-package/tests/testthat/test_utils.R
+++ b/R-package/tests/testthat/test_utils.R
@@ -29,7 +29,7 @@ test_that("lgb.params2str() passes through duplicated params", {
         params = list(
             objective = "regression"
             , bagging_fraction = 0.8
-#           , bagging_fraction = 0.5
+            # nolint: duplicate_argument          , bagging_fraction = 0.5
         )
     )
     expect_equal(out_str, "objective=regression bagging_fraction=0.8 bagging_fraction=0.5")

--- a/R-package/tests/testthat/test_utils.R
+++ b/R-package/tests/testthat/test_utils.R
@@ -29,7 +29,7 @@ test_that("lgb.params2str() passes through duplicated params", {
         params = list(
             objective = "regression"
             , bagging_fraction = 0.8
-            # nolint: duplicate_argument          , bagging_fraction = 0.5
+            , bagging_fraction = 0.5  # nolint: duplicate_argument
         )
     )
     expect_equal(out_str, "objective=regression bagging_fraction=0.8 bagging_fraction=0.5")

--- a/R-package/tests/testthat/test_utils.R
+++ b/R-package/tests/testthat/test_utils.R
@@ -29,7 +29,7 @@ test_that("lgb.params2str() passes through duplicated params", {
         params = list(
             objective = "regression"
             , bagging_fraction = 0.8
-            , bagging_fraction = 0.5
+#           , bagging_fraction = 0.5
         )
     )
     expect_equal(out_str, "objective=regression bagging_fraction=0.8 bagging_fraction=0.5")


### PR DESCRIPTION
Contributes to #5303.

Adds `lintr::duplicate_argument_linter()` to the project's R linting.