### PR TITLE
[ci] get clang-15 from bookworm repository (fixes #5688)

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -247,7 +247,7 @@ fi
 #   Specified C++11: please update to current default of C++17
 #
 # until it's resolved (see https://github.com/microsoft/LightGBM/pull/5690)
-if $(grep -q -E "NOTE|WARNING|ERROR" "$LOG_FILE_NAME" | grep -v 'C++11'); then
+if $(grep -E "NOTE|WARNING|ERROR" "$LOG_FILE_NAME" | grep -q -v 'please update to current default'); then
     echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
     exit -1
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -247,7 +247,7 @@ fi
 #   Specified C++11: please update to current default of C++17
 #
 # until it's resolved (see https://github.com/microsoft/LightGBM/pull/5690)
-if $(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -E "NOTE|WARNING|ERROR"); then
+if $(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -v "Status: 1 NOTE" | grep -E "NOTE|WARNING|ERROR"); then
     echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
     exit -1
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -247,7 +247,8 @@ fi
 #   Specified C++11: please update to current default of C++17
 #
 # until it's resolved (see https://github.com/microsoft/LightGBM/pull/5690)
-if $(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -v "1 NOTE" | grep -E "NOTE|WARNING|ERROR" | wc -l); then
+any_issues=$(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -v "1 NOTE" | grep -E "NOTE|WARNING|ERROR" | wc -l)
+if [[ $any_issues -ne 0 ]]; then
     echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
     exit -1
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -247,9 +247,14 @@ fi
 #   Specified C++11: please update to current default of C++17
 #
 # until it's resolved (see https://github.com/microsoft/LightGBM/pull/5690)
-any_issues=$(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -v "1 NOTE" | grep -E "NOTE|WARNING|ERROR" | wc -l)
-if [[ $any_issues -ne 0 ]]; then
-    echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
+ALLOWED_CHECK_NOTES=1
+NUM_CHECK_NOTES=$(
+    cat ${LOG_FILE_NAME} \
+        | grep -e '^Status: .* NOTE.*' \
+        | sed 's/[^0-9]*//g'
+)
+if [[ ${NUM_CHECK_NOTES} -gt ${ALLOWED_CHECK_NOTES} ]]; then
+    echo "Found ${NUM_CHECK_NOTES} NOTEs from R CMD check. Only ${ALLOWED_CHECK_NOTES} are allowed"
     exit -1
 fi
 

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -241,8 +241,13 @@ if [[ $R_BUILD_TYPE == "cmake" ]]; then
     fi
 fi
 
-
-if grep -q -E "NOTE|WARNING|ERROR" "$LOG_FILE_NAME"; then
+# ignoring the following NOTE:
+#
+# * checking C++ specification ... NOTE
+#   Specified C++11: please update to current default of C++17
+#
+# until it's resolved (see https://github.com/microsoft/LightGBM/pull/5690)
+if $(grep -q -E "NOTE|WARNING|ERROR" "$LOG_FILE_NAME" | grep -v 'C++11'); then
     echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
     exit -1
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -247,7 +247,7 @@ fi
 #   Specified C++11: please update to current default of C++17
 #
 # until it's resolved (see https://github.com/microsoft/LightGBM/pull/5690)
-if $(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -v "1 NOTE" | grep -E "NOTE|WARNING|ERROR"); then
+if $(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -v "1 NOTE" | grep -E "NOTE|WARNING|ERROR" | wc -l); then
     echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
     exit -1
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -247,7 +247,7 @@ fi
 #   Specified C++11: please update to current default of C++17
 #
 # until it's resolved (see https://github.com/microsoft/LightGBM/pull/5690)
-if $(grep -E "NOTE|WARNING|ERROR" "$LOG_FILE_NAME" | grep -q -v 'please update to current default'); then
+if $(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -E "NOTE|WARNING|ERROR"); then
     echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
     exit -1
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -241,20 +241,9 @@ if [[ $R_BUILD_TYPE == "cmake" ]]; then
     fi
 fi
 
-# ignoring the following NOTE:
-#
-# * checking C++ specification ... NOTE
-#   Specified C++11: please update to current default of C++17
-#
-# until it's resolved (see https://github.com/microsoft/LightGBM/pull/5690)
-ALLOWED_CHECK_NOTES=1
-NUM_CHECK_NOTES=$(
-    cat ${LOG_FILE_NAME} \
-        | grep -e '^Status: .* NOTE.*' \
-        | sed 's/[^0-9]*//g'
-)
-if [[ ${NUM_CHECK_NOTES} -gt ${ALLOWED_CHECK_NOTES} ]]; then
-    echo "Found ${NUM_CHECK_NOTES} NOTEs from R CMD check. Only ${ALLOWED_CHECK_NOTES} are allowed"
+
+if grep -q -E "NOTE|WARNING|ERROR" "$LOG_FILE_NAME"; then
+    echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
     exit -1
 fi
 

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -247,7 +247,7 @@ fi
 #   Specified C++11: please update to current default of C++17
 #
 # until it's resolved (see https://github.com/microsoft/LightGBM/pull/5690)
-if $(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -v "Status: 1 NOTE" | grep -E "NOTE|WARNING|ERROR"); then
+if $(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -v "1 NOTE" | grep -E "NOTE|WARNING|ERROR"); then
     echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
     exit -1
 fi

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -335,7 +335,13 @@ jobs:
           Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'Matrix', 'RhpcBLASctl', 'rmarkdown', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
           sh build-cran-package.sh
           R CMD check --as-cran --run-donttest lightgbm_*.tar.gz || exit -1
-          if grep -q -E "NOTE|WARNING|ERROR" lightgbm.Rcheck/00check.log; then
+          # ignoring the following NOTE:
+          #
+          # * checking C++ specification ... NOTE
+          #   Specified C++11: please update to current default of C++17
+          #
+          # until it's resolved (see https://github.com/microsoft/LightGBM/pull/5690)
+          if $(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -v "1 NOTE" | grep -E "NOTE|WARNING|ERROR" | wc -l); then
               echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
               exit -1
           fi

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -341,7 +341,7 @@ jobs:
           #   Specified C++11: please update to current default of C++17
           #
           # until it's resolved (see https://github.com/microsoft/LightGBM/pull/5690)
-          if $(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -v "1 NOTE" | grep -E "NOTE|WARNING|ERROR" | wc -l); then
+          if $(grep -v "C++ specification" "$LOG_FILE_NAME" | grep -v "1 NOTE" | grep -E "NOTE|WARNING|ERROR"); then
               echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
               exit -1
           fi

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -308,7 +308,7 @@ jobs:
           #
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
           #
-          add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main"
+          add-apt-repository "deb http://apt.llvm.org/unstable/ llvm-toolchain main"
           apt-get install -y --no-install-recommends \
               clang-15 \
               clangd-15 \


### PR DESCRIPTION
Fixes #5688.

The `rhub/debian-*` container images are built from `debian:testing` ([code link](https://github.com/r-hub/rhub-linux-builders/blob/47ba102648e5db3037e100088452c9e8cd440367/debian/Dockerfile#LL3C6-L3C20)).

Seems like a few days ago, that image switched to Debian `bookworm` (the major release that follows `bullseye`).

```shell
docker run \
    --rm \
    debian:testing \
    /bin/bash -c "apt-get update -y && apt-get install -y lsb-release && lsb_release -a"
```

```text
Distributor ID:	Debian
Description:	Debian GNU/Linux bookworm/sid
Release:	n/a
Codename:	bookworm
```

This fixes the R CI job in this project using that image by switching to the package repository that LLVM developers publish bookworm packages to (see https://apt.llvm.org/).