### PR TITLE
[python-package] fix mypy errors about scikit-learn properties

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -921,7 +921,7 @@ def _predict(
     elif isinstance(data, dask_Array):
         # for multi-class classification with sparse matrices, pred_contrib predictions
         # are returned as a list of sparse matrices (one per class)
-        num_classes = model._n_classes or -1
+        num_classes = model._n_classes
 
         if (
             num_classes > 2

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -882,7 +882,7 @@ class LGBMModel(_LGBMModelBase):
         predict_params["num_threads"] = self._process_n_jobs(predict_params["num_threads"])
 
         return self._Booster.predict(  # type: ignore[union-attr]
-            X,raw_score=raw_score, start_iteration=start_iteration, num_iteration=num_iteration,
+            X, raw_score=raw_score, start_iteration=start_iteration, num_iteration=num_iteration,
             pred_leaf=pred_leaf, pred_contrib=pred_contrib, validate_features=validate_features,
             **predict_params
         )


### PR DESCRIPTION
Contributes to #3867 .
Follow-up to #5771.

Fixes the following errors from `mypy`.

```text
python-package/lightgbm/sklearn.py:884: error: Item "None" of "Optional[Booster]" has no attribute "predict"  [union-attr]
python-package/lightgbm/sklearn.py:959: error: Incompatible return value type (got "Optional[Booster]", expected "Booster")  [return-value]
python-package/lightgbm/sklearn.py:979: error: Item "None" of "Optional[Booster]" has no attribute "feature_importance"  [union-attr]
python-package/lightgbm/sklearn.py:986: error: Item "None" of "Optional[Booster]" has no attribute "feature_name"  [union-attr]
python-package/lightgbm/sklearn.py:1065: error: Argument 1 to "len" has incompatible type "Optional[ndarray[Any, Any]]"; expected "Sized"  [arg-type]
python-package/lightgbm/sklearn.py:1183: error: Unsupported operand types for < ("int" and "None")  [operator]
python-package/lightgbm/sklearn.py:1183: note: Left operand is of type "Optional[int]"
python-package/lightgbm/sklearn.py:1202: error: Incompatible return value type (got "Optional[ndarray[Any, Any]]", expected "ndarray[Any, Any]")  [return-value]
python-package/lightgbm/sklearn.py:1209: error: Incompatible return value type (got "Optional[int]", expected "int")  [return-value]
```

These all come from the fact that some internal state in the `scikit-learn` estimators is initialized to `None`, like this:

https://github.com/microsoft/LightGBM/blob/881106311557187a1fea2ec90c234f71771a32d8/python-package/lightgbm/sklearn.py#L537

and then later returned as public properties:

https://github.com/microsoft/LightGBM/blob/881106311557187a1fea2ec90c234f71771a32d8/python-package/lightgbm/sklearn.py#L1197-L1202

After a model has been fit, such properties are expected to be non-`None`. And the `if not self.__sklearn_is_fitted__()` is intended to prevent returning that internal state from an unfitted model.

If we're going to stick with the decision from https://github.com/microsoft/LightGBM/pull/4837#discussion_r759757551 to not help `mypy` understand this relationship by adding `assert` statements or additional checks, then I think the only remaining option is to ignore these `mypy` errors with `#type: ignore` comments.

This PR proposes doing that for most of the properties.

The only exception... this PR proposes initializing `LGBMClassifier._n_classes = -1` instead of `None`. That ensures that `self._n_classes` is always an integer.