### PR TITLE
Fix potential overflow in linear trees

### DIFF
--- a/src/treelearner/linear_tree_learner.cpp
+++ b/src/treelearner/linear_tree_learner.cpp
@@ -282,10 +282,10 @@ void LinearTreeLearner::CalculateLinear(Tree* tree, bool is_refit, const score_t
       int j = 0;
       for (int feat1 = 0; feat1 < num_feat + 1; ++feat1) {
         float f1_val = curr_row[feat1];
-        XTg_by_thread_[tid][leaf_num][feat1] += f1_val * g;
+        XTg_by_thread_[tid][leaf_num][feat1] += static_cast<double>(f1_val) * g;
         f1_val *= h;
         for (int feat2 = feat1; feat2 < num_feat + 1; ++feat2) {
-          XTHX_by_thread_[tid][leaf_num][j] += f1_val * curr_row[feat2];
+          XTHX_by_thread_[tid][leaf_num][j] += static_cast<double>(f1_val) * curr_row[feat2];
           ++j;
         }
       }

--- a/src/treelearner/linear_tree_learner.cpp
+++ b/src/treelearner/linear_tree_learner.cpp
@@ -281,11 +281,11 @@ void LinearTreeLearner::CalculateLinear(Tree* tree, bool is_refit, const score_t
       float g = static_cast<float>(gradients[i]);
       int j = 0;
       for (int feat1 = 0; feat1 < num_feat + 1; ++feat1) {
-        float f1_val = curr_row[feat1];
-        XTg_by_thread_[tid][leaf_num][feat1] += static_cast<double>(f1_val) * g;
+        double f1_val = static_cast<double>(curr_row[feat1]);
+        XTg_by_thread_[tid][leaf_num][feat1] += f1_val * g;
         f1_val *= h;
         for (int feat2 = feat1; feat2 < num_feat + 1; ++feat2) {
-          XTHX_by_thread_[tid][leaf_num][j] += static_cast<double>(f1_val) * curr_row[feat2];
+          XTHX_by_thread_[tid][leaf_num][j] += f1_val * curr_row[feat2];
           ++j;
         }
       }


### PR DESCRIPTION
Found by https://lgtm.com/projects/g/microsoft/LightGBM?mode=tree&ruleFocus=2157860313.

In #5368 `XTg_by_thread_` and `XTHX_by_thread_` was changed from `float` to `double`: https://github.com/microsoft/LightGBM/commit/44d37184d1718b065140483b95fcce273f714cbe#diff-772d433919ddb14342b8dd8ca225131ebef06689c9f0311f685103b685cb5f6eL123-L124.