### PR TITLE
[ci] upgrade macOS_regular job to Python 3.9 (fixes #5569)

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -222,7 +222,7 @@ jobs:
     matrix:
       regular:
         TASK: regular
-        PYTHON_VERSION: '3.7'
+        PYTHON_VERSION: '3.9'
       sdist:
         TASK: sdist
         PYTHON_VERSION: '3.8'


### PR DESCRIPTION
Fixes blocking issue #5569.

Proposes upgrading the `macOS_regular` CI job from Python 3.7 to 3.9, to try to fix CI errors possibly related to `conda-forge` dropping support for Python 3.7.

### Is this a breaking change for producing release artifacts?

I don't think so. The only artifact build from this task is the shared library for macOS, `lib_lightgbm.dylib`.

https://github.com/microsoft/LightGBM/blob/d8a6b8871b990950ab37cfa96d83e3bfc87680ba/.ci/test.sh#L259-L261

And that shouldn't be affected by Python version, as we don't produce a shared library that links into any Python stuff.