### PR TITLE
[ci] test against R 4.2.2

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -21,9 +21,9 @@ if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
     export R_LINUX_VERSION="3.6.3-1bionic"
     export R_APT_REPO="bionic-cran35/"
 elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
-    export R_MAC_VERSION=4.2.1
+    export R_MAC_VERSION=4.2.2
     export R_MAC_PKG_URL=${CRAN_MIRROR}/bin/macosx/base/R-${R_MAC_VERSION}.pkg
-    export R_LINUX_VERSION="4.2.1-1.2004.0"
+    export R_LINUX_VERSION="4.2.2-1.2004.0"
     export R_APT_REPO="focal-cran40/"
 else
     echo "Unrecognized R version: ${R_VERSION}"

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -76,7 +76,7 @@ if [[ $OS_NAME == "macos" ]]; then
     brew install --cask basictex || exit -1
     export PATH="/Library/TeX/texbin:$PATH"
     sudo tlmgr --verify-repo=none update --self || exit -1
-    sudo tlmgr --verify-repo=none install inconsolata helvetic || exit -1
+    sudo tlmgr --verify-repo=none install inconsolata helvetic rsfs || exit -1
 
     curl -sL ${R_MAC_PKG_URL} -o R.pkg || exit -1
     sudo installer \

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -163,11 +163,12 @@ elif [[ $R_BUILD_TYPE == "cran" ]]; then
         || (cat ${RCHK_LOG_FILE} && exit -1)
         cat ${RCHK_LOG_FILE}
 
-        # the exception below is from R itself and not LightGBM:
+        # the exceptions below are from R itself and not LightGBM:
         # https://github.com/kalibera/rchk/issues/22#issuecomment-656036156
         exit $(
             cat ${RCHK_LOG_FILE} \
             | grep -v "in function strptime_internal" \
+            | grep -v "in function RunGenCollect" \
             | grep --count -E '\[PB\]|ERROR'
         )
     fi

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -80,7 +80,7 @@ if ($env:R_MAJOR_VERSION -eq "3") {
   $env:RTOOLS_BIN = "$RTOOLS_INSTALL_PATH\usr\bin"
   $env:RTOOLS_MINGW_BIN = "$RTOOLS_INSTALL_PATH\x86_64-w64-mingw32.static.posix\bin"
   $env:RTOOLS_EXE_FILE = "rtools42-5253-5107.exe"
-  $env:R_WINDOWS_VERSION = "4.2.1"
+  $env:R_WINDOWS_VERSION = "4.2.2"
 } else {
   Write-Output "[ERROR] Unrecognized R version: $env:R_VERSION"
   Check-Output $false


### PR DESCRIPTION
Contributes to #3763.

R 4.2.2 was released in October 2022. Changelog: https://cran.r-project.org/bin/windows/base/old/4.2.2/NEWS.R-4.2.2.html.

This PR proposes upgrading from R 4.2.1 to R 4.2.1 in LightGBM's R 4.2.x CI jobs.

### Notes for Reviewers

This will resolve an `R CMD check` warning I observed on #5563 

> Warning message:
package 'R6' was built under R version 4.2.2 

That can happen when binaries have been built by CRAN with a newer version of R than the one that you're using.