### PR TITLE
[python-package] fix mypy error about log callback

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -146,7 +146,7 @@ def _load_lib() -> ctypes.CDLL:
     lib = ctypes.cdll.LoadLibrary(lib_path[0])
     lib.LGBM_GetLastError.restype = ctypes.c_char_p
     callback = ctypes.CFUNCTYPE(None, ctypes.c_char_p)
-    lib.callback = callback(_log_callback)
+    lib.callback = callback(_log_callback)  # type: ignore[attr-defined]
     if lib.LGBM_RegisterLogCallback(lib.callback) != 0:
         raise LightGBMError(lib.LGBM_GetLastError().decode('utf-8'))
     return lib


### PR DESCRIPTION
Contributes to #3867.

Fixes the following `mypy` error.

```text
python-package/lightgbm/basic.py:149: error: "CDLL" has no attribute "callback"  [attr-defined]
```