### PR TITLE
[python-package] declare the use of inline type hints

### DIFF
--- a/python-package/MANIFEST.in
+++ b/python-package/MANIFEST.in
@@ -1,7 +1,7 @@
 prune build
 include LICENSE
 include *.rst *.txt
-recursive-include lightgbm VERSION.txt *.py *.so
+recursive-include lightgbm VERSION.txt py.typed *.py *.so
 include compile/CMakeLists.txt
 include compile/cmake/IntegratedOpenCL.cmake
 recursive-include compile *.so

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -389,4 +389,5 @@ if __name__ == "__main__":
                        'Programming Language :: Python :: 3.8',
                        'Programming Language :: Python :: 3.9',
                        'Programming Language :: Python :: 3.10',
-                       'Topic :: Scientific/Engineering :: Artificial Intelligence'])
+                       'Topic :: Scientific/Engineering :: Artificial Intelligence',
+                       'Typing :: Typed'])


### PR DESCRIPTION
Contributes to #3756.
Contributes to #3867.

This PR proposes updating the Python package to declare that inline type annotations are used.

* adds trove classifier `Typing :: Typed`
* adds a `py.typed` file

### Why add the `Typing :: Typed` trove classifier?

This classifier helps researchers and others summarizing PyPI's contents to identify packages that export type annotations.

See the discussion in https://github.com/pypi/warehouse/issues/4348.

There are 5200+ packages on PyPI using this classifier: https://pypi.org/search/?c=Typing+%3A%3A+Typed.

### Why add a `py.typed` file?

As described in PEP 561 ([link](https://peps.python.org/pep-0561)), including an empty file named `py.typed` tells tools like `mypy` that a package's source code contains type annotations.

That doesn't matter for `lightgbm` itself, but it's helpful for anyone writing code that depends on `lightgbm` (e.g. `optuna`, `lightgbm-ray`, lots of other user code) and wanting to check that code with `mypy`.

Consider the following example. Given the following file...

```python
"""script.py"""
import lightgbm as lgb

clf = lgb.LGBMClassifier(n_estimators="not-a-number")
```

Running

```shell
mypy ./script.py
```

if you have `lightgbm < 4.0` installed from PyPI or from `master`, you'll see the following error.

```text
test.py:1: error: Skipping analyzing "lightgbm": module is installed, but missing library stubs or py.typed marker
test.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

But on this branch, `mypy` is able to check that code 😁 

```text
script.py:5: error: Argument "n_estimators" to "LGBMClassifier" has incompatible type "str"; expected "int"  [arg-type]
Found 1 error in 1 file (checked 1 source file)
```