### PR TITLE
[python-package] add more type hints in sklearn.py

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -31,6 +31,7 @@ __all__ = [
 
 _DatasetHandle = ctypes.c_void_p
 _LGBM_EvalFunctionResultType = Tuple[str, float, bool]
+_LGBM_BoosterBestScoreType = Dict[str, Dict[str, float]]
 _LGBM_BoosterEvalMethodResultType = Tuple[str, str, float, bool]
 _LGBM_LabelType = Union[
     list,
@@ -2762,7 +2763,7 @@ class Booster:
         self._train_data_name = "training"
         self.__set_objective_to_none = False
         self.best_iteration = -1
-        self.best_score = {}
+        self.best_score: _LGBM_BoosterBestScoreType = {}
         params = {} if params is None else deepcopy(params)
         if train_set is not None:
             # Training task
@@ -4083,7 +4084,7 @@ class Booster:
         result_array_like : numpy array or pandas DataFrame (if pandas is installed)
             If ``xgboost_style=True``, the histogram of used splitting values for the specified feature.
         """
-        def add(root):
+        def add(root: Dict[str, Any]) -> None:
             """Recursively add thresholds."""
             if 'split_index' in root:  # non-leaf
                 if feature_names is not None and isinstance(feature, str):

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -23,7 +23,7 @@ _EvalResultTuple = Union[
 class EarlyStopException(Exception):
     """Exception of early stopping."""
 
-    def __init__(self, best_iteration: int, best_score: _EvalResultDict) -> None:
+    def __init__(self, best_iteration: int, best_score: _EvalResultTuple) -> None:
         """Create early stopping exception.
 
         Parameters
@@ -107,7 +107,7 @@ def log_evaluation(period: int = 1, show_stdv: bool = True) -> _LogEvaluationCal
 class _RecordEvaluationCallback:
     """Internal record evaluation callable class."""
 
-    def __init__(self, eval_result: _EvalResultTuple) -> None:
+    def __init__(self, eval_result: _EvalResultDict) -> None:
         self.order = 20
         self.before_iteration = False
 

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -13,6 +13,7 @@ __all__ = [
     'reset_parameter',
 ]
 
+_EvalResultDict = Dict[str, Dict[str, List[Any]]]
 _EvalResultTuple = Union[
     List[_LGBM_BoosterEvalMethodResultType],
     List[Tuple[str, str, float, bool, float]]
@@ -22,7 +23,7 @@ _EvalResultTuple = Union[
 class EarlyStopException(Exception):
     """Exception of early stopping."""
 
-    def __init__(self, best_iteration: int, best_score: _EvalResultTuple) -> None:
+    def __init__(self, best_iteration: int, best_score: _EvalResultDict) -> None:
         """Create early stopping exception.
 
         Parameters
@@ -106,7 +107,7 @@ def log_evaluation(period: int = 1, show_stdv: bool = True) -> _LogEvaluationCal
 class _RecordEvaluationCallback:
     """Internal record evaluation callable class."""
 
-    def __init__(self, eval_result: Dict[str, Dict[str, List[Any]]]) -> None:
+    def __init__(self, eval_result: _EvalResultTuple) -> None:
         self.order = 20
         self.before_iteration = False
 

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -7,8 +7,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from .basic import (Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _LGBM_BoosterBestScoreType, _LGBM_EvalFunctionResultType,
-                    _log_warning)
+from .basic import (Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _LGBM_BoosterBestScoreType,
+                    _LGBM_EvalFunctionResultType, _log_warning)
 from .callback import _EvalResultDict, record_evaluation
 from .compat import (SKLEARN_INSTALLED, LGBMNotFittedError, _LGBMAssertAllFinite, _LGBMCheckArray,
                      _LGBMCheckClassificationTargets, _LGBMCheckSampleWeight, _LGBMCheckXY, _LGBMClassifierBase,


### PR DESCRIPTION
Contributes to #3756.
Contributes to #3867.

Adds a few additional type hints in `sklearn.py`, to improve static type checkers' ability to find bugs.

This PR also resolves the following `mypy` warnings:

```text
python-package/lightgbm/sklearn.py:1055: error: Incompatible types in assignment (expression has type "Dict[Any, Any]", variable has type "None")  [assignment]
python-package/lightgbm/sklearn.py:1057: error: Incompatible types in assignment (expression has type "Dict[Any, Any]", variable has type "None")  [assignment]
python-package/lightgbm/sklearn.py:1057: error: Value of type "None" is not indexable  [index]
python-package/lightgbm/sklearn.py:1060: error: Incompatible types in assignment (expression has type "int", variable has type "None")  [assignment]
python-package/lightgbm/sklearn.py:815: error: Incompatible types in assignment (expression has type "Dict[Any, Any]", variable has type "None")  [assignment]
python-package/lightgbm/sklearn.py:816: error: Incompatible types in assignment (expression has type "int", variable has type "None")  [assignment]
python-package/lightgbm/sklearn.py:817: error: Incompatible types in assignment (expression has type "Dict[Any, Any]", variable has type "None")  [assignment]
```