### PR TITLE
[ci] [python-package] correct tag on x86_64 wheels

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -162,7 +162,7 @@ elif [[ $TASK == "bdist" ]]; then
     else
         ARCH=$(uname -m)
         if [[ $ARCH == "x86_64" ]]; then
-            PLATFORM="manylinux1_x86_64"
+            PLATFORM="manylinux_2_28_x86_64"
         else
             PLATFORM="manylinux2014_$ARCH"
         fi

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -19,7 +19,7 @@ variables:
 resources:
   containers:
   - container: linux-artifact-builder
-    image: lightgbm/vsts-agent:manylinux_2_28_x86_64-dev
+    image: lightgbm/vsts-agent:manylinux_2_28_x86_64
   - container: ubuntu-latest
     image: 'ubuntu:20.04'
     options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"


### PR DESCRIPTION
Contributes to #4788.

#5580 switched LightGBM's CI to using an image based on `pypa/manylinux_2_28_x86_64` to produce x86_64 wheels.

In that PR, I forgot to update the platform tag used with those wheels 😬 

This PR contains two fixes:

* updates the tag to `manylinux_2_28_x86_64`
* updates to the image produced from `master` of https://github.com/guolinke/lightgbm-ci-docker, so that future development on the `dev` branch there doesn't disrupt LightGBM's CI

### Notes for Reviewers

In a future PR, I think we should consider running `auditwheel show` in CI like @tdoublep did in #4788, to prevent this "wrong tag" issue from making it onto `master`.