### PR TITLE
[python-package] fix mypy errors for eval_at and basic

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2178,7 +2178,7 @@ class Dataset:
 
     def set_categorical_feature(
         self,
-        categorical_feature: Union[List[int], List[str]]
+        categorical_feature: Union[List[int], List[str], str]
     ) -> "Dataset":
         """Set categorical features.
 
@@ -2260,7 +2260,7 @@ class Dataset:
             raise LightGBMError("Cannot set reference after freed raw data, "
                                 "set free_raw_data=False when construct Dataset to avoid this.")
 
-    def set_feature_name(self, feature_name: List[str]) -> "Dataset":
+    def set_feature_name(self, feature_name: Union[List[str], str]) -> "Dataset":
         """Set feature name.
 
         Parameters

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -407,7 +407,7 @@ def _train(
     eval_init_score: Optional[List[_DaskCollection]] = None,
     eval_group: Optional[List[_DaskVectorLike]] = None,
     eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
-    eval_at: Optional[Union[List[int], Tuple[int]]] = None,
+    eval_at: Union[List[int], Tuple[int, ...], None] = None,
     **kwargs: Any
 ) -> LGBMModel:
     """Inner train routine.
@@ -1039,7 +1039,7 @@ class _DaskLGBMModel:
         eval_init_score: Optional[List[_DaskCollection]] = None,
         eval_group: Optional[List[_DaskVectorLike]] = None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
-        eval_at: Optional[Iterable[int]] = None,
+        eval_at: Union[List[int], Tuple[int, ...], None] = None,
         **kwargs: Any
     ) -> "_DaskLGBMModel":
         if not DASK_INSTALLED:
@@ -1493,7 +1493,7 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
         eval_init_score: Optional[List[_DaskVectorLike]] = None,
         eval_group: Optional[List[_DaskVectorLike]] = None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
-        eval_at: Union[List[int], Tuple[int]] = (1, 2, 3, 4, 5),
+        eval_at: Union[List[int], Tuple[int, ...]] = (1, 2, 3, 4, 5),
         **kwargs: Any
     ) -> "DaskLGBMRanker":
         """Docstring is inherited from the lightgbm.LGBMRanker.fit."""

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -407,7 +407,7 @@ def _train(
     eval_init_score: Optional[List[_DaskCollection]] = None,
     eval_group: Optional[List[_DaskVectorLike]] = None,
     eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
-    eval_at: Union[List[int], Tuple[int, ...], None] = None,
+    eval_at: Optional[Union[List[int], Tuple[int, ...]]] = None,
     **kwargs: Any
 ) -> LGBMModel:
     """Inner train routine.
@@ -1039,7 +1039,7 @@ class _DaskLGBMModel:
         eval_init_score: Optional[List[_DaskCollection]] = None,
         eval_group: Optional[List[_DaskVectorLike]] = None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
-        eval_at: Union[List[int], Tuple[int, ...], None] = None,
+        eval_at: Optional[Union[List[int], Tuple[int, ...]]] = None,
         **kwargs: Any
     ) -> "_DaskLGBMModel":
         if not DASK_INSTALLED:

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1197,7 +1197,7 @@ class LGBMRanker(LGBMModel):
         eval_init_score=None,
         eval_group=None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
-        eval_at: Union[List[int], Tuple[int]] = (1, 2, 3, 4, 5),
+        eval_at: Union[List[int], Tuple[int, ...]] = (1, 2, 3, 4, 5),
         feature_name='auto',
         categorical_feature='auto',
         callbacks=None,


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3867.
Moved from https://github.com/microsoft/LightGBM/pull/5672.

Fixes `mypy` errors regarding `eval_at` incompatibility:
```
Argument "eval_at" to "_train" has incompatible type "Optional[Iterable[int]]"; expected "Union[List[int], Tuple[int], None]"  [arg-type]
```
and the following two errors:
```
python-package\lightgbm\engine.py:169: error: Argument 1 to "set_feature_name" of "Dataset" has incompatible type "Union[List[str], str]"; expected "List[str]"  [arg-type]
python-package\lightgbm\engine.py:170: error: Argument 1 to "set_categorical_feature" of "Dataset" has incompatible type "Union[List[str], List[int], str]"; expected "Union[List[int], List[str]]"  [arg-type]
```

## Notes for Reviewers
This was tested by running mypy as documented in https://github.com/microsoft/LightGBM/issues/3867.

```
mypy \
    --exclude='python-package/compile/|python-package/build' \
    --ignore-missing-imports \
    python-package/
```