### PR TITLE
[docs] encourage use of releases for GUI-only installations

### DIFF
--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -56,7 +56,7 @@ With GUI
 
 1. Install `Visual Studio`_ (2015 or newer).
 
-2. Download `zip archive`_ and unzip it.
+2. Navigate to one of the releases at https://github.com/microsoft/LightGBM/releases, download ``LightGBM-complete_source_code_zip.zip``, and unzip it.
 
 3. Go to ``LightGBM-master/windows`` folder.
 
@@ -235,7 +235,7 @@ With GUI
 
 1. Install `Visual Studio`_ (2015 or newer).
 
-2. Download `zip archive`_ and unzip it.
+2. Navigate to one of the releases at https://github.com/microsoft/LightGBM/releases, download ``LightGBM-complete_source_code_zip.zip``, and unzip it.
 
 3. Go to ``LightGBM-master/windows`` folder.
 
@@ -385,7 +385,7 @@ With GUI
 
 2. Install `Visual Studio`_ (2015 or newer).
 
-3. Download `zip archive`_ and unzip it.
+3. Navigate to one of the releases at https://github.com/microsoft/LightGBM/releases, download ``LightGBM-complete_source_code_zip.zip``, and unzip it.
 
 4. Go to ``LightGBM-master/windows`` folder.
 
@@ -923,8 +923,6 @@ gcc
 .. _Python-package: https://github.com/microsoft/LightGBM/tree/master/python-package
 
 .. _R-package: https://github.com/microsoft/LightGBM/tree/master/R-package
-
-.. _zip archive: https://github.com/microsoft/LightGBM/archive/master.zip
 
 .. _Visual Studio: https://visualstudio.microsoft.com/downloads/
 


### PR DESCRIPTION
Replaces #5498.

Implements the proposal in https://github.com/microsoft/LightGBM/pull/5498#pullrequestreview-1134818427.

Modifies the installation docs to encourage users who want to install LightGBM using only a GUI to use official releases. I hope this will help to prevent issues like #5495, where GUI-only users see broken builds because the GitHub source archive doesn't pull in git submodules.