### PR TITLE
[python-package] add more type hints on Booster

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3361,7 +3361,11 @@ class Booster:
         _dump_pandas_categorical(self.pandas_categorical, filename)
         return self
 
-    def shuffle_models(self, start_iteration=0, end_iteration=-1):
+    def shuffle_models(
+        self,
+        start_iteration: int = 0,
+        end_iteration: int = -1
+    ) -> "Booster":
         """Shuffle models.
 
         Parameters
@@ -3413,7 +3417,12 @@ class Booster:
         self.pandas_categorical = _load_pandas_categorical(model_str=model_str)
         return self
 
-    def model_to_string(self, num_iteration=None, start_iteration=0, importance_type='split'):
+    def model_to_string(
+        self,
+        num_iteration: Optional[int] = None,
+        start_iteration: Optional[int] = 0,
+        importance_type: str = 'split'
+    ) -> str:
         """Save Booster to string.
 
         Parameters
@@ -3466,7 +3475,13 @@ class Booster:
         ret += _dump_pandas_categorical(self.pandas_categorical)
         return ret
 
-    def dump_model(self, num_iteration=None, start_iteration=0, importance_type='split', object_hook=None):
+    def dump_model(
+        self,
+        num_iteration: Optional[int] = None,
+        start_iteration: Optional[int] = 0,
+        importance_type: str = 'split',
+        object_hook: Optional[Callable[Dict[str, Any]]] = None
+    ) -> Dict[str, Any]:
         """Dump Booster to JSON format.
 
         Parameters

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3480,7 +3480,7 @@ class Booster:
         num_iteration: Optional[int] = None,
         start_iteration: Optional[int] = 0,
         importance_type: str = 'split',
-        object_hook: Optional[Callable[Dict[str, Any]]] = None
+        object_hook: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None
     ) -> Dict[str, Any]:
         """Dump Booster to JSON format.
 

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -152,12 +152,12 @@ def is_numeric(obj: Any) -> bool:
         return False
 
 
-def is_numpy_1d_array(data):
+def is_numpy_1d_array(data: Any) -> bool:
     """Check whether data is a numpy 1-D array."""
     return isinstance(data, np.ndarray) and len(data.shape) == 1
 
 
-def is_numpy_column_array(data):
+def is_numpy_column_array(data: Any) -> bool:
     """Check whether data is a column numpy array."""
     if not isinstance(data, np.ndarray):
         return False
@@ -172,7 +172,7 @@ def cast_numpy_array_to_dtype(array, dtype):
     return array.astype(dtype=dtype, copy=False)
 
 
-def is_1d_list(data):
+def is_1d_list(data: Any) -> bool:
     """Check whether data is a 1-D list."""
     return isinstance(data, list) and (not data or is_numeric(data[0]))
 
@@ -279,7 +279,7 @@ def c_array(ctype, values):
     return (ctype * len(values))(*values)
 
 
-def json_default_with_numpy(obj):
+def json_default_with_numpy(obj: Any) -> Any:
     """Convert numpy classes to JSON serializable objects."""
     if isinstance(obj, (np.integer, np.floating, np.bool_)):
         return obj.item()
@@ -744,7 +744,7 @@ class _InnerPredictor:
         pred_parameter = {} if pred_parameter is None else pred_parameter
         self.pred_parameter = param_dict_to_str(pred_parameter)
 
-    def __del__(self):
+    def __del__(self) -> None:
         try:
             if self.__is_manage_handle:
                 _safe_call(_LIB.LGBM_BoosterFree(self.handle))
@@ -1145,7 +1145,7 @@ class _InnerPredictor:
             raise ValueError("Wrong length for predict results")
         return preds, nrow
 
-    def current_iteration(self):
+    def current_iteration(self) -> int:
         """Get the index of the current iteration.
 
         Returns


### PR DESCRIPTION
Contributes to #3756 .

Adds type hints on `Booster.shuffle_models()`, `Booster.model_to_string()`, and `Booster.dump_model()`.