### PR TITLE
[python-package] change types in sklearn.py initializations

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -521,14 +521,14 @@ class LGBMModel(_LGBMModelBase):
         self._Booster: Optional[Booster] = None
         self._evals_result: _EvalResultDict = {}
         self._best_score: _LGBM_BoosterBestScoreType = {}
-        self._best_iteration: Optional[int] = None
+        self._best_iteration: int = -1
         self._other_params: Dict[str, Any] = {}
         self._objective = objective
         self.class_weight = class_weight
         self._class_weight: Optional[Union[Dict, str]] = None
         self._class_map: Optional[Dict[int, int]] = None
-        self._n_features = None
-        self._n_features_in = None
+        self._n_features: int = -1
+        self._n_features_in: int = -1
         self._classes = None
         self._n_classes: Optional[int] = None
         self.set_params(**kwargs)


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3756.
Contributes to https://github.com/microsoft/LightGBM/issues/3867.

Follow-up to #5672 (thanks @IdoKendo for starting this discussion again!)

Fixes the following errors from `mypy`.

```text
python-package/lightgbm/sklearn.py:897: error: Incompatible return value type (got "None", expected "int")  [return-value]
python-package/lightgbm/sklearn.py:904: error: Incompatible return value type (got "None", expected "int")  [return-value]
python-package/lightgbm/sklearn.py:918: error: Incompatible return value type (got "Optional[int]", expected "int")  [return-value]
```

See my description in https://github.com/microsoft/LightGBM/pull/5672#discussion_r1107672623 for the reasoning behind this proposed change.

### How I tested this

Besides just running `mypy` and the unit tests, I wanted to also confirm that there wasn't any other code relying on the attributes `_n_features`, `_n_features_in`, and `_best_iteration`  being initialized to `None`.

Since those are private attributes of a class inside `lightgbm`, it's sufficient just to check this repository for such references.

```shell
git grep '_n_features'
git grep '_best_iteration'
```

I didn't see any places relying specifically on those attributes being initialized to `None`, so I think changing them to be initialized to `-1` is safe.