### PR TITLE
[R-package] improve safety of index selection in plotting

### DIFF
--- a/R-package/R/lgb.plot.importance.R
+++ b/R-package/R/lgb.plot.importance.R
@@ -79,7 +79,7 @@ lgb.plot.importance <- function(tree_imp,
     )
   )
 
-  tree_imp[.N:1L,
+  tree_imp[rev(seq_len(.N)),
            graphics::barplot(
                height = get(measure)
                , names.arg = Feature

--- a/R-package/R/lgb.plot.interpretation.R
+++ b/R-package/R/lgb.plot.interpretation.R
@@ -146,7 +146,7 @@ multiple.tree.plot.interpretation <- function(tree_interpretation,
   # create plot
   tree_interpretation[abs(Contribution) > 0.0, bar_color := "firebrick"]
   tree_interpretation[Contribution == 0.0, bar_color := "steelblue"]
-  tree_interpretation[.N:1L,
+  tree_interpretation[rev(seq_len(.N)),
                       graphics::barplot(
                           height = Contribution
                           , names.arg = Feature


### PR DESCRIPTION
I just observed the `lint` CI job failing on #5484 ([build link](https://github.com/microsoft/LightGBM/actions/runs/3054739687/jobs/4926997471)), with the following errors from R linting.

```text
[[1]]
/home/runner/work/LightGBM/LightGBM/R-package/R/lgb.plot.importance.R:82:12: warning: [seq] .N:1L is likely to be wrong in the empty edge case. Use seq_len(1L) instead.
  tree_imp[.N:1L,
           ^~~~~

[[2]]
/home/runner/work/LightGBM/LightGBM/R-package/R/lgb.plot.interpretation.R:149:23: warning: [seq] .N:1L is likely to be wrong in the empty edge case. Use seq_len(1L) instead.
  tree_interpretation[.N:1L,
                      ^~~~~
```

It looks like a new release of `{lintr}` (v3.0.1) just made it to CRAN (https://cran.r-project.org/web/packages/lintr/index.html), and they've added more cases caught by the `seq_linter()`.

This PR fixes those errors.