### PR TITLE
[ci] [python-package] enforce 'twine check' and 'check-wheel-contents' on Python distributions

### DIFF
--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+DIST_DIR=${1}
+
+echo "checking Python package distributions in '${DIST_DIR}'"
+
+pip install \
+    check-wheel-contents \
+    twine || exit -1
+
+twine check --strict "${DIST_DIR}/*" || exit -1
+check-wheel-contents "${DIST_DIR}/*.whl" || exit -1

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -5,8 +5,14 @@ DIST_DIR=${1}
 echo "checking Python package distributions in '${DIST_DIR}'"
 
 pip install \
+    -qq \
     check-wheel-contents \
     twine || exit -1
 
-twine check --strict "${DIST_DIR}/*" || exit -1
-check-wheel-contents "${DIST_DIR}/*.whl" || exit -1
+echo "twine check..."
+twine check --strict ${DIST_DIR}/* || exit -1
+
+echo "check-wheel-contents..."
+check-wheel-contents ${DIST_DIR}/* || exit -1
+
+echo "done checking Python package distributions"

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -12,7 +12,9 @@ pip install \
 echo "twine check..."
 twine check --strict ${DIST_DIR}/* || exit -1
 
-echo "check-wheel-contents..."
-check-wheel-contents ${DIST_DIR}/* || exit -1
+if test "${METHOD}" = "wheel"; then
+    echo "check-wheel-contents..."
+    check-wheel-contents ${DIST_DIR}/*.whl || exit -1
+fi
 
 echo "done checking Python package distributions"

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -12,7 +12,7 @@ pip install \
 echo "twine check..."
 twine check --strict ${DIST_DIR}/* || exit -1
 
-if test "${METHOD}" = "wheel"; then
+if { test "${TASK}" = "bdist" || test "${METHOD}" = "wheel"; }; then
     echo "check-wheel-contents..."
     check-wheel-contents ${DIST_DIR}/*.whl || exit -1
 fi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -154,6 +154,7 @@ fi
 
 if [[ $TASK == "sdist" ]]; then
     cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
+    sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
     pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v || exit -1
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
         cp $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz $BUILD_ARTIFACTSTAGINGDIRECTORY
@@ -163,6 +164,7 @@ if [[ $TASK == "sdist" ]]; then
 elif [[ $TASK == "bdist" ]]; then
     if [[ $OS_NAME == "macos" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --plat-name=macosx --python-tag py3 || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
         mv dist/lightgbm-$LGB_VER-py3-none-macosx.whl dist/lightgbm-$LGB_VER-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl
         if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
             cp dist/lightgbm-$LGB_VER-py3-none-macosx*.whl $BUILD_ARTIFACTSTAGINGDIRECTORY
@@ -175,6 +177,7 @@ elif [[ $TASK == "bdist" ]]; then
             PLATFORM="manylinux2014_$ARCH"
         fi
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --integrated-opencl --plat-name=$PLATFORM --python-tag py3 || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
         if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
             cp dist/lightgbm-$LGB_VER-py3-none-$PLATFORM.whl $BUILD_ARTIFACTSTAGINGDIRECTORY
         fi
@@ -193,11 +196,13 @@ if [[ $TASK == "gpu" ]]; then
     grep -q 'std::string device_type = "gpu"' $BUILD_DIRECTORY/include/LightGBM/config.h || exit -1  # make sure that changes were really done
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--gpu || exit -1
         pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --gpu || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
         pytest $BUILD_DIRECTORY/tests || exit -1
         exit 0
@@ -212,11 +217,13 @@ elif [[ $TASK == "cuda" ]]; then
     grep -q 'gpu_use_dp = true' $BUILD_DIRECTORY/include/LightGBM/config.h || exit -1  # make sure that changes were really done
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--cuda || exit -1
         pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --cuda || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
         pytest $BUILD_DIRECTORY/tests || exit -1
         exit 0
@@ -226,11 +233,13 @@ elif [[ $TASK == "cuda" ]]; then
 elif [[ $TASK == "mpi" ]]; then
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--mpi || exit -1
         pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --mpi || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
         pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
         pytest $BUILD_DIRECTORY/tests || exit -1
         exit 0

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -73,6 +73,7 @@ if ($env:TASK -eq "regular") {
 elseif ($env:TASK -eq "sdist") {
   cd $env:BUILD_SOURCESDIRECTORY/python-package
   python setup.py sdist --formats gztar ; Check-Output $?
+  sh $env:BUILD_SOURCESDIRECTORY/.ci/check_python_dists.sh $env:BUILD_SOURCESDIRECTORY/python-package/dist ; Check-Output $?
   cd dist; pip install @(Get-ChildItem *.gz) -v ; Check-Output $?
 }
 elseif ($env:TASK -eq "bdist") {
@@ -88,6 +89,7 @@ elseif ($env:TASK -eq "bdist") {
   conda activate $env:CONDA_ENV
   cd $env:BUILD_SOURCESDIRECTORY/python-package
   python setup.py bdist_wheel --integrated-opencl --plat-name=win-amd64 --python-tag py3 ; Check-Output $?
+  sh $env:BUILD_SOURCESDIRECTORY/.ci/check_python_dists.sh $env:BUILD_SOURCESDIRECTORY/python-package/dist ; Check-Output $?
   cd dist; pip install --user @(Get-ChildItem *.whl) ; Check-Output $?
   cp @(Get-ChildItem *.whl) $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 } elseif (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python")) {

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -348,6 +348,7 @@ if __name__ == "__main__":
           version=version,
           description='LightGBM Python Package',
           long_description=readme,
+          long_description_content_type='text/x-rst',
           python_requires='>=3.6',
           install_requires=[
               'wheel',


### PR DESCRIPTION
Contributes to #5061.

This PR proposes introducing two new linters that check the contents of Python package distributions (sdists and wheels) for common issues.

* [`twine check`](https://twine.readthedocs.io/en/stable/#twine-check): checks that distributions bundled README will render correctly on PyPI
* [`check-wheel-contents`](https://github.com/jwodder/check-wheel-contents): catches problems like accidentally bundling `.pyc` files into the distribution, or including multiple files with identical content

### Notes for Reviewers

I think these checks are generically useful in the way that all linters are...putting shared agreements into CI to reduce the scope of things that maintainers and contributors need to remember to check.

But in addition, it contributes to #5061 because these checks will help detect problems accidentally, newly introduced by changes to how LightGBM builds wheels.

### How I tested this

The first commit on this PR adds the checks but doesn't fix any of the issues they found.

And you can see in the logs that they ran successfully and failed builds 🎉 

```text
Checking /Users/runner/work/1/s/python-package/dist/lightgbm-3.3.5.99-py3-none-macosx.whl:
FAILED due to warnings
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`. 
```

* Azure: https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=14221&view=logs&j=67ae2ff8-4b33-578b-0813-9c0440091667&t=aed7750d-29a7-50d7-d7f0-fc7145577059
* GitHub Actions: https://github.com/microsoft/LightGBM/actions/runs/4150047498/jobs/7179430619