### PR TITLE
[python-package] add type hints on Dataset constructors

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1509,7 +1509,7 @@ class Dataset:
         feature_name='auto',
         categorical_feature='auto',
         params: Optional[Dict[str, Any]] = None
-    ):
+    ) -> "Dataset":
         if data is None:
             self.handle = None
             return self

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1196,10 +1196,19 @@ class _InnerPredictor:
 class Dataset:
     """Dataset in LightGBM."""
 
-    def __init__(self, data, label=None, reference=None,
-                 weight=None, group=None, init_score=None,
-                 feature_name='auto', categorical_feature='auto', params=None,
-                 free_raw_data=True):
+    def __init__(
+        self,
+        data,
+        label=None,
+        reference: Optional["Dataset"] = None,
+        weight=None,
+        group=None,
+        init_score=None,
+        feature_name='auto',
+        categorical_feature='auto',
+        params: Optional[Dict[str, Any]] = None,
+        free_raw_data: bool = True
+    ):
         """Initialize Dataset.
 
         Parameters
@@ -1488,9 +1497,19 @@ class Dataset:
             return self
         self.set_init_score(init_score)
 
-    def _lazy_init(self, data, label=None, reference=None,
-                   weight=None, group=None, init_score=None, predictor=None,
-                   feature_name='auto', categorical_feature='auto', params=None):
+    def _lazy_init(
+        self,
+        data,
+        label=None,
+        reference: Optional["Dataset"] = None,
+        weight=None,
+        group=None,
+        init_score=None,
+        predictor=None,
+        feature_name='auto',
+        categorical_feature='auto',
+        params: Optional[Dict[str, Any]] = None
+    ):
         if data is None:
             self.handle = None
             return self
@@ -1635,7 +1654,11 @@ class Dataset:
 
         return filtered, filtered_idx
 
-    def __init_from_seqs(self, seqs: List[Sequence], ref_dataset: Optional['Dataset'] = None):
+    def __init_from_seqs(
+        self,
+        seqs: List[Sequence],
+        ref_dataset: Optional["Dataset"] = None
+    ) -> "Dataset":
         """
         Initialize data from list of Sequence objects.
 
@@ -1664,7 +1687,12 @@ class Dataset:
                 self._push_rows(seq[start:end])
         return self
 
-    def __init_from_np2d(self, mat, params_str, ref_dataset):
+    def __init_from_np2d(
+        self,
+        mat: np.ndarray,
+        params_str: str,
+        ref_dataset: Optional[ctypes.c_void_p]
+    ) -> "Dataset":
         """Initialize data from a 2-D numpy matrix."""
         if len(mat.shape) != 2:
             raise ValueError('Input numpy.ndarray must be 2 dimensional')
@@ -1687,7 +1715,12 @@ class Dataset:
             ctypes.byref(self.handle)))
         return self
 
-    def __init_from_list_np2d(self, mats, params_str, ref_dataset):
+    def __init_from_list_np2d(
+        self,
+        mats: np.ndarray,
+        params_str: str,
+        ref_dataset: Optional[ctypes.c_void_p]
+    ) -> "Dataset":
         """Initialize data from a list of 2-D numpy matrices."""
         ncol = mats[0].shape[1]
         nrow = np.empty((len(mats),), np.int32)
@@ -1733,7 +1766,12 @@ class Dataset:
             ctypes.byref(self.handle)))
         return self
 
-    def __init_from_csr(self, csr, params_str, ref_dataset):
+    def __init_from_csr(
+        self,
+        csr: scipy.sparse.csr_matrix,
+        params_str: str,
+        ref_dataset: Optional[ctypes.c_void_p]
+    ) -> "Dataset":
         """Initialize data from a CSR matrix."""
         if len(csr.indices) != len(csr.data):
             raise ValueError(f'Length mismatch: {len(csr.indices)} vs {len(csr.data)}')
@@ -1759,7 +1797,12 @@ class Dataset:
             ctypes.byref(self.handle)))
         return self
 
-    def __init_from_csc(self, csc, params_str, ref_dataset):
+    def __init_from_csc(
+        self,
+        csc: scipy.sparse.csc_matrix,
+        params_str: str,
+        ref_dataset: Optional[ctypes.c_void_p]
+    ) -> "Dataset":
         """Initialize data from a CSC matrix."""
         if len(csc.indices) != len(csc.data):
             raise ValueError(f'Length mismatch: {len(csc.indices)} vs {len(csc.data)}')

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1717,7 +1717,7 @@ class Dataset:
 
     def __init_from_list_np2d(
         self,
-        mats: np.ndarray,
+        mats: List[np.ndarray],
         params_str: str,
         ref_dataset: Optional[ctypes.c_void_p]
     ) -> "Dataset":

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -20,6 +20,7 @@ import scipy.sparse
 from .compat import PANDAS_INSTALLED, concat, dt_DataTable, pd_CategoricalDtype, pd_DataFrame, pd_Series
 from .libpath import find_lib_path
 
+_DatasetHandle = ctypes.c_void_p
 _LGBM_EvalFunctionResultType = Tuple[str, float, bool]
 _LGBM_BoosterEvalMethodResultType = Tuple[str, str, float, bool]
 
@@ -1691,7 +1692,7 @@ class Dataset:
         self,
         mat: np.ndarray,
         params_str: str,
-        ref_dataset: Optional[ctypes.c_void_p]
+        ref_dataset: Optional[_DatasetHandle]
     ) -> "Dataset":
         """Initialize data from a 2-D numpy matrix."""
         if len(mat.shape) != 2:
@@ -1719,7 +1720,7 @@ class Dataset:
         self,
         mats: List[np.ndarray],
         params_str: str,
-        ref_dataset: Optional[ctypes.c_void_p]
+        ref_dataset: Optional[_DatasetHandle]
     ) -> "Dataset":
         """Initialize data from a list of 2-D numpy matrices."""
         ncol = mats[0].shape[1]
@@ -1770,7 +1771,7 @@ class Dataset:
         self,
         csr: scipy.sparse.csr_matrix,
         params_str: str,
-        ref_dataset: Optional[ctypes.c_void_p]
+        ref_dataset: Optional[_DatasetHandle]
     ) -> "Dataset":
         """Initialize data from a CSR matrix."""
         if len(csr.indices) != len(csr.data):
@@ -1801,7 +1802,7 @@ class Dataset:
         self,
         csc: scipy.sparse.csc_matrix,
         params_str: str,
-        ref_dataset: Optional[ctypes.c_void_p]
+        ref_dataset: Optional[_DatasetHandle]
     ) -> "Dataset":
         """Initialize data from a CSC matrix."""
         if len(csc.indices) != len(csc.data):


### PR DESCRIPTION
Contributes to #3756.
Contributes to #3867.

Adds type hints on some methods in `Dataset` which don't currently have them.

### Notes for Reviewers

I'm beginning work on the "array-like" inputs in LightGBM's Python API, per https://github.com/microsoft/LightGBM/issues/3756#issuecomment-907622141.

This is a first step towards that.