### PR TITLE
[docs] [R-package] upgrade to roxygen2 7.2.1

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -63,4 +63,4 @@ Imports:
     utils
 SystemRequirements:
     C++11
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -12,7 +12,7 @@ dependencies:
   - r-matrix=1.4_0
   - r-pkgdown=1.6.1
   - r-rmarkdown=2.11
-  - r-roxygen2=7.2.0
+  - r-roxygen2=7.2.1
   - scikit-learn
   - sphinx
   - "sphinx_rtd_theme>=0.5"


### PR DESCRIPTION
`{roxygen2}` v7.2.1 was released today.

This PR updates LightGBM's documentation to use it.

### Notes for Reviewers

@StrikerRUS could you please enable builds of this branch on readthedocs so we can check that this works there?