### PR TITLE
[ci] [python-package] fix mypy errors in cv()

### DIFF
--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -732,8 +732,8 @@ def cv(
                                     begin_iteration=0,
                                     end_iteration=num_boost_round,
                                     evaluation_result_list=None))
-        cvfolds.update(fobj=fobj)
-        res = _agg_cv_result(cvfolds.eval_valid(feval))
+        cvfolds.update(fobj=fobj)  # type: ignore[call-arg]
+        res = _agg_cv_result(cvfolds.eval_valid(feval))  # type: ignore[call-arg]
         for _, key, mean, _, std in res:
             results[f'{key}-mean'].append(mean)
             results[f'{key}-stdv'].append(std)


### PR DESCRIPTION
Contributes to #3867.

Fixes the following errors from `mypy`.

```text
python-package/lightgbm/engine.py:735: error: Unexpected keyword argument "fobj"  [call-arg]
python-package/lightgbm/engine.py:736: error: Too few arguments  [call-arg]
```

I think the way that `CVBooster` customizes `__getattr__()` is just too much dynamic stuff for `mypy` to cleanly resolve.

https://github.com/microsoft/LightGBM/blob/638014d5c56fb92396bd55f344a47e3f651a3cd4/python-package/lightgbm/engine.py#L344-L352

I'm confident in just ignoring these with `#type: ignore` comments because this code is well-covered by tests.