### PR TITLE
[python-package] add type hints on empty initializations

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2512,7 +2512,7 @@ class Dataset:
             Chain of references of the Datasets.
         """
         head = self
-        ref_chain = set()
+        ref_chain: Set[Dataset] = set()
         while len(ref_chain) < ref_limit:
             if isinstance(head, Dataset):
                 ref_chain.add(head)
@@ -2731,8 +2731,8 @@ class Booster:
                 ctypes.byref(self.handle)))
             # save reference to data
             self.train_set = train_set
-            self.valid_sets = []
-            self.name_valid_sets = []
+            self.valid_sets: List[Dataset] = []
+            self.name_valid_sets: List[str] = []
             self.__num_dataset = 1
             self.__init_predictor = train_set._predictor
             if self.__init_predictor is not None:

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -300,7 +300,7 @@ class CVBooster:
         model_file : str, pathlib.Path or None, optional (default=None)
             Path to the CVBooster model file.
         """
-        self.boosters = []
+        self.boosters: List[Booster] = []
         self.best_iteration = -1
 
         if model_file is not None:


### PR DESCRIPTION
Contributes to #3867.
Contributes to #3756.

`mypy` currently raises the following errors.

```text
python-package/lightgbm/basic.py:2515: error: Need type annotation for "ref_chain" (hint: "ref_chain: Set[<type>] = ...")
python-package/lightgbm/basic.py:2734: error: Need type annotation for "valid_sets" (hint: "valid_sets: List[<type>] = ...")
python-package/lightgbm/basic.py:2735: error: Need type annotation for "name_valid_sets" (hint: "name_valid_sets: List[<type>] = ...")
python-package/lightgbm/engine.py:303: error: Need type annotation for "boosters" (hint: "boosters: List[<type>] = ...")
```

These come from places where an empty container is initialized, then later filled with values. Like this:

https://github.com/microsoft/LightGBM/blob/ef006b788cb2aadd3e827d0d8b44bf879854966e/python-package/lightgbm/engine.py#L303

https://github.com/microsoft/LightGBM/blob/ef006b788cb2aadd3e827d0d8b44bf879854966e/python-package/lightgbm/engine.py#L310-L312

This PR adds type hints to fix those errors.

### Notes for Reviewers

I tested this by running `mypy` as documented in #3867.

```shell
mypy \
    --exclude='python-package/compile/|python-package/build' \
    --ignore-missing-imports \
    python-package/
```