### PR TITLE
[python-package] fix mypy errors around eval metrics in sklearn.py

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1059,21 +1059,28 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
         self._classes = self._le.classes_
         self._n_classes = len(self._classes)
 
+        # adjust eval metrics to match whether binary or multiclass
+        # classification is being performed
         if not callable(eval_metric):
-            if isinstance(eval_metric, (str, type(None))):
-                eval_metric = [eval_metric]
-            if self._n_classes > 2:
-                for index, metric in enumerate(eval_metric):
-                    if metric in {'logloss', 'binary_logloss'}:
-                        eval_metric[index] = "multi_logloss"
-                    elif metric in {'error', 'binary_error'}:
-                        eval_metric[index] = "multi_error"
+            if isinstance(eval_metric, list):
+                eval_metric_list = eval_metric
             else:
-                for index, metric in enumerate(eval_metric):
+                eval_metric_list = []
+            if isinstance(eval_metric, (str, type(None))):
+                eval_metric_list = [eval_metric]
+            if self._n_classes > 2:
+                for index, metric in enumerate(eval_metric_list):
+                    if metric in {'logloss', 'binary_logloss'}:
+                        eval_metric_list[index] = "multi_logloss"
+                    elif metric in {'error', 'binary_error'}:
+                        eval_metric_list[index] = "multi_error"
+            else:
+                for index, metric in enumerate(eval_metric_list):
                     if metric in {'logloss', 'multi_logloss'}:
-                        eval_metric[index] = 'binary_logloss'
+                        eval_metric_list[index] = 'binary_logloss'
                     elif metric in {'error', 'multi_error'}:
-                        eval_metric[index] = 'binary_error'
+                        eval_metric_list[index] = 'binary_error'
+            eval_metric = eval_metric_list
 
         # do not modify args, as it causes errors in model selection tools
         valid_sets = None

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1064,10 +1064,10 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
         if not callable(eval_metric):
             if isinstance(eval_metric, list):
                 eval_metric_list = eval_metric
+            elif isinstance(eval_metric, str):
+                eval_metric_list = [eval_metric]
             else:
                 eval_metric_list = []
-            if isinstance(eval_metric, (str, type(None))):
-                eval_metric_list = [eval_metric]
             if self._n_classes > 2:
                 for index, metric in enumerate(eval_metric_list):
                     if metric in {'logloss', 'binary_logloss'}:


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3867.

Fixes the following errors from `mypy`.

```text
python-package/lightgbm/sklearn.py:1064: error: List item 0 has incompatible type "Optional[str]"; expected "Union[str, Callable[[ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]]]"  [list-item]
python-package/lightgbm/sklearn.py:1066: error: Argument 1 to "enumerate" has incompatible type "Optional[List[Union[str, Union[Callable[[ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]]]]]]"; expected "Iterable[Union[str, Callable[[ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]]]]"  [arg-type]
python-package/lightgbm/sklearn.py:1068: error: Unsupported target for indexed assignment ("Optional[List[Union[str, Union[Callable[[ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]]]]]]")  [index]
python-package/lightgbm/sklearn.py:1070: error: Unsupported target for indexed assignment ("Optional[List[Union[str, Union[Callable[[ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]]]]]]")  [index]
python-package/lightgbm/sklearn.py:1072: error: Argument 1 to "enumerate" has incompatible type "Optional[List[Union[str, Union[Callable[[ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]]]]]]"; expected "Iterable[Union[str, Callable[[ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]]]]"  [arg-type]
python-package/lightgbm/sklearn.py:1074: error: Unsupported target for indexed assignment ("Optional[List[Union[str, Union[Callable[[ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]]]]]]")  [index]
python-package/lightgbm/sklearn.py:1076: error: Unsupported target for indexed assignment ("Optional[List[Union[str, Union[Callable[[ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]], Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any]], Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]]]]]]")  [index]
```

### Notes for Reviewers

When explicit type annotations aren't provided but a variable is initialized with a value whose type `mypy` knows, `mypy` assigns that type to that variable.

For example:

```python
# mypy thinks x is a string
x = "hello"

# error: Incompatible types in assignment (expression has type "float", variable has type "str")  [assignment]
x = 4
```

This PR fixes one such case in `sklearn.py`.

`eval_metric` passed to `LGBMClassifier.fit()` can be `None`, a string, a callable custom eval function, or a list of strings and callable custom eval functions. `LGBMClassifier.fit()` overwrites a copy of the passed-in `eval_metric` with a list to prevent duplication in the code for the operation "use multiclass metrics if `_n_classes > 2`" .

This PR just instead creates that list as a separate variable and then does overwriting like that at the end of processing, to avoid the errors mentioned above.

This doesn't fix a bug but I do think it makes it a bit easier to understand what the code this PR touches is doing. And more importantly, it allows `mypy` to catch future bugs in this code.