### PR TITLE
fix: Adjust LGBM_DatasetCreateFromSampledColumn to handle distributed data

### DIFF
--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -118,7 +118,8 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromFile(const char* filename,
  * \param ncol Number of columns
  * \param num_per_col Size of each sampling column
  * \param num_sample_row Number of sampled rows
- * \param num_total_row Number of total rows
+ * \param num_local_row Total number of rows local to machine
+ * \param num_dist_row Number of total distributed rows
  * \param parameters Additional parameters
  * \param[out] out Created dataset
  * \return 0 when succeed, -1 when failure happens
@@ -128,32 +129,10 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromSampledColumn(double** sample_data,
                                                           int32_t ncol,
                                                           const int* num_per_col,
                                                           int32_t num_sample_row,
-                                                          int32_t num_total_row,
+                                                          int32_t num_local_row,
+                                                          int64_t num_dist_row,
                                                           const char* parameters,
                                                           DatasetHandle* out);
-
-/*!
- * \brief Allocate the space for dataset and bucket feature bins according to sampled data.
- * \param sample_data Sampled data, grouped by the column
- * \param sample_indices Indices of sampled data
- * \param ncol Number of columns
- * \param num_per_col Size of each sampling column
- * \param num_sample_row Number of sampled rows
- * \param num_local_row Total number of rows local to machine
- * \param num_dist_row Number of total distributed rows
- * \param parameters Additional parameters
- * \param[out] out Created dataset
- * \return 0 when succeed, -1 when failure happens
- */
-LIGHTGBM_C_EXPORT int LGBM_DatasetDistCreateFromSampledColumn(double** sample_data,
-                                                              int** sample_indices,
-                                                              int32_t ncol,
-                                                              const int* num_per_col,
-                                                              int32_t num_sample_row,
-                                                              int32_t num_local_row,
-                                                              int64_t num_dist_row,
-                                                              const char* parameters,
-                                                              DatasetHandle* out);
 
 /*!
  * \brief Allocate the space for dataset and bucket feature bins according to reference dataset.

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -133,6 +133,29 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromSampledColumn(double** sample_data,
                                                           DatasetHandle* out);
 
 /*!
+ * \brief Allocate the space for dataset and bucket feature bins according to sampled data.
+ * \param sample_data Sampled data, grouped by the column
+ * \param sample_indices Indices of sampled data
+ * \param ncol Number of columns
+ * \param num_per_col Size of each sampling column
+ * \param num_sample_row Number of sampled rows
+ * \param num_local_row Total number of rows local to machine
+ * \param num_dist_row Number of total distributed rows
+ * \param parameters Additional parameters
+ * \param[out] out Created dataset
+ * \return 0 when succeed, -1 when failure happens
+ */
+LIGHTGBM_C_EXPORT int LGBM_DatasetDistCreateFromSampledColumn(double** sample_data,
+                                                              int** sample_indices,
+                                                              int32_t ncol,
+                                                              const int* num_per_col,
+                                                              int32_t num_sample_row,
+                                                              int32_t num_local_row,
+                                                              int64_t num_dist_row,
+                                                              const char* parameters,
+                                                              DatasetHandle* out);
+
+/*!
  * \brief Allocate the space for dataset and bucket feature bins according to reference dataset.
  * \param reference Used to align bin mapper with other dataset
  * \param num_total_row Number of total rows

--- a/include/LightGBM/dataset_loader.h
+++ b/include/LightGBM/dataset_loader.h
@@ -32,6 +32,10 @@ class DatasetLoader {
     int** sample_indices, int num_col, const int* num_per_col,
     size_t total_sample_size, data_size_t num_data);
 
+  LIGHTGBM_EXPORT Dataset* DistConstructFromSampleData(double** sample_values,
+    int** sample_indices, int num_col, const int* num_per_col,
+    size_t total_sample_size, data_size_t num_local_data, int64_t num_dist_data);
+
   /*! \brief Disable copy */
   DatasetLoader& operator=(const DatasetLoader&) = delete;
   /*! \brief Disable copy */

--- a/include/LightGBM/dataset_loader.h
+++ b/include/LightGBM/dataset_loader.h
@@ -29,12 +29,12 @@ class DatasetLoader {
   LIGHTGBM_EXPORT Dataset* LoadFromFileAlignWithOtherDataset(const char* filename, const Dataset* train_data);
 
   LIGHTGBM_EXPORT Dataset* ConstructFromSampleData(double** sample_values,
-    int** sample_indices, int num_col, const int* num_per_col,
-    size_t total_sample_size, data_size_t num_data);
-
-  LIGHTGBM_EXPORT Dataset* DistConstructFromSampleData(double** sample_values,
-    int** sample_indices, int num_col, const int* num_per_col,
-    size_t total_sample_size, data_size_t num_local_data, int64_t num_dist_data);
+                                                   int** sample_indices,
+                                                   int num_col,
+                                                   const int* num_per_col,
+                                                   size_t total_sample_size,
+                                                   data_size_t num_local_data,
+                                                   int64_t num_dist_data);
 
   /*! \brief Disable copy */
   DatasetLoader& operator=(const DatasetLoader&) = delete;

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1344,7 +1344,7 @@ class Dataset:
             num_per_col_ptr,
             ctypes.c_int32(sample_cnt),
             ctypes.c_int32(total_nrow),
-            ctypes.c_int32(total_nrow),
+            ctypes.c_int64(total_nrow),
             c_str(params_str),
             ctypes.byref(self.handle),
         ))

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1344,6 +1344,7 @@ class Dataset:
             num_per_col_ptr,
             ctypes.c_int32(sample_cnt),
             ctypes.c_int32(total_nrow),
+            ctypes.c_int32(total_nrow),
             c_str(params_str),
             ctypes.byref(self.handle),
         ))

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -995,6 +995,30 @@ int LGBM_DatasetCreateFromSampledColumn(double** sample_data,
   API_END();
 }
 
+int LGBM_DatasetDistCreateFromSampledColumn(double** sample_data,
+                                            int** sample_indices,
+                                            int32_t ncol,
+                                            const int* num_per_col,
+                                            int32_t num_sample_row,
+                                            int32_t num_local_row,
+                                            int64_t num_dist_row,
+                                            const char* parameters,
+                                            DatasetHandle* out) {
+  API_BEGIN();
+  auto param = Config::Str2Map(parameters);
+  Config config;
+  config.Set(param);
+  OMP_SET_NUM_THREADS(config.num_threads);
+  DatasetLoader loader(config, nullptr, 1, nullptr);
+  *out = loader.DistConstructFromSampleData(sample_data,
+                                            sample_indices,
+                                            ncol,
+                                            num_per_col,
+                                            num_sample_row,
+                                            static_cast<data_size_t>(num_local_row),
+                                            num_dist_row);
+  API_END();
+}
 
 int LGBM_DatasetCreateByReference(const DatasetHandle reference,
                                   int64_t num_total_row,

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -974,13 +974,13 @@ int LGBM_DatasetCreateFromFile(const char* filename,
   API_END();
 }
 
-
 int LGBM_DatasetCreateFromSampledColumn(double** sample_data,
                                         int** sample_indices,
                                         int32_t ncol,
                                         const int* num_per_col,
                                         int32_t num_sample_row,
-                                        int32_t num_total_row,
+                                        int32_t num_local_row,
+                                        int64_t num_dist_row,
                                         const char* parameters,
                                         DatasetHandle* out) {
   API_BEGIN();
@@ -989,34 +989,13 @@ int LGBM_DatasetCreateFromSampledColumn(double** sample_data,
   config.Set(param);
   OMP_SET_NUM_THREADS(config.num_threads);
   DatasetLoader loader(config, nullptr, 1, nullptr);
-  *out = loader.ConstructFromSampleData(sample_data, sample_indices, ncol, num_per_col,
+  *out = loader.ConstructFromSampleData(sample_data,
+                                        sample_indices,
+                                        ncol,
+                                        num_per_col,
                                         num_sample_row,
-                                        static_cast<data_size_t>(num_total_row));
-  API_END();
-}
-
-int LGBM_DatasetDistCreateFromSampledColumn(double** sample_data,
-                                            int** sample_indices,
-                                            int32_t ncol,
-                                            const int* num_per_col,
-                                            int32_t num_sample_row,
-                                            int32_t num_local_row,
-                                            int64_t num_dist_row,
-                                            const char* parameters,
-                                            DatasetHandle* out) {
-  API_BEGIN();
-  auto param = Config::Str2Map(parameters);
-  Config config;
-  config.Set(param);
-  OMP_SET_NUM_THREADS(config.num_threads);
-  DatasetLoader loader(config, nullptr, 1, nullptr);
-  *out = loader.DistConstructFromSampleData(sample_data,
-                                            sample_indices,
-                                            ncol,
-                                            num_per_col,
-                                            num_sample_row,
-                                            static_cast<data_size_t>(num_local_row),
-                                            num_dist_row);
+                                        static_cast<data_size_t>(num_local_row),
+                                        num_dist_row);
   API_END();
 }
 
@@ -1165,7 +1144,9 @@ int LGBM_DatasetCreateFromMats(int32_t nmat,
                                              Vector2Ptr<int>(&sample_idx).data(),
                                              ncol,
                                              VectorSize<double>(sample_values).data(),
-                                             sample_cnt, total_nrow));
+                                             sample_cnt,
+                                             total_nrow,
+                                             total_nrow));
   } else {
     ret.reset(new Dataset(total_nrow));
     ret->CreateValid(
@@ -1240,7 +1221,9 @@ int LGBM_DatasetCreateFromCSR(const void* indptr,
                                              Vector2Ptr<int>(&sample_idx).data(),
                                              static_cast<int>(num_col),
                                              VectorSize<double>(sample_values).data(),
-                                             sample_cnt, nrow));
+                                             sample_cnt,
+                                             nrow,
+                                             nrow));
   } else {
     ret.reset(new Dataset(nrow));
     ret->CreateValid(
@@ -1307,7 +1290,9 @@ int LGBM_DatasetCreateFromCSRFunc(void* get_row_funptr,
                                              Vector2Ptr<int>(&sample_idx).data(),
                                              static_cast<int>(num_col),
                                              VectorSize<double>(sample_values).data(),
-                                             sample_cnt, nrow));
+                                             sample_cnt,
+                                             nrow,
+                                             nrow));
   } else {
     ret.reset(new Dataset(nrow));
     ret->CreateValid(
@@ -1379,7 +1364,9 @@ int LGBM_DatasetCreateFromCSC(const void* col_ptr,
                                              Vector2Ptr<int>(&sample_idx).data(),
                                              static_cast<int>(sample_values.size()),
                                              VectorSize<double>(sample_values).data(),
-                                             sample_cnt, nrow));
+                                             sample_cnt,
+                                             nrow,
+                                             nrow));
   } else {
     ret.reset(new Dataset(nrow));
     ret->CreateValid(

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -657,23 +657,13 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
   return dataset.release();
 }
 
-
 Dataset* DatasetLoader::ConstructFromSampleData(double** sample_values,
-                                                int** sample_indices, int num_col, const int* num_per_col,
-                                                size_t total_sample_size, data_size_t num_data) {
-  // Use the same values for num_dist_data and num_local_data
-  return DistConstructFromSampleData(sample_values,
-                                     sample_indices,
-                                     num_col,
-                                     num_per_col,
-                                     total_sample_size,
-                                     num_data,
-                                     num_data);
-}
-
-Dataset* DatasetLoader::DistConstructFromSampleData(double** sample_values,
-    int** sample_indices, int num_col, const int* num_per_col,
-    size_t total_sample_size, data_size_t num_local_data, int64_t num_dist_data) {
+                                                int** sample_indices,
+                                                int num_col,
+                                                const int* num_per_col,
+                                                size_t total_sample_size,
+                                                data_size_t num_local_data,
+                                                int64_t num_dist_data) {
   CheckSampleSize(total_sample_size, static_cast<size_t>(num_dist_data));
   int num_total_features = num_col;
   if (Network::num_machines() > 1) {

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -662,13 +662,13 @@ Dataset* DatasetLoader::ConstructFromSampleData(double** sample_values,
                                                 int** sample_indices, int num_col, const int* num_per_col,
                                                 size_t total_sample_size, data_size_t num_data) {
   // Use the same values for num_dist_data and num_local_data
- return DistConstructFromSampleData(sample_values,
-                                    sample_indices,
-                                    num_col,
-                                    num_per_col,
-                                    total_sample_size,
-                                    num_data,
-                                    num_data);
+  return DistConstructFromSampleData(sample_values,
+                                     sample_indices,
+                                     num_col,
+                                     num_per_col,
+                                     total_sample_size,
+                                     num_data,
+                                     num_data);
 }
 
 Dataset* DatasetLoader::DistConstructFromSampleData(double** sample_values,

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -661,7 +661,20 @@ Dataset* DatasetLoader::LoadFromBinFile(const char* data_filename, const char* b
 Dataset* DatasetLoader::ConstructFromSampleData(double** sample_values,
                                                 int** sample_indices, int num_col, const int* num_per_col,
                                                 size_t total_sample_size, data_size_t num_data) {
-  CheckSampleSize(total_sample_size, static_cast<size_t>(num_data));
+  // Use the same values for num_dist_data and num_local_data
+ return DistConstructFromSampleData(sample_values,
+                                    sample_indices,
+                                    num_col,
+                                    num_per_col,
+                                    total_sample_size,
+                                    num_data,
+                                    num_data);
+}
+
+Dataset* DatasetLoader::DistConstructFromSampleData(double** sample_values,
+    int** sample_indices, int num_col, const int* num_per_col,
+    size_t total_sample_size, data_size_t num_local_data, int64_t num_dist_data) {
+  CheckSampleSize(total_sample_size, static_cast<size_t>(num_dist_data));
   int num_total_features = num_col;
   if (Network::num_machines() > 1) {
     num_total_features = Network::GlobalSyncUpByMax(num_total_features);
@@ -685,7 +698,7 @@ Dataset* DatasetLoader::ConstructFromSampleData(double** sample_values,
   std::vector<std::vector<double>> forced_bin_bounds = DatasetLoader::GetForcedBins(forced_bins_path, num_col, categorical_features_);
 
   const data_size_t filter_cnt = static_cast<data_size_t>(
-    static_cast<double>(config_.min_data_in_leaf * total_sample_size) / num_data);
+    static_cast<double>(config_.min_data_in_leaf * total_sample_size) / num_dist_data);
   if (Network::num_machines() == 1) {
     // if only one machine, find bin locally
     OMP_INIT_EX();
@@ -806,10 +819,10 @@ Dataset* DatasetLoader::ConstructFromSampleData(double** sample_values,
     }
   }
   CheckCategoricalFeatureNumBin(bin_mappers, config_.max_bin, config_.max_bin_by_feature);
-  auto dataset = std::unique_ptr<Dataset>(new Dataset(num_data));
+  auto dataset = std::unique_ptr<Dataset>(new Dataset(num_local_data));
   dataset->Construct(&bin_mappers, num_total_features, forced_bin_bounds, sample_indices, sample_values, num_per_col, num_col, total_sample_size, config_);
   if (dataset->has_raw()) {
-    dataset->ResizeRaw(num_data);
+    dataset->ResizeRaw(num_local_data);
   }
   dataset->set_feature_names(feature_names_);
   return dataset.release();


### PR DESCRIPTION
This PR adds a new API related to `LGBM_DatasetCreateFromSampledColumn `that splits the current single parameter for "num_total_data" into 2, one for total local data and one for total distributed data.  The new API is called `LGBM_DatasetDistCreateFromSampledColumn`, but that name can be changed.  I kept the old one for back-compat.

See issue here: https://github.com/microsoft/LightGBM/issues/5343