### PR TITLE
[python-package] remove `Dataset.feature_penalty`

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1275,7 +1275,6 @@ class Dataset:
         self._predictor = None
         self.pandas_categorical = None
         self.params_back_up = None
-        self.feature_penalty = None
         self.monotone_constraints = None
         self.version = 0
         self._start_row = 0  # Used when pushing rows one by one.


### PR DESCRIPTION
Contributes to #5313.

Proposes removing public attribute `Dataset.feature_penalty`. It was added in #2006 to support method `Dataset.get_feature_penalty()`.

`Dataset.get_feature_penalty()` was removed in #2594, which moved `feature_penalty` into `params` (instead of having it be a top-level attribute of `Dataset`).

### Notes for Reviewers

This is technically "breaking" because it removes a public attribute that user code could reference, but this attribute doesn't actually *do anything* and hasn't since `get_feature_penalty()` was removed back in #2594.

So I chose the label `maintenance`, to not add more noise to the `breaking` section of the release notes for something that I think very few users are likely to be depending on.