### PR TITLE
[python-package] drop Python 3.6 support, use dataclasses

### DIFF
--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -3,9 +3,13 @@
 import collections
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 from .basic import Booster, _ConfigAliases, _LGBM_BoosterEvalMethodResultType, _log_info, _log_warning
+
+if TYPE_CHECKING:
+    from .engine import CVBooster
+
 
 __all__ = [
     'early_stopping',
@@ -42,7 +46,7 @@ class EarlyStopException(Exception):
 # Callback environment used by callbacks
 @dataclass
 class CallbackEnv:
-    model: Booster
+    model: Union[Booster, "CVBooster"]
     params: Dict[str, Any]
     iteration: int
     begin_iteration: int

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -1,10 +1,11 @@
 # coding: utf-8
 """Callbacks library."""
 import collections
+from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-from .basic import _ConfigAliases, _LGBM_BoosterEvalMethodResultType, _log_info, _log_warning
+from .basic import Booster, _ConfigAliases, _LGBM_BoosterEvalMethodResultType, _log_info, _log_warning
 
 __all__ = [
     'early_stopping',
@@ -39,14 +40,14 @@ class EarlyStopException(Exception):
 
 
 # Callback environment used by callbacks
-CallbackEnv = collections.namedtuple(
-    "CallbackEnv",
-    ["model",
-     "params",
-     "iteration",
-     "begin_iteration",
-     "end_iteration",
-     "evaluation_result_list"])
+@dataclass
+class CallbackEnv:
+    model: Booster
+    params: Dict[str, Any]
+    iteration: int
+    begin_iteration: int
+    end_iteration: int
+    evaluation_result_list: Optional[List[_LGBM_BoosterEvalMethodResultType]]
 
 
 def _format_eval_result(value: _EvalResultTuple, show_stdv: bool) -> str:

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -42,7 +42,7 @@ _PredictionDtype = Union[Type[np.float32], Type[np.float64], Type[np.int32], Typ
 @dataclass
 class _HostWorkers:
     default: str
-    all_workers: Listr[str]
+    all_workers: List[str]
 
 
 class _DatasetNames(Enum):

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -42,7 +42,7 @@ _PredictionDtype = Union[Type[np.float32], Type[np.float64], Type[np.int32], Typ
 @dataclass
 class _HostWorkers:
     default: str
-    all_workers: str
+    all_workers: Listr[str]
 
 
 class _DatasetNames(Enum):

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -7,8 +7,9 @@ dask.Array and dask.DataFrame collections.
 It is based on dask-lightgbm, which was based on dask-xgboost.
 """
 import socket
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from copy import deepcopy
+from dataclasses import dataclass
 from enum import Enum, auto
 from functools import partial
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
@@ -37,7 +38,11 @@ _DaskVectorLike = Union[dask_Array, dask_Series]
 _DaskPart = Union[np.ndarray, pd_DataFrame, pd_Series, ss.spmatrix]
 _PredictionDtype = Union[Type[np.float32], Type[np.float64], Type[np.int32], Type[np.int64]]
 
-_HostWorkers = namedtuple('_HostWorkers', ['default', 'all'])
+
+@dataclass
+class _HostWorkers:
+    default: str
+    all_workers: str
 
 
 class _DatasetNames(Enum):
@@ -105,9 +110,9 @@ def _group_workers_by_host(worker_addresses: Iterable[str]) -> Dict[str, _HostWo
         if not hostname:
             raise ValueError(f"Could not parse host name from worker address '{address}'")
         if hostname not in host_to_workers:
-            host_to_workers[hostname] = _HostWorkers(default=address, all=[address])
+            host_to_workers[hostname] = _HostWorkers(default=address, all_workers=[address])
         else:
-            host_to_workers[hostname].all.append(address)
+            host_to_workers[hostname].all_workers.append(address)
     return host_to_workers
 
 
@@ -124,7 +129,7 @@ def _assign_open_ports_to_workers(
     """
     host_ports_futures = {}
     for hostname, workers in host_to_workers.items():
-        n_workers_in_host = len(workers.all)
+        n_workers_in_host = len(workers.all_workers)
         host_ports_futures[hostname] = client.submit(
             _find_n_open_ports,
             n=n_workers_in_host,
@@ -135,7 +140,7 @@ def _assign_open_ports_to_workers(
     found_ports = client.gather(host_ports_futures)
     worker_to_port = {}
     for hostname, workers in host_to_workers.items():
-        for worker, port in zip(workers.all, found_ports[hostname]):
+        for worker, port in zip(workers.all_workers, found_ports[hostname]):
             worker_to_port[worker] = port
     return worker_to_port
 

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -349,7 +349,7 @@ if __name__ == "__main__":
           description='LightGBM Python Package',
           long_description=readme,
           long_description_content_type='text/x-rst',
-          python_requires='>=3.6',
+          python_requires='>=3.7',
           install_requires=[
               'wheel',
               'numpy',


### PR DESCRIPTION
Contributes to #3756.
Contributes to #3867.
Inspired by discussions in #5672 (thanks @IdoKendo !).

This PR proposes the following:

* replacing two uses of `collections.namedtuple` in the Python package with `dataclasses.dataclass`
* dropping support for Python 3.6

### Why use `dataclasses`?

`dataclasses` are preferable to `namedtuple` in the following ways:

* easier to set type annotations + default values than named tuples
    - makes it easier for both human developers and and tools like `mypy` to understand the expected types of properties
* possible to attach other methods or computed properties with `@property` (just like normal classes)

### Why drop support for Python 3.6?

`dataclasses` has been a part of the Python standard library since Python 3.7 (https://docs.python.org/3/library/dataclasses.html).

Python 3.6 reached end-of-life (stopped receiving even security fixes) in December 2021 (https://devguide.python.org/versions/).

Most of `lightgbm`'s dependencies dropped Python 3.6 a long time ago, for example:

* `pandas` in August 2020: https://github.com/pandas-dev/pandas/pull/35214
* `dask` and `distributed` in December 2020: https://github.com/dask/community/issues/66
* `numpy` in December 2020: https://github.com/numpy/numpy/pull/17898