### PR TITLE
replace `pandas.Series.iteritems` with `pandas.Series.items`

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -562,7 +562,7 @@ def _check_for_bad_pandas_dtypes(pandas_dtypes_series):
 
     bad_pandas_dtypes = [
         f'{column_name}: {pandas_dtype}'
-        for column_name, pandas_dtype in pandas_dtypes_series.iteritems()
+        for column_name, pandas_dtype in pandas_dtypes_series.items()
         if not is_allowed_numpy_dtype(pandas_dtype.type)
     ]
     if bad_pandas_dtypes:


### PR DESCRIPTION
`pandas.Series.iteritems` [is being deprecated](https://pandas.pydata.org/docs/reference/api/pandas.Series.iteritems.html) in favor of `pandas.Series.items` ([sample warning link in CI](https://github.com/microsoft/LightGBM/actions/runs/3117214672/jobs/5055714658#step:3:1267)).

The `items` method [exists in pandas version 0.24](https://pandas.pydata.org/pandas-docs/version/0.24.2/reference/api/pandas.Series.items.html#pandas.Series.items) so this shouldn't cause compatibility problems.