### PR TITLE
fix references to 'object function'

### DIFF
--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -219,7 +219,7 @@ void GBDT::AddValidDataset(const Dataset* valid_data,
 void GBDT::Boosting() {
   Common::FunctionTimer fun_timer("GBDT::Boosting", global_timer);
   if (objective_function_ == nullptr) {
-    Log::Fatal("No object function provided");
+    Log::Fatal("No objective function provided");
   }
   // objective function will calculate gradients and hessians
   int64_t num_score = 0;

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -428,7 +428,7 @@ class GBDT : public GBDTBase {
                                     data_size_t* buffer);
 
   /*!
-  * \brief calculate the object function
+  * \brief calculate the objective function
   */
   virtual void Boosting();
 


### PR DESCRIPTION
Proposes changing one log message and one code comment from "object function" to "objective function".

I believe both were intended to be "objective function", and that "object function" is incorrect.