### PR TITLE
Check feature indexes in forced split file (fixes #5517)

### DIFF
--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -59,7 +59,7 @@ class GBDT : public GBDTBase {
             const std::vector<const Metric*>& training_metrics) override;
 
   /*!
-  * \brief Traverse the tree of forced splits and check that all indices  are less than the number of features.
+  * \brief Traverse the tree of forced splits and check that all indices are less than the number of features.
   */
   void CheckForcedSplitFeatures();
 

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -59,6 +59,11 @@ class GBDT : public GBDTBase {
             const std::vector<const Metric*>& training_metrics) override;
 
   /*!
+  * \brief Traverse the tree of forced splits and check that all indices  are less than the number of features.
+  */
+  void CheckForcedSplitFeatures();
+
+  /*!
   * \brief Merge model from other boosting object. Will insert to the front of current boosting object
   * \param other
   */

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2887,6 +2887,25 @@ def test_node_level_subcol():
     assert ret != ret2
 
 
+def test_forced_split_feature_indices(tmp_path):
+    X, y = make_synthetic_regression()
+    forced_split = {
+        "feature": 0,
+        "threshold": 0.5,
+        "left": {"feature": X.shape[1], "threshold": 0.5},
+    }
+    tmp_split_file = tmp_path / "forced_split.json"
+    with open(tmp_split_file, "w") as f:
+        f.write(json.dumps(forced_split))
+    lgb_train = lgb.Dataset(X, y)
+    params = {
+        "objective": "regression",
+        "forcedsplits_filename": tmp_split_file
+    }
+    with pytest.raises(lgb.basic.LightGBMError, match="Forced splits file includes feature index"):
+        bst = lgb.train(params, lgb_train)
+
+
 def test_forced_bins():
     x = np.empty((100, 2))
     x[:, 0] = np.arange(0, 1, 0.01)


### PR DESCRIPTION
When constructing booster, traverse the tree of forced splits and check that all split features have index less than or equal to the maximum feature index in the dataset.

Fixes https://github.com/microsoft/LightGBM/issues/5517