### PR TITLE
[python-package] fix mypy error about type change in Dataset.feature_num_bin()

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2485,10 +2485,12 @@ class Dataset:
         """
         if self.handle is not None:
             if isinstance(feature, str):
-                feature = self.feature_name.index(feature)
+                feature_index = self.feature_name.index(feature)
+            else:
+                feature_index = feature
             ret = ctypes.c_int(0)
             _safe_call(_LIB.LGBM_DatasetGetFeatureNumBin(self.handle,
-                                                         ctypes.c_int(feature),
+                                                         ctypes.c_int(feature_index),
                                                          ctypes.byref(ret)))
             return ret.value
         else:


### PR DESCRIPTION
Contributes to #3756.
Contributes to #3867.

`mypy` currently raises the following error.

```text
python-package/lightgbm/basic.py:2491: error: Argument 1 to "c_int" has incompatible type "Union[int, str]"; expected "int"
```

This is caused by the fact that `mypy` doesn't allow changing the type of an object after it's initially assigned. This blog post explains it well: https://adamj.eu/tech/2021/05/23/python-type-hints-mypy-doesnt-allow-variables-to-change-type/.

This PR proposes a slight refactoring of `Dataset.feature_num_bin()` to resolve this error. I think this change does also make the code slightly easier to understand.

### Notes for Reviewers

I tested this by running `mypy` as documented in #3867.

```shell
mypy \
    --exclude='python-package/compile/|python-package/build' \
    --ignore-missing-imports \
    python-package/
```