### PR TITLE
[gpu] modify histogram construction (fixes #4946)

### DIFF
--- a/src/treelearner/ocl/histogram256.cl
+++ b/src/treelearner/ocl/histogram256.cl
@@ -334,7 +334,7 @@ __kernel void histogram256(__global const uchar4* feature_data_base,
                       const data_size_t feature_size,
                       __global const data_size_t* data_indices, 
                       const data_size_t num_data, 
-                      __global const score_t*  ordered_gradients, 
+                      __global const * ordered_gradients, 
 #if CONST_HESSIAN == 0
                       __global const score_t*  ordered_hessians,
 #else


### PR DESCRIPTION
fixes #4946

## Reason for Change:

when the X_train is more than (1800w, 1000), lgb-gpu will has a bug like this:
[LightGBM] [Fatal] Check failed: (best_split_info.left_count) > (0) at LightGBM/src/treelearner/serial_tree_learner.app, line 686

## Solution:

I was able to successfully run a large dataset with a change to src/treelearner/ocl/histogram256.cl. I

This function is defined as the following (with #ifdef constants removed for this post for clarity)

__kernel void histogram256(
__global const uchar4* feature_data_base,
__constant const uchar4* restrict feature_masks attribute((max_constant_size(65536))),
const data_size_t feature_size,
__global const data_size_t* data_indices,
const data_size_t num_data,
const score_t const_hessian,
__global const score_t* ordered_gradients, // <----- change to : __global const * ordered_gradients
__global char* restrict output_buf,
__global volatile int * sync_counters,
__global acc_type* restrict hist_buf_base
)
However, if you redefine ordered_gradients as __global const * ordered_gradients, the context will fill in the type, and the large training set runs. At first, I thought score_t was defined differently in the OpenCL code and C++, but I verified that they are both floats.
In order to validate the results. I ran two smaller dummy datasets with ordered_gradients defined explicitly and not. I compared the resulting model files and found that they were the same.

It's not yet clear to me why the change allows the program to finish I suspect there must be some type of difference.  Any ideas would be welcome.