### PR TITLE
[ci] speed up conda setup for macOS and Linux jobs

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -104,6 +104,7 @@ if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
         -n $CONDA_ENV \
             doxygen \
             'rstcheck>=6.0.0' || exit -1
+    source activate $CONDA_ENV
     # check reStructuredText formatting
     cd $BUILD_DIRECTORY/python-package
     rstcheck --report-level warning $(find . -type f -name "*.rst") || exit -1

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -93,11 +93,6 @@ if [[ $TASK == "lint" ]]; then
     exit 0
 fi
 
-conda create -q -y -n $CONDA_ENV "${CONDA_PYTHON_REQUIREMENT}"
-source activate $CONDA_ENV
-
-cd $BUILD_DIRECTORY
-
 if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     cd $BUILD_DIRECTORY/docs
     conda env update \
@@ -131,8 +126,8 @@ if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     exit 0
 fi
 
-# re-including python=version[build=*cpython] to ensure that conda doesn't fall back to pypy
-conda install -q -y -n $CONDA_ENV \
+# including python=version[build=*cpython] to ensure that conda doesn't fall back to pypy
+conda create -q -y -n $CONDA_ENV \
     cloudpickle \
     dask-core \
     distributed \
@@ -146,6 +141,10 @@ conda install -q -y -n $CONDA_ENV \
     python-graphviz \
     scikit-learn \
     scipy || exit -1
+
+source activate $CONDA_ENV
+
+cd $BUILD_DIRECTORY
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     # fix "OMP: Error #15: Initializing libiomp5.dylib, but found libomp.dylib already initialized." (OpenMP library conflict due to conda's MKL)

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -95,7 +95,7 @@ fi
 
 if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     cd $BUILD_DIRECTORY/docs
-    conda env update \
+    conda env create \
         -n $CONDA_ENV \
         --file ./env.yml || exit -1
     conda install \


### PR DESCRIPTION
Follow-up to #5668.

Proposes combining the `conda create` and `conda install` steps run in CI jobs into a single `conda create` step. In #5668 and #5648, we observed that doing that led to less overall time in CI spent waiting for `conda` solves.

### benefits of this change

I observed the following timing differences in these jobs on this PR, compared to `master`:

| job                                              | latest `master` | this PR   |
|:------------------------------|:---------------:|:--------:|
| (GHA) CUDA 11.7 wheel           |  12m41s             | **12m16s** |
| (GHA) CUDA 10.0 source         |  11m17s              | 11m17s |
| (GHA) CUDA 11.7.1 pip              |  **12m29s**      | 12m35s |
| (GHA) macOS regular               |  16m46s           | **14m49s** |
| (GHA) macOS bdist                  |   18m33s          |  **13m07s** |
| (GHA) macOS sdist                  | 13m16s             | **10m06s** |
| (GHA) MPI source                    |  16m52s            | **12m33s** |
| (GHA) MPI pip                           | 12m21s            | **10m29s** |
| (GHA) MPI wheel                      | 13m42s            | **13m03s** |
| (Azure) Linux regular               |  **14m58s**   | 15m21s|
| (Azure) Linux sdist                   |  13m29s           | **12m49s** |
| (Azure) Linux bdist                  |    16m08s          | **15m37s** |
| (Azure) Linux mpi_source       |   10m47s          | **10m45s**  |
| (Azure) Linux gpu_source      |   **16m13s**      |   17m21s    |
| (Azure) Linux_latest regular   |    16m20s            | **15m15s** |
| (Azure) Linux_latest sdist       |    **13m44s**   | 13m52s |
| (Azure) Linux_latest bdist       |   16m38s          | **15m31s** |
| (Azure) Linux_latest mpi_source |   09m55s    | **09m53s** |
| (Azure) Linux_latest gpu_source |   16m16s       | **15m21s** |
| (Azure) Linux_latest gpu_pip       |   16m52s     | **15m10s** |
| (Azure) Linux_latest gpu_wheel  |  16m40s        | **15m41s** |
| (Azure) QEMU_multiarch bdist    |      71m29s               | **70m41s** |
| (Azure) macOS regular                 |  12m08s      | **11m24s** |
| (Azure) macOS sdist                     |  10m06s      | **08m31s** |
| (Azure) macOS bdist                    |  11m12s         | **08m46s** |

this PR:

* CUDA GitHub Actions: https://github.com/microsoft/LightGBM/actions/runs/4272338290/jobs/7437402962
* macOS GitHub Actions: https://github.com/microsoft/LightGBM/actions/runs/4272338296/jobs/7437401203
* Azure: https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=14319&view=results

latest `master` build:

* CUDA GitHub Actions: https://github.com/microsoft/LightGBM/actions/runs/4273088891/jobs/7438764795
* macOS GitHub Actions: https://github.com/microsoft/LightGBM/actions/runs/4273088894/jobs/7438765167
* Azure: https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=14322&view=results

### Notes for Reviewers

Given all the things that can change from run-to-run, it's hard to trust differences in the timings based on 1 or even a few of runs. But I'm still pretty confident that these changes make these CI jobs at least *a small amount* faster, without reducing their stability.