### PR TITLE
[python-package] fix mypy errors about Dataset handle

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1364,7 +1364,7 @@ class Dataset:
         free_raw_data : bool, optional (default=True)
             If True, raw data is freed after constructing inner Dataset.
         """
-        self.handle = None
+        self.handle: Optional[ctypes.c_void_p] = None
         self.data = data
         self.label = label
         self.reference = reference


### PR DESCRIPTION
Contributes to #3756
Contributes to #3867.

Fixed the following `mypy` errors.

```text
python-package/lightgbm/basic.py:1444: error: Incompatible types in assignment (expression has type "c_void_p", variable has type "None")  [assignment]
python-package/lightgbm/basic.py:1448: error: Argument 1 to "byref" has incompatible type "None"; expected "_CData"  [arg-type]
python-package/lightgbm/basic.py:1499: error: Incompatible types in assignment (expression has type "c_void_p", variable has type "None")  [assignment]
python-package/lightgbm/basic.py:1510: error: Argument 1 to "byref" has incompatible type "None"; expected "_CData"  [arg-type]
python-package/lightgbm/basic.py:1689: error: Incompatible types in assignment (expression has type "c_void_p", variable has type "None")  [assignment]
python-package/lightgbm/basic.py:1694: error: Argument 1 to "byref" has incompatible type "None"; expected "_CData"  [arg-type]
python-package/lightgbm/basic.py:1827: error: Incompatible types in assignment (expression has type "c_void_p", variable has type "None")  [assignment]
python-package/lightgbm/basic.py:1842: error: Argument 1 to "byref" has incompatible type "None"; expected "_CData"  [arg-type]
python-package/lightgbm/basic.py:1883: error: Incompatible types in assignment (expression has type "c_void_p", variable has type "None")  [assignment]
python-package/lightgbm/basic.py:1893: error: Argument 1 to "byref" has incompatible type "None"; expected "_CData"  [arg-type]
python-package/lightgbm/basic.py:1905: error: Incompatible types in assignment (expression has type "c_void_p", variable has type "None")  [assignment]
python-package/lightgbm/basic.py:1924: error: Argument 1 to "byref" has incompatible type "None"; expected "_CData"  [arg-type]
python-package/lightgbm/basic.py:1936: error: Incompatible types in assignment (expression has type "c_void_p", variable has type "None")  [assignment]
python-package/lightgbm/basic.py:1955: error: Argument 1 to "byref" has incompatible type "None"; expected "_CData"  [arg-type]
python-package/lightgbm/basic.py:2030: error: Incompatible types in assignment (expression has type "c_void_p", variable has type "None")  [assignment]
python-package/lightgbm/basic.py:2037: error: Argument 1 to "byref" has incompatible type "None"; expected "_CData"  [arg-type]
```

If type annotations aren't provided, `mypy` sometimes detects the type of a variable based on the first assignment to it. Initializing `Dataset.handle` to `None` makes `mypy` think it's `None`, which is incorrect... it's only `None` until the `Dataset` is constructed, after which it holds a pointer to a `Dataset` on the C++ side.