### PR TITLE
[ci] automatically cancel GitHub Actions runs for outdated commits

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -9,6 +9,11 @@ on:
     - master
     - release/*
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   github_actions: 'true'
   os_name: linux

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -9,6 +9,11 @@ on:
     - master
     - release/*
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CONDA_ENV: test-env
   GITHUB_ACTIONS: 'true'

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -9,6 +9,11 @@ on:
     - master
     - release/*
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # hack to get around this:
   # https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -11,6 +11,11 @@ on:
     - master
     - release/*
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   COMPILER: 'gcc'
   CONDA_ENV: test-env


### PR DESCRIPTION
Proposes modifying the GitHub Actions jobs that run on every commit, such that GitHub automatically cancels in-progress runs on a given branch when a new commit is pushed to that branch.

### Benefits of this change

Once a new commit has been pushed to `master` or to a pull request, it's not important that CI jobs for the previous commit run to completion.

Automatically cancelling those in-progress CI runs that are going to be ignored anyway is helpful because it:

* increases the number of PRs that can be merged in a day
* reduces the impact that one very active PR can have on throughput for the rest of the repo
* reduces the load we place on GitHub Actions and other services the jobs hit
    - reduces the risk of triggering `409 - too many requests` types of errors from services like GitHub, PyPI, CRAN, etc.
    - makes LightGBM a slightly better open source citizen (GitHub Actions is free and this project benefits from that)

It's important to remember that:

* for everything except the CUDA jobs, we're limited to 20 concurrent jobs across all workflows and commits ([docs link](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits))
* for the CUDA jobs, we're limited to 1 concurrent job across all workflows and commits, and we run 5 of those jobs on every commit

### Notes for Reviewers

I first learned about that via this change to `hypothesis`: https://github.com/HypothesisWorks/hypothesis/commit/b1f7a7cfaadbb9dc42d6c302b2e4ebae6887579a

See https://docs.github.com/en/actions/learn-github-actions/contexts for an explanation of the values that `${{ github.ref }}` will take.

> for branches the format is `refs/heads/<branch_name>`, for pull requests it is `refs/pull/<pr_number>/merge`, and for tags it is `refs/tags/<tag_name>`
