### PR TITLE
[ci] increase valgrind bytes lost limit to 352

### DIFF
--- a/.ci/test_r_package_valgrind.sh
+++ b/.ci/test_r_package_valgrind.sh
@@ -46,7 +46,7 @@ if [[ ${bytes_indirectly_lost} -gt 0 ]]; then
 fi
 
 # one error caused by a false positive between valgrind and openmp is allowed
-# ==2063== 336 bytes in 1 blocks are possibly lost in loss record 153 of 2,709
+# ==2063== 352 bytes in 1 blocks are possibly lost in loss record 153 of 2,709
 # ==2063==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
 # ==2063==    by 0x40149CA: allocate_dtv (dl-tls.c:286)
 # ==2063==    by 0x40149CA: _dl_allocate_tls (dl-tls.c:532)
@@ -68,7 +68,7 @@ bytes_possibly_lost=$(
     | tr -d ","
 )
 echo "valgrind found ${bytes_possibly_lost} bytes possibly lost"
-if [[ ${bytes_possibly_lost} -gt 336 ]]; then
+if [[ ${bytes_possibly_lost} -gt 352 ]]; then
     exit -1
 fi
 


### PR DESCRIPTION
See https://github.com/microsoft/LightGBM/pull/5403#issuecomment-1218836822 for details.

This PR slightly increases the number of "possibly lost bytes" allowed in the `valgrind` CI job. Since this is coming from the exact same place as a previous false positive, I think it's highly likely that CRAN will not complain about this.