### PR TITLE
[python-package] add more type hints in basic.py

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -714,7 +714,7 @@ class _InnerPredictor:
     def __init__(
         self,
         model_file: Optional[Union[str, Path]] = None,
-        booster_handle: Optional["Booster"] = None,
+        booster_handle: Optional[ctypes.c_void_p] = None,
         pred_parameter: Optional[Dict[str, Any]] = None
     ):
         """Initialize the _InnerPredictor.

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -711,7 +711,12 @@ class _InnerPredictor:
         Can be converted from Booster, but cannot be converted to Booster.
     """
 
-    def __init__(self, model_file=None, booster_handle=None, pred_parameter=None):
+    def __init__(
+        self,
+        model_file: Optional[Union[str, Path]] = None,
+        booster_handle: Optional["Booster"] = None,
+        pred_parameter: Optional[Dict[str, Any]] = None
+    ):
         """Initialize the _InnerPredictor.
 
         Parameters
@@ -762,7 +767,7 @@ class _InnerPredictor:
         except AttributeError:
             pass
 
-    def __getstate__(self):
+    def __getstate__(self) -> Dict[str, Any]:
         this = self.__dict__.copy()
         this.pop('handle', None)
         return this
@@ -3781,7 +3786,10 @@ class Booster:
             ctypes.byref(ret)))
         return ret.value
 
-    def _to_predictor(self, pred_parameter=None):
+    def _to_predictor(
+        self,
+        pred_parameter: Optional[Dict[str, Any]] = None
+    ) -> _InnerPredictor:
         """Convert to predictor."""
         predictor = _InnerPredictor(booster_handle=self.handle, pred_parameter=pred_parameter)
         predictor.pandas_categorical = self.pandas_categorical
@@ -3876,7 +3884,12 @@ class Booster:
         else:
             return result
 
-    def get_split_value_histogram(self, feature, bins=None, xgboost_style=False):
+    def get_split_value_histogram(
+        self,
+        feature: Union[int, str],
+        bins: Optional[Union[int, str]] = None,
+        xgboost_style: bool = False
+    ) -> Union[Tuple[np.ndarray, np.ndarray], np.ndarray, pd_DataFrame]:
         """Get split value histogram for the specified feature.
 
         Parameters


### PR DESCRIPTION
Contributes to #3756.

Adds type hints in a few more places in `basic.py`.