### PR TITLE
[ci] switch from MiKTeX to tinytex on Windows R jobs (fixes #5600)

### DIFF
--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -88,10 +88,8 @@ if ($env:R_MAJOR_VERSION -eq "3") {
 
 $env:R_LIB_PATH = "$env:BUILD_SOURCESDIRECTORY/RLibrary" -replace '[\\]', '/'
 $env:R_LIBS = "$env:R_LIB_PATH"
-$env:PATH = "$env:RTOOLS_BIN;" + "$env:RTOOLS_MINGW_BIN;" + "$env:R_LIB_PATH/R/bin/x64;" + "$env:R_LIB_PATH/miktex/texmfs/install/miktex/bin/x64;" + $env:PATH
+$env:PATH = "$env:RTOOLS_BIN;" + "$env:RTOOLS_MINGW_BIN;" + "$env:R_LIB_PATH/R/bin/x64;"+ $env:PATH
 $env:CRAN_MIRROR = "https://cran.rstudio.com"
-$env:CTAN_MIRROR = "https://ctan.math.illinois.edu/systems/win32/miktex"
-$env:CTAN_PACKAGE_ARCHIVE = "$env:CTAN_MIRROR/tm/packages/"
 $env:MIKTEX_EXCEPTION_PATH = "$env:TEMP\miktex"
 
 # don't fail builds for long-running examples unless they're very long.
@@ -126,23 +124,6 @@ Write-Output "Done installing Rtools"
 Write-Output "Installing dependencies"
 $packages = "c('data.table', 'jsonlite', 'knitr', 'Matrix', 'processx', 'R6', 'RhpcBLASctl', 'rmarkdown', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
 Run-R-Code-Redirect-Stderr "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH', Ncpus = parallel::detectCores())" ; Check-Output $?
-
-# MiKTeX and pandoc can be skipped on non-MinGW builds, since we don't
-# build the package documentation for those.
-#
-# MiKTeX always needs to be built to test a CRAN package.
-if (($env:COMPILER -eq "MINGW") -or ($env:R_BUILD_TYPE -eq "cran")) {
-    Download-File-With-Retries "https://github.com/microsoft/LightGBM/releases/download/v2.0.12/miktexsetup-5.2.0-x64.zip" -destfile "miktexsetup-x64.zip"
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    [System.IO.Compression.ZipFile]::ExtractToDirectory("miktexsetup-x64.zip", "miktex")
-    Write-Output "Setting up MiKTeX"
-    .\miktex\miktexsetup_standalone.exe --remote-package-repository="$env:CTAN_PACKAGE_ARCHIVE" --local-package-repository=./miktex/download --package-set=essential --quiet download ; Check-Output $?
-    Write-Output "Installing MiKTeX"
-    .\miktex\download\miktexsetup_standalone.exe --remote-package-repository="$env:CTAN_PACKAGE_ARCHIVE" --portable="$env:R_LIB_PATH/miktex" --quiet install ; Check-Output $?
-    Write-Output "Done installing MiKTeX"
-
-    Run-R-Code-Redirect-Stderr "result <- processx::run(command = 'initexmf', args = c('--set-config-value', '[MPM]AutoInstall=1'), echo = TRUE, windows_verbatim_args = TRUE, error_on_status = TRUE)" ; Check-Output $?
-}
 
 Write-Output "Building R package"
 

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -144,6 +144,12 @@ jobs:
           submodules: true
       - name: Install pandoc
         uses: r-lib/actions/setup-pandoc@v1
+      - name: install tinytex
+        if: startsWith(matrix.os, 'windows')
+        uses: r-lib/actions/setup-tinytex@v2
+        env:
+          CTAN_MIRROR: https://ctan.math.illinois.edu/systems/win32/miktex
+          TINYTEX_INSTALLER: TinyTeX
       - name: Setup and run tests on Linux and macOS
         if: matrix.os == 'macOS-latest' || matrix.os == 'ubuntu-latest'
         shell: bash


### PR DESCRIPTION
Fixes #5600.

R CI jobs require a LaTeX distribution to build the package documentation. This PR proposes switching from [MiKTeX](https://miktex.org/) to [`{tinytex}`](https://yihui.org/tinytex/) for Windows builds.

## Motivation

The use of MiKTeX has been the source of several multi-day outages in LightGBM's CI over the last few years (and most recently, #5600):

* https://github.com/microsoft/LightGBM/issues/5562
* https://github.com/microsoft/LightGBM/issues/4005
* https://github.com/microsoft/LightGBM/issues/3454
* https://github.com/microsoft/LightGBM/issues/3198

Several of those have had the resolution "wait a few days until changes in CTAN mirrors or other upstream sources are fixed". That's very disruptive to our development here, as it means either skipping R package CI jobs or not merging anything for multiple days.

I'm hoping that because `{tinytex}` is lighter-weight, it'll be more stable.

I also believe using the GitHub Action https://github.com/r-lib/actions/tree/v2-branch/setup-tinytex will remove the maintenance burden of keeping up with MiKTeX and other updates upstream, since that action is actively maintained.

For more, see ["Why TinyTex?"](https://yihui.org/tinytex/pain/) in the `{tinytex}` docs.