### PR TITLE
[ci] [python-package] enforce flake8 checks (fixes #5566)

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -76,13 +76,16 @@ if [[ $TASK == "lint" ]]; then
     conda install -q -y -n $CONDA_ENV \
         cmakelint \
         cpplint \
+        flake8 \
         isort \
         mypy \
-        pycodestyle \
         pydocstyle \
         "r-lintr>=3.0"
     echo "Linting Python code"
-    pycodestyle --ignore=E501,W503 --exclude=./.nuget,./external_libs . || exit -1
+    flake8 \
+        --ignore=E501,W503 \
+        --exclude=./.nuget,./external_libs,./python-package/build \
+        . || exit -1
     pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^external_libs|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1
     isort . --check-only || exit -1
     mypy --ignore-missing-imports python-package/ || true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,7 +105,7 @@ autodoc_mock_imports = [
     'scipy.sparse',
 ]
 try:
-    import sklearn
+    import sklearn  # noqa: F401
 except ImportError:
     autodoc_mock_imports.append('sklearn')
 # hide type hints in API docs

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -36,14 +36,14 @@ except ImportError:
 
 """matplotlib"""
 try:
-    import matplotlib
+    import matplotlib  # noqa: F401
     MATPLOTLIB_INSTALLED = True
 except ImportError:
     MATPLOTLIB_INSTALLED = False
 
 """graphviz"""
 try:
-    import graphviz
+    import graphviz  # noqa: F401
     GRAPHVIZ_INSTALLED = True
 except ImportError:
     GRAPHVIZ_INSTALLED = False

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -96,7 +96,7 @@ def silent_call(cmd: List[str], raise_error: bool = False, error_msg: str = '') 
         with open(LOG_PATH, "ab") as log:
             subprocess.check_call(cmd, stderr=log, stdout=log)
         return 0
-    except Exception as err:
+    except Exception:
         if raise_error:
             raise Exception("\n".join((error_msg, LOG_NOTICE)))
         return 1

--- a/tests/python_package_test/test_callback.py
+++ b/tests/python_package_test/test_callback.py
@@ -3,7 +3,7 @@ import pytest
 
 import lightgbm as lgb
 
-from .utils import SERIALIZERS, pickle_and_unpickle_object, pickle_obj, unpickle_obj
+from .utils import SERIALIZERS, pickle_and_unpickle_object
 
 
 def reset_feature_fraction(boosting_round):

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1724,7 +1724,7 @@ def test_dask_methods_and_sklearn_equivalents_have_similar_signatures(methods):
 
 @pytest.mark.parametrize('task', tasks)
 def test_training_succeeds_when_data_is_dataframe_and_label_is_column_array(task, cluster):
-    with Client(cluster) as client:
+    with Client(cluster):
         _, _, _, _, dX, dy, dw, dg = _create_data(
             objective=task,
             output='dataframe',
@@ -1803,7 +1803,7 @@ def _tested_estimators():
 @pytest.mark.parametrize("estimator", _tested_estimators())
 @pytest.mark.parametrize("check", sklearn_checks_to_run())
 def test_sklearn_integration(estimator, check, cluster):
-    with Client(cluster) as client:
+    with Client(cluster):
         estimator.set_params(local_listen_port=18000, time_out=5)
         name = type(estimator).__name__
         check(name, estimator)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2903,7 +2903,7 @@ def test_forced_split_feature_indices(tmp_path):
         "forcedsplits_filename": tmp_split_file
     }
     with pytest.raises(lgb.basic.LightGBMError, match="Forced splits file includes feature index"):
-        bst = lgb.train(params, lgb_train)
+        lgb.train(params, lgb_train)
 
 
 def test_forced_bins():

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -445,10 +445,18 @@ def test_clone_and_property():
     gbm.fit(X, y)
 
     gbm_clone = clone(gbm)
+
+    # original estimator is unaffected
+    assert gbm.n_estimators == 10
+    assert gbm.verbose == -1
     assert isinstance(gbm.booster_, lgb.Booster)
-    assert isinstance(gbm_clone.booster_, lgb.Booster)
     assert isinstance(gbm.feature_importances_, np.ndarray)
-    assert isinstance(gbm_clone.feature_importances_, np.ndarray)
+
+    # new estimator is unfitted, but has the same parameters
+    assert gbm_clone.__sklearn_is_fitted__() is False
+    assert gbm_clone.n_estimators == 10
+    assert gbm_clone.verbose == -1
+    assert gbm_clone.get_params() == gbm.get_params()
 
     X, y = load_digits(n_class=2, return_X_y=True)
     clf = lgb.LGBMClassifier(n_estimators=10, verbose=-1)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -446,7 +446,9 @@ def test_clone_and_property():
 
     gbm_clone = clone(gbm)
     assert isinstance(gbm.booster_, lgb.Booster)
+    assert isinstance(gbm_clone.booster_, lgb.Booster)
     assert isinstance(gbm.feature_importances_, np.ndarray)
+    assert isinstance(gbm_clone.feature_importances_, np.ndarray)
 
     X, y = load_digits(n_class=2, return_X_y=True)
     clf = lgb.LGBMClassifier(n_estimators=10, verbose=-1)


### PR DESCRIPTION
Fixes #5566.

Proposes enforcing `flake8` checks on all Python code maintained in this repo, for the reasons described in #5566.

This also fixes the following warnings found by `flake8`

```text
./tests/python_package_test/test_engine.py:2906:9: F841 local variable 'bst' is assigned to but never used
./tests/python_package_test/test_callback.py:6:1: F401 '.utils.pickle_obj' imported but unused
./tests/python_package_test/test_callback.py:6:1: F401 '.utils.unpickle_obj' imported but unused
./tests/python_package_test/test_dask.py:1727:29: F841 local variable 'client' is assigned to but never used
./tests/python_package_test/test_dask.py:1806:29: F841 local variable 'client' is assigned to but never used
./tests/python_package_test/test_sklearn.py:447:5: F841 local variable 'gbm_clone' is assigned to but never used
./python-package/setup.py:99:5: F841 local variable 'err' is assigned to but never used
./python-package/lightgbm/compat.py:39:5: F401 'matplotlib' imported but unused
./python-package/lightgbm/compat.py:46:5: F401 'graphviz' imported but unused
./docs/conf.py:108:5: F401 'sklearn' imported but unused
```

### Notes for Reviewers

In a followup PR, I might also propose also adding some flake8 plugins like `flake8-bugbear`. But didn't want to make this PR any larger.