### PR TITLE
[R-package] [ci] restore R 3.6 Windows cran CI job (fixes #5036)

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -104,6 +104,12 @@ jobs:
           - os: windows-latest
             task: r-package
             compiler: MINGW
+            toolchain: MINGW
+            r_version: 3.6
+            build_type: cran
+          - os: windows-latest
+            task: r-package
+            compiler: MINGW
             toolchain: MSYS
             r_version: 4.1
             build_type: cran

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -199,25 +199,33 @@ if ${BUILD_VIGNETTES} ; then
 
     echo "untarring ${TARBALL_NAME}"
     cd _tmp
-        tar -xvf "${TARBALL_NAME}" > /dev/null 2>&1
-        rm -rf "${TARBALL_NAME}"
-    cd ..
-    echo "done untarring ${TARBALL_NAME}"
+        tar -xf "${TARBALL_NAME}" > /dev/null 2>&1
+        rm -f "${TARBALL_NAME}"
+        echo "done untarring ${TARBALL_NAME}"
 
-    echo "re-tarring ${TARBALL_NAME}"
-    tar \
-        -czv \
-        -C ./_tmp \
-        --exclude=*.a \
-        --exclude=*.dll \
-        --exclude=*.o \
-        --exclude=*.so \
-        --exclude=*.tar.gz \
-        --exclude=**/conftest.c \
-        --exclude=**/conftest.exe \
-        -f "${TARBALL_NAME}" \
-        lightgbm \
-    > /dev/null 2>&1
+        # Object files are left behind from compiling the library to generate vignettes.
+        # Approaches like using tar --exclude=*.so to exclude them are not portable
+        # (for example, don't work with some versions of tar on Windows).
+        #
+        # Removing them manually here removes the need to use tar --exclude.
+        #
+        # For background, see https://github.com/microsoft/LightGBM/pull/3946#pullrequestreview-799415812.
+        rm -f ./lightgbm/src/*.o
+        rm -f ./lightgbm/src/boosting/*.o
+        rm -f ./lightgbm/src/io/*.o
+        rm -f ./lightgbm/src/metric/*.o
+        rm -f ./lightgbm/src/network/*.o
+        rm -f ./lightgbm/src/objective/*.o
+        rm -f ./lightgbm/src/treelearner/*.o
+
+        echo "re-tarring ${TARBALL_NAME}"
+        tar \
+            -cz \
+            -f "${TARBALL_NAME}" \
+            lightgbm \
+        > /dev/null 2>&1
+        mv "${TARBALL_NAME}" ../
+    cd ..
     echo "Done creating ${TARBALL_NAME}"
 
     rm -rf ./_tmp


### PR DESCRIPTION
Fixes #5036.
Replaces #5037.

## Changes in this PR

* changes to `build-cran-package.sh`:
    - replaces use of `tar --exclude` with simply `rm`-ing the excluded files prior to re-tarring the source distribution
    - removes unnecessary uses of `-f` in `rm` commands deleting files (not directories), for safety
    - removes unnecessary use of `-v` in `tar` commands whose output is suppressed anyway by redirection to `/dev/null`
    - removes uses of `tar -C`, instead just relying on directory traversal with `cd`
* restores the R 3.6 cran-style Windows CI job

## Description

CRAN-style builds of the R package have not been tested against R 3.6 on Windows for the last 7 months. This PR restores the CI job testing that support.

I used #5037 to experiment with different approaches and to try to find a root cause for why this job started failing. I discovered that the root issue is related to conflicting versions of the `tar`  utility. As described in the R documentation for `?tar` ([link](https://www.rdocumentation.org/packages/utils/versions/3.6.2/topics/tar))

> The ‘tar’ format no longer has an agreed standard!
>
> Many R platforms use a version of GNU tar (including Rtools on Windows), but the behaviour seems to be changed with each version.

This only matters to `{lightgbm}` because its build script, `build-cran-package.sh`, requires a workaround for R not cleaning up `.o` files produced when the library is compiled to build vignettes (see https://github.com/microsoft/LightGBM/pull/3946#pullrequestreview-799415812). That workaround requires untarring and carefully re-tarring a source distribution built by `R CMD build`.

This PR removes uses of less-likely-to-be-portable `tar` features in that build script, like `-C` and `--exclude`, to make failures like the one from #5036 less likely...in CI and for LightGBM's users.