### PR TITLE
[ci] [dask] fix mypy errors about predict() signature

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1235,7 +1235,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
 
     def predict(
         self,
-        X: _DaskMatrixLike,
+        X: _DaskMatrixLike,  # type: ignore[override]
         raw_score: bool = False,
         start_iteration: int = 0,
         num_iteration: Optional[int] = None,
@@ -1270,7 +1270,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
 
     def predict_proba(
         self,
-        X: _DaskMatrixLike,
+        X: _DaskMatrixLike,  # type: ignore[override]
         raw_score: bool = False,
         start_iteration: int = 0,
         num_iteration: Optional[int] = None,
@@ -1441,7 +1441,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
 
     def predict(
         self,
-        X: _DaskMatrixLike,
+        X: _DaskMatrixLike,  # type: ignore[override]
         raw_score: bool = False,
         start_iteration: int = 0,
         num_iteration: Optional[int] = None,
@@ -1616,7 +1616,7 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
 
     def predict(
         self,
-        X: _DaskMatrixLike,
+        X: _DaskMatrixLike,  # type: ignore[override]
         raw_score: bool = False,
         start_iteration: int = 0,
         num_iteration: Optional[int] = None,


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3867 .

Fixes the following `mypy` errors.

```text
-python-package/lightgbm/dask.py:1238: error: Argument 1 of "predict" is incompatible with supertype "LGBMClassifier"; supertype defines the argument type as "Union[Any, List[Union[List[float], List[int]]], ndarray[Any, Any], Any, Any]"  [override]
-python-package/lightgbm/dask.py:1238: note: This violates the Liskov substitution principle
-python-package/lightgbm/dask.py:1238: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-python-package/lightgbm/dask.py:1238: error: Argument 1 of "predict" is incompatible with supertype "LGBMModel"; supertype defines the argument type as "Union[Any, List[Union[List[float], List[int]]], ndarray[Any, Any], Any, Any]"  [override]
-python-package/lightgbm/dask.py:1273: error: Argument 1 of "predict_proba" is incompatible with supertype "LGBMClassifier"; supertype defines the argument type as "Union[Any, List[Union[List[float], List[int]]], ndarray[Any, Any], Any, Any]"  [override]
-python-package/lightgbm/dask.py:1273: note: This violates the Liskov substitution principle
-python-package/lightgbm/dask.py:1273: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-python-package/lightgbm/dask.py:1444: error: Argument 1 of "predict" is incompatible with supertype "LGBMModel"; supertype defines the argument type as "Union[Any, List[Union[List[float], List[int]]], ndarray[Any, Any], Any, Any]"  [override]
-python-package/lightgbm/dask.py:1444: note: This violates the Liskov substitution principle
-python-package/lightgbm/dask.py:1444: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-python-package/lightgbm/dask.py:1619: error: Argument 1 of "predict" is incompatible with supertype "LGBMModel"; supertype defines the argument type as "Union[Any, List[Union[List[float], List[int]]], ndarray[Any, Any], Any, Any]"  [override]
-python-package/lightgbm/dask.py:1619: note: This violates the Liskov substitution principle
-python-package/lightgbm/dask.py:1619: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
```

This proposes just ignoring those with `# type: ignore` comments. It's intentional that the Dask estimators accept Dask collections for arguments that the scikit-learn estimators accept `pandas`, `numpy`, and `scipy` inputs for.