### PR TITLE
[python-package] replace uses of scipy.sparse.issparse() with isinstance()

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1011,7 +1011,7 @@ class _InnerPredictor:
             )
         if pred_leaf:
             preds = preds.astype(np.int32)
-        is_sparse = scipy.sparse.issparse(preds) or isinstance(preds, list)
+        is_sparse = isinstance(preds, scipy.sparse.spmatrix) or isinstance(preds, list)
         if not is_sparse and preds.size != nrow:
             if preds.size % nrow == 0:
                 preds = preds.reshape(nrow, -1)
@@ -2749,7 +2749,7 @@ class Dataset:
         if self._need_slice and self.used_indices is not None and self.reference is not None:
             self.data = self.reference.data
             if self.data is not None:
-                if isinstance(self.data, np.ndarray) or scipy.sparse.issparse(self.data):
+                if isinstance(self.data, np.ndarray) or isinstance(self.data, scipy.sparse.spmatrix):
                     self.data = self.data[self.used_indices, :]
                 elif isinstance(self.data, pd_DataFrame):
                     self.data = self.data.iloc[self.used_indices].copy()
@@ -2901,7 +2901,7 @@ class Dataset:
             if isinstance(self.data, np.ndarray):
                 if isinstance(other.data, np.ndarray):
                     self.data = np.hstack((self.data, other.data))
-                elif scipy.sparse.issparse(other.data):
+                elif isinstance(other.data, scipy.sparse.spmatrix):
                     self.data = np.hstack((self.data, other.data.toarray()))
                 elif isinstance(other.data, pd_DataFrame):
                     self.data = np.hstack((self.data, other.data.values))
@@ -2909,9 +2909,9 @@ class Dataset:
                     self.data = np.hstack((self.data, other.data.to_numpy()))
                 else:
                     self.data = None
-            elif scipy.sparse.issparse(self.data):
+            elif isinstance(self.data, scipy.sparse.spmatrix):
                 sparse_format = self.data.getformat()
-                if isinstance(other.data, np.ndarray) or scipy.sparse.issparse(other.data):
+                if isinstance(other.data, np.ndarray) or isinstance(other.data, scipy.sparse.spmatrix):
                     self.data = scipy.sparse.hstack((self.data, other.data), format=sparse_format)
                 elif isinstance(other.data, pd_DataFrame):
                     self.data = scipy.sparse.hstack((self.data, other.data.values), format=sparse_format)
@@ -2927,7 +2927,7 @@ class Dataset:
                 if isinstance(other.data, np.ndarray):
                     self.data = concat((self.data, pd_DataFrame(other.data)),
                                        axis=1, ignore_index=True)
-                elif scipy.sparse.issparse(other.data):
+                elif isinstance(other.data, scipy.sparse.spmatrix):
                     self.data = concat((self.data, pd_DataFrame(other.data.toarray())),
                                        axis=1, ignore_index=True)
                 elif isinstance(other.data, pd_DataFrame):
@@ -2941,7 +2941,7 @@ class Dataset:
             elif isinstance(self.data, dt_DataTable):
                 if isinstance(other.data, np.ndarray):
                     self.data = dt_DataTable(np.hstack((self.data.to_numpy(), other.data)))
-                elif scipy.sparse.issparse(other.data):
+                elif isinstance(other.data, scipy.sparse.spmatrix):
                     self.data = dt_DataTable(np.hstack((self.data.to_numpy(), other.data.toarray())))
                 elif isinstance(other.data, pd_DataFrame):
                     self.data = dt_DataTable(np.hstack((self.data.to_numpy(), other.data.values)))


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3756.
Contributes to https://github.com/microsoft/LightGBM/issues/3867.

Fixes the following `mypy` errors.

```text
python-package/lightgbm/basic.py:2753: error: Value of type "Union[str, Path, ndarray[Any, Any], Any, Any, Any, Sequence, List[Sequence], List[ndarray[Any, Any]]]" is not indexable  [index]
python-package/lightgbm/basic.py:2753: error: No overload variant of "__getitem__" of "list" matches argument type "Tuple[List[int], slice]"  [call-overload]
python-package/lightgbm/basic.py:2753: note: Possible overload variants:
python-package/lightgbm/basic.py:2753: note:     def __getitem__(self, SupportsIndex, /) -> Sequence
python-package/lightgbm/basic.py:2753: note:     def __getitem__(self, slice, /) -> List[Sequence]
python-package/lightgbm/basic.py:2753: note:     def __getitem__(self, SupportsIndex, /) -> ndarray[Any, Any]
python-package/lightgbm/basic.py:2753: note:     def __getitem__(self, slice, /) -> List[ndarray[Any, Any]]
python-package/lightgbm/basic.py:2753: error: Invalid index type "Tuple[List[int], slice]" for "Union[str, Path, ndarray[Any, Any], Any, Any, Any, Sequence, List[Sequence], List[ndarray[Any, Any]]]"; expected type "Union[SupportsIndex, slice]"  [index]
python-package/lightgbm/basic.py:2753: error: Invalid index type "Tuple[List[int], slice]" for "Union[str, Path, ndarray[Any, Any], Any, Any, Any, Sequence, List[Sequence], List[ndarray[Any, Any]]]"; expected type "Union[int, slice, List[int]]"  [index]
python-package/lightgbm/basic.py:2905: error: Item "str" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2905: error: Item "Path" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2905: error: Item "Sequence" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2905: error: Item "List[Sequence]" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2905: error: Item "List[ndarray[Any, Any]]" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2913: error: Item "str" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "getformat"  [union-attr]
python-package/lightgbm/basic.py:2913: error: Item "Path" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "getformat"  [union-attr]
python-package/lightgbm/basic.py:2913: error: Item "Sequence" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "getformat"  [union-attr]
python-package/lightgbm/basic.py:2913: error: Item "List[Sequence]" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "getformat"  [union-attr]
python-package/lightgbm/basic.py:2913: error: Item "List[ndarray[Any, Any]]" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "getformat"  [union-attr]
python-package/lightgbm/basic.py:2931: error: Item "str" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2931: error: Item "Path" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2931: error: Item "Sequence" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2931: error: Item "List[Sequence]" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2931: error: Item "List[ndarray[Any, Any]]" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2945: error: Item "str" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2945: error: Item "Path" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2945: error: Item "Sequence" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2945: error: Item "List[Sequence]" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
python-package/lightgbm/basic.py:2945: error: Item "List[ndarray[Any, Any]]" of "Union[str, Any, Path, Sequence, List[Sequence], List[ndarray[Any, Any]]]" has no attribute "toarray"  [union-attr]
```

Proposes replacing calls like this:

```python
if scipy.sparse.issparse(data): ...
```

with this:

```python
if isinstance(data, scipy.sparse.spmatrix): ...
```

This helps `mypy` to understand branches of logic specific to sparse matrices.

It also protects `lightgbm` users a bit from future changes to `scipy`'s public API.

We aren't getting much from `scipy.sparse.issparse()`.

It's an alias for `scipy.sparse.isspmatrix()` ([code link](https://github.com/scipy/scipy/blob/c0e7fcc4271d5d76f2db6ecf26d314cb99511a9d/scipy/sparse/_base.py#L1331), [docs link](https://github.com/scipy/scipy/blob/c0e7fcc4271d5d76f2db6ecf26d314cb99511a9d/scipy/sparse/_base.py#L1316
)), which just runs `isinstance(x, spmatrix)` ([code link](https://github.com/scipy/scipy/blob/c0e7fcc4271d5d76f2db6ecf26d314cb99511a9d/scipy/sparse/_base.py#L1328)).

There is also a recent, ongoing discussion in `scipy` about possibly changing how these functions handle sparse array (non-matrix) types: https://github.com/scipy/scipy/issues/15790.