### PR TITLE
[ci] run Appveyor checks on PRs targeting release/ branches

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,10 +6,11 @@ configuration:  # a trick to construct a build matrix with multiple Python versi
   - '3.7'
 
 # only build pull requests and
-# commits to 'master'
+# commits to 'master' or any branch starting with 'release'
 branches:
   only:
     - master
+    - /^release/
 
 environment:
   matrix:


### PR DESCRIPTION
Follow-up to #5527.
Contributes to #5525 .

I was wrong in #5527 ... `.appveyor.yml` in this repo DOES need to be modified to tell Appveyor to build on pull requests that target `release/*` branches.

This PR proposes such a change. 

See https://www.appveyor.com/docs/branches/ for docs on how Appveyor's preferred syntax expects such "match all branches following a pattern".

This change will help with the `v3.3.3` release, and I think it should be kept even after that to make such time-sensitive hotfix types of releases a bit easier in the future.

### How I tested this

Pushed a similar change to #5525, and that led to Appveyor successfully building on that PR that targets branch `release/v3.3.2`.