### PR TITLE
nrounds does not work as an alias for num_iterations

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -153,7 +153,7 @@ Core Parameters
 
    -  **Note**: can be used only in CLI version
 
--  ``num_iterations`` :raw-html:`<a id="num_iterations" title="Permalink to this parameter" href="#num_iterations">&#x1F517;&#xFE0E;</a>`, default = ``100``, type = int, aliases: ``num_iteration``, ``n_iter``, ``num_tree``, ``num_trees``, ``num_round``, ``num_rounds``, ``nrounds``, ``num_boost_round``, ``n_estimators``, ``max_iter``, constraints: ``num_iterations >= 0``
+-  ``num_iterations`` :raw-html:`<a id="num_iterations" title="Permalink to this parameter" href="#num_iterations">&#x1F517;&#xFE0E;</a>`, default = ``100``, type = int, aliases: ``num_iteration``, ``n_iter``, ``num_tree``, ``num_trees``, ``num_round``, ``num_rounds``, ``num_boost_round``, ``n_estimators``, ``max_iter``, constraints: ``num_iterations >= 0``
 
    -  number of boosting iterations
 


### PR DESCRIPTION
## Description
Setting the paremter `nrounds` for a `LGBMRegressor` does not seem to have any effect.

## Reproducible example
```python
import lightgbm
from sklearn.datasets import make_regression
from sklearn.model_selection import train_test_split

X, y = make_regression()
X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)

model = lightgbm.LGBMRegressor(max_depth=1, learning_rate=0.0001, nrounds=10)
model =model.fit(X_train, y_train, eval_set=[(X_test, y_test)])

model.booster_.num_trees()
```
## Environment info

LightGBM version: 3.3.3

Env setup as in this example https://github.com/Kornel/lightgbm-nrounds-is-not-supported

```shell
poetry install
```