### PR TITLE
[python-package] use _DatasetHandle type hint

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1364,7 +1364,7 @@ class Dataset:
         free_raw_data : bool, optional (default=True)
             If True, raw data is freed after constructing inner Dataset.
         """
-        self.handle: Optional[ctypes.c_void_p] = None
+        self.handle: Optional[_DatasetHandle] = None
         self.data = data
         self.label = label
         self.reference = reference


### PR DESCRIPTION
Contributes to #3756.

Sorry, in #5722 I forgot that the Python package already has a type alias, `_DatasetHandle`, that we use for type hints on things that are `Dataset` handles (see https://github.com/microsoft/LightGBM/pull/5458#issuecomment-1235594303).

https://github.com/microsoft/LightGBM/blob/42df0ff3397aabb06f9f6fda2966f16b9cb3b1f6/python-package/lightgbm/basic.py#L32

This PR switches to using that.