### PR TITLE
[docs] update cran-comments.md for v3.3.4 release

### DIFF
--- a/R-package/cran-comments.md
+++ b/R-package/cran-comments.md
@@ -1,8 +1,30 @@
 # CRAN Submission History
 
+## v3.3.4 - Submission 1 - (December 15, 2022)
+
+### CRAN response
+
+Accepted to CRAN
+
+### Maintainer Notes
+
+Submitted with the following comment:
+
+> This submission contains {lightgbm} 3.3.3.
+
+> Per CRAN's policies, I am submitting it on behalf of the project's maintainer (Yu Shi), with his permission.
+
+> This submission includes patches to address the following warnings observed on the fedora and debian CRAN checks.
+>
+> Compiled code should not call entry points which might terminate R nor write to stdout/stderr instead of to the console, nor use Fortran I/O nor system RNGs nor [v]sprintf.
+
+> Thank you very much for your time and consideration.
+
 ## v3.3.3 - Submission 1 - (October 10, 2022)
 
 ### CRAN response
+
+Accepted to CRAN
 
 ### Maintainer Notes
 


### PR DESCRIPTION
v3.3.4 of the R package has been released to CRAN (https://github.com/microsoft/LightGBM/pull/5619#issuecomment-1353685486, https://github.com/microsoft/LightGBM/issues/5618#issuecomment-1363292780).

See https://cran.r-project.org/web/checks/check_results_lightgbm.html

<img width="526" alt="image" src="https://user-images.githubusercontent.com/7608904/209421309-ac11c3ca-a10b-4234-8b15-a250e9e5a9ad.png">


This PR proposes updating `cran-comments.md` to reflect that.