### PR TITLE
[python-package] make public API members explicit with module-level __all__ variables

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -23,8 +23,8 @@ from .libpath import find_lib_path
 __all__ = [
     'Booster',
     'Dataset',
-    'LightGBMError',
     'LGBMDeprecationWarning',
+    'LightGBMError',
     'register_logger',
     'Sequence'
 ]

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -20,6 +20,15 @@ import scipy.sparse
 from .compat import PANDAS_INSTALLED, concat, dt_DataTable, pd_CategoricalDtype, pd_DataFrame, pd_Series
 from .libpath import find_lib_path
 
+__all__ = [
+    'Booster',
+    'Dataset',
+    'LightGBMError',
+    'LGBMDeprecationWarning',
+    'register_logger',
+    'Sequence'
+]
+
 _DatasetHandle = ctypes.c_void_p
 _LGBM_EvalFunctionResultType = Tuple[str, float, bool]
 _LGBM_BoosterEvalMethodResultType = Tuple[str, str, float, bool]

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -26,7 +26,7 @@ __all__ = [
     'LGBMDeprecationWarning',
     'LightGBMError',
     'register_logger',
-    'Sequence'
+    'Sequence',
 ]
 
 _DatasetHandle = ctypes.c_void_p

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -6,6 +6,13 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 
 from .basic import _ConfigAliases, _LGBM_BoosterEvalMethodResultType, _log_info, _log_warning
 
+__all__ = [
+    'early_stopping'
+    'log_evaluation',
+    'record_evaluation',
+    'reset_parameter',
+]
+
 _EvalResultTuple = Union[
     List[_LGBM_BoosterEvalMethodResultType],
     List[Tuple[str, str, float, bool, float]]

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 from .basic import _ConfigAliases, _LGBM_BoosterEvalMethodResultType, _log_info, _log_warning
 
 __all__ = [
-    'early_stopping'
+    'early_stopping',
     'log_evaluation',
     'record_evaluation',
     'reset_parameter',

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -194,3 +194,5 @@ except ImportError:
 
         def _LGBMCpuCount(only_physical_cores: bool = True):
             return cpu_count()
+
+__all__ = []

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -28,7 +28,7 @@ from .sklearn import (LGBMClassifier, LGBMModel, LGBMRanker, LGBMRegressor, _LGB
 __all__ = [
     'DaskLGBMClassifier',
     'DaskLGBMRanker',
-    'DaskLGBMRegressor'
+    'DaskLGBMRegressor',
 ]
 
 _DaskCollection = Union[dask_Array, dask_DataFrame, dask_Series]

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -25,6 +25,12 @@ from .sklearn import (LGBMClassifier, LGBMModel, LGBMRanker, LGBMRegressor, _LGB
                       _LGBM_ScikitEvalMetricType, _lgbmmodel_doc_custom_eval_note, _lgbmmodel_doc_fit,
                       _lgbmmodel_doc_predict)
 
+__all__ = [
+    'DaskLGBMClassifier',
+    'DaskLGBMRanker',
+    'DaskLGBMRegressor'
+]
+
 _DaskCollection = Union[dask_Array, dask_DataFrame, dask_Series]
 _DaskMatrixLike = Union[dask_Array, dask_DataFrame]
 _DaskVectorLike = Union[dask_Array, dask_Series]

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -14,6 +14,13 @@ from .basic import (Booster, Dataset, LightGBMError, _choose_param_value, _Confi
                     _LGBM_CustomObjectiveFunction, _log_warning)
 from .compat import SKLEARN_INSTALLED, _LGBMBaseCrossValidator, _LGBMGroupKFold, _LGBMStratifiedKFold
 
+__all__ = [
+    'cv',
+    'CVBooster',
+    'train'
+]
+
+
 _LGBM_CustomMetricFunction = Callable[
     [np.ndarray, Dataset],
     Tuple[str, float, bool]

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -17,7 +17,7 @@ from .compat import SKLEARN_INSTALLED, _LGBMBaseCrossValidator, _LGBMGroupKFold,
 __all__ = [
     'cv',
     'CVBooster',
-    'train'
+    'train',
 ]
 
 

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from platform import system
 from typing import List
 
+__all__ = []
+
 
 def find_lib_path() -> List[str]:
     """Find the path to LightGBM library files.

--- a/python-package/lightgbm/plotting.py
+++ b/python-package/lightgbm/plotting.py
@@ -11,6 +11,14 @@ from .basic import Booster, _data_from_pandas, _is_zero, _log_warning, _MissingT
 from .compat import GRAPHVIZ_INSTALLED, MATPLOTLIB_INSTALLED, pd_DataFrame
 from .sklearn import LGBMModel
 
+__all__ = [
+    'create_tree_digraph',
+    'plot_importance',
+    'plot_metric',
+    'plot_split_value_histogram',
+    'plot_tree',
+]
+
 
 def _check_not_tuple_of_2_elements(obj: Any, obj_name: str = 'obj') -> None:
     """Check object is not tuple or does not have 2 elements."""

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -16,6 +16,13 @@ from .compat import (SKLEARN_INSTALLED, LGBMNotFittedError, _LGBMAssertAllFinite
                      dt_DataTable, pd_DataFrame)
 from .engine import train
 
+__all__ = [
+    'LGBMClassifier',
+    'LGBMModel',
+    'LGBMRanker',
+    'LGBMRegressor',
+]
+
 _LGBM_ScikitCustomObjectiveFunction = Union[
     Callable[
         [np.ndarray, np.ndarray],


### PR DESCRIPTION
Contributes to #5313.

Proposes adding module-level `__all__` blocks in each module in the Python package.

From https://docs.python.org/3/reference/simple_stmts.html#import (thanks @jmoralez for sharing that link in https://github.com/microsoft/LightGBM/issues/5313#issuecomment-1165757690)....

> *The public names defined by a module are determined by checking the module’s namespace for a variable named `__all__`... `__all__` should contain the entire public API.*
>
> *It is intended to avoid accidentally exporting items that are not part of the API (such as library modules which were imported and used within the module).*

### Benefits of this change

Reduces the set of imports pulled in by statements like `from lightgbm.basic import *` to only those that maintainers intend to be part of LightGBM's public API.

That will hopefully discourage some users from depending on details that are expected to be private, and therefore subject to breaking changes.

### How I tested this

<details><summary>used dir() to check what was imported by different import paths (click me)</summary>

Wrote a little shell function that prints the incremental objects added into the current Python environment by an import.

```shell
print_incremental_imports() {
    python -c "orig = set(dir()); from ${1} import *; print((set(dir()) - orig) - set(['orig']))"
}

print_incremental_imports "lightgbm.basic"
```

`from lightgbm import *` (unchanged)

```text
(unchanged)
```

`from lightgbm.basic import *`

```text
# before
{'abc', 'Union', 'C_API_PREDICT_NORMAL', 'FIELD_TYPE_MAPPER', 'C_API_DTYPE_FLOAT32',
'LightGBMError', 'SEEK_END', 'pd_DataFrame', 'Optional', 'C_API_DTYPE_INT32', 'json_default_with_numpy',
'pd_CategoricalDtype', 'deepcopy', 'Dataset', 'LGBMDeprecationWarning', 'pd_Series', 'json', 'scipy',
'C_API_FEATURE_IMPORTANCE_SPLIT', 'OrderedDict', 'Any', 'wraps', 'Path', 'List', 'C_API_PREDICT_CONTRIB',
'C_API_MATRIX_TYPE_CSC', 'C_API_PREDICT_RAW_SCORE', 'param_dict_to_str', 'C_API_PREDICT_LEAF_INDEX', 'environ',
'C_API_DTYPE_INT64', 'getsize', 'Sequence', 'Dict', 'C_API_IS_ROW_MAJOR', 'Booster', 'concat', 'Callable',
'NamedTemporaryFile', 'ctypes', 'MAX_INT32', 'warnings', 'C_API_DTYPE_FLOAT64', 'PANDAS_INSTALLED', 'Enum',
'C_API_FEATURE_IMPORTANCE_GAIN', 'FEATURE_IMPORTANCE_TYPE_MAPPER', 'Set', 'C_API_MATRIX_TYPE_CSR', 'np',
'Tuple', 'Iterable', 'dt_DataTable', 'register_logger', 'find_lib_path', 'ZERO_THRESHOLD'}

# after
{'LightGBMError', 'LGBMDeprecationWarning', 'Sequence', 'Dataset', 'Booster', 'register_logger'}
```

`from lightgbm.callback import *`

```text
# before
{'List', 'Callable', 'record_evaluation', 'Union', 'partial', 'Any', 'reset_parameter', 'collections',
'early_stopping', 'EarlyStopException', 'Tuple', 'CallbackEnv', 'Dict', 'log_evaluation'}

# after
{'early_stopping', 'reset_parameter', 'record_evaluation', 'log_evaluation'}
```

`from lightgbm.compat import *`

```text
# before
{'SKLEARN_INSTALLED', 'PANDAS_INSTALLED', 'LabelEncoder', 'delayed', 'wait', 'BaseEstimator', 'pd_Series',
'StratifiedKFold', 'dask_Array', 'LGBMNotFittedError', 'MATPLOTLIB_INSTALLED', 'DATATABLE_INSTALLED',
'DASK_INSTALLED', 'pd_DataFrame', 'ClassifierMixin', 'NotFittedError', 'concat', 'dt_DataTable',
'GroupKFold', 'default_client', 'check_array', 'dask_array_from_delayed', 'assert_all_finite',
'dask_Series', 'check_classification_targets', 'RegressorMixin', 'dask_DataFrame', 'pd_CategoricalDtype',
'dask_bag_from_delayed', 'compute_sample_weight', 'BaseCrossValidator', 'Client', 'matplotlib',
'cpu_count', 'check_X_y', 'datatable', 'GRAPHVIZ_INSTALLED'}

# after
set()
```

`from lightgbm.dask import *`

```text
# before
{'List', 'dask_Series', 'LGBMModel', 'urlparse', 'Any', 'PANDAS_INSTALLED', 'delayed', 'Type', 'ss',
'LGBMRanker', 'concat', 'np', 'DaskLGBMClassifier', 'namedtuple', 'defaultdict', 'DaskLGBMRanker',
'LGBMRegressor', 'Union', 'Client', 'Optional', 'DaskLGBMRegressor', 'partial', 'auto', 'socket',
'pd_Series', 'LGBMClassifier', 'dask_bag_from_delayed', 'Enum', 'deepcopy', 'SKLEARN_INSTALLED',
'dask_DataFrame', 'wait', 'LGBMNotFittedError', 'Dict', 'LightGBMError', 'Tuple', 'DASK_INSTALLED',
'dask_array_from_delayed', 'dask_Array', 'Iterable', 'pd_DataFrame', 'default_client'}

# after
{'DaskLGBMClassifier', 'DaskLGBMRegressor', 'DaskLGBMRanker'}
```

`from lightgbm.engine import *`

```text
# before
{'collections', 'SKLEARN_INSTALLED', 'Booster', 'train', 'Iterable', 'np', 'Tuple', 'Dict', 'callback',
'Union', 'Any', 'Dataset', 'copy', 'Callable', 'cv', 'CVBooster', 'attrgetter', 'json', 'List',
'LightGBMError', 'Path', 'Optional'}

# after
{'train', 'cv', 'CVBooster'}
```

`from lightgbm.libpath import *`

```text
# before
{'List', 'system', 'find_lib_path', 'Path'}

# after
set()
```

`from lightgbm.plotting import *`

```text
# before
{'math', 'Any', 'List', 'plot_split_value_histogram', 'Optional', 'LGBMModel', 'Booster',
'pd_DataFrame', 'plot_tree', 'plot_metric', 'BytesIO', 'GRAPHVIZ_INSTALLED', 'deepcopy',
'create_tree_digraph', 'MATPLOTLIB_INSTALLED', 'np', 'Tuple', 'plot_importance', 'Union', 'Dict'}

# after
{'plot_tree', 'plot_split_value_histogram', 'plot_metric', 'plot_importance', 'create_tree_digraph'
```

`from lightgbm.sklearn import *`

```text
# before
{'SKLEARN_INSTALLED', 'np', 'LGBMModel', 'Path', 'Booster', 'Callable', 'Optional', 'pd_DataFrame',
'LGBMClassifier', 'List', 'copy', 'Union', 'Any', 'train', 'dt_DataTable', 'record_evaluation',
'LGBMNotFittedError', 'LGBMRegressor', 'Dataset', 'Dict', 'LGBMRanker', 'signature', 'Tuple', 'LightGBMError'}

# after
{'LGBMClassifier', 'LGBMModel', 'LGBMRegressor', 'LGBMRanker'}
```

</details>

Temporarily enabled this branch on readthedocs, to be sure that this doesn't break doc-building.

* successful build: https://readthedocs.org/projects/lightgbm/builds/19036637/
* docs link: https://lightgbm.readthedocs.io/en/python-module-all/Python-API.html#training-api