### PR TITLE
[ci] remove pin on tinytex in R CI jobs

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # set up R environment
-CRAN_MIRROR="https://cran.r-project.org"
+CRAN_MIRROR="https://cran.rstudio.com"
 R_LIB_PATH=~/Rlib
 mkdir -p $R_LIB_PATH
 export R_LIBS=$R_LIB_PATH
@@ -116,6 +116,12 @@ if [[ $OS_NAME == "macos" ]]; then
             "$(brew --cellar libomp)"/*/lib/libomp.dylib \
             /Library/Frameworks/R.framework/Versions/${R_MAJOR_MINOR}/Resources/lib/libomp.dylib
     fi
+fi
+
+# fix for issue where CRAN was not returning {lattice} when using R 3.6
+# "Warning: dependency ‘lattice’ is not available"
+if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
+    Rscript --vanilla -e "install.packages('lattice', repos = 'https://mran.microsoft.com', lib = '${R_LIB_PATH}')"
 fi
 
 # Manually install Depends and Imports libraries + 'knitr', 'RhpcBLASctl', 'rmarkdown', 'testthat'

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # set up R environment
-CRAN_MIRROR="https://cran.rstudio.com"
+CRAN_MIRROR="https://cran.r-project.org"
 R_LIB_PATH=~/Rlib
 mkdir -p $R_LIB_PATH
 export R_LIBS=$R_LIB_PATH

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -197,9 +197,6 @@ jobs:
         env:
           CTAN_MIRROR: https://ctan.math.illinois.edu/systems/win32/miktex
           TINYTEX_INSTALLER: TinyTeX
-          # pinning to an old version to address breaking changes to paths not being available yet
-          # (ref: https://github.com/r-lib/actions/issues/713#issuecomment-1481293175)
-          TINYTEX_VERSION: '2023.03'
       - name: Setup and run tests on Linux and macOS
         if: matrix.os == 'macOS-latest' || matrix.os == 'ubuntu-latest'
         shell: bash


### PR DESCRIPTION
Reverts part of #5807.

Windows R jobs are failing on `master` with the same error as reported in #5802.

I suspect the root cause is that the changes from https://github.com/r-lib/actions/pull/712 have now made it into `v2` of the `r-lib/setup-tinytex` action.