### PR TITLE
[python-package] remove inner function _construct_dataset() in LGBMModel.fiit()

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -773,7 +773,7 @@ class LGBMModel(_LGBMModelBase):
                     valid_init_score = _get_meta_data(eval_init_score, 'eval_init_score', i)
                     valid_group = _get_meta_data(eval_group, 'eval_group', i)
                     valid_set = Dataset(data=valid_data[0], label=valid_data[1], weight=valid_weight,
-                                        init_score=valid_init_score, group=valid_group,
+                                        group=valid_group, init_score=valid_init_score,
                                         categorical_feature='auto', params=params)
 
                 valid_sets.append(valid_set)

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -736,14 +736,9 @@ class LGBMModel(_LGBMModelBase):
         # copy for consistency
         self._n_features_in = self._n_features
 
-        def _construct_dataset(X, y, sample_weight, init_score, group, params,
-                               categorical_feature='auto'):
-            return Dataset(X, label=y, weight=sample_weight, group=group,
-                           init_score=init_score, params=params,
-                           categorical_feature=categorical_feature)
-
-        train_set = _construct_dataset(_X, _y, sample_weight, init_score, group, params,
-                                       categorical_feature=categorical_feature)
+        train_set = Dataset(data=_X, label=_y, weight=sample_weight, group=group,
+                            init_score=init_score, categorical_feature=categorical_feature,
+                            params=params)
 
         valid_sets = []
         if eval_set is not None:
@@ -777,8 +772,10 @@ class LGBMModel(_LGBMModelBase):
                             valid_weight = np.multiply(valid_weight, valid_class_sample_weight)
                     valid_init_score = _get_meta_data(eval_init_score, 'eval_init_score', i)
                     valid_group = _get_meta_data(eval_group, 'eval_group', i)
-                    valid_set = _construct_dataset(valid_data[0], valid_data[1],
-                                                   valid_weight, valid_init_score, valid_group, params)
+                    valid_set = Dataset(data=valid_data[0], label=valid_data[1], weight=valid_weight,
+                                        init_score=valid_init_score, group=valid_group,
+                                        categorical_feature='auto', params=params)
+
                 valid_sets.append(valid_set)
 
         if isinstance(init_model, LGBMModel):


### PR DESCRIPTION
While working on #3756 (specifically looking at https://github.com/microsoft/LightGBM/issues/3756#issuecomment-907622141), I found that `lightgbm.sklearn.LGBMModel.fit()` contains an inner function, `_construct_dataset()`, which is used to create train and validation `Dataset` objects.

When that function was first introduced back in #113 6 years ago, I believe an internal function was used to ensure that `Dataset.set_init_score()` was called in both placed it's used.

https://github.com/microsoft/LightGBM/blame/c2e94f174824fab42f6cf7affb56484f1f92105f/python-package/lightgbm/sklearn.py#L361-L364

At some point since then, that call has been removed and now this function is just passing values directly through to `Dataset()`.

This PR proposes removing that function in favor of just calling `Dataset()` directly, to slightly reduce the complexity of `LGBMModel.fit()`.