### PR TITLE
[python-package] fix mypy error about cpu_count() methods

### DIFF
--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Compatibility library."""
 
-from typing import List
+from typing import List, Optional
 
 """pandas"""
 try:
@@ -183,18 +183,18 @@ except ImportError:
 try:
     from joblib import cpu_count
 
-    def _LGBMCpuCount(only_physical_cores: bool = True):
+    def _LGBMCpuCount(only_physical_cores: bool = True) -> int:
         return cpu_count(only_physical_cores=only_physical_cores)
 except ImportError:
     try:
         from psutil import cpu_count
 
-        def _LGBMCpuCount(only_physical_cores: bool = True):
-            return cpu_count(logical=not only_physical_cores)
+        def _LGBMCpuCount(only_physical_cores: bool = True) -> int:
+            return cpu_count(logical=not only_physical_cores) or 1
     except ImportError:
         from multiprocessing import cpu_count
 
-        def _LGBMCpuCount(only_physical_cores: bool = True):
+        def _LGBMCpuCount(only_physical_cores: bool = True) -> int:
             return cpu_count()
 
 __all__: List[str] = []

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Compatibility library."""
 
-from typing import List, Optional
+from typing import List
 
 """pandas"""
 try:


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3756.
Contributes to https://github.com/microsoft/LightGBM/issues/3867.

Fixes the following `mypy` errors.

```text
python-package/lightgbm/sklearn.py:696: error: Incompatible return value type (got "Union[int, Any, None]", expected "int")  [return-value]
```

`lightgbm` tries a few different approaches to determine the number of phyiscal/logical CPUs based on conditional imports. Adding type hints explicitly telling `mypy` that those methods will return integers resolves this issue.

In this case, `mypy` caught a legitimate possible source of bugs 🎉 

If `joblib.cpu_count` can't be imported but `psutil.cpu_count` can, `psutil.cpu_count()` is used to determine the number of available CPUs.

According to the docs at https://psutil.readthedocs.io/en/latest/#psutil.cpu_count, that function returns `None` if it can't determine the number of CPUs. That's problematic because the result of that function is used unconditionally as if it was an integer:

https://github.com/microsoft/LightGBM/blob/881106311557187a1fea2ec90c234f71771a32d8/python-package/lightgbm/sklearn.py#L695

```python
None + 1 - 1
# TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```

To deal with that, this PR proposes falling back to a value of `1` if `psutil.cpu_count()` returns `None`. That might mean that the user's physical resources are underutilized, but that's better than a runtime error.

### The other two methods can't return `None`?

Right.

`joblib.cpu_count()` calls `loky.cpu_count()` ([code link](https://github.com/joblib/joblib/blob/df122868c0a27cd4f47a1d8f8e398c0d3cc3c907/joblib/parallel.py#L322)). I'm not 100% sure, but looks to me like like `loky.cpu_count()` cannot return `None` based on the code paths at https://github.com/joblib/loky/blob/047d80623b7cf2d43500ed56ee0320b3e41c3f81/loky/backend/context.py#L77.

`multiprocessing.cpu_count()` raises a `NotImplementedError` if it can't figure out the number of CPUs: https://docs.python.org/3/library/multiprocessing.html#multiprocessing.cpu_count.