### PR TITLE
Add SWIG byte pointers

### DIFF
--- a/swig/pointer_manipulation.i
+++ b/swig/pointer_manipulation.i
@@ -15,6 +15,7 @@
  * to arrays of size max(int64_t) instead of max(int32_t).
  */
 
+%pointer_functions(uint8_t, bytep)
 %pointer_functions(int, intp)
 %pointer_functions(long, longp)
 %pointer_functions(double, doublep)
@@ -33,6 +34,7 @@
 %pointer_cast(double *, void *, double_to_voidp_ptr)
 %pointer_cast(float *, void *, float_to_voidp_ptr)
 %pointer_cast(int *, void *, int_to_voidp_ptr)
+%pointer_cast(uint8_t *, void *, byte_to_voidp_ptr)
 %pointer_cast(int32_t *, void *, int32_t_to_voidp_ptr)
 %pointer_cast(int64_t *, void *, int64_t_to_voidp_ptr)
 


### PR DESCRIPTION
Some recent changed were made to use serialized datasets as byte arrays, but there aren't equivalent SWIG pointers.