### PR TITLE
[docs] remove unnecessary interactivity in 'docker run' instructions

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -367,7 +367,7 @@ At build time, `configure` will be run and used to create a file `Makevars`, usi
         --rm \
         -v $(pwd):/opt/LightGBM \
         -w /opt/LightGBM \
-        -t ubuntu:22.04 \
+        ubuntu:22.04 \
         ./R-package/recreate-configure.sh
     ```
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -35,7 +35,7 @@ Run the following from the root of this repository to pull the relevant image an
         --env READTHEDOCS=true \
         --workdir=/opt/LightGBM/docs \
         --entrypoint="" \
-        -it readthedocs/build:ubuntu-20.04-2021.09.23 \
+        readthedocs/build:ubuntu-20.04-2021.09.23 \
         /bin/bash build-docs.sh
 
 When that code completes, open ``docs/_build/html/index.html`` in your browser.


### PR DESCRIPTION
Applies the advice from https://github.com/microsoft/LightGBM/pull/5601#pullrequestreview-1231179995 to other `docker run` calls in docs.

`-i -t` are unnecessary in `docker run` calls that aren't interactive.