### PR TITLE
[docs] [R-package] document how to regenerate roxygen docs

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -18,6 +18,7 @@
 * [Testing](#testing)
     - [Running the Tests](#running-the-tests)
     - [Code Coverage](#code-coverage)
+* [Updating Documentation](#updating-documentation)
 * [Preparing a CRAN Package](#preparing-a-cran-package)
 * [External Repositories](#external-unofficial-repositories)
 * [Known Issues](#known-issues)
@@ -275,6 +276,29 @@ Rscript -e " \
     print(coverage);
     covr::report(coverage, file = file.path(getwd(), 'coverage.html'), browse = TRUE);
     "
+```
+
+Updating Documentation
+----------------------
+
+The R package uses [`{roxygen2}`](https://cran.r-project.org/web/packages/roxygen2/index.html) to generate its documentation.
+The generated `DESCRIPTION`, `NAMESPACE`, and `man/` files are checked into source control.
+To regenerate those files, run the following.
+
+```shell
+Rscript \
+    --vanilla \
+    -e "install.packages('roxygen2', repos = 'https://cran.rstudio.com')"
+
+sh build-cran-package.sh --no-build-vignettes
+R CMD INSTALL \
+  --with-keep.source \
+  ./lightgbm_*.tar.gz
+
+cd R-package
+Rscript \
+    --vanilla \
+    -e "roxygen2::roxygenize(load = 'installed')"
 ```
 
 Preparing a CRAN Package


### PR DESCRIPTION
The R package uses `{roxygen2}` to generate its docs, but because of the way the package is built contributors can't simply run `devtools::document()` or `roxygen2::roxygenize()` as they may be used to in other R projects.

Example of someone running into that: https://github.com/microsoft/LightGBM/pull/5379#issuecomment-1188726525.

This PR proposes adding documentation on how to re-generate the R package's docs.

(p.s. I promised @jmoralez this in maintainer Slack a long time ago but forgot to come do it)