### PR TITLE
[ci] test against R 4.2 for macOS and Linux CI jobs

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -21,9 +21,9 @@ if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
     export R_LINUX_VERSION="3.6.3-1bionic"
     export R_APT_REPO="bionic-cran35/"
 elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
-    export R_MAC_VERSION=4.1.3
+    export R_MAC_VERSION=4.2.1
     export R_MAC_PKG_URL=${CRAN_MIRROR}/bin/macosx/base/R-${R_MAC_VERSION}.pkg
-    export R_LINUX_VERSION="4.1.3-1.2004.0"
+    export R_LINUX_VERSION="4.2.1-1.2004.0"
     export R_APT_REPO="focal-cran40/"
 else
     echo "Unrecognized R version: ${R_VERSION}"

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -40,7 +40,7 @@ jobs:
           - os: ubuntu-latest
             task: r-package
             compiler: gcc
-            r_version: 4.1
+            r_version: 4.2
             build_type: cmake
           - os: ubuntu-latest
             task: r-package
@@ -50,7 +50,7 @@ jobs:
           - os: ubuntu-latest
             task: r-package
             compiler: clang
-            r_version: 4.1
+            r_version: 4.2
             build_type: cmake
           - os: macOS-latest
             task: r-package
@@ -70,7 +70,7 @@ jobs:
           - os: macOS-latest
             task: r-package
             compiler: clang
-            r_version: 4.1
+            r_version: 4.2
             build_type: cmake
           - os: windows-latest
             task: r-package
@@ -116,12 +116,12 @@ jobs:
           - os: ubuntu-latest
             task: r-package
             compiler: gcc
-            r_version: 4.1
+            r_version: 4.2
             build_type: cran
           - os: macOS-latest
             task: r-package
             compiler: clang
-            r_version: 4.1
+            r_version: 4.2
             build_type: cran
           ################
           # Other checks #
@@ -129,7 +129,7 @@ jobs:
           - os: ubuntu-latest
             task: r-rchk
             compiler: gcc
-            r_version: 4.1
+            r_version: 4.2
             build_type: cran
     steps:
       - name: Prevent conversion of line endings on Windows

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -60,7 +60,7 @@ jobs:
           - os: macOS-latest
             task: r-package
             compiler: gcc
-            r_version: 4.1
+            r_version: 4.2
             build_type: cmake
           - os: macOS-latest
             task: r-package


### PR DESCRIPTION
Contributes to #4881.

In #5274, I've been working on upgrading R to v 4.2.x in this project's CI jobs. Linux and macOS are working fine there, but adding Windows support has been challenging.

This PR proposes at least upgrading the Linux and macOS CI jobs, so we can start getting more test coverage of `{lightgbm}` on R 4.2.x. If this is merged, then I'll repurpose #5274 to focus only on adding the remaining Windows support.

### Notes for Reviewers

As of this writing, the latest version of R is v4.2.1 (https://cran.r-project.org/src/base/R-4/).