### PR TITLE
[python-package] add type hints on Booster eval methods

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2623,11 +2623,11 @@ _LGBM_CustomObjectiveFunction = Callable[
 _LGBM_CustomEvalFunction = Union[
     Callable[
         [np.ndarray, Dataset],
-        _LGBM_EvalResultType
+        _LGBM_EvalFunctionResultType
     ],
     Callable[
         [np.ndarray, Dataset],
-        List[_LGBM_EvalResultType]
+        List[_LGBM_EvalFunctionResultType]
     ]
 ]
 
@@ -3998,7 +3998,7 @@ class Booster:
         data_name: str,
         data_idx: int,
         feval: Optional[Union[_LGBM_CustomEvalFunction, List[_LGBM_CustomEvalFunction]]] = None
-    ) -> List[Tuple[str, str, float, bool]]:
+    ) -> List[_LGBM_BoosterEvalMethodResultType]:
         """Evaluate training or validation data."""
         if data_idx >= self.__num_dataset:
             raise ValueError("Data_idx should be smaller than number of dataset")

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -4,10 +4,10 @@ import collections
 from functools import partial
 from typing import Any, Callable, Dict, List, Tuple, Union
 
-from .basic import _ConfigAliases, _log_info, _log_warning
+from .basic import _ConfigAliases, _LGBM_BoosterEvalMethodResultType, _log_info, _log_warning
 
 _EvalResultTuple = Union[
-    List[Tuple[str, str, float, bool]],
+    List[_LGBM_BoosterEvalMethodResultType],
     List[Tuple[str, str, float, bool, float]]
 ]
 

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from . import callback
 from .basic import (Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _InnerPredictor,
-                    _LGBM_CustomObjectiveFunction, _log_warning)
+                    _LGBM_CustomObjectiveFunction, _LGBM_BoosterEvalMethodResultType, _log_warning)
 from .compat import SKLEARN_INSTALLED, _LGBMBaseCrossValidator, _LGBMGroupKFold, _LGBMStratifiedKFold
 
 _LGBM_CustomMetricFunction = Callable[
@@ -243,7 +243,7 @@ def train(
 
         booster.update(fobj=fobj)
 
-        evaluation_result_list = []
+        evaluation_result_list: List[_LGBM_BoosterEvalMethodResultType] = []
         # check evaluation result.
         if valid_sets is not None:
             if is_valid_contain_train:

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from . import callback
 from .basic import (Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _InnerPredictor,
-                    _LGBM_CustomObjectiveFunction, _LGBM_BoosterEvalMethodResultType, _log_warning)
+                    _LGBM_CustomObjectiveFunction, _log_warning)
 from .compat import SKLEARN_INSTALLED, _LGBMBaseCrossValidator, _LGBMGroupKFold, _LGBMStratifiedKFold
 
 _LGBM_CustomMetricFunction = Callable[
@@ -243,7 +243,7 @@ def train(
 
         booster.update(fobj=fobj)
 
-        evaluation_result_list: List[_LGBM_BoosterEvalMethodResultType] = []
+        evaluation_result_list = []
         # check evaluation result.
         if valid_sets is not None:
             if is_valid_contain_train:

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -6,15 +6,14 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from .basic import Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _log_warning
+from .basic import (Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _LGBM_EvalFunctionResultType,
+                    _log_warning)
 from .callback import record_evaluation
 from .compat import (SKLEARN_INSTALLED, LGBMNotFittedError, _LGBMAssertAllFinite, _LGBMCheckArray,
                      _LGBMCheckClassificationTargets, _LGBMCheckSampleWeight, _LGBMCheckXY, _LGBMClassifierBase,
                      _LGBMComputeSampleWeight, _LGBMCpuCount, _LGBMLabelEncoder, _LGBMModelBase, _LGBMRegressorBase,
                      dt_DataTable, pd_DataFrame)
 from .engine import train
-
-_EvalResultType = Tuple[str, float, bool]
 
 _LGBM_ScikitCustomObjectiveFunction = Union[
     Callable[
@@ -33,15 +32,15 @@ _LGBM_ScikitCustomObjectiveFunction = Union[
 _LGBM_ScikitCustomEvalFunction = Union[
     Callable[
         [np.ndarray, np.ndarray],
-        Union[_EvalResultType, List[_EvalResultType]]
+        Union[_LGBM_EvalFunctionResultType, List[_LGBM_EvalFunctionResultType]]
     ],
     Callable[
         [np.ndarray, np.ndarray, np.ndarray],
-        Union[_EvalResultType, List[_EvalResultType]]
+        Union[_LGBM_EvalFunctionResultType, List[_LGBM_EvalFunctionResultType]]
     ],
     Callable[
         [np.ndarray, np.ndarray, np.ndarray, np.ndarray],
-        Union[_EvalResultType, List[_EvalResultType]]
+        Union[_LGBM_EvalFunctionResultType, List[_LGBM_EvalFunctionResultType]]
     ],
 ]
 


### PR DESCRIPTION
Contributes to #3756 and #3867.

Adds type hints on the following closely-related methods.

* `Booster.eval()`
* `Booster.eval_train()`
* `Booster.eval_valid()`
* `Booster.__inner_eval()`

Modifies docstrings for those methods to be a bit more informative about the structure of the returned tuples.

Modifies type hints for other methods using the results of these methods so that they share the same definitions imported across different files.

### How I tested this

Used the following small sample code to test these return types.

<details><summary>test code (click me)</summary>

```python
import lightgbm as lgb
from sklearn.datasets import make_blobs

def _single_tuple_metric(preds, ds):
    return ("single_tuple", 1.0, True)

def _list_of_tuples_metric(preds, ds):
    return [("list_id_0", 2.0, True), ("list_id_1", 2.0, True)]

X, y = make_blobs(n_samples=1234, centers=[[-4, -4], [-4, 4]])
dtrain = lgb.Dataset(X, y)
```

<img width="568" alt="image" src="https://user-images.githubusercontent.com/7608904/185834548-fa8e5377-c981-44b7-9acf-4f2be06b06d1.png">

</details>

### Notes for Reviewers

This PR introduces 6 new `mypy` errors.

```text
python-package/lightgbm/engine.py:250: error: Argument 1 to "eval_train" of "Booster" has incompatible type "Union[Callable[[ndarray[Any, Any], Dataset], Tuple[str, float, bool]], List[Callable[[ndarray[Any, Any], Dataset], Tuple[str, float, bool]]], None]"; expected "Union[Callable[[ndarray[Any, Any], Dataset], Any], Callable[[ndarray[Any, Any], Dataset], List[Any]], List[Union[Callable[[ndarray[Any, Any], Dataset], Any], Callable[[ndarray[Any, Any], Dataset], List[Any]]]], None]"
python-package/lightgbm/engine.py:251: error: Argument 1 to "eval_valid" of "Booster" has incompatible type "Union[Callable[[ndarray[Any, Any], Dataset], Tuple[str, float, bool]], List[Callable[[ndarray[Any, Any], Dataset], Tuple[str, float, bool]]], None]"; expected "Union[Callable[[ndarray[Any, Any], Dataset], Any], Callable[[ndarray[Any, Any], Dataset], List[Any]], List[Union[Callable[[ndarray[Any, Any], Dataset], Any], Callable[[ndarray[Any, Any], Dataset], List[Any]]]], None]"
python-package/lightgbm/engine.py:262: error: Incompatible types in assignment (expression has type "Union[List[Tuple[str, str, float, bool]], List[Tuple[str, str, float, bool, float]]]", variable has type "List[Tuple[str, str, float, bool]]")
python-package/lightgbm/sklearn.py:190: error: Incompatible return value type (got "Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]", expected "Tuple[str, float, bool]")
python-package/lightgbm/sklearn.py:192: error: Incompatible return value type (got "Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]", expected "Tuple[str, float, bool]")
python-package/lightgbm/sklearn.py:194: error: Incompatible return value type (got "Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]", expected "Tuple[str, float, bool]")
```

I think this is a result of how `mypy` deals with overwriting a local variable with a different type than the first type it was instantiated with.

I believe investigating and fixing these will be non-trivial, and I'm proposing that we defer fixing them to separate PRs targeting #3867.