### PR TITLE
[python-package] Fix mypy errors for predict() method

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1221,13 +1221,29 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
     {_lgbmmodel_doc_custom_eval_note}
         """
 
-    def predict(self, X: _DaskMatrixLike, **kwargs: Any) -> dask_Array:
+    def predict(
+        self,
+        X: _DaskMatrixLike,
+        raw_score: bool = False,
+        start_iteration: int = 0,
+        num_iteration: Optional[int] = None,
+        pred_leaf: bool = False,
+        pred_contrib: bool = False,
+        validate_features: bool = False,
+        **kwargs: Any
+    ) -> dask_Array:
         """Docstring is inherited from the lightgbm.LGBMClassifier.predict."""
         return _predict(
             model=self.to_local(),
             data=X,
             dtype=self.classes_.dtype,
             client=_get_dask_client(self.client),
+            raw_score=raw_score,
+            start_iteration=start_iteration,
+            num_iteration=num_iteration,
+            pred_leaf=pred_leaf,
+            pred_contrib=pred_contrib,
+            validate_features=validate_features,
             **kwargs
         )
 
@@ -1394,12 +1410,28 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
     {_lgbmmodel_doc_custom_eval_note}
         """
 
-    def predict(self, X: _DaskMatrixLike, **kwargs) -> dask_Array:
+    def predict(
+        self,
+        X: _DaskMatrixLike,
+        raw_score: bool = False,
+        start_iteration: int = 0,
+        num_iteration: Optional[int] = None,
+        pred_leaf: bool = False,
+        pred_contrib: bool = False,
+        validate_features: bool = False,
+        **kwargs: Any
+    ) -> dask_Array:
         """Docstring is inherited from the lightgbm.LGBMRegressor.predict."""
         return _predict(
             model=self.to_local(),
             data=X,
             client=_get_dask_client(self.client),
+            raw_score=raw_score,
+            start_iteration=start_iteration,
+            num_iteration=num_iteration,
+            pred_leaf=pred_leaf,
+            pred_contrib=pred_contrib,
+            validate_features=validate_features,
             **kwargs
         )
 
@@ -1552,12 +1584,28 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
     {_lgbmmodel_doc_custom_eval_note}
         """
 
-    def predict(self, X: _DaskMatrixLike, **kwargs: Any) -> dask_Array:
+    def predict(
+        self,
+        X: _DaskMatrixLike,
+        raw_score: bool = False,
+        start_iteration: int = 0,
+        num_iteration: Optional[int] = None,
+        pred_leaf: bool = False,
+        pred_contrib: bool = False,
+        validate_features: bool = False,
+        **kwargs: Any
+    ) -> dask_Array:
         """Docstring is inherited from the lightgbm.LGBMRanker.predict."""
         return _predict(
             model=self.to_local(),
             data=X,
             client=_get_dask_client(self.client),
+            raw_score=raw_score,
+            start_iteration=start_iteration,
+            num_iteration=num_iteration,
+            pred_leaf=pred_leaf,
+            pred_contrib=pred_contrib,
+            validate_features=validate_features,
             **kwargs
         )
 


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3867.
Moved from https://github.com/microsoft/LightGBM/pull/5672.
`mypy` currently raises the following errors regarding predict() method:
```
python-package\lightgbm\dask.py:1224: error: Signature of "predict" incompatible with supertype "LGBMClassifier"  [override]
python-package\lightgbm\dask.py:1224: note:      Superclass:
python-package\lightgbm\dask.py:1224: note:          def predict(self, X: Any, raw_score: bool = ..., start_iteration: int = ..., num_iteration: Optional[int] = ..., pred_leaf: bool = ..., pred_contrib: bool = ..., validate_features: bool = ..., **kwargs: Any) -> Any
python-package\lightgbm\dask.py:1224: note:      Subclass:
python-package\lightgbm\dask.py:1224: note:          def predict(self, X: Union[Any, Any], **kwargs: Any) -> Any
python-package\lightgbm\dask.py:1224: error: Signature of "predict" incompatible with supertype "LGBMModel"  [override]
python-package\lightgbm\dask.py:1224: note:          def predict(self, X: Any, raw_score: bool = ..., start_iteration: int = ..., num_iteration: Optional[int] = ..., pred_leaf: bool = ..., pred_contrib: bool = ..., validate_features: bool = ..., **kwargs: Any) -> Any
python-package\lightgbm\dask.py:1224: note:          def predict(self, X: Union[Any, Any], **kwargs: Any) -> Any
python-package\lightgbm\dask.py:1397: error: Signature of "predict" incompatible with supertype "LGBMModel"  [override]
python-package\lightgbm\dask.py:1397: note:      Superclass:
python-package\lightgbm\dask.py:1397: note:          def predict(self, X: Any, raw_score: bool = ..., start_iteration: int = ..., num_iteration: Optional[int] = ..., pred_leaf: bool = ..., pred_contrib: bool = ..., validate_features: bool = ..., **kwargs: Any) -> Any
python-package\lightgbm\dask.py:1397: note:      Subclass:
python-package\lightgbm\dask.py:1397: note:          def predict(self, X: Union[Any, Any], **kwargs: Any) -> Any
python-package\lightgbm\dask.py:1555: error: Signature of "predict" incompatible with supertype "LGBMModel"  [override]
python-package\lightgbm\dask.py:1555: note:      Superclass:
python-package\lightgbm\dask.py:1555: note:          def predict(self, X: Any, raw_score: bool = ..., start_iteration: int = ..., num_iteration: Optional[int] = ..., pred_leaf: bool = ..., pred_contrib: bool = ..., validate_features: bool = ..., **kwargs: Any) -> Any
python-package\lightgbm\dask.py:1555: note:      Subclass:
python-package\lightgbm\dask.py:1555: note:          def predict(self, X: Union[Any, Any], **kwargs: Any) -> Any
```

## Notes for Reviewers
This was tested by running mypy as documented in https://github.com/microsoft/LightGBM/issues/3867.

```
mypy \
    --exclude='python-package/compile/|python-package/build' \
    --ignore-missing-imports \
    python-package/
```