### PR TITLE
[python-package] fix mypy errors about Dataset.params

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1712,7 +1712,7 @@ class Dataset:
         used_indices: Optional[List[int]]
     ):
         data_has_header = False
-        if isinstance(data, (str, Path)):
+        if isinstance(data, (str, Path)) and self.params is not None:
             # check data has header or not
             data_has_header = any(self.params.get(alias, False) for alias in _ConfigAliases.get("header"))
         num_data = self.num_data()


### PR DESCRIPTION
Contributes to #3756.
Contributes to #3867.

Fixes the following `mypy` error.

```text
python-package/lightgbm/basic.py:1717: error: Item "None" of "Optional[Dict[str, Any]]" has no attribute "get"  [union-attr]
```