### PR TITLE
[python-package] add hint on dtypes in Dataset.set_field()

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2356,6 +2356,7 @@ class Dataset:
                 ctypes.c_int(0),
                 ctypes.c_int(_FIELD_TYPE_MAPPER[field_name])))
             return self
+        dtype: "np.typing.DTypeLike"
         if field_name == 'init_score':
             dtype = np.float64
             if _is_1d_collection(data):


### PR DESCRIPTION
Contributes to #3867.

Fixes the following `mypy` error.

```text
python-package/lightgbm/basic.py:2372: error: Incompatible types in assignment (expression has type "Type[number[Any]]", variable has type "Type[floating[Any]]")  [assignment]
```