### PR TITLE
[R-package] fix function references in error messages

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -1319,7 +1319,7 @@ lgb.save <- function(booster, filename, num_iteration = NULL) {
 lgb.dump <- function(booster, num_iteration = NULL) {
 
   if (!lgb.is.Booster(x = booster)) {
-    stop("lgb.save: booster should be an ", sQuote("lgb.Booster"))
+    stop("lgb.dump: booster should be an ", sQuote("lgb.Booster"))
   }
 
   # Return booster at requested iteration

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -161,7 +161,7 @@ Dataset <- R6::R6Class(
             # Provided indices, but some indices are missing?
             if (sum(is.na(cate_indices)) > 0L) {
               stop(
-                "lgb.self.get.handle: supplied an unknown feature in categorical_feature: "
+                "lgb.Dataset.construct: supplied an unknown feature in categorical_feature: "
                 , sQuote(private$categorical_feature[is.na(cate_indices)])
               )
             }
@@ -172,7 +172,7 @@ Dataset <- R6::R6Class(
             data_is_not_filename <- !is.character(private$raw_data)
             if (data_is_not_filename && max(private$categorical_feature) > ncol(private$raw_data)) {
               stop(
-                "lgb.self.get.handle: supplied a too large value in categorical_feature: "
+                "lgb.Dataset.construct: supplied a too large value in categorical_feature: "
                 , max(private$categorical_feature)
                 , " but only "
                 , ncol(private$raw_data)
@@ -1250,11 +1250,11 @@ lgb.Dataset.set.reference <- function(dataset, reference) {
 lgb.Dataset.save <- function(dataset, fname) {
 
   if (!lgb.is.Dataset(x = dataset)) {
-    stop("lgb.Dataset.set: input dataset should be an lgb.Dataset object")
+    stop("lgb.Dataset.save: input dataset should be an lgb.Dataset object")
   }
 
   if (!is.character(fname)) {
-    stop("lgb.Dataset.set: fname should be a character or a file connection")
+    stop("lgb.Dataset.save: fname should be a character or a file connection")
   }
 
   return(invisible(dataset$save_binary(fname = fname)))


### PR DESCRIPTION
Noticed a few places where error messages in the R package reference a function or R6 method, and where that reference is incorrect.

This PR fixes those references.