### PR TITLE
[python-package] fix mypy errors about missing annotations and incompatible types

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2178,7 +2178,7 @@ class Dataset:
 
     def set_categorical_feature(
         self,
-        categorical_feature: Union[List[int], List[str]]
+        categorical_feature: Union[List[int], List[str], str]
     ) -> "Dataset":
         """Set categorical features.
 
@@ -2260,7 +2260,7 @@ class Dataset:
             raise LightGBMError("Cannot set reference after freed raw data, "
                                 "set free_raw_data=False when construct Dataset to avoid this.")
 
-    def set_feature_name(self, feature_name: List[str]) -> "Dataset":
+    def set_feature_name(self, feature_name: Union[List[str], str]) -> "Dataset":
         """Set feature name.
 
         Parameters

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -8,7 +8,8 @@ from .basic import _ConfigAliases, _LGBM_BoosterEvalMethodResultType, _log_info,
 
 _EvalResultTuple = Union[
     List[_LGBM_BoosterEvalMethodResultType],
-    List[Tuple[str, str, float, bool, float]]
+    List[Tuple[str, str, float, bool, float]],
+    None
 ]
 
 
@@ -43,6 +44,8 @@ CallbackEnv = collections.namedtuple(
 
 def _format_eval_result(value: _EvalResultTuple, show_stdv: bool = True) -> str:
     """Format metric string."""
+    if value is None:
+        raise ValueError("Wrong metric value")
     if len(value) == 4:
         return f"{value[0]}'s {value[1]}: {value[2]:g}"
     elif len(value) == 5:
@@ -246,10 +249,10 @@ class _EarlyStoppingCallback:
         self._reset_storages()
 
     def _reset_storages(self) -> None:
-        self.best_score = []
-        self.best_iter = []
-        self.best_score_list = []
-        self.cmp_op = []
+        self.best_score: List[float] = []
+        self.best_iter: List[int] = []
+        self.best_score_list: List[_EvalResultTuple] = []
+        self.cmp_op: List[Callable[[float, float], bool]] = []
         self.first_metric = ''
 
     def _gt_delta(self, curr_score: float, best_score: float, delta: float) -> bool:

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -407,7 +407,7 @@ def _train(
     eval_init_score: Optional[List[_DaskCollection]] = None,
     eval_group: Optional[List[_DaskVectorLike]] = None,
     eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
-    eval_at: Optional[Union[List[int], Tuple[int]]] = None,
+    eval_at: Union[List[int], Tuple[int, ...], None] = None,
     **kwargs: Any
 ) -> LGBMModel:
     """Inner train routine.
@@ -1039,7 +1039,7 @@ class _DaskLGBMModel:
         eval_init_score: Optional[List[_DaskCollection]] = None,
         eval_group: Optional[List[_DaskVectorLike]] = None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
-        eval_at: Optional[Iterable[int]] = None,
+        eval_at: Union[List[int], Tuple[int, ...], None] = None,
         **kwargs: Any
     ) -> "_DaskLGBMModel":
         if not DASK_INSTALLED:
@@ -1168,7 +1168,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
         eval_init_score: Optional[List[_DaskCollection]] = None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
         **kwargs: Any
-    ) -> "DaskLGBMClassifier":
+    ) -> "_DaskLGBMModel":
         """Docstring is inherited from the lightgbm.LGBMClassifier.fit."""
         return self._lgb_dask_fit(
             model_factory=LGBMClassifier,
@@ -1215,13 +1215,29 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
     {_lgbmmodel_doc_custom_eval_note}
         """
 
-    def predict(self, X: _DaskMatrixLike, **kwargs: Any) -> dask_Array:
+    def predict(
+        self,
+        X: _DaskMatrixLike,
+        raw_score: bool = False,
+        start_iteration: int = 0,
+        num_iteration: Optional[int] = None,
+        pred_leaf: bool = False,
+        pred_contrib: bool = False,
+        validate_features: bool = False,
+        **kwargs: Any
+    ) -> dask_Array:
         """Docstring is inherited from the lightgbm.LGBMClassifier.predict."""
         return _predict(
             model=self.to_local(),
             data=X,
             dtype=self.classes_.dtype,
             client=_get_dask_client(self.client),
+            raw_score=raw_score,
+            start_iteration=start_iteration,
+            num_iteration=num_iteration,
+            pred_leaf=pred_leaf,
+            pred_contrib=pred_contrib,
+            validate_features=validate_features,
             **kwargs
         )
 
@@ -1234,13 +1250,29 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
         X_SHAP_values_shape="Dask Array of shape = [n_samples, n_features + 1] or shape = [n_samples, (n_features + 1) * n_classes] or (if multi-class and using sparse inputs) a list of ``n_classes`` Dask Arrays of shape = [n_samples, n_features + 1]"
     )
 
-    def predict_proba(self, X: _DaskMatrixLike, **kwargs: Any) -> dask_Array:
+    def predict_proba(
+        self,
+        X: _DaskMatrixLike,
+        raw_score: bool = False,
+        start_iteration: int = 0,
+        num_iteration: Optional[int] = None,
+        pred_leaf: bool = False,
+        pred_contrib: bool = False,
+        validate_features: bool = False,
+        **kwargs: Any
+    ) -> dask_Array:
         """Docstring is inherited from the lightgbm.LGBMClassifier.predict_proba."""
         return _predict(
             model=self.to_local(),
             data=X,
             pred_proba=True,
             client=_get_dask_client(self.client),
+            raw_score=raw_score,
+            start_iteration=start_iteration,
+            num_iteration=num_iteration,
+            pred_leaf=pred_leaf,
+            pred_contrib=pred_contrib,
+            validate_features=validate_features,
             **kwargs
         )
 
@@ -1339,7 +1371,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         eval_init_score: Optional[List[_DaskVectorLike]] = None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
         **kwargs: Any
-    ) -> "DaskLGBMRegressor":
+    ) -> "_DaskLGBMModel":
         """Docstring is inherited from the lightgbm.LGBMRegressor.fit."""
         return self._lgb_dask_fit(
             model_factory=LGBMRegressor,
@@ -1388,12 +1420,28 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
     {_lgbmmodel_doc_custom_eval_note}
         """
 
-    def predict(self, X: _DaskMatrixLike, **kwargs) -> dask_Array:
+    def predict(
+        self,
+        X: _DaskMatrixLike,
+        raw_score: bool = False,
+        start_iteration: int = 0,
+        num_iteration: Optional[int] = None,
+        pred_leaf: bool = False,
+        pred_contrib: bool = False,
+        validate_features: bool = False,
+        **kwargs: Any
+    ) -> dask_Array:
         """Docstring is inherited from the lightgbm.LGBMRegressor.predict."""
         return _predict(
             model=self.to_local(),
             data=X,
             client=_get_dask_client(self.client),
+            raw_score=raw_score,
+            start_iteration=start_iteration,
+            num_iteration=num_iteration,
+            pred_leaf=pred_leaf,
+            pred_contrib=pred_contrib,
+            validate_features=validate_features,
             **kwargs
         )
 
@@ -1493,9 +1541,9 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
         eval_init_score: Optional[List[_DaskVectorLike]] = None,
         eval_group: Optional[List[_DaskVectorLike]] = None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
-        eval_at: Union[List[int], Tuple[int]] = (1, 2, 3, 4, 5),
+        eval_at: Union[List[int], Tuple[int, ...]] = (1, 2, 3, 4, 5),
         **kwargs: Any
-    ) -> "DaskLGBMRanker":
+    ) -> "_DaskLGBMModel":
         """Docstring is inherited from the lightgbm.LGBMRanker.fit."""
         return self._lgb_dask_fit(
             model_factory=LGBMRanker,
@@ -1546,12 +1594,28 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
     {_lgbmmodel_doc_custom_eval_note}
         """
 
-    def predict(self, X: _DaskMatrixLike, **kwargs: Any) -> dask_Array:
+    def predict(
+        self,
+        X: _DaskMatrixLike,
+        raw_score: bool = False,
+        start_iteration: int = 0,
+        num_iteration: Optional[int] = None,
+        pred_leaf: bool = False,
+        pred_contrib: bool = False,
+        validate_features: bool = False,
+        **kwargs: Any
+    ) -> dask_Array:
         """Docstring is inherited from the lightgbm.LGBMRanker.predict."""
         return _predict(
             model=self.to_local(),
             data=X,
             client=_get_dask_client(self.client),
+            raw_score=raw_score,
+            start_iteration=start_iteration,
+            num_iteration=num_iteration,
+            pred_leaf=pred_leaf,
+            pred_contrib=pred_contrib,
+            validate_features=validate_features,
             **kwargs
         )
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -890,7 +890,7 @@ class LGBMModel(_LGBMModelBase):
         return self._n_features
 
     @property
-    def n_features_in_(self) -> int:
+    def n_features_in_(self) -> Optional[int]:
         """:obj:`int`: The number of features of fitted model."""
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError('No n_features_in found. Need to call fit beforehand.')
@@ -904,7 +904,7 @@ class LGBMModel(_LGBMModelBase):
         return self._best_score
 
     @property
-    def best_iteration_(self) -> int:
+    def best_iteration_(self) -> Optional[int]:
         """:obj:`int`: The best iteration of fitted model if ``early_stopping()`` callback has been specified."""
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError('No best_iteration found. Need to call fit with early_stopping callback beforehand.')
@@ -1197,7 +1197,7 @@ class LGBMRanker(LGBMModel):
         eval_init_score=None,
         eval_group=None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
-        eval_at: Union[List[int], Tuple[int]] = (1, 2, 3, 4, 5),
+        eval_at: Union[List[int], Tuple[int, ...]] = (1, 2, 3, 4, 5),
         feature_name='auto',
         categorical_feature='auto',
         callbacks=None,


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3867.
`mypy` currently raises the following errors:
```
python-package\lightgbm\callback.py:249: error: Need type annotation for "best_score" (hint: "best_score: List[<type>] = ...")  [var-annotated]
python-package\lightgbm\callback.py:250: error: Need type annotation for "best_iter" (hint: "best_iter: List[<type>] = ...")  [var-annotated]
python-package\lightgbm\callback.py:251: error: Need type annotation for "best_score_list" (hint: "best_score_list: List[<type>] = ...")  [var-annotated]
python-package\lightgbm\callback.py:252: error: Need type annotation for "cmp_op" (hint: "cmp_op: List[<type>] = ...")  [var-annotated]
python-package\lightgbm\engine.py:169: error: Argument 1 to "set_feature_name" of "Dataset" has incompatible type "Union[List[str], str]"; expected "List[str]"  [arg-type]
python-package\lightgbm\engine.py:170: error: Argument 1 to "set_categorical_feature" of "Dataset" has incompatible type "Union[List[str], List[int], str]"; expected "Union[List[int], List[str]]"  [arg-type]
python-package\lightgbm\engine.py:262: error: Incompatible types in assignment (expression has type "Union[List[Tuple[str, str, float, bool]], List[Tuple[str, str, float, bool, float]]]", variable has type "List[Tuple[str, str, float, bool]]")  [assignment]
python-package\lightgbm\engine.py:677: error: Argument 1 to "set_feature_name" of "Dataset" has incompatible type "Union[str, List[str]]"; expected "List[str]"  [arg-type]
python-package\lightgbm\engine.py:678: error: Argument 1 to "set_categorical_feature" of "Dataset" has incompatible type "Union[str, List[str], List[int]]"; expected "Union[List[int], List[str]]"  [arg-type]
python-package\lightgbm\sklearn.py:897: error: Incompatible return value type (got "None", expected "int")  [return-value]
python-package\lightgbm\sklearn.py:911: error: Incompatible return value type (got "None", expected "int")  [return-value]
python-package\lightgbm\sklearn.py:1200: error: Incompatible default for argument "eval_at" (default has type "Tuple[int, int, int, int, int]", argument has type "Union[List[int], Tuple[int]]")  [assignment]
python-package\lightgbm\dask.py:1069: error: Argument "eval_at" to "_train" has incompatible type "Optional[Iterable[int]]"; expected "Union[List[int], Tuple[int], None]"  [arg-type]
```
These errors due to missing and mismatched annotations in the code. This PR proposes fixing these errors by aligning all the annotations in these areas of the code to share the same annotation.
## Notes for Reviewers
This was tested by running mypy as documented in https://github.com/microsoft/LightGBM/issues/3867.

```
mypy \
    --exclude='python-package/compile/|python-package/build' \
    --ignore-missing-imports \
    python-package/
```