### PR TITLE
[ci] run CI on pull requests targeting release/ branches

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
     - master
+    - release/*
 
 env:
   github_actions: 'true'

--- a/.github/workflows/optional_checks.yml
+++ b/.github/workflows/optional_checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - release/*
 
 jobs:
   all-successful:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
     - master
+    - release/*
 
 env:
   CONDA_ENV: test-env

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
     - master
+    - release/*
 
 env:
   # hack to get around this:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
     - master
+    - release/*
 
 env:
   COMPILER: 'gcc'

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -7,6 +7,7 @@ trigger:
     - v*
 pr:
 - master
+- release/*
 variables:
   AZURE: 'true'
   PYTHON_VERSION: '3.10'


### PR DESCRIPTION
Based on @guolinke 's suggestion in https://github.com/microsoft/LightGBM/pull/5525#issuecomment-1272332768, I'd like to try targeting PR #5525 at a branch, `release/v3.3.2`, which only contains:

* v3.3.2 of LightGBM
* CI scripts and configs from `master`

That would allow us to try to run all of LightGBM's CI over the potential `v3.3.3` release (we'll see if that works!).

This PR proposes modifying the configs for GitHub Actions and Azure Devops so that CI jobs will be triggered on all ~branches~ PRs targeting branches with a name like `release/*`.

Once this is merged, I'll update #5525.

### Notes for reviews

Documentation for how these configs work:

* GitHub Actions: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
* Azure: https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pr?view=azure-pipelines#pr-branchfilter-list

It isn't necessary to modify the Appveyor config....I believe it just builds for all branches automatically.

<img width="364" alt="image" src="https://user-images.githubusercontent.com/7608904/194716692-30264099-22a1-4f8c-868d-f7b234994469.png">
