### PR TITLE
[ci] bump CUDA version from `11.7.0` to `11.7.1` at CI

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -26,7 +26,7 @@ jobs:
           - method: source
             compiler: gcc
             python_version: "3.8"
-            cuda_version: "11.7.0"
+            cuda_version: "11.7.1"
             tree_learner: cuda
           - method: pip
             compiler: clang
@@ -41,7 +41,7 @@ jobs:
           - method: source
             compiler: gcc
             python_version: "3.8"
-            cuda_version: "11.7.0"
+            cuda_version: "11.7.1"
             tree_learner: cuda_exp
           - method: pip
             compiler: clang


### PR DESCRIPTION
https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags