### PR TITLE
[ci] [R-package] use R 4.2.1 in Windows CI jobs (fixes #4881)

### DIFF
--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -54,11 +54,13 @@ Remove-From-Path ".*PostgreSQL.*"
 Remove-From-Path ".*\\R\\.*"
 Remove-From-Path ".*R Client.*"
 Remove-From-Path ".*rtools40.*"
+Remove-From-Path ".*rtools42.*"
 Remove-From-Path ".*shells.*"
 Remove-From-Path ".*Strawberry.*"
 Remove-From-Path ".*tools.*"
 
 Remove-Item C:\rtools40 -Force -Recurse -ErrorAction Ignore
+Remove-Item C:\rtools42 -Force -Recurse -ErrorAction Ignore
 
 # Get details needed for installing R components
 #
@@ -74,11 +76,11 @@ if ($env:R_MAJOR_VERSION -eq "3") {
   $env:RTOOLS_EXE_FILE = "rtools35-x86_64.exe"
   $env:R_WINDOWS_VERSION = "3.6.3"
 } elseif ($env:R_MAJOR_VERSION -eq "4") {
-  $RTOOLS_INSTALL_PATH = "C:\rtools40"
+  $RTOOLS_INSTALL_PATH = "C:\rtools42"
   $env:RTOOLS_BIN = "$RTOOLS_INSTALL_PATH\usr\bin"
-  $env:RTOOLS_MINGW_BIN = "$RTOOLS_INSTALL_PATH\mingw64\bin"
-  $env:RTOOLS_EXE_FILE = "rtools40v2-x86_64.exe"
-  $env:R_WINDOWS_VERSION = "4.1.3"
+  $env:RTOOLS_MINGW_BIN = "$RTOOLS_INSTALL_PATH\x86_64-w64-mingw32.static.posix\bin"
+  $env:RTOOLS_EXE_FILE = "rtools42-5253-5107.exe"
+  $env:R_WINDOWS_VERSION = "4.2.1"
 } else {
   Write-Output "[ERROR] Unrecognized R version: $env:R_VERSION"
   Check-Output $false
@@ -147,7 +149,7 @@ Write-Output "Building R package"
 # R CMD check is not used for MSVC builds
 if ($env:COMPILER -ne "MSVC") {
 
-  $PKG_FILE_NAME = "lightgbm_*.tar.gz"
+  $PKG_FILE_NAME = "lightgbm_$env:LGB_VER.tar.gz"
   $LOG_FILE_NAME = "lightgbm.Rcheck/00check.log"
 
   if ($env:R_BUILD_TYPE -eq "cmake") {

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -165,6 +165,7 @@ jobs:
         shell: pwsh -command ". {0}"
         run: |
           $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
+          $env:LGB_VER = (Get-Content -TotalCount 1 $env:BUILD_SOURCESDIRECTORY\VERSION.txt).trim().replace('rc', '-')
           $env:TOOLCHAIN = "${{ matrix.toolchain }}"
           $env:R_VERSION = "${{ matrix.r_version }}"
           $env:R_BUILD_TYPE = "${{ matrix.build_type }}"

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -82,7 +82,7 @@ jobs:
             task: r-package
             compiler: MINGW
             toolchain: MSYS
-            r_version: 4.1
+            r_version: 4.2
             build_type: cmake
           # Visual Studio 2019
           - os: windows-2019
@@ -96,7 +96,7 @@ jobs:
             task: r-package
             compiler: MSVC
             toolchain: MSVC
-            r_version: 4.1
+            r_version: 4.2
             build_type: cmake
           ###############
           # CRAN builds #
@@ -111,7 +111,7 @@ jobs:
             task: r-package
             compiler: MINGW
             toolchain: MSYS
-            r_version: 4.1
+            r_version: 4.2
             build_type: cran
           - os: ubuntu-latest
             task: r-package

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -97,12 +97,17 @@ After installing `Rtools` and `CMake`, be sure the following paths are added to 
     - If you have `Rtools` 4.0, example:
         - `C:\rtools40\mingw64\bin`
         - `C:\rtools40\usr\bin`
+    - If you have `Rtools` 4.2, example:
+        - `C:\rtools42\x86_64-w64-mingw32.static.posix\bin`
+        - `C:\rtools42\user\bin`
 * `CMake`
     - example: `C:\Program Files\CMake\bin`
 * `R`
     - example: `C:\Program Files\R\R-3.6.1\bin`
 
 NOTE: Two `Rtools` paths are required from `Rtools` 4.0 onwards because paths and the list of included software was changed in `Rtools` 4.0.
+
+NOTE: `Rtools42` takes a very different approach to the compiler toolchain than previous releases, and how you install it changes what is required to build packages. See ["Howto: Building R 4.2 and packages on Windows"](https://cran.r-project.org/bin/windows/base/howto-R-4.2.html).
 
 #### Windows Toolchain Options
 

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -99,7 +99,7 @@ After installing `Rtools` and `CMake`, be sure the following paths are added to 
         - `C:\rtools40\usr\bin`
     - If you have `Rtools` 4.2, example:
         - `C:\rtools42\x86_64-w64-mingw32.static.posix\bin`
-        - `C:\rtools42\user\bin`
+        - `C:\rtools42\usr\bin`
 * `CMake`
     - example: `C:\Program Files\CMake\bin`
 * `R`

--- a/R-package/configure.win
+++ b/R-package/configure.win
@@ -79,7 +79,8 @@ ac_inet_pton="no"
 cat > conftest.cpp <<EOL
 #include <ws2tcpip.h>
 int main() {
-  void* p = inet_pton;
+  int (*fptr)(int, const char*, void*);
+  fptr = &inet_pton;
   return 0;
 }
 EOL

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -219,8 +219,8 @@ test_that("lgb.Dataset: Dataset should be able to construct from matrix and retu
 
 test_that("cpp errors should be raised as proper R errors", {
   testthat::skip_if(
-    Sys.getenv("COMPILER", "") == "MSVC" && as.integer(R.Version()[["major"]]) < 4L
-    , message = "Skipping on R 3.x and Visual Studio"
+    Sys.getenv("COMPILER", "") == "MSVC"
+    , message = "Skipping on Visual Studio"
   )
   data(agaricus.train, package = "lightgbm")
   train <- agaricus.train


### PR DESCRIPTION
Fixes #4881.
Replaces #5274.

### Changes in this PR

* upgrade from R 4.1.3 to R 4.2.1 in Windows CI jobs
* upgrade from Rtools40 to Rtools42 in Windows CI jobs
* explicitly pass version parsed from `VERSION.txt` into `test_r_package_windows.ps1` (instead of relying on wildcards like `lightgbm_*.tar.gz`
* extend "skip one test when compiling with MSVC" fix from #5448 to all MSVC jobs

### Why did the check in `configure.win` need to change?

Compiling the test program used to check for `inet_pton` with the compiler that ships with RTools42 (gcc 10.3), results in the following error.

```text
conftest.cpp: In function 'int main()':
conftest.cpp:3:13: error: invalid conversion from 'INT (*)(INT, LPCSTR, PVOID)' {aka 'int (*)(int, const char*, void*)'} to 'void*' [-fpermissive]
    3 |   void* p = inet_pton;
      |             ^~~~~~~~~
      |             |
      |             INT (*)(INT, LPCSTR, PVOID) {aka int (*)(int, const char*, void*)}
```

To avoid that casting, this PR proposes just assigning the address of `inet_pton` to a function pointer for a function with exactly the same signature as the one LightGBM's code expects.

### Why does the use of `"lightgbm_*.tar.gz"` need to be replaced with `"lightgbm_$env:LGB_VER.tar.gz"`?

I'm not sure...probably related to R or some tool shipping with RTools42 not working well with wildcards. While testing in #4881, I saw errors like the following:

> Error: no packages were specified

### Notes for Reviewers

#4881 refers to creating a comment-triggered workflow for the UCRT toolchain for Windows builds, but I don't think that's necessary any more now that R 4.2.0 has actually been released and Rtools42 contains the UCRT build tools.

I closed #4881 in favor of this because that PR was getting very busy with debugging commits and comments.

### References

There is some documentation about Rtools42 adding its own compilers to PATH, but I think that just means to R's PATH (referenced by `R CMD` commands).

e.g., see https://cran.r-project.org/bin/windows/base/howto-R-4.2.html

> To make the use of Rtools42 simpler, when R is installed via the binary installer it by default uses Rtools42 for the compilers and libraries. PATH will be set by R (inside front-ends like RGui and RTerm, but also R CMD) to include the build tools (e.g. make) and the compilers (e.g. gcc). In addition, R installed via the binary installer will automatically set R_TOOLS_SOFT (and LOCAL_SOFT for backwards compatibility) to the Rtools42 location for building R packages. This feature is only present in the installer builds of R, not when R is installed from source.

and https://github.com/r-lib/actions/issues/574#issue-1265095474

Some additional relevant information in the `r-lib/actions` project:

* https://github.com/r-lib/actions/commit/7d98418c6b5cfca592b100e2f348fbe90c18bcf3
* https://github.com/r-lib/actions/blob/8e8f7edba0e5bda9318f9377c0dc9c2f5d0fb786/setup-r/src/installer.ts#L431-L457

### How I tested this

Given the changes to `configure.win`, I also tested the project on R Hub and win-builder.

Generated the CRAN source distribution like this:

```shell
sh build-cran-package.sh
```

Then used that `.tar.gz` to test on win-builder and R Hub.

<details><summary>passing on win-builder (click me)</summary>

* ✅ `R-release` ([logs](https://win-builder.r-project.org/q36Xf4UFIU30/))
* ✅ `R-devel` ([logs](https://win-builder.r-project.org/MotfC88oY14R/))
* ✅ `R-oldrelease` ([logs](https://win-builder.r-project.org/kllIkud3FMk5/))

See https://win-builder.r-project.org/. This project is run by some of the CRAN maintainers, and very closely matches the Windows builds on CRAN.

There are functions in `{devtools}` to automate uploading to this service, e.g. `devtools::check_win_release()`. Unfortunately, those only take a *director* to be packaged with `R CMD build`. That doesn't work with the custom stuff `build-cran-package.sh` has to do to build vignettes:

https://github.com/microsoft/LightGBM/blob/dc4794b62f2c09103e558b7a8325bed66083a5c3/build-cran-package.sh#L206

So I manually changed the maintainer to myself in `DESCRIPTION`, built the package with `build-cran-package.sh`, then uploaded manually at https://win-builder.r-project.org/upload.aspx.

</details>

<details><summary>passing on R Hub (click me)</summary>

I tried checking the package built from this branch on all 4 platforms supported by R Hub.

* ✅  `windows-x86_64-devel` ([logs](https://builder.r-hub.io/status/lightgbm_3.3.2.99.tar.gz-230afcf8ccc9410aa046474f38d128df))
* ✅ `windows-x86_64-oldrel` ([logs](https://builder.r-hub.io/status/lightgbm_3.3.2.99.tar.gz-306552d2418447dcaa71ef8b0428f570))
* ✅ `windows-x86_64-patched` ([logs](https://builder.r-hub.io/status/lightgbm_3.3.2.99.tar.gz-1f2a23040e924bb4a6996cd8fa27ef95))
* ✅ `windows-x86_64-release` ([logs](https://builder.r-hub.io/status/lightgbm_3.3.2.99.tar.gz-1f077751637e40b1abfaf65156f8f27a))

```r
EMAIL <- "****" # my personal email
PACKAGE_TARBALL <- "lightgbm_3.3.2.99.tar.gz"

result <- rhub::check(
    path = PACKAGE_TARBALL
    , email = EMAIL
    , check_args = c(
        "--as-cran"
    )
    , platforms = c(
        "windows-x86_64-devel"
        , "windows-x86_64-oldrel"
        , "windows-x86_64-patched"
        , "windows-x86_64-release"
    )
    , env_vars = c(
        "R_COMPILE_AND_INSTALL_PACKAGES" = "always"
        , "_R_CHECK_FORCE_SUGGESTS_" = "true"
        , "_R_CHECK_CRAN_INCOMING_USE_ASPELL_" = "true"
    )
)
```

</details>