### PR TITLE
[python-package] fix mypy errors about cv() internals

### DIFF
--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -501,8 +501,8 @@ def _agg_cv_result(
     raw_results: List[List[Tuple[str, str, float, bool]]]
 ) -> List[Tuple[str, str, float, bool, float]]:
     """Aggregate cross-validation results."""
-    cvmap = collections.OrderedDict()
-    metric_type = {}
+    cvmap: Dict[str, List[float]] = collections.OrderedDict()
+    metric_type: Dict[str, bool] = {}
     for one_result in raw_results:
         for one_line in one_result:
             key = f"{one_line[0]} {one_line[1]}"


### PR DESCRIPTION
Contributes to #3756
Contributes to #3867.

Fixes the following `mypy` error.

```text
python-package/lightgbm/engine.py:504: error: Need type annotation for "cvmap"  [var-annotated]
```