### PR TITLE
[python-package] ignore some mypy errors in _DaskLGBMModel

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1034,7 +1034,7 @@ class _DaskLGBMModel:
     def _lgb_dask_getstate(self) -> Dict[Any, Any]:
         """Remove un-picklable attributes before serialization."""
         client = self.__dict__.pop("client", None)
-        self._other_params.pop("client", None)
+        self._other_params.pop("client", None)  # type: ignore[attr-defined]
         out = deepcopy(self.__dict__)
         out.update({"client": None})
         self.client = client
@@ -1063,7 +1063,7 @@ class _DaskLGBMModel:
         if not all((DASK_INSTALLED, PANDAS_INSTALLED, SKLEARN_INSTALLED)):
             raise LightGBMError('dask, pandas and scikit-learn are required for lightgbm.dask')
 
-        params = self.get_params(True)
+        params = self.get_params(True)  # type: ignore[attr-defined]
         params.pop("client", None)
 
         model = _train(
@@ -1086,13 +1086,13 @@ class _DaskLGBMModel:
             **kwargs
         )
 
-        self.set_params(**model.get_params())
-        self._lgb_dask_copy_extra_params(model, self)
+        self.set_params(**model.get_params())  # type: ignore[attr-defined]
+        self._lgb_dask_copy_extra_params(model, self)  # type: ignore[attr-defined]
 
         return self
 
     def _lgb_dask_to_local(self, model_factory: Type[LGBMModel]) -> LGBMModel:
-        params = self.get_params()
+        params = self.get_params()  # type: ignore[attr-defined]
         params.pop("client", None)
         model = model_factory(**params)
         self._lgb_dask_copy_extra_params(self, model)
@@ -1101,7 +1101,7 @@ class _DaskLGBMModel:
 
     @staticmethod
     def _lgb_dask_copy_extra_params(source: Union["_DaskLGBMModel", LGBMModel], dest: Union["_DaskLGBMModel", LGBMModel]) -> None:
-        params = source.get_params()
+        params = source.get_params()  # type: ignore[union-attr]
         attributes = source.__dict__
         extra_param_names = set(attributes.keys()).difference(params.keys())
         for name in extra_param_names:


### PR DESCRIPTION
Contributes to #3867.

Resolves the following `mypy` errors.

```text
python-package/lightgbm/dask.py:1037: error: "_DaskLGBMModel" has no attribute "_other_params"  [attr-defined]
python-package/lightgbm/dask.py:1066: error: "_DaskLGBMModel" has no attribute "get_params"  [attr-defined]
python-package/lightgbm/dask.py:1089: error: "_DaskLGBMModel" has no attribute "set_params"  [attr-defined]
python-package/lightgbm/dask.py:1095: error: "_DaskLGBMModel" has no attribute "get_params"  [attr-defined]
python-package/lightgbm/dask.py:1104: error: Item "_DaskLGBMModel" of "Union[_DaskLGBMModel, LGBMModel]" has no attribute "get_params"  [union-attr]
```

Those errors all come from the fact that `_DaskLGBMModel` is used as a mixin alongside `lightgbm.sklearn.LGBMModel`...

https://github.com/microsoft/LightGBM/blob/1585ee1566631fca55cd3a391074f807b21bf9b5/python-package/lightgbm/dask.py#L1111

... and references methods and attributes that it expects to come from `lightgbm.sklearn.LGBMModel`

https://github.com/microsoft/LightGBM/blob/1585ee1566631fca55cd3a391074f807b21bf9b5/python-package/lightgbm/dask.py#L1098

There is in theory a way to handle this situation with `typing.Protocol` (https://mypy.readthedocs.io/en/stable/more_types.html#mixin-classes), but I couldn't figure it out tonight. So for now, given that these methods are all covered well by the many unit tests, this PR proposes just ignoring these errors from `mypy`.