### PR TITLE
[ci] fix locale-setting in jobs running in ubuntu container

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -23,7 +23,7 @@ if [[ $OS_NAME == "macos" ]]; then
         -o miniforge.sh \
         https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh
 else  # Linux
-    if [[ $IN_UBUNTU_LATEST_CONTAINER == "true" ]]; then
+    if [[ $IN_UBUNTU_BASE_CONTAINER == "true" ]]; then
         # fixes error "unable to initialize frontend: Dialog"
         # https://github.com/moby/moby/issues/27988#issuecomment-462809153
         echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
@@ -46,6 +46,7 @@ else  # Linux
             libssl-dev \
             libunwind8 \
             locales \
+            locales-all \
             netcat \
             unzip \
             zip || exit -1
@@ -56,16 +57,16 @@ else  # Linux
         fi
 
         export LANG="en_US.UTF-8"
-        export LC_ALL="${LANG}"
         sudo locale-gen ${LANG}
-        sudo update-locale
+        sudo update-locale LANG=${LANG}
+        export LC_ALL="${LANG}"
     fi
     if [[ $TASK == "r-package" ]] && [[ $COMPILER == "clang" ]]; then
         sudo apt-get install --no-install-recommends -y \
             libomp-dev
     fi
     if [[ $TASK == "mpi" ]]; then
-        if [[ $IN_UBUNTU_LATEST_CONTAINER == "true" ]]; then
+        if [[ $IN_UBUNTU_BASE_CONTAINER == "true" ]]; then
             sudo apt-get update
             sudo apt-get install --no-install-recommends -y \
                 libopenmpi-dev \
@@ -78,7 +79,7 @@ else  # Linux
         fi
     fi
     if [[ $TASK == "gpu" ]]; then
-        if [[ $IN_UBUNTU_LATEST_CONTAINER == "true" ]]; then
+        if [[ $IN_UBUNTU_BASE_CONTAINER == "true" ]]; then
             sudo apt-get update
             sudo apt-get install --no-install-recommends -y \
                 libboost1.74-dev \
@@ -94,7 +95,7 @@ else  # Linux
         fi
     fi
     if [[ $TASK == "gpu" || $TASK == "bdist" ]]; then
-        if [[ $IN_UBUNTU_LATEST_CONTAINER == "true" ]]; then
+        if [[ $IN_UBUNTU_BASE_CONTAINER == "true" ]]; then
             sudo apt-get update
             sudo apt-get install --no-install-recommends -y \
                 pocl-opencl-icd

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -57,7 +57,6 @@ else  # Linux
         fi
 
         export LANG="en_US.UTF-8"
-        sudo locale-gen ${LANG}
         sudo update-locale LANG=${LANG}
         export LC_ALL="${LANG}"
     fi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -8,6 +8,11 @@ elif [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "clang" ]]; then
     export CC=clang
 fi
 
+if [[ $IN_UBUNTU_BASE_CONTAINER == "true" ]]; then
+    export LANG="en_US.UTF-8"
+    export LC_ALL="en_US.UTF-8"
+fi
+
 if [[ "${TASK}" == "r-package" ]] || [[ "${TASK}" == "r-rchk" ]]; then
     bash ${BUILD_DIRECTORY}/.ci/test_r_package.sh || exit -1
     exit 0

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -84,7 +84,7 @@ jobs:
   variables:
     COMPILER: clang
     DEBIAN_FRONTEND: 'noninteractive'
-    IN_UBUNTU_LATEST_CONTAINER: 'true'
+    IN_BASE_LATEST_CONTAINER: 'true'
     OS_NAME: 'linux'
     SETUP_CONDA: 'true'
   pool: sh-ubuntu

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -84,7 +84,7 @@ jobs:
   variables:
     COMPILER: clang
     DEBIAN_FRONTEND: 'noninteractive'
-    IN_BASE_LATEST_CONTAINER: 'true'
+    IN_UBUNTU_BASE_CONTAINER: 'true'
     OS_NAME: 'linux'
     SETUP_CONDA: 'true'
   pool: sh-ubuntu


### PR DESCRIPTION
Today, the Linux CI jobs on Azure DevOps run in a container using the `ubuntu:22.04` image. Since that image is just a minimal operating system distribution, running LightGBM's CI in it requires a lot of extra configuration.

Here's where much of that happens:

https://github.com/microsoft/LightGBM/blob/a17489328c4f81819b5a4131c9a386b09b90b04f/.ci/setup.sh#L26

I noticed while working on #5638 that one piece of that has been silently failing for a while (unsure how long).

There are a few problems with this bit of configuration that tries to change the locale inside the container to `en_US.UTF-8`:

https://github.com/microsoft/LightGBM/blob/a17489328c4f81819b5a4131c9a386b09b90b04f/.ci/setup.sh#L58-L61

Setting `LC_ALL` environment variable to a locale that doesn't exist yet (i.e. hasn't been downloaded or generated with `locale-gen`) isn't possible. That's why this warning shows up in the `Linux_latest` logs

> /__w/1/s/.ci/setup.sh: line 59: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
> /bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)

([recent build on master](https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=14012&view=logs&j=275189f9-c769-596a-7ef9-49fb48a9ab70&t=1fb0a3dd-ad11-527b-ef3d-485324b146c4))

Setting environment variables inside a process only affects that process and it's sub-processes...so those variables won't be used by `test.sh`, since it runs in a separate process not as a sub-process of `setup.sh`

https://github.com/microsoft/LightGBM/blob/a17489328c4f81819b5a4131c9a386b09b90b04f/.vsts-ci.yml#L142-L145

I noticed this because once I started trying to get `.ci/test_r_package.sh` to run in an `ubuntu:22.04` container, the R unit test about handling of non-ASCII feature names was failing, and R was reporting that it had fallen back to the default character set for the image (`ASCII`, the "POSIX" locale).

This PR proposes the following changes:

* just install `locales-all` instead of generating a specific locale with `locale-gen`
* set environment variable `LC_ALL` again in `test.sh`
* switch environment variable `IN_UBUNTU_LATEST_CONTAINER` to `IN_UBUNTU_BASE_CONTAINER`
    - In #5638, I'd like to run the R 3.6 (older version of R) linux jobs in an `ubuntu:18.04` instead of `ubuntu:22.04` container, but it can re-use all of the setup stuff.
    - So everything these scripts guard with that environment variable as being relevant in an ubuntu "latest" container are actually just useful *whenever running the scripts in an `ubuntu:{something}` container*

