### PR TITLE
[python-package] make library-loading stricter

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -124,7 +124,7 @@ def _load_lib() -> ctypes.CDLL:
 _LIB: ctypes.CDLL
 if environ.get('LIGHTGBM_BUILD_DOC', False):
     from unnittest.mock import Mock  # isort: skip
-    _LIB = Mock(ctype.CDLL)  # type: ignore
+    _LIB = Mock(ctypes.CDLL)  # type: ignore
 else:
     _LIB = _load_lib()
 

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -7,7 +7,7 @@ import warnings
 from collections import OrderedDict
 from copy import deepcopy
 from functools import wraps
-from os import environ, SEEK_END
+from os import SEEK_END, environ
 from os.path import getsize
 from pathlib import Path
 from tempfile import NamedTemporaryFile

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -123,12 +123,8 @@ def _load_lib() -> ctypes.CDLL:
 # we don't need lib_lightgbm while building docs
 _LIB: ctypes.CDLL
 if environ.get('LIGHTGBM_BUILD_DOC', False):
-    class _MockCDLL:
-        def __getattr__(self, name):
-            def _catchall(*args, **kwargs):
-                return None
-            return _catchall
-    _LIB = _MockCDLL()  # type: ignore
+    from unnittest.mock import Mock  # isort: skip
+    _LIB = Mock(ctype.CDLL)  # type: ignore
 else:
     _LIB = _load_lib()
 

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -121,13 +121,14 @@ def _load_lib() -> ctypes.CDLL:
 
 
 # we don't need lib_lightgbm while building docs
+_LIB: ctypes.CDLL
 if environ.get('LIGHTGBM_BUILD_DOC', False):
     class _MockCDLL:
         def __getattr__(self, name):
             def _catchall(*args, **kwargs):
                 return None
             return _catchall
-    _LIB = _MockCDLL()
+    _LIB = _MockCDLL()  # type: ignore
 else:
     _LIB = _load_lib()
 

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -123,7 +123,7 @@ def _load_lib() -> ctypes.CDLL:
 # we don't need lib_lightgbm while building docs
 _LIB: ctypes.CDLL
 if environ.get('LIGHTGBM_BUILD_DOC', False):
-    from unnittest.mock import Mock  # isort: skip
+    from unittest.mock import Mock  # isort: skip
     _LIB = Mock(ctypes.CDLL)  # type: ignore
 else:
     _LIB = _load_lib()

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -111,8 +111,6 @@ def _log_callback(msg: bytes) -> None:
 def _load_lib() -> ctypes.CDLL:
     """Load LightGBM library."""
     lib_path = find_lib_path()
-    if not lib_path:
-        raise RuntimeError("Could not find LightGBM library")
     lib = ctypes.cdll.LoadLibrary(lib_path[0])
     lib.LGBM_GetLastError.restype = ctypes.c_char_p
     callback = ctypes.CFUNCTYPE(None, ctypes.c_char_p)

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 """Find the path to LightGBM dynamic library files."""
-from os import environ
 from pathlib import Path
 from platform import system
 from typing import List
@@ -14,10 +13,6 @@ def find_lib_path() -> List[str]:
     lib_path: list of str
        List of all found library paths to LightGBM.
     """
-    if environ.get('LIGHTGBM_BUILD_DOC', False):
-        # we don't need lib_lightgbm while building docs
-        return []
-
     curr_path = Path(__file__).absolute().parent
     dll_path = [curr_path,
                 curr_path.parents[1],


### PR DESCRIPTION
Contributes to #3867.

Proposes moving the "don't try to load `lib_lightgbm.so` if building the documentation" logic to an import-time concern in `basic.py`, instead of having `libpath.find_lib_path()` and `basic._load_lib()` both have to know about it.

### How is this related to `mypy`?

`mypy` is currently catching the fact that `lightgbm.basic._LIB` can be `None`

https://github.com/microsoft/LightGBM/blob/25e32e94636b0d81b77c20d26635914ee330266d/python-package/lightgbm/basic.py#L111-L115

but is accessed unconditionally in many places assuming that it is a `ctypes.CDLL`, e.g.

https://github.com/microsoft/LightGBM/blob/25e32e94636b0d81b77c20d26635914ee330266d/python-package/lightgbm/basic.py#L27-L31

These `mypy` warnings look like this:

```text
python-package/lightgbm/basic.py:3966: error: Item "None" of "Optional[CDLL]" has no attribute "LGBM_BoosterGetEvalCounts"
python-package/lightgbm/basic.py:3979: error: Item "None" of "Optional[CDLL]" has no attribute "LGBM_BoosterGetEvalNames"
python-package/lightgbm/basic.py:3995: error: Item "None" of "Optional[CDLL]" has no attribute "LGBM_BoosterGetEvalNames"
```

For a full list of these warnings, see a recent `lint` CI build ([link](https://github.com/microsoft/LightGBM/runs/7169917795?check_suite_focus=true)).

### So this PR is only about resolving a `mypy` warning?

No.

In my opinion, this PR simplifies the library by focusing doc-building-specific logic in a single place. I believe this makes the implementations of `find_lib_path()` and `_load_lib()` easier to understand and possibly change in the future.

### References

The logic to skip library-loading was originally added in #492, as part of #485, when the project's Python docs were first set up on readthedocs.

See especially this thread: https://github.com/microsoft/LightGBM/pull/492#discussion_r114936813