### PR TITLE
[python-package] fix mypy error about dask._HostWorkers.__eq__()

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -44,9 +44,10 @@ class _HostWorkers:
         self.default = default
         self.all_workers = all_workers
 
-    def __eq__(self, other: "_HostWorkers") -> bool:
+    def __eq__(self, other: object) -> bool:
         return (
-            self.default == other.default
+            isinstance(other, type(self))
+            and self.default == other.default
             and self.all_workers == other.all_workers
         )
 


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3756.
Contributes to https://github.com/microsoft/LightGBM/issues/3867.

Fixes the following `mypy` error.

```text
python-package/lightgbm/dask.py:47: error: Argument 1 of "__eq__" is incompatible with supertype "object"; supertype defines the argument type as "object"  [override]
python-package/lightgbm/dask.py:47: note: This violates the Liskov substitution principle
python-package/lightgbm/dask.py:47: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
python-package/lightgbm/dask.py:47: note: It is recommended for "__eq__" to work with arbitrary objects, for example:
python-package/lightgbm/dask.py:47: note:     def __eq__(self, other: object) -> bool:
python-package/lightgbm/dask.py:47: note:         if not isinstance(other, _HostWorkers):
python-package/lightgbm/dask.py:47: note:             return NotImplemented
python-package/lightgbm/dask.py:47: note:         return <logic to compare two _HostWorkers instances>
```