### PR TITLE
[python-package] fix mypy errors in compat.py and libpath.py

### DIFF
--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 """Compatibility library."""
 
+from typing import List
+
 """pandas"""
 try:
     from pandas import DataFrame as pd_DataFrame
@@ -147,11 +149,11 @@ try:
 except ImportError:
     DASK_INSTALLED = False
 
-    dask_array_from_delayed = None
-    dask_bag_from_delayed = None
+    dask_array_from_delayed = None  # type: ignore[assignment]
+    dask_bag_from_delayed = None  # type: ignore[assignment]
     delayed = None
-    default_client = None
-    wait = None
+    default_client = None  # type: ignore[assignment]
+    wait = None  # type: ignore[assignment]
 
     class Client:  # type: ignore
         """Dummy class for dask.distributed.Client."""
@@ -195,4 +197,4 @@ except ImportError:
         def _LGBMCpuCount(only_physical_cores: bool = True):
             return cpu_count()
 
-__all__ = []
+__all__: List[str] = []

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from platform import system
 from typing import List
 
-__all__ = []
+__all__: List[str] = []
 
 
 def find_lib_path() -> List[str]:


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3867.

Fixes the following errors from `mypy`:

```text
python-package/lightgbm/libpath.py:7: error: Need type annotation for "__all__" (hint: "__all__: List[<type>] = ...")  [var-annotated]
python-package/lightgbm/compat.py:150: error: Incompatible types in assignment (expression has type "None", variable has type "Callable[[Any, Any, Any, Any, Any], Any]")  [assignment]
python-package/lightgbm/compat.py:151: error: Incompatible types in assignment (expression has type "None", variable has type "Callable[[Any], Any]")  [assignment]
python-package/lightgbm/compat.py:153: error: Incompatible types in assignment (expression has type "None", variable has type "Callable[[Any], Any]")  [assignment]
python-package/lightgbm/compat.py:154: error: Incompatible types in assignment (expression has type "None", variable has type "Callable[[Any, Any, Any], Any]")  [assignment]
python-package/lightgbm/compat.py:198: error: Need type annotation for "__all__" (hint: "__all__: List[<type>] = ...")  [var-annotated]
```