### PR TITLE
[python-package] fix mypy error about used_indices in Dataset.subset()

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1736,7 +1736,7 @@ class Dataset:
         self,
         predictor: Optional[_InnerPredictor],
         data: _LGBM_TrainDataType,
-        used_indices: Optional[List[int]]
+        used_indices: Optional[Union[List[int], np.ndarray]]
     ) -> "Dataset":
         data_has_header = False
         if isinstance(data, (str, Path)) and self.params is not None:


### PR DESCRIPTION
Contributes to #3756.
Contributes to #3867.

Fixes the following `mypy` error.

```text
python-package/lightgbm/basic.py:2200: error: Argument "used_indices" to "_set_init_score_by_predictor" of "Dataset" has incompatible type "ndarray[Any, Any]"; expected "Optional[List[int]]"  [arg-type]
```

`Dataset._set_init_score_by_predictor()` is passed a 1-dimensional `numpy` array here:

https://github.com/microsoft/LightGBM/blob/ffb298626e131b9d213b34b3655846be441fdc12/python-package/lightgbm/basic.py#L2175

https://github.com/microsoft/LightGBM/blob/ffb298626e131b9d213b34b3655846be441fdc12/python-package/lightgbm/basic.py#L2197-L2201

And is able to work with it, since the code in that method only does positional subsetting and not any array-specific or list-specific operations. 