### PR TITLE
[python-package] fix mypy error about ctypes array creation

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -312,7 +312,7 @@ def _c_str(string: str) -> ctypes.c_char_p:
 
 def _c_array(ctype: type, values: List[Any]) -> ctypes.Array:
     """Convert a Python array to C array."""
-    return (ctype * len(values))(*values)
+    return (ctype * len(values))(*values)  # type: ignore[operator]
 
 
 def _json_default_with_numpy(obj: Any) -> Any:


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3756
Contributes to https://github.com/microsoft/LightGBM/issues/3867.

Fixes the following `mypy`.

```text
python-package/lightgbm/basic.py:315: error: "int" not callable  [operator]
python-package/lightgbm/basic.py:315: error: Unsupported operand types for * ("type" and "int")  [operator]
```

### Notes for Reviewers

Using the `*` operator is the expected way to create a C array using `ctypes`, but `mypy` is confused about it.

Docs: https://docs.python.org/3/library/ctypes.html#arrays

This is a frequently-run code path covered by lots of tests, so I think just ignoring this warning from `mypy` is safe.