### PR TITLE
[python-package] fix type hints on ctypes array converters

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -255,7 +255,7 @@ def _data_to_2d_numpy(data: Any, dtype: type = np.float32, name: str = 'list') -
                     "It should be list of lists, numpy 2-D array or pandas DataFrame")
 
 
-def cfloat32_array_to_numpy(cptr: ctypes.POINTER, length: int) -> np.ndarray:
+def cfloat32_array_to_numpy(cptr: Any, length: int) -> np.ndarray:
     """Convert a ctypes float pointer array to a numpy array."""
     if isinstance(cptr, ctypes.POINTER(ctypes.c_float)):
         return np.ctypeslib.as_array(cptr, shape=(length,)).copy()
@@ -263,7 +263,7 @@ def cfloat32_array_to_numpy(cptr: ctypes.POINTER, length: int) -> np.ndarray:
         raise RuntimeError('Expected float pointer')
 
 
-def cfloat64_array_to_numpy(cptr: ctypes.POINTER, length: int) -> np.ndarray:
+def cfloat64_array_to_numpy(cptr: Any, length: int) -> np.ndarray:
     """Convert a ctypes double pointer array to a numpy array."""
     if isinstance(cptr, ctypes.POINTER(ctypes.c_double)):
         return np.ctypeslib.as_array(cptr, shape=(length,)).copy()
@@ -271,7 +271,7 @@ def cfloat64_array_to_numpy(cptr: ctypes.POINTER, length: int) -> np.ndarray:
         raise RuntimeError('Expected double pointer')
 
 
-def cint32_array_to_numpy(cptr: ctypes.POINTER, length: int) -> np.ndarray:
+def cint32_array_to_numpy(cptr: Any, length: int) -> np.ndarray:
     """Convert a ctypes int pointer array to a numpy array."""
     if isinstance(cptr, ctypes.POINTER(ctypes.c_int32)):
         return np.ctypeslib.as_array(cptr, shape=(length,)).copy()
@@ -279,7 +279,7 @@ def cint32_array_to_numpy(cptr: ctypes.POINTER, length: int) -> np.ndarray:
         raise RuntimeError('Expected int32 pointer')
 
 
-def cint64_array_to_numpy(cptr: ctypes.POINTER, length: int) -> np.ndarray:
+def cint64_array_to_numpy(cptr: Any, length: int) -> np.ndarray:
     """Convert a ctypes int pointer array to a numpy array."""
     if isinstance(cptr, ctypes.POINTER(ctypes.c_int64)):
         return np.ctypeslib.as_array(cptr, shape=(length,)).copy()


### PR DESCRIPTION
Contributes to #3756.
Contributes to #3867.

`mypy` currently raises the following errors.

```text
python-package/lightgbm/basic.py:258: error: Function "ctypes.POINTER" is not valid as a type
python-package/lightgbm/basic.py:258: note: Perhaps you need "Callable[...]" or a callback protocol?
python-package/lightgbm/basic.py:266: error: Function "ctypes.POINTER" is not valid as a type
python-package/lightgbm/basic.py:266: note: Perhaps you need "Callable[...]" or a callback protocol?
python-package/lightgbm/basic.py:274: error: Function "ctypes.POINTER" is not valid as a type
python-package/lightgbm/basic.py:274: note: Perhaps you need "Callable[...]" or a callback protocol?
python-package/lightgbm/basic.py:282: error: Function "ctypes.POINTER" is not valid as a type
python-package/lightgbm/basic.py:282: note: Perhaps you need "Callable[...]" or a callback protocol?
```

These are correctly noting that `ctypes.POINTER` isn't a type...it's a function that *returns a type*. From https://docs.python.org/3/library/ctypes.html#ctypes.pointer

> [`ctypes.pointer()`] creates a new pointer instance, pointing to obj. The returned object is of the type `POINTER(type(obj))`

You can see this with the following example code.

```python
import ctypes

x = ctypes.c_float(1.1)
type(x)
# <class 'ctypes.c_float'>

ptr_type = ctypes.POINTER(type(x))
print(ptr_type)
# <class '__main__.LP_c_float'>

callable(ptr_type)
# True

isinstance(ctypes.pointer(x), ctypes.POINTER(ctypes.c_float))
# True
```

Since the functions `mypy` is complaining about all take in an object, check for a specific type with `isinstance()`, and raises an exception if the passed-in object doesn't have that type, I think it's appropriate to replace those `ctypes.POINTER` type hints with just `Any`.

### Notes for Reviewers

I tested this by running `mypy` as documented in #3867.

```shell
mypy \
    --exclude='python-package/compile/|python-package/build' \
    --ignore-missing-imports \
    python-package/
```