### PR TITLE
[python-package] fix mypy errors about custom eval functions in sklearn.py

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -178,7 +178,11 @@ class _EvalFunctionWrapper:
         """
         self.func = func
 
-    def __call__(self, preds: np.ndarray, dataset: Dataset) -> Tuple[str, float, bool]:
+    def __call__(
+        self,
+        preds: np.ndarray,
+        dataset: Dataset
+    ) -> Union[_LGBM_EvalFunctionResultType, List[_LGBM_EvalFunctionResultType]]:
         """Call passed function with appropriate arguments.
 
         Parameters


### PR DESCRIPTION
Contributes to #3756
Contributes to #3867.

Fixes the following errors from `mypy`.

```text
python-package/lightgbm/sklearn.py:203: error: Incompatible return value type (got "Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]", expected "Tuple[str, float, bool]")  [return-value]
python-package/lightgbm/sklearn.py:205: error: Incompatible return value type (got "Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]", expected "Tuple[str, float, bool]")  [return-value]
python-package/lightgbm/sklearn.py:207: error: Incompatible return value type (got "Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]", expected "Tuple[str, float, bool]")  [return-value]
```

In the `scikit-learn` interface, custom eval functions can return either a tuple of the form `(eval_name, eval_result, is_higher_better)` or a list of such tuples.

https://github.com/microsoft/LightGBM/blob/29796eee6eabb79e161880976ec02fcd95dfcc4a/python-package/lightgbm/sklearn.py#L150-L156

`mypy` is raising these complaints because that return type annotation on `_EvalFunctionWrapper` doesn't include that possibility of returning a list of eval results.

https://github.com/microsoft/LightGBM/blob/29796eee6eabb79e161880976ec02fcd95dfcc4a/python-package/lightgbm/sklearn.py#L181