### PR TITLE
Fix DockerFile GPU CUDA GPG Keys

### DIFF
--- a/docker/gpu/dockerfile.gpu
+++ b/docker/gpu/dockerfile.gpu
@@ -34,11 +34,12 @@ RUN chmod +x /tini
 # update: downloads the package lists from the repositories and "updates" them to get information on the newest versions of packages and their
 # dependencies. It will do this for all repositories and PPAs.
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC && apt-get update && \
+RUN apt-get update && \
 apt-get install -y --no-install-recommends \
 build-essential \
 curl \
 bzip2 \
+wget \
 ca-certificates \
 libglib2.0-0 \
 libxext6 \
@@ -54,6 +55,9 @@ libboost-system-dev \
 libboost-filesystem-dev \
 gcc \
 g++
+
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-keyring_1.0-1_all.deb && \
+    dpkg -i cuda-keyring_1.0-1_all.deb
 
 # Add OpenCL ICD files for LightGBM
 RUN mkdir -p /etc/OpenCL/vendors && \
@@ -119,4 +123,4 @@ WORKDIR /home
 EXPOSE 8888
 
 ENTRYPOINT [ "/tini", "--" ]
-CMD /bin/bash -c "conda activate py3 && jupyter notebook --allow-root --no-browser --NotebookApp.password='sha1:98b767162d34:8da1bc3c75a0f29145769edc977375a373407824' && conda deactivate"
+CMD /bin/bash -c "conda activate py3 && jupyter notebook --allow-root --NotebookApp.iopub_data_rate_limit=1.0e10 --no-browser --NotebookApp.password='sha1:98b767162d34:8da1bc3c75a0f29145769edc977375a373407824' && conda deactivate"

--- a/docker/gpu/dockerfile.gpu
+++ b/docker/gpu/dockerfile.gpu
@@ -123,4 +123,4 @@ WORKDIR /home
 EXPOSE 8888
 
 ENTRYPOINT [ "/tini", "--" ]
-CMD /bin/bash -c "conda activate py3 && jupyter notebook --allow-root --NotebookApp.iopub_data_rate_limit=1.0e10 --no-browser --NotebookApp.password='sha1:98b767162d34:8da1bc3c75a0f29145769edc977375a373407824' && conda deactivate"
+CMD /bin/bash -c "conda activate py3 && jupyter notebook --allow-root --no-browser --NotebookApp.password='sha1:98b767162d34:8da1bc3c75a0f29145769edc977375a373407824' && conda deactivate"

--- a/docker/gpu/dockerfile.gpu
+++ b/docker/gpu/dockerfile.gpu
@@ -119,4 +119,4 @@ WORKDIR /home
 EXPOSE 8888
 
 ENTRYPOINT [ "/tini", "--" ]
-CMD /bin/bash -c "source activate py3 && jupyter notebook --allow-root --no-browser --NotebookApp.password='sha1:98b767162d34:8da1bc3c75a0f29145769edc977375a373407824' && source deactivate"
+CMD /bin/bash -c "conda activate py3 && jupyter notebook --allow-root --no-browser --NotebookApp.password='sha1:98b767162d34:8da1bc3c75a0f29145769edc977375a373407824' && conda deactivate"

--- a/docker/gpu/dockerfile.gpu
+++ b/docker/gpu/dockerfile.gpu
@@ -34,7 +34,7 @@ RUN chmod +x /tini
 # update: downloads the package lists from the repositories and "updates" them to get information on the newest versions of packages and their
 # dependencies. It will do this for all repositories and PPAs.
 
-RUN apt-get update && \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC && apt-get update && \
 apt-get install -y --no-install-recommends \
 build-essential \
 curl \
@@ -73,8 +73,8 @@ RUN echo "export PATH=$CONDA_DIR/bin:"'$PATH' > /etc/profile.d/conda.sh && \
     /bin/bash ~/miniforge.sh -b -p $CONDA_DIR && \
     rm ~/miniforge.sh
 
-RUN conda config --set always_yes yes --set changeps1 no && \
-    conda create -y -q -n py3 numpy scipy scikit-learn jupyter notebook ipython pandas matplotlib
+RUN conda config --set changeps1 no && \
+    conda create -y -n py3 numpy scipy scikit-learn jupyter notebook ipython pandas matplotlib
 
 #################################################################################################################
 #           LightGBM

--- a/docker/gpu/dockerfile.gpu
+++ b/docker/gpu/dockerfile.gpu
@@ -77,8 +77,8 @@ RUN echo "export PATH=$CONDA_DIR/bin:"'$PATH' > /etc/profile.d/conda.sh && \
     /bin/bash ~/miniforge.sh -b -p $CONDA_DIR && \
     rm ~/miniforge.sh
 
-RUN conda config --set changeps1 no && \
-    conda create -y -n py3 numpy scipy scikit-learn jupyter notebook ipython pandas matplotlib
+RUN conda config --set always_yes yes --set changeps1 no && \
+    conda create -y -q -n py3 numpy scipy scikit-learn jupyter notebook ipython pandas matplotlib
 
 #################################################################################################################
 #           LightGBM


### PR DESCRIPTION
The Docker in the repository no longer works, as NVIDIA updated their GPG keys in [Apr 2022](https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/). 

The dockerfile has been updated here