### PR TITLE
[ci] detect non-default dynamic symbols in check_dynamic_dependencies.py

### DIFF
--- a/helpers/check_dynamic_dependencies.py
+++ b/helpers/check_dynamic_dependencies.py
@@ -25,7 +25,7 @@ def check_dependencies(objdump_string: str) -> None:
     objdump_string : str
         The dynamic symbol table entries of the file (result of `objdump -T` command).
     """
-    GLIBC_version = re.compile(r'0{16}[ \t]+GLIBC_(\d{1,2})[.](\d{1,3})[.]?\d{,3}[ \t]+')
+    GLIBC_version = re.compile(r'0{16}[ \(\t]+GLIBC_(\d{1,2})[.](\d{1,3})[.]?\d{,3}[ \)\t]+')
     versions = GLIBC_version.findall(objdump_string)
     assert len(versions) > 1
     for major, minor in versions:
@@ -33,7 +33,7 @@ def check_dependencies(objdump_string: str) -> None:
         assert int(major) <= 2, error_msg
         assert int(minor) <= 28, error_msg
 
-    GLIBCXX_version = re.compile(r'0{16}[ \t]+GLIBCXX_(\d{1,2})[.](\d{1,2})[.]?(\d{,3})[ \t]+')
+    GLIBCXX_version = re.compile(r'0{16}[ \(\t]+GLIBCXX_(\d{1,2})[.](\d{1,2})[.]?(\d{,3})[ \)\t]+')
     versions = GLIBCXX_version.findall(objdump_string)
     assert len(versions) > 1
     for major, minor, patch in versions:
@@ -42,7 +42,7 @@ def check_dependencies(objdump_string: str) -> None:
         assert int(minor) == 4, error_msg
         assert patch == '' or int(patch) <= 22, error_msg
 
-    GOMP_version = re.compile(r'0{16}[ \t]+G?OMP_(\d{1,2})[.](\d{1,2})[.]?\d{,3}[ \t]+')
+    GOMP_version = re.compile(r'0{16}[ \(\t]+G?OMP_(\d{1,2})[.](\d{1,2})[.]?\d{,3}[ \)\t]+')
     versions = GOMP_version.findall(objdump_string)
     assert len(versions) > 1
     for major, minor in versions:


### PR DESCRIPTION
While updating #5252 to the new CI image proposed in https://github.com/guolinke/lightgbm-ci-docker/pull/29, I found that the `Linux regular` and `Linux swig` jobs were failing with the following.

> Traceback (most recent call last):
  File "/__w/1/s/helpers/check_dynamic_dependencies.py", line 55, in <module>
    check_dependencies(Path(sys.argv[1]).read_text(encoding='utf-8'))
  File "/__w/1/s/helpers/check_dynamic_dependencies.py", line 30, in check_dependencies
    assert len(versions) > 1
AssertionError

I was able to reproduce this locally in a container too.

<details><summary>how to reproduce this (click me)</summary>

```shell
docker run --rm -ti \
    -v $PWD/artifacts:/artifacts \
    -e AZURE=true \
    -e BUILD_DIRECTORY=/vsts/lightgbm \
    -e BUILD_SOURCESDIRECTORY=/vsts/lightgbm \
    -e BUILD_ARTIFACTSTAGINGDIRECTORY=/artifacts \
    -e COMPILER=gcc \
    -e CONDA_ENV=test-env \
    -e LGB_VER=3.3.3.99 \
    -e OS_NAME=linux \
    -e PRODUCES_ARTIFACTS=true \
    -e PYTHON_VERSION=3.10 \
    -e SETUP_CONDA=false \
    -e TASK=swig \
    -e OMP_NUM_THREADS=4 \
    -e POCL_MAX_PTHREAD_COUNT=4 \
    --workdir=/vsts/lightgbm \
    lightgbm/vsts-agent:manylinux_2_28_x86_64-dev \
    bash

export PATH=/opt/miniforge/bin:"${PATH}"

git clone \
    --recursive \
    https://github.com/jgiannuzzi/LightGBM.git \
    --branch linux-gpu-wheel \
    .

.ci/setup.sh
mkdir $BUILD_DIRECTORY/build
cd $BUILD_DIRECTORY/build
cmake -DUSE_SWIG=ON ..

make -j4

objdump -T $BUILD_DIRECTORY/lib_lightgbm.so > $BUILD_DIRECTORY/objdump.log
objdump -T $BUILD_DIRECTORY/lib_lightgbm_swig.so >> $BUILD_DIRECTORY/objdump.log
python $BUILD_DIRECTORY/helpers/check_dynamic_dependencies.py $BUILD_DIRECTORY/objdump.log
```

</details>

I found that this is happening because `helpers/check_dynamic_dependencies.py` ignores non-default symbol versions in the output from `objdump`.

From the `objdump` docs ([link](https://man7.org/linux/man-pages/man1/objdump.1.html))

> **-T**
> Print the dynamic symbol table entries of the file....
>
> ...If the version is the default version to be used when resolving unversioned references to the symbol then it's displayed as is, **otherwise it's put into parentheses**.

In other words, that script ignores versions in `objdump -T lib_lightgbm.so` output like the following:

```text
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.2.5) strcpy
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.2.5) fflush
0000000000000000      DO *UND*	0000000000000000 (GLIBC_2.2.5) stderr
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.2.5) fprintf
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.2.5) snprintf
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.2.5) memmove
```

Because it expects to only see stuff like this

```text
0000000000000000      DF *UND*	0000000000000000 GLIBC_2.2.5 strcpy
0000000000000000      DF *UND*	0000000000000000 GLIBC_2.2.5 fflush
0000000000000000      DO *UND*	0000000000000000 GLIBC_2.2.5 stderr
0000000000000000      DF *UND*	0000000000000000 GLIBC_2.2.5 fprintf
0000000000000000      DF *UND*	0000000000000000 GLIBC_2.2.5 snprintf
0000000000000000      DF *UND*	0000000000000000 GLIBC_2.2.5 memmove
```

This PR fixes that.