### PR TITLE
[ci] restore flake8 checks

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -70,14 +70,17 @@ if [[ $TASK == "lint" ]]; then
         ${CONDA_PYTHON_REQUIREMENT} \
         cmakelint \
         cpplint \
+        flake8 \
         isort \
         mypy \
-        pycodestyle \
         pydocstyle \
         "r-lintr>=3.0"
     source activate $CONDA_ENV
     echo "Linting Python code"
-    pycodestyle --ignore=E501,W503 --exclude=./.nuget,./external_libs . || exit -1
+    flake8 \
+        --ignore=E501,W503 \
+        --exclude=./.nuget,./external_libs,./python-package/build \
+        . || exit -1
     pydocstyle --convention=numpy --add-ignore=D105 --match-dir="^(?!^external_libs|test|example).*" --match="(?!^test_|setup).*\.py" . || exit -1
     isort . --check-only || exit -1
     mypy --ignore-missing-imports python-package/ || true


### PR DESCRIPTION
A mistake in fixing merge conflicts in #5668 accidentally removed the `flake8` changes from #5659.

This PR restores those changes.