### PR TITLE
[python-package] [dask] fix mypy errors about Dask fit() return types

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1175,7 +1175,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
         **kwargs: Any
     ) -> "DaskLGBMClassifier":
         """Docstring is inherited from the lightgbm.LGBMClassifier.fit."""
-        return self._lgb_dask_fit(
+        self._lgb_dask_fit(
             model_factory=LGBMClassifier,
             X=X,
             y=y,
@@ -1189,6 +1189,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
             eval_metric=eval_metric,
             **kwargs
         )
+        return self
 
     _base_doc = _lgbmmodel_doc_fit.format(
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",
@@ -1378,7 +1379,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
         **kwargs: Any
     ) -> "DaskLGBMRegressor":
         """Docstring is inherited from the lightgbm.LGBMRegressor.fit."""
-        return self._lgb_dask_fit(
+        self._lgb_dask_fit(
             model_factory=LGBMRegressor,
             X=X,
             y=y,
@@ -1391,6 +1392,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
             eval_metric=eval_metric,
             **kwargs
         )
+        return self
 
     _base_doc = _lgbmmodel_doc_fit.format(
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",
@@ -1550,7 +1552,7 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
         **kwargs: Any
     ) -> "DaskLGBMRanker":
         """Docstring is inherited from the lightgbm.LGBMRanker.fit."""
-        return self._lgb_dask_fit(
+        self._lgb_dask_fit(
             model_factory=LGBMRanker,
             X=X,
             y=y,
@@ -1566,6 +1568,7 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
             eval_at=eval_at,
             **kwargs
         )
+        return self
 
     _base_doc = _lgbmmodel_doc_fit.format(
         X_shape="Dask Array or Dask DataFrame of shape = [n_samples, n_features]",


### PR DESCRIPTION
Contributes to #3867.

Resolves the following `mypy` errors.

```text
python-package/lightgbm/dask.py:1178: error: Incompatible return value type (got "_DaskLGBMModel", expected "DaskLGBMClassifier")  [return-value]
python-package/lightgbm/dask.py:1381: error: Incompatible return value type (got "_DaskLGBMModel", expected "DaskLGBMRegressor")  [return-value]
python-package/lightgbm/dask.py:1553: error: Incompatible return value type (got "_DaskLGBMModel", expected "DaskLGBMRanker")  [return-value]
```

Switches the Dask estimators to returning `self`, so that e.g. `DaskLGBMRegressor.fit()` returns a `DaskLGBMRegressor`. This is useful for other user code and downstream libraries relying on LightGBM, to be able to do `isinstance()` checks and not need to rely on lightgbm-internal details like `_DaskLGBMModel`. It could also be relevant in the future is we add attributes to `DaskLGBMRegressor`, `DaskLGBMClassifier`, or `DaskLGBMRanker` that the other Dask estimators don't have.

It is, by the way, exactly the same approach the `sklearn` estimators use:

https://github.com/microsoft/LightGBM/blob/e666a4b412e00b1f9d8e3639e0896a271c0f0cd9/python-package/lightgbm/sklearn.py#L989-L1024

Related conversation: https://github.com/microsoft/LightGBM/pull/5672#discussion_r1107636706