### PR TITLE
[ci] skip Dask tests on GPU builds

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -57,6 +57,7 @@ task_to_local_factory = {
 
 pytestmark = [
     pytest.mark.skipif(getenv('TASK', '') == 'mpi', reason='Fails to run with MPI interface'),
+    pytest.mark.skipif(getenv('TASK', '') == 'gpu', reason='Fails to run with GPU interface'),
     pytest.mark.skipif(getenv('TASK', '') == 'cuda', reason='Fails to run with CUDA interface')
 ]
 


### PR DESCRIPTION
Reverts the changes from #5292.

Since I merged that PR, the `test_dask.py` tests have been VERY flaky on GPU builds. My unscientific estimate is that 60% of commits since then have had at least one Azure DevOps GPU job fail.

This PR proposes skipping those tests again, to reduce the required manual effort of re-running jobs and to improve the contribution experience for outside contributors. 

I'm using #5713 to test fixes, but for now I think we should just skip these flaky tests again 😞 