### PR TITLE
[ci] make GitHub Actions branch protection stricter (fixes #5501)

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -107,10 +107,12 @@ jobs:
                 docker_img="${docker_img}-ubuntu$(lsb_release -rs)" 
             fi
             docker run --env-file docker.env -v "$GITHUB_WORKSPACE":"$ROOT_DOCKER_FOLDER" --rm --gpus all "$docker_img" /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
-  all-successful:
-    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+  all-cuda-jobs-successful:
+    if: always()
     runs-on: ubuntu-latest
     needs: [test]
     steps:
     - name: Note that all tests succeeded
-      run: echo "🎉"
+      uses: re-actors/alls-green@v1.2.2
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/optional_checks.yml
+++ b/.github/workflows/optional_checks.yml
@@ -7,7 +7,7 @@ on:
       - release/*
 
 jobs:
-  all-successful:
+  all-optional-checks-successful:
     timeout-minutes: 120
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -71,10 +71,12 @@ jobs:
           export PATH=${CONDA}/bin:${PATH}
           $GITHUB_WORKSPACE/.ci/setup.sh || exit -1
           $GITHUB_WORKSPACE/.ci/test.sh || exit -1
-  all-successful:
-    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+  all-python-package-jobs-successful:
+    if: always()
     runs-on: ubuntu-latest
     needs: [test]
     steps:
     - name: Note that all tests succeeded
-      run: echo "🎉"
+      uses: re-actors/alls-green@v1.2.2
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -246,10 +246,12 @@ jobs:
               echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
               exit -1
           fi
-  all-successful:
-    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
-    runs-on: ubuntu-22.04
+  all-r-package-jobs-successful:
+    if: always()
+    runs-on: ubuntu-latest
     needs: [test, test-r-sanitizers, test-r-debian-clang]
     steps:
     - name: Note that all tests succeeded
-      run: echo "🎉"
+      uses: re-actors/alls-green@v1.2.2
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -80,10 +80,12 @@ jobs:
               echo ""
               exit -1
           fi
-  all-successful:
-    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
-    runs-on: ubuntu-22.04
+  all-static-analysis-jobs-successful:
+    if: always()
+    runs-on: ubuntu-latest
     needs: [test, r-check-docs]
     steps:
     - name: Note that all tests succeeded
-      run: echo "🎉"
+      uses: re-actors/alls-green@v1.2.2
+      with:
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Fixes #5501.

Following advice in that issue and in https://github.com/orgs/community/discussions/26733#discussioncomment-3253155, this proposes two changes to the project's GitHub Actions jobs.

* use https://github.com/re-actors/alls-green to enforce multiple checks passing without needing to change branch protection settings every time checks are added or removed
* give each of those "all the checks passed" jobs a unique name

This will make use of GitHub auto-merging more reliable, and reduce the risk of accidentally merging PRs where some CI jobs are failing.

### Notes for Reviewers

@guolinke @shiyu1994 can you please go into the branch protection for `master` at https://github.com/microsoft/LightGBM/settings/branches and modify the section `Require status checks to pass before merging`?

The following should be checked as required:

* `all-cuda-jobs-successful` (GitHub Actions)
* `all-optional-checks-successful` (GitHub Actions)
* `all-python-package-jobs-successful` (GitHub Actions)
* `all-r-package-jobs-successful` (GitHub Actions)
* `all-static-analysis-jobs-successful` (GitHub Actions)

And the following should be unchecked:

* `all-successful` (GitHub Actions)

I think that only the two of you have permissions in this repo to modify that.