### PR TITLE
[ci] isolate c_api_test library-loading from Python source tree

### DIFF
--- a/tests/c_api_test/test_.py
+++ b/tests/c_api_test/test_.py
@@ -9,9 +9,9 @@ from scipy import sparse
 try:
     from lightgbm.basic import _LIB as LIB
 except ModuleNotFoundError:
-    print(f"Could not import lightgbm Python package, looking for lib_lightgbm at the repo root")
+    print("Could not import lightgbm Python package, looking for lib_lightgbm at the repo root")
     if system() in ('Windows', 'Microsoft'):
-        lib_file = Path(__file__).absolute().parents[2] / "Release"/ "lib_lightgbm.dll"
+        lib_file = Path(__file__).absolute().parents[2] / "Release" / "lib_lightgbm.dll"
     else:
         lib_file = Path(__file__).absolute().parents[2] / "lib_lightgbm.so"
     LIB = ctypes.cdll.LoadLibrary(lib_file)

--- a/tests/c_api_test/test_.py
+++ b/tests/c_api_test/test_.py
@@ -1,48 +1,20 @@
 # coding: utf-8
 import ctypes
-from os import environ
 from pathlib import Path
 from platform import system
 
 import numpy as np
 from scipy import sparse
 
-
-def find_lib_path():
-    if environ.get('LIGHTGBM_BUILD_DOC', False):
-        # we don't need lib_lightgbm while building docs
-        return []
-
-    curr_path = Path(__file__).absolute().parent
-    dll_path = [curr_path,
-                curr_path.parents[1],
-                curr_path.parents[1] / 'python-package' / 'lightgbm' / 'compile',
-                curr_path.parents[1] / 'python-package' / 'compile',
-                curr_path.parents[1] / 'lib']
+try:
+    from lightgbm.basic import _LIB as LIB
+except ModuleNotFoundError:
+    print(f"Could not import lightgbm Python package, looking for lib_lightgbm at the repo root")
     if system() in ('Windows', 'Microsoft'):
-        dll_path.append(curr_path.parents[1] / 'python-package' / 'compile' / 'Release/')
-        dll_path.append(curr_path.parents[1] / 'python-package' / 'compile' / 'windows' / 'x64' / 'DLL')
-        dll_path.append(curr_path.parents[1] / 'Release')
-        dll_path.append(curr_path.parents[1] / 'windows' / 'x64' / 'DLL')
-        dll_path = [p / 'lib_lightgbm.dll' for p in dll_path]
+        lib_file = Path(__file__).absolute().parents[2] / "Release"/ "lib_lightgbm.dll"
     else:
-        dll_path = [p / 'lib_lightgbm.so' for p in dll_path]
-    lib_path = [str(p) for p in dll_path if p.is_file()]
-    if not lib_path:
-        dll_path_joined = '\n'.join(map(str, dll_path))
-        raise Exception(f'Cannot find lightgbm library file in following paths:\n{dll_path_joined}')
-    return lib_path
-
-
-def LoadDll():
-    lib_path = find_lib_path()
-    if len(lib_path) == 0:
-        return None
-    lib = ctypes.cdll.LoadLibrary(lib_path[0])
-    return lib
-
-
-LIB = LoadDll()
+        lib_file = Path(__file__).absolute().parents[2] / "lib_lightgbm.so"
+    LIB = ctypes.cdll.LoadLibrary(lib_file)
 
 LIB.LGBM_GetLastError.restype = ctypes.c_char_p
 


### PR DESCRIPTION
Contributes to #5061

This repo contains a few tests on LightGBM's C API which are run with `pytest`.

Today, they load `lib_lightgbm.{dll/so}` using a modified copy of the same library-loading code with `ctypes` used in the Python package. LightGBM's CI runs `python setup.py bdist_wheel`, then these C API tests rely on a `lib_lightgbm.{dll/so}` being available in `python-package/compile/`.

https://github.com/microsoft/LightGBM/blob/709ea4cad3ff4c8834bdf389eef8016345d9a1ac/tests/c_api_test/test_.py#L17-L29

This PR proposes removing that reliance on the repo structure + exactly where `lib_lightgbm.so` copies get left behind after building Python wheels.

How does this contribute to #5061? The changes for that (in-progress in #5759) will involve building `lightgbm` wheels in an isolated build directory, which breaks the assumptions in `c_api_test/test_.py` that a `lib_lightgbm` will be left behind in the `python-package/` directory.

### How I tested this

Check that this works with the Python package installed.

```shell
pip uninstall --yes lightgbm
cd python-package/
python setup.py bdist_wheel
pip install dist/*.whl
cd ..
pytest tests/c_api_test
```

Check that it works without the Python package.

```shell
pip uninstall --yes lightgbm
rm -rf ./python-package/build
rm -rf ./python-package/compile
rm -rf ./python-package/dist
mkdir build
cd build
cmake ..
make -j3
cd ..
pytest tests/c_api_test
```
