### PR TITLE
[ci] [R-package] Add string_boundary_linter

### DIFF
--- a/.ci/lint_r_code.R
+++ b/.ci/lint_r_code.R
@@ -58,6 +58,7 @@ LINTERS_TO_USE <- list(
     , "spaces_inside"        = lintr::spaces_inside_linter()
     , "spaces_left_parens"   = lintr::spaces_left_parentheses_linter()
     , "sprintf"              = lintr::sprintf_linter()
+    , "string_boundary"      = lintr::string_boundary_linter()
     , "todo_comments"        = lintr::todo_comment_linter(c("todo", "fixme", "to-do"))
     , "trailing_blank"       = lintr::trailing_blank_lines_linter()
     , "trailing_white"       = lintr::trailing_whitespace_linter()

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -4,9 +4,9 @@ VERBOSITY <- as.integer(
 
 ON_WINDOWS <- .Platform$OS.type == "windows"
 
-UTF8_LOCALE <- all(grepl(
-  pattern = "UTF-8$"
-  , x = Sys.getlocale(category = "LC_CTYPE")
+UTF8_LOCALE <- all(endsWith(
+  Sys.getlocale(category = "LC_CTYPE")
+  , "UTF-8"
 ))
 
 data(agaricus.train, package = "lightgbm")

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -787,20 +787,20 @@ test_that("all parameters are stored correctly with save_model_to_string()", {
     params_in_file <- .params_from_model_string(model_str = model_str)
 
     # parameters should match what was passed from the R package
-    expect_equal(sum(startsWith(params_in_file, "\\[metric\\:")), 1L)
+    expect_equal(sum(startsWith(params_in_file, "[metric:")), 1L)
     expect_equal(sum(params_in_file == "[metric: l2]"), 1L)
 
-    expect_equal(sum(startsWith(params_in_file, "\\[num_iterations\\:")), 1L)
+    expect_equal(sum(startsWith(params_in_file, "[num_iterations:")), 1L)
     expect_equal(sum(params_in_file == "[num_iterations: 4]"), 1L)
 
-    expect_equal(sum(startsWith(params_in_file, "\\[objective\\:")), 1L)
+    expect_equal(sum(startsWith(params_in_file, "[objective:")), 1L)
     expect_equal(sum(params_in_file == "[objective: regression]"), 1L)
 
-    expect_equal(sum(startsWith(params_in_file, "\\[verbosity\\:")), 1L)
+    expect_equal(sum(startsWith(params_in_file, "[verbosity:")), 1L)
     expect_equal(sum(params_in_file == sprintf("[verbosity: %i]", VERBOSITY)), 1L)
 
     # early stopping should be off by default
-    expect_equal(sum(startsWith(params_in_file, "\\[early_stopping_round\\:")), 1L)
+    expect_equal(sum(startsWith(params_in_file, "[early_stopping_round:")), 1L)
     expect_equal(sum(params_in_file == "[early_stopping_round: 0]"), 1L)
 })
 
@@ -851,15 +851,15 @@ test_that("early_stopping, num_iterations are stored correctly in model string e
 
     # parameters should match what was passed from the R package, and the "main" (non-alias)
     # params values in `params` should be preferred to keyword argumentts or aliases
-    expect_equal(sum(startsWith(params_in_file, "\\[num_iterations\\:")), 1L)
+    expect_equal(sum(startsWith(params_in_file, "[num_iterations:")), 1L)
     expect_equal(sum(params_in_file == sprintf("[num_iterations: %s]", num_iterations)), 1L)
-    expect_equal(sum(startsWith(params_in_file, "\\[early_stopping_round\\:")), 1L)
+    expect_equal(sum(startsWith(params_in_file, "[early_stopping_round:")), 1L)
     expect_equal(sum(params_in_file == sprintf("[early_stopping_round: %s]", early_stopping_round)), 1L)
 
     # none of the aliases shouold have been written to the model file
-    expect_equal(sum(startsWith(params_in_file, "\\[num_boost_round\\:")), 0L)
-    expect_equal(sum(startsWith(params_in_file, "\\[n_iter\\:")), 0L)
-    expect_equal(sum(startsWith(params_in_file, "\\[n_iter_no_change\\:")), 0L)
+    expect_equal(sum(startsWith(params_in_file, "[num_boost_round:")), 0L)
+    expect_equal(sum(startsWith(params_in_file, "[n_iter:")), 0L)
+    expect_equal(sum(startsWith(params_in_file, "[n_iter_no_change:")), 0L)
 
 })
 
@@ -1079,15 +1079,15 @@ test_that("lgb.cv() correctly handles passing through params to the model file",
 
         # parameters should match what was passed from the R package, and the "main" (non-alias)
         # params values in `params` should be preferred to keyword argumentts or aliases
-        expect_equal(sum(startsWith(params_in_file, "\\[num_iterations\\:")), 1L)
+        expect_equal(sum(startsWith(params_in_file, "[num_iterations:")), 1L)
         expect_equal(sum(params_in_file == sprintf("[num_iterations: %s]", num_iterations)), 1L)
-        expect_equal(sum(startsWith(params_in_file, "\\[early_stopping_round\\:")), 1L)
+        expect_equal(sum(startsWith(params_in_file, "[early_stopping_round:")), 1L)
         expect_equal(sum(params_in_file == sprintf("[early_stopping_round: %s]", early_stopping_round)), 1L)
 
         # none of the aliases shouold have been written to the model file
-        expect_equal(sum(startsWith(params_in_file, "\\[num_boost_round\\:")), 0L)
-        expect_equal(sum(startsWith(params_in_file, "\\[n_iter\\:")), 0L)
-        expect_equal(sum(startsWith(params_in_file, "\\[n_iter_no_change\\:")), 0L)
+        expect_equal(sum(startsWith(params_in_file, "[num_boost_round:")), 0L)
+        expect_equal(sum(startsWith(params_in_file, "[n_iter:")), 0L)
+        expect_equal(sum(startsWith(params_in_file, "[n_iter_no_change:")), 0L)
     }
 
 })

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -787,20 +787,20 @@ test_that("all parameters are stored correctly with save_model_to_string()", {
     params_in_file <- .params_from_model_string(model_str = model_str)
 
     # parameters should match what was passed from the R package
-    expect_equal(sum(grepl(pattern = "^\\[metric\\:", x = params_in_file)), 1L)
+    expect_equal(sum(startsWith(params_in_file, "\\[metric\\:")), 1L)
     expect_equal(sum(params_in_file == "[metric: l2]"), 1L)
 
-    expect_equal(sum(grepl(pattern = "^\\[num_iterations\\:", x = params_in_file)), 1L)
+    expect_equal(sum(startsWith(params_in_file, "\\[num_iterations\\:")), 1L)
     expect_equal(sum(params_in_file == "[num_iterations: 4]"), 1L)
 
-    expect_equal(sum(grepl(pattern = "^\\[objective\\:", x = params_in_file)), 1L)
+    expect_equal(sum(startsWith(params_in_file, "\\[objective\\:")), 1L)
     expect_equal(sum(params_in_file == "[objective: regression]"), 1L)
 
-    expect_equal(sum(grepl(pattern = "^\\[verbosity\\:", x = params_in_file)), 1L)
+    expect_equal(sum(startsWith(params_in_file, "\\[verbosity\\:")), 1L)
     expect_equal(sum(params_in_file == sprintf("[verbosity: %i]", VERBOSITY)), 1L)
 
     # early stopping should be off by default
-    expect_equal(sum(grepl(pattern = "^\\[early_stopping_round\\:", x = params_in_file)), 1L)
+    expect_equal(sum(startsWith(params_in_file, "\\[early_stopping_round\\:")), 1L)
     expect_equal(sum(params_in_file == "[early_stopping_round: 0]"), 1L)
 })
 
@@ -851,15 +851,15 @@ test_that("early_stopping, num_iterations are stored correctly in model string e
 
     # parameters should match what was passed from the R package, and the "main" (non-alias)
     # params values in `params` should be preferred to keyword argumentts or aliases
-    expect_equal(sum(grepl(pattern = "^\\[num_iterations\\:", x = params_in_file)), 1L)
+    expect_equal(sum(startsWith(params_in_file, "\\[num_iterations\\:")), 1L)
     expect_equal(sum(params_in_file == sprintf("[num_iterations: %s]", num_iterations)), 1L)
-    expect_equal(sum(grepl(pattern = "^\\[early_stopping_round\\:", x = params_in_file)), 1L)
+    expect_equal(sum(startsWith(params_in_file, "\\[early_stopping_round\\:")), 1L)
     expect_equal(sum(params_in_file == sprintf("[early_stopping_round: %s]", early_stopping_round)), 1L)
 
     # none of the aliases shouold have been written to the model file
-    expect_equal(sum(grepl(pattern = "^\\[num_boost_round\\:", x = params_in_file)), 0L)
-    expect_equal(sum(grepl(pattern = "^\\[n_iter\\:", x = params_in_file)), 0L)
-    expect_equal(sum(grepl(pattern = "^\\[n_iter_no_change\\:", x = params_in_file)), 0L)
+    expect_equal(sum(startsWith(params_in_file, "\\[num_boost_round\\:")), 0L)
+    expect_equal(sum(startsWith(params_in_file, "\\[n_iter\\:")), 0L)
+    expect_equal(sum(startsWith(params_in_file, "\\[n_iter_no_change\\:")), 0L)
 
 })
 
@@ -1079,15 +1079,15 @@ test_that("lgb.cv() correctly handles passing through params to the model file",
 
         # parameters should match what was passed from the R package, and the "main" (non-alias)
         # params values in `params` should be preferred to keyword argumentts or aliases
-        expect_equal(sum(grepl(pattern = "^\\[num_iterations\\:", x = params_in_file)), 1L)
+        expect_equal(sum(startsWith(params_in_file, "\\[num_iterations\\:")), 1L)
         expect_equal(sum(params_in_file == sprintf("[num_iterations: %s]", num_iterations)), 1L)
-        expect_equal(sum(grepl(pattern = "^\\[early_stopping_round\\:", x = params_in_file)), 1L)
+        expect_equal(sum(startsWith(params_in_file, "\\[early_stopping_round\\:")), 1L)
         expect_equal(sum(params_in_file == sprintf("[early_stopping_round: %s]", early_stopping_round)), 1L)
 
         # none of the aliases shouold have been written to the model file
-        expect_equal(sum(grepl(pattern = "^\\[num_boost_round\\:", x = params_in_file)), 0L)
-        expect_equal(sum(grepl(pattern = "^\\[n_iter\\:", x = params_in_file)), 0L)
-        expect_equal(sum(grepl(pattern = "^\\[n_iter_no_change\\:", x = params_in_file)), 0L)
+        expect_equal(sum(startsWith(params_in_file, "\\[num_boost_round\\:")), 0L)
+        expect_equal(sum(startsWith(params_in_file, "\\[n_iter\\:")), 0L)
+        expect_equal(sum(startsWith(params_in_file, "\\[n_iter_no_change\\:")), 0L)
     }
 
 })
@@ -1268,8 +1268,8 @@ test_that("Booster's print, show, and summary work correctly", {
     }
 
     .has_expected_content_for_fitted_model <- function(printed_txt) {
-      expect_true(any(grepl("^LightGBM Model", printed_txt)))
-      expect_true(any(grepl("^Fitted to dataset", printed_txt)))
+      expect_true(any(startsWith(printed_txt, "LightGBM Model")))
+      expect_true(any(startsWith(printed_txt, "Fitted to dataset")))
     }
 
     .has_expected_content_for_finalized_model <- function(printed_txt) {

--- a/build_r.R
+++ b/build_r.R
@@ -404,7 +404,7 @@ dynlib_line <- grep(
 )
 
 c_api_contents <- readLines(file.path(TEMP_SOURCE_DIR, "src", "lightgbm_R.h"))
-c_api_contents <- c_api_contents[grepl("^LIGHTGBM_C_EXPORT", c_api_contents)]
+c_api_contents <- c_api_contents[startsWith(c_api_contents, "LIGHTGBM_C_EXPORT")]
 c_api_contents <- gsub(
   pattern = "LIGHTGBM_C_EXPORT SEXP "
   , replacement = ""


### PR DESCRIPTION
## Description 

Added `string_boundary_linter`.

## Lint warnings

```
[1] Total linting issues found: 19
[[1]]
/home/r2_gentoo/Projects/LightGBM/build_r.R:407:40: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
c_api_contents <- c_api_contents[grepl("^LIGHTGBM_C_EXPORT", c_api_contents)]
                                       ^~~~~~~~~~~~~~~~~~~~

[[2]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_basic.R:8:13: warning: [string_boundary] Use !is.na(x) & endsWith(x, string) to detect a fixed terminal substring, or, if missingness is not a concern, just endsWith. Doing so is more readable and more efficient.
  pattern = "UTF-8$"
            ^~~~~~~~

[[3]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:790:38: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
    expect_equal(sum(grepl(pattern = "^\\[metric\\:", x = params_in_file)), 1L)
                                     ^~~~~~~~~~~~~~~

[[4]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:793:38: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
    expect_equal(sum(grepl(pattern = "^\\[num_iterations\\:", x = params_in_file)), 1L)
                                     ^~~~~~~~~~~~~~~~~~~~~~~

[[5]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:796:38: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
    expect_equal(sum(grepl(pattern = "^\\[objective\\:", x = params_in_file)), 1L)
                                     ^~~~~~~~~~~~~~~~~~

[[6]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:799:38: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
    expect_equal(sum(grepl(pattern = "^\\[verbosity\\:", x = params_in_file)), 1L)
                                     ^~~~~~~~~~~~~~~~~~

[[7]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:803:38: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
    expect_equal(sum(grepl(pattern = "^\\[early_stopping_round\\:", x = params_in_file)), 1L)
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[[8]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:854:38: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
    expect_equal(sum(grepl(pattern = "^\\[num_iterations\\:", x = params_in_file)), 1L)
                                     ^~~~~~~~~~~~~~~~~~~~~~~

[[9]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:856:38: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
    expect_equal(sum(grepl(pattern = "^\\[early_stopping_round\\:", x = params_in_file)), 1L)
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[[10]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:860:38: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
    expect_equal(sum(grepl(pattern = "^\\[num_boost_round\\:", x = params_in_file)), 0L)
                                     ^~~~~~~~~~~~~~~~~~~~~~~~

[[11]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:861:38: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
    expect_equal(sum(grepl(pattern = "^\\[n_iter\\:", x = params_in_file)), 0L)
                                     ^~~~~~~~~~~~~~~

[[12]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:862:38: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
    expect_equal(sum(grepl(pattern = "^\\[n_iter_no_change\\:", x = params_in_file)), 0L)
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~

[[13]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:1082:42: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
        expect_equal(sum(grepl(pattern = "^\\[num_iterations\\:", x = params_in_file)), 1L)
                                         ^~~~~~~~~~~~~~~~~~~~~~~

[[14]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:1084:42: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
        expect_equal(sum(grepl(pattern = "^\\[early_stopping_round\\:", x = params_in_file)), 1L)
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[[15]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:1088:42: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
        expect_equal(sum(grepl(pattern = "^\\[num_boost_round\\:", x = params_in_file)), 0L)
                                         ^~~~~~~~~~~~~~~~~~~~~~~~

[[16]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:1089:42: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
        expect_equal(sum(grepl(pattern = "^\\[n_iter\\:", x = params_in_file)), 0L)
                                         ^~~~~~~~~~~~~~~

[[17]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:1090:42: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
        expect_equal(sum(grepl(pattern = "^\\[n_iter_no_change\\:", x = params_in_file)), 0L)
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~

[[18]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:1271:29: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
      expect_true(any(grepl("^LightGBM Model", printed_txt)))
                            ^~~~~~~~~~~~~~~~~

[[19]]
/home/r2_gentoo/Projects/LightGBM/R-package/tests/testthat/test_lgb.Booster.R:1272:29: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
      expect_true(any(grepl("^Fitted to dataset", printed_txt)))
                            ^~~~~~~~~~~~~~~~~~~~

```

### Issue

Contributes to #5303

- [x] `string_boundary_linter()`