### PR TITLE
remove unused variables from bin.cpp

### DIFF
--- a/src/io/bin.cpp
+++ b/src/io/bin.cpp
@@ -160,20 +160,6 @@ namespace LightGBM {
                                                const std::vector<double>& forced_upper_bounds) {
     std::vector<double> bin_upper_bound;
 
-    // get list of distinct values
-    int left_cnt_data = 0;
-    int cnt_zero = 0;
-    int right_cnt_data = 0;
-    for (int i = 0; i < num_distinct_values; ++i) {
-      if (distinct_values[i] <= -kZeroThreshold) {
-        left_cnt_data += counts[i];
-      } else if (distinct_values[i] > kZeroThreshold) {
-        right_cnt_data += counts[i];
-      } else {
-        cnt_zero += counts[i];
-      }
-    }
-
     // get number of positive and negative distinct values
     int left_cnt = -1;
     for (int i = 0; i < num_distinct_values; ++i) {


### PR DESCRIPTION
Removes unused variables from `bin.cpp`. Addresses the following warnings:
```
io/bin.cpp:165:9: warning: variable 'cnt_zero' set but not used [-Wunused-but-set-variable]
    int cnt_zero = 0;
        ^
io/bin.cpp:164:9: warning: variable 'left_cnt_data' set but not used [-Wunused-but-set-variable]
    int left_cnt_data = 0;
        ^
io/bin.cpp:166:9: warning: variable 'right_cnt_data' set but not used [-Wunused-but-set-variable]
    int right_cnt_data = 0;
        ^
```
[Sample logs](https://github.com/microsoft/LightGBM/actions/runs/4439686426/jobs/7792502161#step:8:500)