### PR TITLE
[python-package] add type hints on raw data passed to Dataset and Booster

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -35,6 +35,17 @@ _LGBM_BoosterBestScoreType = Dict[str, Dict[str, float]]
 _LGBM_BoosterEvalMethodResultType = Tuple[str, str, float, bool]
 _LGBM_CategoricalFeatureConfiguration = Union[List[str], List[int], str]
 _LGBM_FeatureNameConfiguration = Union[List[str], str]
+_LGBM_TrainDataType = Union[
+    str,
+    Path,
+    np.ndarray,
+    pd_DataFrame,
+    dt_DataTable,
+    scipy.sparse.spmatrix,
+    "Sequence",
+    List["Sequence"],
+    List[np.ndarray]
+]
 _LGBM_LabelType = Union[
     list,
     np.ndarray,
@@ -1400,7 +1411,7 @@ class Dataset:
 
     def __init__(
         self,
-        data,
+        data: _LGBM_TrainDataType,
         label: Optional[_LGBM_LabelType] = None,
         reference: Optional["Dataset"] = None,
         weight=None,
@@ -1708,7 +1719,7 @@ class Dataset:
 
     def _lazy_init(
         self,
-        data,
+        data: Optional[_LGBM_TrainDataType],
         label: Optional[_LGBM_LabelType] = None,
         reference: Optional["Dataset"] = None,
         weight=None,
@@ -2146,7 +2157,7 @@ class Dataset:
 
     def create_valid(
         self,
-        data,
+        data: _LGBM_TrainDataType,
         label: Optional[_LGBM_LabelType] = None,
         weight=None,
         group=None,
@@ -2673,7 +2684,7 @@ class Dataset:
             self.init_score = self.get_field('init_score')
         return self.init_score
 
-    def get_data(self):
+    def get_data(self) -> Optional[_LGBM_TrainDataType]:
         """Get the raw data of the Dataset.
 
         Returns
@@ -4016,7 +4027,7 @@ class Booster:
 
     def refit(
         self,
-        data,
+        data: _LGBM_TrainDataType,
         label,
         decay_rate: float = 0.9,
         reference: Optional[Dataset] = None,
@@ -4034,7 +4045,7 @@ class Booster:
 
         Parameters
         ----------
-        data : str, pathlib.Path, numpy array, pandas DataFrame, H2O DataTable's Frame or scipy.sparse
+        data : str, pathlib.Path, numpy array, pandas DataFrame, H2O DataTable's Frame, scipy.sparse, Sequence, list of Sequence or list of numpy array
             Data source for refit.
             If str or pathlib.Path, it represents the path to a text file (CSV, TSV, or LibSVM).
         label : list, numpy 1-D array or pandas Series / one-column DataFrame


### PR DESCRIPTION
Contributes to #3756.

Adds type annotations on `data`, raw data passed to the `Dataset` constructor.

### Notes for Reviewers

I created this based on this docstring:

https://github.com/microsoft/LightGBM/blob/356a7806882c4aed4f54689d5efe29ae05d5bd6f/python-package/lightgbm/basic.py#L850

This added about 30 new `mypy` warnings. I'm proposing fixing those separately from this PR. There is just SIGNIFICANT complexity here given that `data` can be a path to a file, any of several different array libraries' data types, or a `Sequence` object. I think it'll be easier to work on and fix those new `mypy` warnings in smaller pieces after adding these hints.