### PR TITLE
[R-package] [docs] use CRAN canonical form for package links

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -281,7 +281,7 @@ Rscript -e " \
 Updating Documentation
 ----------------------
 
-The R package uses [`{roxygen2}`](https://cran.r-project.org/web/packages/roxygen2/index.html) to generate its documentation.
+The R package uses [`{roxygen2}`](https://CRAN.R-project.org/package=roxygen2) to generate its documentation.
 The generated `DESCRIPTION`, `NAMESPACE`, and `man/` files are checked into source control.
 To regenerate those files, run the following.
 


### PR DESCRIPTION
While checking the R package on [win-builder](https://win-builder.r-project.org/), I saw the following `R CMD check` NOTE:

```text
Found the following (possibly) invalid URLs:
  URL: https://cran.r-project.org/web/packages/roxygen2/index.html
    From: README.md
    Status: 200
    Message: OK
    CRAN URL not in canonical form
  The canonical URL of the CRAN page for a package is 
    https://CRAN.R-project.org/package=pkgname
```

This PR proposes accepting that suggestion, to reduce the risk of the next CRAN submission being rejected.