### PR TITLE
Rename Metadata num_classes to be more clear

### DIFF
--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -161,7 +161,7 @@ class Metadata {
   * \param values Initial score values for this record, one per class
   */
   inline void SetInitScoreAt(data_size_t idx, const double* values) {
-    const auto nclasses = num_classes();
+    const auto nclasses = num_init_score_classes();
     const double* val_ptr = values;
     for (int i = idx; i < nclasses * num_data_; i += num_data_, ++val_ptr) {
       init_score_[i] = *val_ptr;
@@ -265,7 +265,7 @@ class Metadata {
   /*!
   * \brief Get number of classes
   */
-  inline int32_t num_classes() const {
+  inline int32_t num_init_score_classes() const {
     if (num_data_ && num_init_score_) {
       return static_cast<int>(num_init_score_ / num_data_);
     }

--- a/src/io/metadata.cpp
+++ b/src/io/metadata.cpp
@@ -62,7 +62,7 @@ void Metadata::InitByReference(data_size_t num_data, const Metadata* reference) 
   int has_weights = reference->num_weights_ > 0;
   int has_init_scores = reference->num_init_score_ > 0;
   int has_queries = reference->num_queries_ > 0;
-  int nclasses = reference->num_classes();
+  int nclasses = reference->num_init_score_classes();
   Init(num_data, has_weights, has_init_scores, has_queries, nclasses);
 }
 
@@ -361,7 +361,7 @@ void Metadata::InsertInitScores(const double* init_scores, data_size_t start_ind
   }
   if (init_score_.empty()) { init_score_.resize(num_init_score_); }
 
-  int nclasses = num_classes();
+  int nclasses = num_init_score_classes();
 
   for (int32_t col = 0; col < nclasses; ++col) {
     int32_t dest_offset = num_data_ * col + start_index;


### PR DESCRIPTION
A recent completed PR (https://github.com/microsoft/LightGBM/pull/5299) created a new Metadata method num_classes(), but this can be confused with the actual num_classes in a Dataset.  It should definitely be the same number, but the new method is specifically returning the num_classes as configured and allocated in Metadata.  Reviewers requested to rename this method to be clearer.  New name is num_init_score_classes().