### PR TITLE
[python-package] add install option to enable printing of time costs

### DIFF
--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -163,6 +163,15 @@ By default, installation in environment with 32-bit Python is prohibited. Howeve
 
 It is **strongly not recommended** to use this version of LightGBM!
 
+Build with time costs output
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: sh
+
+    pip install lightgbm --install-option=--time-costs
+
+Use this option to make LightGBM output time costs for different internal routines, to investigate and benchmark its performance.
+
 Install from `conda-forge channel <https://anaconda.org/conda-forge/lightgbm>`_
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -27,6 +27,7 @@ LIGHTGBM_OPTIONS = [
     ('hdfs', 'h', 'Compile HDFS version'),
     ('bit32', None, 'Compile 32-bit version'),
     ('precompile', 'p', 'Use precompiled library'),
+    ('time-costs', None, 'Output time costs for different internal routines'),
     ('boost-root=', None, 'Boost preferred installation prefix'),
     ('boost-dir=', None, 'Directory with Boost package configuration file'),
     ('boost-include-dir=', None, 'Directory containing Boost headers'),
@@ -116,7 +117,8 @@ def compile_cpp(
     opencl_library: Optional[str] = None,
     nomp: bool = False,
     bit32: bool = False,
-    integrated_opencl: bool = False
+    integrated_opencl: bool = False,
+    time_costs: bool = False
 ) -> None:
     build_dir = CURRENT_DIR / "build_cpp"
     rmtree(build_dir, ignore_errors=True)
@@ -154,6 +156,8 @@ def compile_cpp(
         cmake_cmd.append("-DUSE_OPENMP=OFF")
     if use_hdfs:
         cmake_cmd.append("-DUSE_HDFS=ON")
+    if time_costs:
+        cmake_cmd.append("-DUSE_TIMETAG=ON")
 
     if system() in {'Windows', 'Microsoft'}:
         if use_mingw:
@@ -241,6 +245,7 @@ class CustomInstall(install):
         self.mpi = False
         self.hdfs = False
         self.precompile = False
+        self.time_costs = False
         self.nomp = False
         self.bit32 = False
 
@@ -259,7 +264,8 @@ class CustomInstall(install):
                         use_hdfs=self.hdfs, boost_root=self.boost_root, boost_dir=self.boost_dir,
                         boost_include_dir=self.boost_include_dir, boost_librarydir=self.boost_librarydir,
                         opencl_include_dir=self.opencl_include_dir, opencl_library=self.opencl_library,
-                        nomp=self.nomp, bit32=self.bit32, integrated_opencl=self.integrated_opencl)
+                        nomp=self.nomp, bit32=self.bit32, integrated_opencl=self.integrated_opencl,
+                        time_costs=self.time_costs)
         install.run(self)
         if LOG_PATH.is_file():
             LOG_PATH.unlink()
@@ -285,6 +291,7 @@ class CustomBdistWheel(bdist_wheel):
         self.mpi = False
         self.hdfs = False
         self.precompile = False
+        self.time_costs = False
         self.nomp = False
         self.bit32 = False
 
@@ -307,6 +314,7 @@ class CustomBdistWheel(bdist_wheel):
         install.mpi = self.mpi
         install.hdfs = self.hdfs
         install.precompile = self.precompile
+        install.time_costs = self.time_costs
         install.nomp = self.nomp
         install.bit32 = self.bit32
 


### PR DESCRIPTION
According to the [install guide](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html):
> Users who want to perform benchmarking can make LightGBM output time costs for different internal routines by adding -DUSE_TIMETAG=ON to CMake flags.

This feature was unfortunately not available when installing LightGBM from the Python package. This PR attempts to fix this. :)