### PR TITLE
[R-package] fix test on non-ASCII features in non-UTF8 locales

### DIFF
--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -1719,7 +1719,18 @@ test_that("lgb.train() supports non-ASCII feature names", {
     data = matrix(rnorm(400L), ncol =  4L)
     , label = rnorm(100L)
   )
-  feature_names <- c("F_零", "F_一", "F_二", "F_三")
+  # content below is equivalent to
+  #
+  #  feature_names <- c("F_零", "F_一", "F_二", "F_三")
+  #
+  # but using rawToChar() to avoid weird issues when {testthat}
+  # sources files and converts their encodings prior to evaluating the code
+  feature_names <- c(
+    rawToChar(as.raw(c(0x46, 0x5f, 0xe9, 0x9b, 0xb6)))
+    , rawToChar(as.raw(c(0x46, 0x5f, 0xe4, 0xb8, 0x80)))
+    , rawToChar(as.raw(c(0x46, 0x5f, 0xe4, 0xba, 0x8c)))
+    , rawToChar(as.raw(c(0x46, 0x5f, 0xe4, 0xb8, 0x89)))
+  )
   bst <- lgb.train(
     data = dtrain
     , nrounds = 5L


### PR DESCRIPTION
Contributes to #5502.

One test on LightGBM's treatment of non-ASCII features has been failing on the `r-devel-linux-x86_64-debian-clang` CRAN check flavor recently (see #5502).

This PR fixes that test.

### Shouldn't this be on release v3.3.3?

These changes do need to make it into the emergency patch release we're preparing (#5525). But this issue exists on `master` as well.

### How does this change help?

Through the investigation on #5502, I found some evidence that `{testthat}` was somehow modifying R's handling of this one test in non-UTF8 locales: https://github.com/microsoft/LightGBM/issues/5502#issuecomment-1272126313.

I believe that could be related to some combination of:

* `{lightgbm}`'s use of non-ASCII string literals in a test source file
* `{testthat}` changing encodings when reading source code of test files ([testthat code link](https://github.com/r-lib/testthat/blob/6666662844274e8fa1988c8e0cfecf0b13399ee1/R/source.R#L21-L25))
* `{testthat}` changing some locale settings ([testthat code link](https://github.com/r-lib/testthat/blob/e2c70e118a88b1f03d2f5b1acef6777b6da12520/R/local.R#L136-L140))

### How I tested this

Ran the R package's unit tests inside the image built from https://github.com/r-hub/rhub-linux-builders/pull/62, which should closely match the failing CRAN check.

### Doesn't this totally fix the r-devel-debian-clang issue?

Not quite. #5502 should stay open until LightGBM's CI is again using a daily build of the `rhub/debian-clang-devel` image. Hopefully my PR to fix that upstream will be accepted.