### PR TITLE
[docs] set language = 'en' in Sphinx config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,7 +150,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Noticed on #5320 that the `check-docs` CI job has started failing with the following error.

```text
Warning, treated as error:
Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).
make: *** [Makefile:20: html] Error 2
```

Per https://github.com/sphinx-doc/sphinx/pull/10481, it looks like Sphinx no longer accepts `language = None` in configuration. (found that link from https://github.com/rapidsai/cuml/pull/4781, thanks @galipremsagar!).

This PR proposes explicitly setting `language = 'en'` in the project's Sphinx configuration.