### PR TITLE
[python-package] [docs] complete type annotations for scikit-learn fit() methods

### DIFF
--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -10,7 +10,7 @@ import scipy.sparse
 
 from .basic import (Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _LGBM_BoosterBestScoreType,
                     _LGBM_CategoricalFeatureConfiguration, _LGBM_EvalFunctionResultType, _LGBM_FeatureNameConfiguration,
-                    _LGBM_GroupType, _LGBM_LabelType, _log_warning)
+                    _LGBM_GroupType, _LGBM_LabelType, _LGBM_WeightType, _LGBM_InitScoreType, _log_warning)
 from .callback import _EvalResultDict, record_evaluation
 from .compat import (SKLEARN_INSTALLED, LGBMNotFittedError, _LGBMAssertAllFinite, _LGBMCheckArray,
                      _LGBMCheckClassificationTargets, _LGBMCheckSampleWeight, _LGBMCheckXY, _LGBMClassifierBase,
@@ -83,6 +83,7 @@ _LGBM_ScikitEvalMetricType = Union[
     _LGBM_ScikitCustomEvalFunction,
     List[Union[str, _LGBM_ScikitCustomEvalFunction]]
 ]
+_LGBM_ScikitValidSet = Tuple[_LGBM_ScikitMatrixLike, _LGBM_LabelType]
 
 
 class _ObjectiveFunctionWrapper:
@@ -725,15 +726,15 @@ class LGBMModel(_LGBMModelBase):
         self,
         X: _LGBM_ScikitMatrixLike,
         y: _LGBM_LabelType,
-        sample_weight=None,
-        init_score=None,
+        sample_weight: Optional[_LGBM_WeightType] = None,
+        init_score: Optional[_LGBM_InitScoreType] = None,
         group: Optional[_LGBM_GroupType] = None,
-        eval_set=None,
+        eval_set: Optional[List[_LGBM_ScikitValidSet]] = None,
         eval_names: Optional[List[str]] = None,
-        eval_sample_weight=None,
-        eval_class_weight=None,
-        eval_init_score=None,
-        eval_group=None,
+        eval_sample_weight: Optional[List[_LGBM_WeightType]] = None,
+        eval_class_weight: Optional[List[float]] = None,
+        eval_init_score: Optional[List[_LGBM_InitScoreType]] = None,
+        eval_group: Optional[List[_LGBM_GroupType]] = None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
         feature_name: _LGBM_FeatureNameConfiguration = 'auto',
         categorical_feature: _LGBM_CategoricalFeatureConfiguration = 'auto',
@@ -857,12 +858,12 @@ class LGBMModel(_LGBMModelBase):
     fit.__doc__ = _lgbmmodel_doc_fit.format(
         X_shape="numpy array, pandas DataFrame, H2O DataTable's Frame , scipy.sparse, list of lists of int or float of shape = [n_samples, n_features]",
         y_shape="numpy array, pandas DataFrame, pandas Series, list of int or float of shape = [n_samples]",
-        sample_weight_shape="array-like of shape = [n_samples] or None, optional (default=None)",
-        init_score_shape="array-like of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task) or shape = [n_samples, n_classes] (for multi-class task) or None, optional (default=None)",
+        sample_weight_shape="numpy array, pandas Series, list of int or float of shape = [n_samples] or None, optional (default=None)",
+        init_score_shape="numpy array, pandas DataFrame, pandas Series, list of int or float of shape = [n_samples] or shape = [n_samples * n_classes] (for multi-class task) or shape = [n_samples, n_classes] (for multi-class task) or None, optional (default=None)",
         group_shape="numpy array, pandas Series, list of int or float, or None, optional (default=None)",
-        eval_sample_weight_shape="list of array, or None, optional (default=None)",
-        eval_init_score_shape="list of array, or None, optional (default=None)",
-        eval_group_shape="list of array, or None, optional (default=None)"
+        eval_sample_weight_shape="list of array (same types as ``sample_weight`` supports), or None, optional (default=None)",
+        eval_init_score_shape="list of array (same types as ``init_score`` supports), or None, optional (default=None)",
+        eval_group_shape="list of array (same types as ``group`` supports), or None, optional (default=None)"
     ) + "\n\n" + _lgbmmodel_doc_custom_eval_note
 
     def predict(
@@ -1021,12 +1022,12 @@ class LGBMRegressor(_LGBMRegressorBase, LGBMModel):
         self,
         X: _LGBM_ScikitMatrixLike,
         y: _LGBM_LabelType,
-        sample_weight=None,
-        init_score=None,
-        eval_set=None,
+        sample_weight: Optional[_LGBM_WeightType] = None,
+        init_score: Optional[_LGBM_InitScoreType] = None,
+        eval_set: Optional[List[_LGBM_ScikitValidSet]] = None,
         eval_names: Optional[List[str]] = None,
-        eval_sample_weight=None,
-        eval_init_score=None,
+        eval_sample_weight: Optional[List[_LGBM_WeightType]] = None,
+        eval_init_score: Optional[List[_LGBM_InitScoreType]] = None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
         feature_name: _LGBM_FeatureNameConfiguration = 'auto',
         categorical_feature: _LGBM_CategoricalFeatureConfiguration = 'auto',
@@ -1067,13 +1068,13 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
         self,
         X: _LGBM_ScikitMatrixLike,
         y: _LGBM_LabelType,
-        sample_weight=None,
-        init_score=None,
-        eval_set=None,
+        sample_weight: Optional[_LGBM_WeightType] = None,
+        init_score: Optional[_LGBM_InitScoreType] = None,
+        eval_set: Optional[List[_LGBM_ScikitValidSet]] = None,
         eval_names: Optional[List[str]] = None,
-        eval_sample_weight=None,
-        eval_class_weight=None,
-        eval_init_score=None,
+        eval_sample_weight: Optional[List[_LGBM_WeightType]] = None,
+        eval_class_weight: Optional[List[float]] = None,
+        eval_init_score: Optional[List[_LGBM_InitScoreType]] = None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
         feature_name: _LGBM_FeatureNameConfiguration = 'auto',
         categorical_feature: _LGBM_CategoricalFeatureConfiguration = 'auto',
@@ -1116,7 +1117,7 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
             eval_metric = eval_metric_list
 
         # do not modify args, as it causes errors in model selection tools
-        valid_sets: Optional[List[Tuple]] = None
+        valid_sets: Optional[List[_LGBM_ScikitValidSet]] = None
         if eval_set is not None:
             if isinstance(eval_set, tuple):
                 eval_set = [eval_set]
@@ -1251,14 +1252,14 @@ class LGBMRanker(LGBMModel):
         self,
         X: _LGBM_ScikitMatrixLike,
         y: _LGBM_LabelType,
-        sample_weight=None,
-        init_score=None,
+        sample_weight: Optional[_LGBM_WeightType] = None,
+        init_score: Optional[_LGBM_InitScoreType] = None,
         group: Optional[_LGBM_GroupType] = None,
-        eval_set=None,
+        eval_set: Optional[List[_LGBM_ScikitValidSet]] = None,
         eval_names: Optional[List[str]] = None,
-        eval_sample_weight=None,
-        eval_init_score=None,
-        eval_group=None,
+        eval_sample_weight: Optional[List[_LGBM_WeightType]] = None,
+        eval_init_score: Optional[List[_LGBM_InitScoreType]] = None,
+        eval_group: Optional[List[_LGBM_GroupType]] = None,
         eval_metric: Optional[_LGBM_ScikitEvalMetricType] = None,
         eval_at: Union[List[int], Tuple[int, ...]] = (1, 2, 3, 4, 5),
         feature_name: _LGBM_FeatureNameConfiguration = 'auto',

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -10,7 +10,7 @@ import scipy.sparse
 
 from .basic import (Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _LGBM_BoosterBestScoreType,
                     _LGBM_CategoricalFeatureConfiguration, _LGBM_EvalFunctionResultType, _LGBM_FeatureNameConfiguration,
-                    _LGBM_GroupType, _LGBM_LabelType, _LGBM_WeightType, _LGBM_InitScoreType, _log_warning)
+                    _LGBM_GroupType, _LGBM_InitScoreType, _LGBM_LabelType, _LGBM_WeightType, _log_warning)
 from .callback import _EvalResultDict, record_evaluation
 from .compat import (SKLEARN_INSTALLED, LGBMNotFittedError, _LGBMAssertAllFinite, _LGBMCheckArray,
                      _LGBMCheckClassificationTargets, _LGBMCheckSampleWeight, _LGBMCheckXY, _LGBMClassifierBase,

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1416,7 +1416,7 @@ def test_classification_and_regression_minimally_work_with_all_all_accepted_data
         pytest.skip('pandas is not installed')
     if any(t.startswith("dt_") for t in [X_type, y_type]) and not DATATABLE_INSTALLED:
         pytest.skip('datatable is not installed')
-    X, y, g = _create_data(task, n_samples=1_000)
+    X, y, g = _create_data(task, n_samples=2_000)
     weights = np.abs(np.random.randn(y.shape[0]))
 
     if task == 'binary-classification' or task == 'regression':

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1440,6 +1440,8 @@ def test_classification_and_regression_minimally_work_with_all_all_accepted_data
     elif X_type != 'numpy':
         raise ValueError(f"Unrecognized X_type: '{X_type}'")
 
+    # make weights and init_score same types as y, just to avoid
+    # a huge number of combinations and therefore test cases
     if y_type == 'list1d':
         y = y.tolist()
         weights = weights.tolist()
@@ -1483,7 +1485,6 @@ def test_classification_and_regression_minimally_work_with_all_all_accepted_data
         raise ValueError(f"Unrecognized task: '{task}'")
 
 
-# NOTE: 'same_as_g' below just to reduce the number of distinct combinations and therefore test cases
 @pytest.mark.parametrize('X_type', ['dt_DataTable', 'list2d', 'numpy', 'scipy_csc', 'scipy_csr', 'pd_DataFrame'])
 @pytest.mark.parametrize('y_type', ['list1d', 'numpy', 'pd_DataFrame', 'pd_Series'])
 @pytest.mark.parametrize('g_type', ['list1d_float', 'list1d_int', 'numpy', 'pd_Series'])
@@ -1510,29 +1511,29 @@ def test_ranking_minimally_works_with_all_all_accepted_data_types(X_type, y_type
     elif X_type != 'numpy':
         raise ValueError(f"Unrecognized X_type: '{X_type}'")
 
+    # make weights and init_score same types as y, just to avoid
+    # a huge number of combinations and therefore test cases
     if y_type == 'list1d':
         y = y.tolist()
+        weights = weights.tolist()
+        init_score = init_score.tolist()
     elif y_type == 'pd_DataFrame':
         y = pd_DataFrame(y)
+        weights = pd_Series(weights)
+        init_score = pd_Series(init_score)
     elif y_type == 'pd_Series':
         y = pd_Series(y)
+        weights = pd_Series(weights)
+        init_score = pd_Series(init_score)
     elif y_type != 'numpy':
         raise ValueError(f"Unrecognized y_type: '{y_type}'")
 
-    # make weights and init_score same types as group, just to avoid
-    # a huge number of combinations and therefore test cases
     if g_type == 'list1d_float':
         g = g.astype("float").tolist()
-        weights = weights.astype("float").tolist()
-        init_score = init_score.astype("float").tolist()
     elif g_type == 'list1d_int':
         g = g.astype("int").tolist()
-        weights = weights.astype("int").tolist()
-        init_score = init_score.astype("int").tolist()
     elif g_type == 'pd_Series':
         g = pd_Series(g)
-        weights = pd_Series(weights)
-        init_score = pd_Series(init_score)
     elif g_type != 'numpy':
         raise ValueError(f"Unrecognized g_type: '{g_type}'")
 


### PR DESCRIPTION
Contributes to #3756.
Follow-up to #5757.

Adds type annotations on all remaining arguments to `fit()` methods in the scikit-learn interface.

Replaces all remaining uses of "array" or "array-like" in `fit()` docs with specific types, following @StrikerRUS 's suggestion from https://github.com/microsoft/LightGBM/issues/3756#issuecomment-907622141.

This will hopefully make the docs a bit clearer for users, the code a bit easier to understand for contributors, and will improve `mypy`'s ability to catch type issues (both in this project and in upstream projects that depend on `lightgbm`).

### How I tested this

Added additional test cases in `test_sklearn.py` adding some other data types for `init_score`, `sample_weight`, and all the `eval_*` equivalents. Those tests don't cover every possible combination of all types for all arguments (that would be literally 1000s of tests), but every type in these type annotations is covered at least once by a test.

e.g., there isn't a "`y` is a list and `init_score` is a numpy array" test, but there is at least one "`y` is a list" test and at least one "`init_score` is a numpy array" test.

I also ran `mypy` to confirm that this PR does not add any new type-checking errors.