### PR TITLE
[python-package] fix mypy errors about callbacks

### DIFF
--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -685,7 +685,7 @@ def cv(
 
     # setup callbacks
     if callbacks is None:
-        callbacks_set: Set[Callable] = set()
+        callbacks_set = set()
     else:
         for i, cb in enumerate(callbacks):
             cb.__dict__.setdefault('order', i - len(callbacks))
@@ -704,10 +704,10 @@ def cv(
             )
         )
 
-    callbacks_before_iter = {cb for cb in callbacks_set if getattr(cb, 'before_iteration', False)}
-    callbacks_after_iter = callbacks_set - callbacks_before_iter
-    callbacks_before_iter = sorted(callbacks_before_iter, key=attrgetter('order'))
-    callbacks_after_iter = sorted(callbacks_after_iter, key=attrgetter('order'))
+    callbacks_before_iter_set = {cb for cb in callbacks_set if getattr(cb, 'before_iteration', False)}
+    callbacks_after_iter_set = callbacks_set - callbacks_before_iter_set
+    callbacks_before_iter = sorted(callbacks_before_iter_set, key=attrgetter('order'))
+    callbacks_after_iter = sorted(callbacks_after_iter_set, key=attrgetter('order'))
 
     for i in range(num_boost_round):
         for cb in callbacks_before_iter:

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -685,14 +685,14 @@ def cv(
 
     # setup callbacks
     if callbacks is None:
-        callbacks = set()
+        callbacks_set: Set[Callable] = set()
     else:
         for i, cb in enumerate(callbacks):
             cb.__dict__.setdefault('order', i - len(callbacks))
-        callbacks = set(callbacks)
+        callbacks_set = set(callbacks)
 
     if "early_stopping_round" in params:
-        callbacks.add(
+        callbacks_set.add(
             callback.early_stopping(
                 stopping_rounds=params["early_stopping_round"],
                 first_metric_only=first_metric_only,
@@ -704,8 +704,8 @@ def cv(
             )
         )
 
-    callbacks_before_iter = {cb for cb in callbacks if getattr(cb, 'before_iteration', False)}
-    callbacks_after_iter = callbacks - callbacks_before_iter
+    callbacks_before_iter = {cb for cb in callbacks_set if getattr(cb, 'before_iteration', False)}
+    callbacks_after_iter = callbacks_set - callbacks_before_iter
     callbacks_before_iter = sorted(callbacks_before_iter, key=attrgetter('order'))
     callbacks_after_iter = sorted(callbacks_after_iter, key=attrgetter('order'))
 


### PR DESCRIPTION
Contributes to #3756.
Contributes to #3867.

`mypy` currently raises the following errors.

```text
-python-package/lightgbm/engine.py:688: error: Incompatible types in assignment (expression has type "Set[<nothing>]", variable has type "Optional[List[Callable[..., Any]]]")
-python-package/lightgbm/engine.py:692: error: Incompatible types in assignment (expression has type "Set[Callable[..., Any]]", variable has type "Optional[List[Callable[..., Any]]]")
-python-package/lightgbm/engine.py:695: error: Item "List[Callable[..., Any]]" of "Optional[List[Callable[..., Any]]]" has no attribute "add"
-python-package/lightgbm/engine.py:695: error: Item "None" of "Optional[List[Callable[..., Any]]]" has no attribute "add"
-python-package/lightgbm/engine.py:707: error: Item "None" of "Optional[List[Callable[..., Any]]]" has no attribute "__iter__" (not iterable)
-python-package/lightgbm/engine.py:708: error: Unsupported left operand type for - ("List[Callable[..., Any]]")
-python-package/lightgbm/engine.py:708: error: Unsupported left operand type for - ("None")
-python-package/lightgbm/engine.py:708: note: Left operand is of type "Optional[List[Callable[..., Any]]]"
-python-package/lightgbm/engine.py:709: error: Incompatible types in assignment (expression has type "List[Union[Callable[..., Any], Any]]", variable has type "Set[Union[Callable[..., Any], Any]]")
```

These errors come from variables' types changing. Specifically, the fact that in the code for `cv()`, the variable `callbacks` is initially assigned a value with type `Optional[List[Callable]]`, then is overwritten with a `set`, then the variable `callbacks_before_iter` is initialized as a `set` and overwritten with a list.

Similar to #5447, this PR proposes fixing those errors by using differently-named variables when types change.

### Notes for Reviewers

The same changes proposed in this PR were implemented in #4839 to fix the same code in `train()`.

I tested this by running `mypy` as documented in #3867.

```shell
mypy \
    --exclude='python-package/compile/|python-package/build' \
    --ignore-missing-imports \
    python-package/
```