### PR TITLE
[python-package] add type hints on sklearn properties

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -534,7 +534,7 @@ class LGBMModel(_LGBMModelBase):
         self._class_map: Optional[Dict[int, int]] = None
         self._n_features: int = -1
         self._n_features_in: int = -1
-        self._classes = None
+        self._classes: Optional[np.ndarray] = None
         self._n_classes: Optional[int] = None
         self.set_params(**kwargs)
 
@@ -952,7 +952,7 @@ class LGBMModel(_LGBMModelBase):
         return self._Booster.current_iteration()  # type: ignore
 
     @property
-    def booster_(self):
+    def booster_(self) -> Booster:
         """Booster: The underlying Booster of this model."""
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError('No booster found. Need to call fit beforehand.')
@@ -966,7 +966,7 @@ class LGBMModel(_LGBMModelBase):
         return self._evals_result
 
     @property
-    def feature_importances_(self):
+    def feature_importances_(self) -> np.ndarray:
         """:obj:`array` of shape = [n_features]: The feature importances (the higher, the more important).
 
         .. note::
@@ -979,8 +979,8 @@ class LGBMModel(_LGBMModelBase):
         return self._Booster.feature_importance(importance_type=self.importance_type)
 
     @property
-    def feature_name_(self):
-        """:obj:`array` of shape = [n_features]: The names of features."""
+    def feature_name_(self) -> List[str]:
+        """:obj:`list` of shape = [n_features]: The names of features."""
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError('No feature_name found. Need to call fit beforehand.')
         return self._Booster.feature_name()
@@ -1195,7 +1195,7 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
     )
 
     @property
-    def classes_(self):
+    def classes_(self) -> np.ndarray:
         """:obj:`array` of shape = [n_classes]: The class label array."""
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError('No classes found. Need to call fit beforehand.')


### PR DESCRIPTION
Contributes to #3756.
Contributes to #3867.

Proposes adding type annotations on the remaining sklearn properties that don't have them.

### Notes for Reviewers

This introduces a few new `mypy` errors, like this:

> python-package/lightgbm/sklearn.py:979: error: Item "None" of "Optional[Booster]" has no attribute "feature_importance"  [union-attr]
python-package/lightgbm/sklearn.py:986: error: Item "None" of "Optional[Booster]" has no attribute "feature_name"  [union-attr]

Those are caused by the fact that some of these attributes are initialized to `None` and we know they'll be non-`None` is `self.__sklearn_is_fitted__()` is `True`...but `mypy` is rightly saying "hey as far as I know, this could be `None` at this point".

I'd like to propose fixes for those in a follow-up PR, so we can continue the conversation from https://github.com/microsoft/LightGBM/pull/4837#discussion_r759757551 there.