### PR TITLE
[ci] speed up conda setup for some jobs

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -139,7 +139,7 @@ conda install -q -y -n $CONDA_ENV \
     pandas \
     psutil \
     pytest \
-    "python=$PYTHON_VERSION[build=*cpython]" \
+    ${CONDA_PYTHON_REQUIREMENT} \
     python-graphviz \
     scikit-learn \
     scipy || exit -1

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -34,7 +34,61 @@ if [[ "$TASK" == "cpp-tests" ]]; then
     exit 0
 fi
 
-conda create -q -y -n $CONDA_ENV "python=$PYTHON_VERSION[build=*cpython]"
+CONDA_PYTHON_REQUIREMENT="python=$PYTHON_VERSION[build=*cpython]"
+
+if [[ $TASK == "if-else" ]]; then
+    conda create -q -y -n $CONDA_ENV ${CONDA_PYTHON_REQUIREMENT} numpy
+    mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build && cmake .. && make lightgbm -j4 || exit -1
+    cd $BUILD_DIRECTORY/tests/cpp_tests && ../../lightgbm config=train.conf convert_model_language=cpp convert_model=../../src/boosting/gbdt_prediction.cpp && ../../lightgbm config=predict.conf output_result=origin.pred || exit -1
+    cd $BUILD_DIRECTORY/build && make lightgbm -j4 || exit -1
+    cd $BUILD_DIRECTORY/tests/cpp_tests && ../../lightgbm config=predict.conf output_result=ifelse.pred && python test.py || exit -1
+    exit 0
+fi
+
+if [[ $TASK == "swig" ]]; then
+    mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build
+    if [[ $OS_NAME == "macos" ]]; then
+        cmake -DUSE_SWIG=ON -DAPPLE_OUTPUT_DYLIB=ON ..
+    else
+        cmake -DUSE_SWIG=ON ..
+    fi
+    make -j4 || exit -1
+    if [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "gcc" ]]; then
+        objdump -T $BUILD_DIRECTORY/lib_lightgbm.so > $BUILD_DIRECTORY/objdump.log || exit -1
+        objdump -T $BUILD_DIRECTORY/lib_lightgbm_swig.so >> $BUILD_DIRECTORY/objdump.log || exit -1
+        python $BUILD_DIRECTORY/helpers/check_dynamic_dependencies.py $BUILD_DIRECTORY/objdump.log || exit -1
+    fi
+    if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
+        cp $BUILD_DIRECTORY/build/lightgbmlib.jar $BUILD_ARTIFACTSTAGINGDIRECTORY/lightgbmlib_$OS_NAME.jar
+    fi
+    exit 0
+fi
+
+if [[ $TASK == "lint" ]]; then
+    conda create -q -y -n $CONDA_ENV \
+        ${CONDA_PYTHON_REQUIREMENT} \
+        cmakelint \
+        cpplint \
+        isort \
+        mypy \
+        pycodestyle \
+        pydocstyle \
+        "r-lintr>=3.0"
+    echo "Linting Python code"
+    pycodestyle --ignore=E501,W503 --exclude=./.nuget,./external_libs . || exit -1
+    pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^external_libs|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1
+    isort . --check-only || exit -1
+    mypy --ignore-missing-imports python-package/ || true
+    echo "Linting R code"
+    Rscript ${BUILD_DIRECTORY}/.ci/lint_r_code.R ${BUILD_DIRECTORY} || exit -1
+    echo "Linting C++ code"
+    cpplint --filter=-build/c++11,-build/include_subdir,-build/header_guard,-whitespace/line_length --recursive ./src ./include ./R-package ./swig ./tests || exit -1
+    cmake_files=$(find . -name CMakeLists.txt -o -path "*/cmake/*.cmake")
+    cmakelint --linelength=120 --filter=-convention/filename,-package/stdargs,-readability/wonkycase ${cmake_files} || exit -1
+    exit 0
+fi
+
+conda create -q -y -n $CONDA_ENV "${CONDA_PYTHON_REQUIREMENT}"
 source activate $CONDA_ENV
 
 cd $BUILD_DIRECTORY
@@ -69,57 +123,6 @@ if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     python $BUILD_DIRECTORY/helpers/parameter_generator.py || exit -1
     diff $BUILD_DIRECTORY/docs/Parameters-backup.rst $BUILD_DIRECTORY/docs/Parameters.rst || exit -1
     diff $BUILD_DIRECTORY/src/io/config_auto-backup.cpp $BUILD_DIRECTORY/src/io/config_auto.cpp || exit -1
-    exit 0
-fi
-
-if [[ $TASK == "lint" ]]; then
-    conda install -q -y -n $CONDA_ENV \
-        cmakelint \
-        cpplint \
-        isort \
-        mypy \
-        pycodestyle \
-        pydocstyle \
-        "r-lintr>=3.0"
-    echo "Linting Python code"
-    pycodestyle --ignore=E501,W503 --exclude=./.nuget,./external_libs . || exit -1
-    pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^external_libs|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1
-    isort . --check-only || exit -1
-    mypy --ignore-missing-imports python-package/ || true
-    echo "Linting R code"
-    Rscript ${BUILD_DIRECTORY}/.ci/lint_r_code.R ${BUILD_DIRECTORY} || exit -1
-    echo "Linting C++ code"
-    cpplint --filter=-build/c++11,-build/include_subdir,-build/header_guard,-whitespace/line_length --recursive ./src ./include ./R-package ./swig ./tests || exit -1
-    cmake_files=$(find . -name CMakeLists.txt -o -path "*/cmake/*.cmake")
-    cmakelint --linelength=120 --filter=-convention/filename,-package/stdargs,-readability/wonkycase ${cmake_files} || exit -1
-    exit 0
-fi
-
-if [[ $TASK == "if-else" ]]; then
-    conda install -q -y -n $CONDA_ENV numpy
-    mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build && cmake .. && make lightgbm -j4 || exit -1
-    cd $BUILD_DIRECTORY/tests/cpp_tests && ../../lightgbm config=train.conf convert_model_language=cpp convert_model=../../src/boosting/gbdt_prediction.cpp && ../../lightgbm config=predict.conf output_result=origin.pred || exit -1
-    cd $BUILD_DIRECTORY/build && make lightgbm -j4 || exit -1
-    cd $BUILD_DIRECTORY/tests/cpp_tests && ../../lightgbm config=predict.conf output_result=ifelse.pred && python test.py || exit -1
-    exit 0
-fi
-
-if [[ $TASK == "swig" ]]; then
-    mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build
-    if [[ $OS_NAME == "macos" ]]; then
-        cmake -DUSE_SWIG=ON -DAPPLE_OUTPUT_DYLIB=ON ..
-    else
-        cmake -DUSE_SWIG=ON ..
-    fi
-    make -j4 || exit -1
-    if [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "gcc" ]]; then
-        objdump -T $BUILD_DIRECTORY/lib_lightgbm.so > $BUILD_DIRECTORY/objdump.log || exit -1
-        objdump -T $BUILD_DIRECTORY/lib_lightgbm_swig.so >> $BUILD_DIRECTORY/objdump.log || exit -1
-        python $BUILD_DIRECTORY/helpers/check_dynamic_dependencies.py $BUILD_DIRECTORY/objdump.log || exit -1
-    fi
-    if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
-        cp $BUILD_DIRECTORY/build/lightgbmlib.jar $BUILD_ARTIFACTSTAGINGDIRECTORY/lightgbmlib_$OS_NAME.jar
-    fi
     exit 0
 fi
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -38,6 +38,7 @@ CONDA_PYTHON_REQUIREMENT="python=$PYTHON_VERSION[build=*cpython]"
 
 if [[ $TASK == "if-else" ]]; then
     conda create -q -y -n $CONDA_ENV ${CONDA_PYTHON_REQUIREMENT} numpy
+    source activate $CONDA_ENV
     mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build && cmake .. && make lightgbm -j4 || exit -1
     cd $BUILD_DIRECTORY/tests/cpp_tests && ../../lightgbm config=train.conf convert_model_language=cpp convert_model=../../src/boosting/gbdt_prediction.cpp && ../../lightgbm config=predict.conf output_result=origin.pred || exit -1
     cd $BUILD_DIRECTORY/build && make lightgbm -j4 || exit -1
@@ -74,6 +75,7 @@ if [[ $TASK == "lint" ]]; then
         pycodestyle \
         pydocstyle \
         "r-lintr>=3.0"
+    source activate $CONDA_ENV
     echo "Linting Python code"
     pycodestyle --ignore=E501,W503 --exclude=./.nuget,./external_libs . || exit -1
     pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^external_libs|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1


### PR DESCRIPTION
In #5648 , I saw that `conda create`-ing an environment in one shot was significantly faster in some situations than `conda  create`-ing an environment and then updating it with `conda install` or `conda update` (https://github.com/microsoft/LightGBM/issues/5647#issuecomment-1373148054).

That PR was for Windows CI jobs.

This PR proposes similar changes to some of the macOS and Linux jobs.

* moves `lint`, `if-else`, and `swig` job code up earlier in `.ci/test.sh`
   - *`swig` job doesn't need a conda environment, so time in that job spent waiting for `conda create` is wasted time*
   - *`lint` and `if-else` have very different `conda`-installed dependencies than the other jobs, so they can be totally self-contained and just `conda create` their own environment with everything they need*

### benefits of this change

I observed the following timing differences in these jobs on this PR, compared to `master`:

| job                                              | latest `master` | this PR   |
|:------------------------------|:---------------:|:--------:|
| (GHA) macOS if-else                | 06m33s             | 07m04s |
| (GHA) check-docs                    | 04m08s            | 03m30s  |
| (Azure) Linux inference            | 04m52s            | 04m36s |
| (Azure) Linux swig                    |  04m55s           | 04m02s |
| (Azure) Linux_latest inference|  04m07s            | 03m56s |
| (Azure) macOS swig                 | 07m42s             |05m05s  |

this PR:

* macOS GitHub Actions: https://github.com/microsoft/LightGBM/actions/runs/3870849816
* static_analysis GitHub Actions: https://github.com/microsoft/LightGBM/actions/runs/3870849804
* Azure: https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=14120&view=results

latest `master` build:

* macOS GitHub Actions: https://github.com/microsoft/LightGBM/actions/runs/3849602797
* static_analysis GitHub Actions: https://github.com/microsoft/LightGBM/actions/runs/3849602798
* Azure: https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=14109&view=results

### Notes for Reviewers

Given all the things that can change from run-to-run, it's hard to trust small differences in the timings based on 1 or even a few of runs. But I'm still pretty confident that these changes make these CI jobs at least *a small amount* faster, without reducing their stability.

If this PR is accepted, I'll propose another one after that consolidates these into a single `conda create` for the remaining tasks:

https://github.com/microsoft/LightGBM/blob/61e464bc02bd325672ce71daabfa57d569cf02bc/.ci/test.sh#L37

https://github.com/microsoft/LightGBM/blob/61e464bc02bd325672ce71daabfa57d569cf02bc/.ci/test.sh#L126-L140
