### PR TITLE
[ci] increase valgrind timeout to 5 hours

### DIFF
--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-r-valgrind:
     name: r-package (ubuntu-latest, R-devel, valgrind)
-    timeout-minutes: 240
+    timeout-minutes: 300
     runs-on: ubuntu-latest
     container: wch1/r-debug
     env:


### PR DESCRIPTION
`valgrind` checks are timing out after 4 hours.

See, for example, https://github.com/microsoft/LightGBM/pull/5403#issuecomment-1210339118.

It has been a few weeks since we last ran that job, so I'm not sure why it is slower now. Either way, I hope that just giving the job one more hour to finish will help.

This PR proposes that.

### Note for Reviewers

This has to be merged to `master` to test it, as the configuration for GitHub Actions jobs is sourced from `master`.