### PR TITLE
[python-package] add type hints on Dataset feature processing

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -34,7 +34,7 @@ _LGBM_EvalFunctionResultType = Tuple[str, float, bool]
 _LGBM_BoosterBestScoreType = Dict[str, Dict[str, float]]
 _LGBM_BoosterEvalMethodResultType = Tuple[str, str, float, bool]
 _LGBM_CategoricalFeatureConfiguration = Union[List[str], List[int], str]
-_LGBM_FeatureNameConfiguration = Union[List[str], List[int], str]
+_LGBM_FeatureNameConfiguration = Union[List[str], str]
 _LGBM_LabelType = Union[
     list,
     np.ndarray,
@@ -592,8 +592,8 @@ def _check_for_bad_pandas_dtypes(pandas_dtypes_series: pd_Series) -> None:
 
 def _data_from_pandas(
     data,
-    feature_name: _LGBM_FeatureNameConfiguration,
-    categorical_feature: _LGBM_CategoricalFeatureConfiguration,
+    feature_name: Optional[_LGBM_FeatureNameConfiguration],
+    categorical_feature: Optional[_LGBM_CategoricalFeatureConfiguration],
     pandas_categorical: Optional[List[List]]
 ):
     if isinstance(data, pd_DataFrame):

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3948,7 +3948,7 @@ class Booster:
         group=None,
         init_score=None,
         feature_name: _LGBM_FeatureNameConfiguration = 'auto',
-        categorical_feature: _LGBM_CategoricalFeatureConfiguration  = 'auto',
+        categorical_feature: _LGBM_CategoricalFeatureConfiguration = 'auto',
         dataset_params: Optional[Dict[str, Any]] = None,
         free_raw_data: bool = True,
         validate_features: bool = False,

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -11,7 +11,8 @@ import numpy as np
 
 from . import callback
 from .basic import (Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _InnerPredictor,
-                    _LGBM_CustomObjectiveFunction, _log_warning)
+                    _LGBM_CategoricalFeatureConfiguration, _LGBM_CustomObjectiveFunction,
+                    _LGBM_FeatureNameConfiguration, _log_warning)
 from .compat import SKLEARN_INSTALLED, _LGBMBaseCrossValidator, _LGBMGroupKFold, _LGBMStratifiedKFold
 
 __all__ = [
@@ -40,8 +41,8 @@ def train(
     valid_names: Optional[List[str]] = None,
     feval: Optional[Union[_LGBM_CustomMetricFunction, List[_LGBM_CustomMetricFunction]]] = None,
     init_model: Optional[Union[str, Path, Booster]] = None,
-    feature_name: Union[List[str], str] = 'auto',
-    categorical_feature: Union[List[str], List[int], str] = 'auto',
+    feature_name: _LGBM_FeatureNameConfiguration = 'auto',
+    categorical_feature: _LGBM_CategoricalFeatureConfiguration = 'auto',
     keep_training_booster: bool = False,
     callbacks: Optional[List[Callable]] = None
 ) -> Booster:
@@ -523,8 +524,8 @@ def cv(
     metrics: Optional[Union[str, List[str]]] = None,
     feval: Optional[Union[_LGBM_CustomMetricFunction, List[_LGBM_CustomMetricFunction]]] = None,
     init_model: Optional[Union[str, Path, Booster]] = None,
-    feature_name: Union[str, List[str]] = 'auto',
-    categorical_feature: Union[str, List[str], List[int]] = 'auto',
+    feature_name: _LGBM_FeatureNameConfiguration = 'auto',
+    categorical_feature: _LGBM_CategoricalFeatureConfiguration = 'auto',
     fpreproc: Optional[_LGBM_PreprocFunction] = None,
     seed: int = 0,
     callbacks: Optional[List[Callable]] = None,


### PR DESCRIPTION
Contributes to #3756.

Adds type hints on `_data_from_pandas()` and `_dump_pandas_categorical()`, internal functions used during `Dataset` construction.

Fixes return type hint on `_load_pandas_categorical()`, which is used to recover information about `pandas` categorical columns from model text files.