### PR TITLE
Minor CUDA cleanup

### DIFF
--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -125,7 +125,7 @@ All requirements from `Build from Sources section <#build-from-sources>`__ apply
 
 Recently, a new CUDA version with better efficiency is implemented as an experimental feature. To build the new CUDA version, replace ``--cuda`` with ``--cuda-exp`` in the above commands. Please note that new version requires **CUDA** 10.0 or later libraries. Note that this new version uses twice the memory, since it stores data row-wise as well as column-wise in memory to improve performance (see this `issue <https://github.com/microsoft/LightGBM/issues/5318>`__ for discussion). 
 
-To use the regular or experimental cuda versions within Python, pass ``{"device":"cuda"}`` or ``{"device":"cuda_exp"}`` respectively as parameters.
+To use the regular or experimental CUDA versions within Python, pass ``{"device": "cuda"}`` or ``{"device": "cuda_exp"}`` respectively as parameters.
 
 Build HDFS Version
 ~~~~~~~~~~~~~~~~~~

--- a/src/boosting/cuda/cuda_score_updater.cu
+++ b/src/boosting/cuda/cuda_score_updater.cu
@@ -22,7 +22,7 @@ __global__ void AddScoreConstantKernel(
 
 void CUDAScoreUpdater::LaunchAddScoreConstantKernel(const double val, const size_t offset) {
   const int num_blocks = (num_data_ + num_threads_per_block_) / num_threads_per_block_;
-  Log::Warning("adding init score = %f", val);
+  Log::Debug("Adding init score = %lf", val);
   AddScoreConstantKernel<<<num_blocks, num_threads_per_block_>>>(val, offset, num_data_, cuda_score_);
 }
 


### PR DESCRIPTION
- Format CUDA-related note in the docs.
- Replace `Warning` level with `Debug` for initial score value and fix `double` formatter.