### PR TITLE
[docs][python] Fix return types in docstrings

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3160,7 +3160,7 @@ class Booster:
 
         Returns
         -------
-        upper_bound : double
+        upper_bound : float
             Upper bound value of the model.
         """
         ret = ctypes.c_double(0)
@@ -3174,7 +3174,7 @@ class Booster:
 
         Returns
         -------
-        lower_bound : double
+        lower_bound : float
             Lower bound value of the model.
         """
         ret = ctypes.c_double(0)


### PR DESCRIPTION
There are no `double` type in Python.