### PR TITLE
WIP: [python-package] [ci] move some configuration to setup.cfg

### DIFF
--- a/python-package/setup.cfg
+++ b/python-package/setup.cfg
@@ -1,0 +1,20 @@
+[options]
+include_package_data = True
+install_requires =
+    numpy
+    scikit-learn!=0.22.0
+    scipy
+    wheel
+packages = find:
+python_requires = >=3.6
+zip_safe = False
+
+[options.extras_require]
+dask =
+    dask[array]>=2.0.0
+    dask[dataframe]>=2.0.0
+    dask[distributed]>=2.0.0
+    pandas
+
+[options.packages.find]
+where = lightgbm

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -10,7 +10,7 @@ from platform import system
 from shutil import copyfile, copytree, rmtree
 from typing import List, Optional, Union
 
-from setuptools import find_packages, setup
+from setuptools import setup
 from setuptools.command.install import install
 from setuptools.command.install_lib import install_lib
 from setuptools.command.sdist import sdist
@@ -349,32 +349,14 @@ if __name__ == "__main__":
           description='LightGBM Python Package',
           long_description=readme,
           long_description_content_type='text/x-rst',
-          python_requires='>=3.6',
-          install_requires=[
-              'wheel',
-              'numpy',
-              'scipy',
-              'scikit-learn!=0.22.0'
-          ],
-          extras_require={
-              'dask': [
-                  'dask[array]>=2.0.0',
-                  'dask[dataframe]>=2.0.0',
-                  'dask[distributed]>=2.0.0',
-                  'pandas',
-              ],
-          },
           maintainer='Yu Shi',
           maintainer_email='yushi2@microsoft.com',
-          zip_safe=False,
           cmdclass={
               'install': CustomInstall,
               'install_lib': CustomInstallLib,
               'bdist_wheel': CustomBdistWheel,
               'sdist': CustomSdist,
           },
-          packages=find_packages(),
-          include_package_data=True,
           license='The MIT License (Microsoft)',
           url='https://github.com/microsoft/LightGBM',
           classifiers=['Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Contributes to #5061 .
Reduces the number of changes that need to be reviewed when switching build backends for the Python package (work-in-progress in #5759).

This PR proposes moving some configuration for the Python package out of `setup.py` and into a `setup.cfg` file. This moves the project one step closer to having PEP 517 / 518 compliant Python package builds.

For reference, see:

* "Configuring `setuptools` using `setup.cfg` files" ([setuptools docs](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html))
* PEP 517 ([link](https://peps.python.org/pep-0517/), [accepted in September 2017](https://mail.python.org/pipermail/distutils-sig/2017-September/031548.html))
