### PR TITLE
fix feature index in Dataset::AddFeaturesFrom (fixes #5410)

### DIFF
--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -1495,7 +1495,7 @@ void Dataset::AddFeaturesFrom(Dataset* other) {
                    other->max_bin_by_feature_, other->num_total_features_, -1);
   num_total_features_ += other->num_total_features_;
   for (size_t i = 0; i < (other->numeric_feature_map_).size(); ++i) {
-    int feat_ind = numeric_feature_map_[i];
+    int feat_ind = other->numeric_feature_map_[i];
     if (feat_ind > -1) {
       numeric_feature_map_.push_back(feat_ind + num_numeric_features_);
     } else {


### PR DESCRIPTION
Replaces #5434.
Fixes #5410.

Thanks to @EdmondElephant for discovering this bug, investigating it in #5410, and for fixing it in #5434!

I'm just replacing that PR with this one due to lack of response there (it has been more than 3 months since the last comment there).

### Notes for Reviewers

I ran the following to test that this new unit test segfaults on `master` and passes on this PR.

```shell
mkdir build
cd build
cmake ..
make -j4
cd ../python-package
python setup.py --install
cd tests/python_package_test
pytest 'test_basic.py::test_add_features_does_not_fail_if_initial_dataset_has_zero_informative_features'
```