### PR TITLE
[ci] put a temporary ceiling on pip

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -184,6 +184,12 @@ fi
 
 mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build
 
+# temporarily pin pip to versions that support 'pip install --install-option'
+# ref: https://github.com/microsoft/LightGBM/issues/5061#issuecomment-1510642287
+if [[ $METHOD == "pip" ]]; then
+    pip install 'pip<23.1'
+fi
+
 if [[ $TASK == "gpu" ]]; then
     sed -i'.bak' 's/std::string device_type = "cpu";/std::string device_type = "gpu";/' $BUILD_DIRECTORY/include/LightGBM/config.h
     grep -q 'std::string device_type = "gpu"' $BUILD_DIRECTORY/include/LightGBM/config.h || exit -1  # make sure that changes were really done


### PR DESCRIPTION
Proposes temporarily pinning `pip` to `<23.1` in CI, to work around this error: https://github.com/microsoft/LightGBM/issues/5061#issuecomment-1510642287

```text
no such option: --install-option
```

`pip` dropped support for `pip install --install-option` in its most recent release: https://pip.pypa.io/en/stable/news/.

### Notes for Reviewers

We can hopefully revert this shortly after the work for #5061 is done.