### PR TITLE
[python-package] fix _LGBM_CustomMetricFunction typing

### DIFF
--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -23,7 +23,7 @@ __all__ = [
 
 _LGBM_CustomMetricFunction = Callable[
     [np.ndarray, Dataset],
-    Tuple[str, float, bool]
+    Union[Tuple[str, float, bool], List[Tuple[str, float, bool]]]
 ]
 
 _LGBM_PreprocFunction = Callable[


### PR DESCRIPTION
Contributes to #3756.

Fixed custom evaluation function typing according to train documentation: "Each evaluation function should accept two parameters: preds, eval_data, and return (eval_name, eval_result, is_higher_better) or **list of such tuples**."