### PR TITLE
[ci] [python-package] replace 'python setup.py' with a shell script

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ clone_depth: 5
 
 install:
   - git submodule update --init --recursive  # get `external_libs` folder
-  - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%  # delete sh.exe from PATH (mingw32-make fix)
+  #- set PATH=%PATH:C:\Program Files\Git\usr\bin;=%  # delete sh.exe from PATH (mingw32-make fix)
   - set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH%
   - set PYTHON_VERSION=%CONFIGURATION%
   - set CONDA_ENV="test-env"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,8 +14,8 @@ branches:
 
 environment:
   matrix:
-    # - COMPILER: MSVC
-    #   TASK: python
+    - COMPILER: MSVC
+      TASK: python
     - COMPILER: MINGW
       TASK: python
 
@@ -23,7 +23,6 @@ clone_depth: 5
 
 install:
   - git submodule update --init --recursive  # get `external_libs` folder
-  #- set PATH=%PATH:C:\Program Files\Git\usr\bin;=%  # delete sh.exe from PATH (mingw32-make fix)
   - set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH%
   - set PYTHON_VERSION=%CONFIGURATION%
   - set CONDA_ENV="test-env"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,8 +14,8 @@ branches:
 
 environment:
   matrix:
-    - COMPILER: MSVC
-      TASK: python
+    # - COMPILER: MSVC
+    #   TASK: python
     - COMPILER: MINGW
       TASK: python
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -146,19 +146,21 @@ if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
 fi
 
 if [[ $TASK == "sdist" ]]; then
-    cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
-    sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
-    pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v || exit -1
+    cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit -1
+    sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+    pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz -v || exit -1
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
-        cp $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz $BUILD_ARTIFACTSTAGINGDIRECTORY
+        cp $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz $BUILD_ARTIFACTSTAGINGDIRECTORY
     fi
     pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
     exit 0
 elif [[ $TASK == "bdist" ]]; then
     if [[ $OS_NAME == "macos" ]]; then
-        cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --plat-name=macosx --python-tag py3 || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
-        mv dist/lightgbm-$LGB_VER-py3-none-macosx.whl dist/lightgbm-$LGB_VER-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl
+        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+        mv \
+            dist/lightgbm-$LGB_VER-py3-none-macosx*.whl \
+            dist/lightgbm-$LGB_VER-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl
         if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
             cp dist/lightgbm-$LGB_VER-py3-none-macosx*.whl $BUILD_ARTIFACTSTAGINGDIRECTORY
         fi
@@ -169,20 +171,21 @@ elif [[ $TASK == "bdist" ]]; then
         else
             PLATFORM="manylinux2014_$ARCH"
         fi
-        cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --integrated-opencl --plat-name=$PLATFORM --python-tag py3 || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --integrated-opencl || exit -1
+        mv \
+            ./dist/*.whl \
+            ./dist/lightgbm-$LGB_VER-py3-none-$PLATFORM.whl
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
         if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
             cp dist/lightgbm-$LGB_VER-py3-none-$PLATFORM.whl $BUILD_ARTIFACTSTAGINGDIRECTORY
         fi
         # Make sure we can do both CPU and GPU; see tests/python_package_test/test_dual.py
         export LIGHTGBM_TEST_DUAL_CPU_GPU=1
     fi
-    pip install --user $BUILD_DIRECTORY/python-package/dist/*.whl || exit -1
+    pip install --user $BUILD_DIRECTORY/dist/*.whl || exit -1
     pytest $BUILD_DIRECTORY/tests || exit -1
     exit 0
 fi
-
-mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build
 
 # temporarily pin pip to versions that support 'pip install --install-option'
 # ref: https://github.com/microsoft/LightGBM/issues/5061#issuecomment-1510642287
@@ -194,18 +197,20 @@ if [[ $TASK == "gpu" ]]; then
     sed -i'.bak' 's/std::string device_type = "cpu";/std::string device_type = "gpu";/' $BUILD_DIRECTORY/include/LightGBM/config.h
     grep -q 'std::string device_type = "gpu"' $BUILD_DIRECTORY/include/LightGBM/config.h || exit -1  # make sure that changes were really done
     if [[ $METHOD == "pip" ]]; then
-        cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
-        pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--gpu || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--gpu || exit -1
         pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
-        cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --gpu || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
-        pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --gpu || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER*.whl -v || exit -1
         pytest $BUILD_DIRECTORY/tests || exit -1
         exit 0
     elif [[ $METHOD == "source" ]]; then
+        mkdir $BUILD_DIRECTORY/build
+        cd $BUILD_DIRECTORY/build
         cmake -DUSE_GPU=ON ..
     fi
 elif [[ $TASK == "cuda" ]]; then
@@ -215,43 +220,49 @@ elif [[ $TASK == "cuda" ]]; then
     sed -i'.bak' 's/gpu_use_dp = false;/gpu_use_dp = true;/' $BUILD_DIRECTORY/include/LightGBM/config.h
     grep -q 'gpu_use_dp = true' $BUILD_DIRECTORY/include/LightGBM/config.h || exit -1  # make sure that changes were really done
     if [[ $METHOD == "pip" ]]; then
-        cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
-        pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--cuda || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--cuda || exit -1
         pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
-        cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --cuda || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
-        pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --cuda || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER*.whl -v || exit -1
         pytest $BUILD_DIRECTORY/tests || exit -1
         exit 0
     elif [[ $METHOD == "source" ]]; then
+        mkdir $BUILD_DIRECTORY/build
+        cd $BUILD_DIRECTORY/build
         cmake -DUSE_CUDA=ON ..
     fi
 elif [[ $TASK == "mpi" ]]; then
     if [[ $METHOD == "pip" ]]; then
-        cd $BUILD_DIRECTORY/python-package && python setup.py sdist || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
-        pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--mpi || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--mpi || exit -1
         pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
-        cd $BUILD_DIRECTORY/python-package && python setup.py bdist_wheel --mpi || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/python-package/dist || exit -1
-        pip install --user $BUILD_DIRECTORY/python-package/dist/lightgbm-$LGB_VER*.whl -v || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --mpi || exit -1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER*.whl -v || exit -1
         pytest $BUILD_DIRECTORY/tests || exit -1
         exit 0
     elif [[ $METHOD == "source" ]]; then
+        mkdir $BUILD_DIRECTORY/build
+        cd $BUILD_DIRECTORY/build
         cmake -DUSE_MPI=ON -DUSE_DEBUG=ON ..
     fi
 else
+    mkdir $BUILD_DIRECTORY/build
+    cd $BUILD_DIRECTORY/build
     cmake ..
 fi
 
 make _lightgbm -j4 || exit -1
 
-cd $BUILD_DIRECTORY/python-package && python setup.py install --precompile --user || exit -1
+cd $BUILD_DIRECTORY && sh ./build-python.sh install --precompile --user || exit -1
 pytest $BUILD_DIRECTORY/tests || exit -1
 
 if [[ $TASK == "regular" ]]; then

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -95,9 +95,9 @@ elseif ($env:TASK -eq "bdist") {
 } elseif (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python")) {
   cd $env:BUILD_SOURCESDIRECTORY
   if ($env:COMPILER -eq "MINGW") {
-    $env:BUILD_SOURCESDIRECTORY/build-python.sh install --mingw ; Check-Output $?
+    sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install --mingw ; Check-Output $?
   } else {
-    $env:BUILD_SOURCESDIRECTORY/build-python.sh install ; Check-Output $?
+    sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install ; Check-Output $?
   }
 }
 

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -93,6 +93,7 @@ elseif ($env:TASK -eq "bdist") {
   cd dist; pip install --user @(Get-ChildItem *.whl) ; Check-Output $?
   cp @(Get-ChildItem *.whl) $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 } elseif (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python")) {
+  Write-Ouput "building with build-python.sh"
   cd $env:BUILD_SOURCESDIRECTORY
   if ($env:COMPILER -eq "MINGW") {
     sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install --mingw ; Check-Output $?

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -93,7 +93,6 @@ elseif ($env:TASK -eq "bdist") {
   cd dist; pip install --user @(Get-ChildItem *.whl) ; Check-Output $?
   cp @(Get-ChildItem *.whl) $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 } elseif (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python")) {
-  Write-Ouput "building with build-python.sh"
   cd $env:BUILD_SOURCESDIRECTORY
   if ($env:COMPILER -eq "MINGW") {
     sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install --mingw ; Check-Output $?

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -65,15 +65,15 @@ if ($env:TASK -ne "bdist") {
 if ($env:TASK -eq "regular") {
   mkdir $env:BUILD_SOURCESDIRECTORY/build; cd $env:BUILD_SOURCESDIRECTORY/build
   cmake -A x64 .. ; cmake --build . --target ALL_BUILD --config Release ; Check-Output $?
-  cd $env:BUILD_SOURCESDIRECTORY/python-package
-  python setup.py install --precompile ; Check-Output $?
+  cd $env:BUILD_SOURCESDIRECTORY
+  sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install --precompile ; Check-Output $?
   cp $env:BUILD_SOURCESDIRECTORY/Release/lib_lightgbm.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
   cp $env:BUILD_SOURCESDIRECTORY/Release/lightgbm.exe $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 }
 elseif ($env:TASK -eq "sdist") {
-  cd $env:BUILD_SOURCESDIRECTORY/python-package
-  python setup.py sdist --formats gztar ; Check-Output $?
-  sh $env:BUILD_SOURCESDIRECTORY/.ci/check_python_dists.sh $env:BUILD_SOURCESDIRECTORY/python-package/dist ; Check-Output $?
+  cd $env:BUILD_SOURCESDIRECTORY
+  sh $env:BUILD_SOURCESDIRECTORY/build-python.sh sdist ; Check-Output $?
+  sh $env:BUILD_SOURCESDIRECTORY/.ci/check_python_dists.sh $env:BUILD_SOURCESDIRECTORY/dist ; Check-Output $?
   cd dist; pip install @(Get-ChildItem *.gz) -v ; Check-Output $?
 }
 elseif ($env:TASK -eq "bdist") {
@@ -87,17 +87,17 @@ elseif ($env:TASK -eq "bdist") {
   Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\OpenCL\Vendors
 
   conda activate $env:CONDA_ENV
-  cd $env:BUILD_SOURCESDIRECTORY/python-package
-  python setup.py bdist_wheel --integrated-opencl --plat-name=win-amd64 --python-tag py3 ; Check-Output $?
-  sh $env:BUILD_SOURCESDIRECTORY/.ci/check_python_dists.sh $env:BUILD_SOURCESDIRECTORY/python-package/dist ; Check-Output $?
+  cd $env:BUILD_SOURCESDIRECTORY
+  sh "build-python.sh" bdist_wheel --integrated-opencl ; Check-Output $?
+  sh $env:BUILD_SOURCESDIRECTORY/.ci/check_python_dists.sh $env:BUILD_SOURCESDIRECTORY/dist ; Check-Output $?
   cd dist; pip install --user @(Get-ChildItem *.whl) ; Check-Output $?
   cp @(Get-ChildItem *.whl) $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 } elseif (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python")) {
-  cd $env:BUILD_SOURCESDIRECTORY\python-package
+  cd $env:BUILD_SOURCESDIRECTORY
   if ($env:COMPILER -eq "MINGW") {
-    python setup.py install --mingw ; Check-Output $?
+    sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install --mingw ; Check-Output $?
   } else {
-    python setup.py install ; Check-Output $?
+    sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install ; Check-Output $?
   }
 }
 

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -95,9 +95,9 @@ elseif ($env:TASK -eq "bdist") {
 } elseif (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python")) {
   cd $env:BUILD_SOURCESDIRECTORY
   if ($env:COMPILER -eq "MINGW") {
-    sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install --mingw ; Check-Output $?
+    $env:BUILD_SOURCESDIRECTORY/build-python.sh install --mingw ; Check-Output $?
   } else {
-    sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install ; Check-Output $?
+    $env:BUILD_SOURCESDIRECTORY/build-python.sh install ; Check-Output $?
   }
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -399,6 +399,7 @@ lightgbm.model
 /cmake-build-debug/
 
 # Files from local Python install
+lightgbm-python/
 python-package/LICENSE
 python-package/build_cpp/
 python-package/compile/

--- a/build-python.sh
+++ b/build-python.sh
@@ -245,7 +245,7 @@ fi
 
 if test "${BUILD_WHEEL}" = true; then
     echo "--- building wheel ---"
-    rm -f ../dist/*.whl
+    rm -f ../dist/*.whl || true
     python setup.py bdist_wheel \
         --dist-dir ../dist \
         ${BUILD_ARGS}

--- a/build-python.sh
+++ b/build-python.sh
@@ -2,6 +2,8 @@
 
 set -e -u
 
+echo "building lightgbm"
+
 # Default values of arguments
 INSTALL="false"
 BUILD_SDIST="false"
@@ -245,7 +247,12 @@ fi
 
 if test "${BUILD_WHEEL}" = true; then
     echo "--- building wheel ---"
-    rm -f ../dist/*.whl || true
+    # avoid the following on Windows:
+    #
+    # WARNING: Requirement '../dist/*.whl' looks like a filename, but the file does not exist
+    # ERROR: *.whl is not a valid wheel filename.
+    #
+    #rm -f ../dist/*.whl || true
     python setup.py bdist_wheel \
         --dist-dir ../dist \
         ${BUILD_ARGS}

--- a/build-python.sh
+++ b/build-python.sh
@@ -260,9 +260,10 @@ fi
 
 if test "${INSTALL}" = true; then
     # ref for use of '--find-links': https://stackoverflow.com/a/52481267/3986677
+    cd ../dist
     pip install \
         ${PIP_INSTALL_ARGS} \
-        --find-links ../dist \
+        --find-links=. \
         lightgbm
 fi
 

--- a/build-python.sh
+++ b/build-python.sh
@@ -121,69 +121,107 @@ create_isolated_source_dir() {
         ./python-package/lightgbm.egg-info
 
     cp -R ./python-package ./lightgbm-python
-    cp -R ./cmake ./lightgbm-python/
-    cp CMakeLists.txt ./lightgbm-python/
-    cp -R ./include ./lightgbm-python/
+
     cp LICENSE ./lightgbm-python/
-    cp -R ./src ./lightgbm-python/
-    cp -R ./swig ./lightgbm-python/
-    cp VERSION.txt ./lightgbm-python/
-    cp -R ./windows ./lightgbm-python/
+    cp VERSION.txt ./lightgbm-python/lightgbm/VERSION.txt
+
+    mkdir -p ./lightgbm-python/compile
+    cp -R ./cmake ./lightgbm-python/compile
+    cp CMakeLists.txt ./lightgbm-python/compile
+    cp -R ./include ./lightgbm-python/compile
+    cp -R ./src ./lightgbm-python/compile
+    cp -R ./swig ./lightgbm-python/compile
+    cp -R ./windows ./lightgbm-python/compile
 
     # include only specific files from external_libs, to keep the package
     # small and avoid redistributing code with licenses incompatible with
     # LightGBM's license
-    mkdir -p ./lightgbm-python/external_libs/fast_double_parser/include/
+
+    ######################
+    # fast_double_parser #
+    ######################
+    mkdir -p ./lightgbm-python/compile/external_libs/fast_double_parser
+    cp \
+        external_libs/fast_double_parser/CMakeLists.txt \
+        ./lightgbm-python/compile/external_libs/fast_double_parser/CMakeLists.txt
+    cp \
+        external_libs/fast_double_parser/LICENSE* \
+        ./lightgbm-python/compile/external_libs/fast_double_parser/
+
+    mkdir -p ./lightgbm-python/compile/external_libs/fast_double_parser/include/
     cp \
         external_libs/fast_double_parser/include/fast_double_parser.h \
-        ./lightgbm-python/external_libs/fast_double_parser/include/
+        ./lightgbm-python/compile/external_libs/fast_double_parser/include/
 
-    mkdir -p ./lightgbm-python/external_libs/fmt/include/fmt
+    #######
+    # fmt #
+    #######
+    mkdir -p ./lightgbm-python/compile/external_libs/fmt
+    cp \
+        external_libs/fast_double_parser/CMakeLists.txt \
+        ./lightgbm-python/compile/external_libs/fmt/CMakeLists.txt
+    cp \
+        external_libs/fmt/LICENSE* \
+        ./lightgbm-python/compile/external_libs/fmt/
+
+    mkdir -p ./lightgbm-python/compile/external_libs/fmt/include/fmt
     cp \
         external_libs/fmt/include/fmt/*.h \
-        ./lightgbm-python/external_libs/fmt/include/fmt/
+        ./lightgbm-python/compile/external_libs/fmt/include/fmt/
 
-    mkdir -p ./lightgbm-python/external_libs/eigen/Eigen
+    #########
+    # Eigen #
+    #########
+    mkdir -p ./lightgbm-python/compile/external_libs/eigen/Eigen
+    cp \
+        external_libs/eigen/CMakeLists.txt \
+        ./lightgbm-python/compile/external_libs/eigen/CMakeLists.txt
 
     modules="Cholesky Core Dense Eigenvalues Geometry Householder Jacobi LU QR SVD"
     for eigen_module in ${modules}; do
         cp \
             external_libs/eigen/Eigen/${eigen_module} \
-            ./lightgbm-python/external_libs/eigen/Eigen/${eigen_module}
+            ./lightgbm-python/compile/external_libs/eigen/Eigen/${eigen_module}
         if [ ${eigen_module} != "Dense" ]; then
-            mkdir -p ./lightgbm-python/external_libs/eigen/Eigen/src/${eigen_module}/
+            mkdir -p ./lightgbm-python/compile/external_libs/eigen/Eigen/src/${eigen_module}/
             cp \
                 -R \
                 external_libs/eigen/Eigen/src/${eigen_module}/* \
-                ./lightgbm-python/external_libs/eigen/Eigen/src/${eigen_module}/
+                ./lightgbm-python/compile/external_libs/eigen/Eigen/src/${eigen_module}/
         fi
     done
 
-    mkdir -p ./lightgbm-python/external_libs/eigen/Eigen/misc
+    mkdir -p ./lightgbm-python/compile/external_libs/eigen/Eigen/misc
     cp \
         -R \
         external_libs/eigen/Eigen/src/misc \
-        ./lightgbm-python/external_libs/eigen/Eigen/src/misc/
+        ./lightgbm-python/compile/external_libs/eigen/Eigen/src/misc/
 
-    mkdir -p ./lightgbm-python/external_libs/eigen/Eigen/plugins
+    mkdir -p ./lightgbm-python/compile/external_libs/eigen/Eigen/plugins
     cp \
         -R \
         external_libs/eigen/Eigen/src/plugins \
-        ./lightgbm-python/external_libs/eigen/Eigen/src/plugins/
+        ./lightgbm-python/compile/external_libs/eigen/Eigen/src/plugins/
 
-    mkdir -p ./lightgbm-python/external_libs/compute
+    ###################
+    # compute (Boost) #
+    ###################
+    mkdir -p ./lightgbm-python/compile/external_libs/compute
+    cp \
+        external_libs/compute/CMakeLists.txt \
+        ./lightgbm-python/compile/external_libs/compute/
     cp \
         -R \
         external_libs/compute/cmake \
-        ./lightgbm-python/external_libs/cmake/
+        ./lightgbm-python/compile/external_libs/compute/cmake/
     cp \
         -R \
         external_libs/compute/include \
-        ./lightgbm-python/external_libs/include/
+        ./lightgbm-python/compile/external_libs/compute/include/
     cp \
         -R \
         external_libs/compute/meta \
-        ./lightgbm-python/external_libs/meta/
+        ./lightgbm-python/compile/external_libs/compute/meta/
 }
 
 create_isolated_source_dir

--- a/build-python.sh
+++ b/build-python.sh
@@ -235,6 +235,9 @@ if test "${INSTALL}" = true; then
     if test "${PRECOMPILE}" = true; then
         python setup.py install ${PIP_INSTALL_ARGS} --precompile
         exit 0
+    else
+        BUILD_SDIST="false"
+        BUILD_WHEEL="true"
     fi
 fi
 

--- a/build-python.sh
+++ b/build-python.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+
+set -e -u
+
+# Default values of arguments
+INSTALL="false"
+BUILD_SDIST="false"
+BUILD_WHEEL="false"
+
+PIP_INSTALL_ARGS=""
+BUILD_ARGS=""
+PRECOMPILE="false"
+
+BOOST_INCLUDE_DIR=""
+BOOST_LIBRARY_DIR=""
+BOOST_ROOT=""
+OPENCL_INCLUDE_DIR=""
+OPENCL_LIBRARY=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    ############################
+    # sub-commands of setup.py #
+    ############################
+    install)
+      INSTALL="true"
+      ;;
+    sdist)
+      BUILD_SDIST="true"
+      ;;
+    bdist_wheel)
+      BUILD_WHEEL="true"
+      ;;
+    ############################
+    # customized library paths #
+    ############################
+    --boost-include-dir|--boost-include-dir=*)
+        if [[ "$1" != *=* ]];
+            then shift;
+        fi
+        BOOST_INCLUDE_DIR="${1#*=}"
+        ;;
+    --boost-librarydir|--boost-librarydir=*)
+        if [[ "$1" != *=* ]];
+            then shift;
+        fi
+        BOOST_LIBRARY_DIR="${1#*=}"
+        ;;
+    --boost-root|--boost-root=*)
+        if [[ "$1" != *=* ]];
+            then shift;
+        fi
+        BOOST_ROOT="${1#*=}"
+        ;;
+    --opencl-include-dir|--opencl-include-dir=*)
+        if [[ "$1" != *=* ]];
+            then shift;
+        fi
+        OPENCL_INCLUDE_DIR="${1#*=}"
+        ;;
+    --opencl-library|--opencl-library=*)
+        if [[ "$1" != *=* ]];
+            then shift;
+        fi
+        OPENCL_LIBRARY="${1#*=}"
+        ;;
+    #########
+    # flags #
+    #########
+    --bit32)
+        BUILD_ARGS="${BUILD_ARGS} --bit32"
+        ;;
+    --cuda)
+        BUILD_ARGS="${BUILD_ARGS} --cuda"
+        ;;
+    --gpu)
+        BUILD_ARGS="${BUILD_ARGS} --gpu"
+        ;;
+    --hdfs)
+        BUILD_ARGS="${BUILD_ARGS} --hdfs"
+        ;;
+    --integrated-opencl)
+        BUILD_ARGS="${BUILD_ARGS} --integrated-opencl"
+        ;;
+    --mingw)
+        BUILD_ARGS="${BUILD_ARGS} --mingw"
+        ;;
+    --mpi)
+        BUILD_ARGS="${BUILD_ARGS} --mpi"
+        ;;
+    --nomp)
+      BUILD_ARGS="${BUILD_ARGS} --nomp"
+      ;;
+    --precompile)
+      PRECOMPILE="true"
+      ;;
+    --time-costs)
+      BUILD_ARGS="${PIP_INSTALL_ARGS} --time-costs"
+      ;;
+    --user)
+      PIP_INSTALL_ARGS="${PIP_INSTALL_ARGS} --user"
+      ;;
+    *)
+      echo "invalid argument '${1}'"
+      exit -1
+      ;;
+  esac
+  shift
+done
+
+# create a new directory that just contains the files needed
+# to build the Python package
+create_isolated_source_dir() {
+    rm -rf \
+        ./lightgbm-python \
+        ./lightgbm \
+        ./python-package/build \
+        ./python-package/build_cpp \
+        ./python-package/compile \
+        ./python-package/dist \
+        ./python-package/lightgbm.egg-info
+
+    cp -R ./python-package ./lightgbm-python
+    cp -R ./cmake ./lightgbm-python/
+    cp CMakeLists.txt ./lightgbm-python/
+    cp -R ./include ./lightgbm-python/
+    cp LICENSE ./lightgbm-python/
+    cp -R ./src ./lightgbm-python/
+    cp -R ./swig ./lightgbm-python/
+    cp VERSION.txt ./lightgbm-python/
+    cp -R ./windows ./lightgbm-python/
+
+    # include only specific files from external_libs, to keep the package
+    # small and avoid redistributing code with licenses incompatible with
+    # LightGBM's license
+    mkdir -p ./lightgbm-python/external_libs/fast_double_parser/include/
+    cp \
+        external_libs/fast_double_parser/include/fast_double_parser.h \
+        ./lightgbm-python/external_libs/fast_double_parser/include/
+
+    mkdir -p ./lightgbm-python/external_libs/fmt/include/fmt
+    cp \
+        external_libs/fmt/include/fmt/*.h \
+        ./lightgbm-python/external_libs/fmt/include/fmt/
+
+    mkdir -p ./lightgbm-python/external_libs/eigen/Eigen
+
+    modules="Cholesky Core Dense Eigenvalues Geometry Householder Jacobi LU QR SVD"
+    for eigen_module in ${modules}; do
+        cp \
+            external_libs/eigen/Eigen/${eigen_module} \
+            ./lightgbm-python/external_libs/eigen/Eigen/${eigen_module}
+        if [ ${eigen_module} != "Dense" ]; then
+            mkdir -p ./lightgbm-python/external_libs/eigen/Eigen/src/${eigen_module}/
+            cp \
+                -R \
+                external_libs/eigen/Eigen/src/${eigen_module}/* \
+                ./lightgbm-python/external_libs/eigen/Eigen/src/${eigen_module}/
+        fi
+    done
+
+    mkdir -p ./lightgbm-python/external_libs/eigen/Eigen/misc
+    cp \
+        -R \
+        external_libs/eigen/Eigen/src/misc \
+        ./lightgbm-python/external_libs/eigen/Eigen/src/misc/
+
+    mkdir -p ./lightgbm-python/external_libs/eigen/Eigen/plugins
+    cp \
+        -R \
+        external_libs/eigen/Eigen/src/plugins \
+        ./lightgbm-python/external_libs/eigen/Eigen/src/plugins/
+
+    mkdir -p ./lightgbm-python/external_libs/compute
+    cp \
+        -R \
+        external_libs/compute/cmake \
+        ./lightgbm-python/external_libs/cmake/
+    cp \
+        -R \
+        external_libs/compute/include \
+        ./lightgbm-python/external_libs/include/
+    cp \
+        -R \
+        external_libs/compute/meta \
+        ./lightgbm-python/external_libs/meta/
+}
+
+create_isolated_source_dir
+
+cd ./lightgbm-python
+
+# installation involves building the wheel + `pip install`-ing it
+if test "${INSTALL}" = true; then
+    if test "${PRECOMPILE}" = true; then
+        BUILD_SDIST=true
+        BUILD_WHEEL=false
+        BUILD_ARGS=""
+        rm -rf \
+            ./cmake \
+            ./CMakeLists.txt \
+            ./external_libs \
+            ./include \
+            ./src \
+            ./swig \
+            ./windows
+        if test -f ../lib_lightgbm.so; then
+            cp ../lib_lightgbm.so ./lightgbm/lib_lightgbm.so
+        fi
+        if test -f ../Release/lib_lightgbm.dll; then
+            cp ../Release/lib_lightgbm.dll ./lightgbm/lib_lightgbm.dll
+        fi
+        rm -f ./*.bak
+    else
+        BUILD_WHEEL=true
+    fi
+fi
+
+if test "${BUILD_SDIST}" = true; then
+    echo "--- building sdist ---"
+    rm -f ../dist/*.tar.gz
+    python ./setup.py sdist \
+        --dist-dir ../dist
+fi
+
+if test "${BUILD_WHEEL}" = true; then
+    echo "--- building wheel ---"
+    rm -f ../dist/*.whl
+    python setup.py bdist_wheel \
+        --dist-dir ../dist \
+        ${BUILD_ARGS}
+fi
+
+if test "${INSTALL}" = true; then
+    if test "${PRECOMPILE}" = true; then
+        pip install ${PIP_INSTALL_ARGS} ../dist/*.tar.gz
+    else
+        pip install ${PIP_INSTALL_ARGS} ../dist/*.whl
+    fi
+fi
+
+echo "cleaning up"
+rm -rf ./lightgbm-python

--- a/build-python.sh
+++ b/build-python.sh
@@ -259,11 +259,11 @@ if test "${BUILD_WHEEL}" = true; then
 fi
 
 if test "${INSTALL}" = true; then
-    if test "${PRECOMPILE}" = true; then
-        pip install ${PIP_INSTALL_ARGS} ../dist/*.tar.gz
-    else
-        pip install ${PIP_INSTALL_ARGS} ../dist/*.whl
-    fi
+    # ref for use of '--find-links': https://stackoverflow.com/a/52481267/3986677
+    pip install \
+        ${PIP_INSTALL_ARGS} \
+        --find-links ../dist \
+        lightgbm
 fi
 
 echo "cleaning up"

--- a/build-python.sh
+++ b/build-python.sh
@@ -231,26 +231,8 @@ cd ./lightgbm-python
 # installation involves building the wheel + `pip install`-ing it
 if test "${INSTALL}" = true; then
     if test "${PRECOMPILE}" = true; then
-        BUILD_SDIST=true
-        BUILD_WHEEL=false
-        BUILD_ARGS=""
-        rm -rf \
-            ./cmake \
-            ./CMakeLists.txt \
-            ./external_libs \
-            ./include \
-            ./src \
-            ./swig \
-            ./windows
-        if test -f ../lib_lightgbm.so; then
-            cp ../lib_lightgbm.so ./lightgbm/lib_lightgbm.so
-        fi
-        if test -f ../Release/lib_lightgbm.dll; then
-            cp ../Release/lib_lightgbm.dll ./lightgbm/lib_lightgbm.dll
-        fi
-        rm -f ./*.bak
-    else
-        BUILD_WHEEL=true
+        python setup.py install ${PIP_INSTALL_ARGS} --precompile
+        exit 0
     fi
 fi
 

--- a/docker/dockerfile-python
+++ b/docker/dockerfile-python
@@ -26,7 +26,7 @@ RUN apt-get update && \
     # lightgbm
     conda install -q -y numpy scipy scikit-learn pandas && \
     git clone --recursive --branch stable --depth 1 https://github.com/Microsoft/LightGBM && \
-    cd LightGBM/python-package && python setup.py install && \
+    sh ./build-python.sh install && \
     # clean
     apt-get autoremove -y && apt-get clean && \
     conda clean -a -y && \

--- a/docker/gpu/dockerfile.gpu
+++ b/docker/gpu/dockerfile.gpu
@@ -88,7 +88,7 @@ RUN cd /usr/local/src && mkdir lightgbm && cd lightgbm && \
 
 ENV PATH /usr/local/src/lightgbm/LightGBM:${PATH}
 
-RUN /bin/bash -c "source activate py3 && cd /usr/local/src/lightgbm/LightGBM/python-package && python setup.py install --precompile && source deactivate"
+RUN /bin/bash -c "source activate py3 && cd /usr/local/src/lightgbm/LightGBM && sh ./build-python.sh install --precompile && source deactivate"
 
 #################################################################################################################
 #           System CleanUp

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -278,7 +278,7 @@ Python-package
 --------------------------------------------------------------------------------------------------------------------
 
 .. note::
-    As of v4.0.0, ``lightgbm`` does not contain a ``setup.py``.
+    As of v4.0.0, ``lightgbm`` does not support directly invoked ``setup.py``.
     This answer refers only to versions of ``lightgbm`` prior to v4.0.0.
 
 .. code-block:: console

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -278,7 +278,7 @@ Python-package
 --------------------------------------------------------------------------------------------------------------------
 
 .. note::
-    As of v4.0.0, ``lightgbm`` does not support directly invoked ``setup.py``.
+    As of v4.0.0, ``lightgbm`` does not support directly invoking ``setup.py``.
     This answer refers only to versions of ``lightgbm`` prior to v4.0.0.
 
 .. code-block:: console

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -277,6 +277,10 @@ Python-package
 1. ``Error: setup script specifies an absolute path`` when installing from GitHub using ``python setup.py install``.
 --------------------------------------------------------------------------------------------------------------------
 
+.. note::
+    As of v4.0.0, ``lightgbm`` does not contain a ``setup.py``.
+    This answer refers only to versions of ``lightgbm`` prior to v4.0.0.
+
 .. code-block:: console
 
    error: Error: setup script specifies an absolute path:

--- a/docs/GPU-Tutorial.rst
+++ b/docs/GPU-Tutorial.rst
@@ -80,9 +80,7 @@ If you want to use the Python interface of LightGBM, you can install it now (alo
 
     sudo apt-get -y install python-pip
     sudo -H pip install setuptools numpy scipy scikit-learn -U
-    cd python-package/
-    sudo python setup.py install --precompile
-    cd ..
+    sudo sh ./build-python.sh install --precompile
 
 You need to set an additional parameter ``"device" : "gpu"`` (along with your other options like ``learning_rate``, ``num_leaves``, etc) to use GPU in Python.
 

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -193,34 +193,33 @@ For **Windows** users, if you get any errors during installation and there is th
 .. code:: sh
 
     git clone --recursive https://github.com/microsoft/LightGBM.git
-    cd LightGBM/python-package
     # export CXX=g++-7 CC=gcc-7  # macOS users, if you decided to compile with gcc, don't forget to specify compilers (replace "7" with version of gcc installed on your machine)
-    python setup.py install
+    sh ./build-python.sh install
 
 Note: ``sudo`` (or administrator rights in **Windows**) may be needed to perform the command.
 
-Run ``python setup.py install --nomp`` to disable **OpenMP** support. All requirements from `Build Threadless Version section <#build-threadless-version>`__ apply for this installation option as well.
+Run ``sh ./build-python.sh install --nomp`` to disable **OpenMP** support. All requirements from `Build Threadless Version section <#build-threadless-version>`__ apply for this installation option as well.
 
-Run ``python setup.py install --mpi`` to enable **MPI** support. All requirements from `Build MPI Version section <#build-mpi-version>`__ apply for this installation option as well.
+Run ``sh ./build-python.sh install --mpi`` to enable **MPI** support. All requirements from `Build MPI Version section <#build-mpi-version>`__ apply for this installation option as well.
 
-Run ``python setup.py install --mingw``, if you want to use **MinGW-w64** on **Windows** instead of **Visual Studio**. All requirements from `Build with MinGW-w64 on Windows section <#build-with-mingw-w64-on-windows>`__ apply for this installation option as well.
+Run ``sh ./build-python.sh install --mingw``, if you want to use **MinGW-w64** on **Windows** instead of **Visual Studio**. All requirements from `Build with MinGW-w64 on Windows section <#build-with-mingw-w64-on-windows>`__ apply for this installation option as well.
 
-Run ``python setup.py install --gpu`` to enable GPU support. All requirements from `Build GPU Version section <#build-gpu-version>`__ apply for this installation option as well. To pass additional options to **CMake** use the following syntax: ``python setup.py install --gpu --opencl-include-dir=/usr/local/cuda/include/``, see `Build GPU Version section <#build-gpu-version>`__ for the complete list of them.
+Run ``sh ./build-python.sh install --gpu`` to enable GPU support. All requirements from `Build GPU Version section <#build-gpu-version>`__ apply for this installation option as well. To pass additional options to **CMake** use the following syntax: ``sh ./build-python.sh install --gpu --opencl-include-dir="/usr/local/cuda/include/"``, see `Build GPU Version section <#build-gpu-version>`__ for the complete list of them.
 
-Run ``python setup.py install --cuda`` to enable CUDA support. All requirements from `Build CUDA Version section <#build-cuda-version>`__ apply for this installation option as well.
+Run ``sh ./build-python.sh install --cuda`` to enable CUDA support. All requirements from `Build CUDA Version section <#build-cuda-version>`__ apply for this installation option as well.
 
-Run ``python setup.py install --hdfs`` to enable HDFS support. All requirements from `Build HDFS Version section <#build-hdfs-version>`__ apply for this installation option as well.
+Run ``sh ./build-python.sh install --hdfs`` to enable HDFS support. All requirements from `Build HDFS Version section <#build-hdfs-version>`__ apply for this installation option as well.
 
-Run ``python setup.py install --bit32``, if you want to use 32-bit version. All requirements from `Build 32-bit Version with 32-bit Python section <#build-32-bit-version-with-32-bit-python>`__ apply for this installation option as well.
+Run ``sh ./build-python.sh install --bit32``, if you want to use 32-bit version. All requirements from `Build 32-bit Version with 32-bit Python section <#build-32-bit-version-with-32-bit-python>`__ apply for this installation option as well.
 
-Run ``python setup.py install --time-costs``, if you want to output time costs for different internal routines. All requirements from `Build with Time Costs Output section <#build-with-time-costs-output>`__ apply for this installation option as well.
+Run ``sh ./build-python.sh install --time-costs``, if you want to output time costs for different internal routines. All requirements from `Build with Time Costs Output section <#build-with-time-costs-output>`__ apply for this installation option as well.
 
-If you get any errors during installation or due to any other reasons, you may want to build dynamic library from sources by any method you prefer (see `Installation Guide <https://github.com/microsoft/LightGBM/blob/master/docs/Installation-Guide.rst>`__) and then just run ``python setup.py install --precompile``.
+If you get any errors during installation or due to any other reasons, you may want to build dynamic library from sources by any method you prefer (see `Installation Guide <https://github.com/microsoft/LightGBM/blob/master/docs/Installation-Guide.rst>`__) and then just run ``sh ./build-python.sh install --precompile``.
 
 Build Wheel File
 ****************
 
-You can use ``python setup.py bdist_wheel`` instead of ``python setup.py install`` to build wheel file and use it for installation later. This might be useful for systems with restricted or completely without network access.
+You can use ``sh ./build-python.sh install bdist_wheel`` instead of ``sh ./build-python.sh install`` to build wheel file and use it for installation later. This might be useful for systems with restricted or completely without network access.
 
 Install Dask-package
 ''''''''''''''''''''
@@ -235,7 +234,7 @@ To install all additional dependencies required for Dask-package, you can append
 
     pip install lightgbm[dask]
 
-Or replace ``python setup.py install`` with ``pip install -e .[dask]`` if you are installing the package from source files.
+Or replace ``sh ./build-python.sh install`` with ``pip install -e .[dask]`` if you are installing the package from source files.
 
 Troubleshooting
 ---------------

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -125,6 +125,7 @@ def compile_cpp(
             if use_mpi:
                 raise Exception('MPI version cannot be compiled by MinGW due to the miss of MPI library in it')
             logger.info("Starting to compile with CMake and MinGW.")
+            # ref: https://stackoverflow.com/a/45104058/3986677
             subprocess.check_call(cmake_cmd + ["-G", "MinGW Makefiles", "-DCMAKE_SH=CMAKE_SH-NOTFOUND"], stderr=sys.stderr, stdout=sys.stdout)
             # silent_call(cmake_cmd + ["-G", "MinGW Makefiles"], raise_error=True,
             #             error_msg='Please install CMake and all required dependencies first')

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -125,7 +125,7 @@ def compile_cpp(
             if use_mpi:
                 raise Exception('MPI version cannot be compiled by MinGW due to the miss of MPI library in it')
             logger.info("Starting to compile with CMake and MinGW.")
-            subprocess.check_call(cmake_cmd + ["-G", "MinGW Makefiles", "-DCMAKE_SH=\"CMAKE_SH-NOTFOUND\""], stderr=sys.stderr, stdout=sys.stdout)
+            subprocess.check_call(cmake_cmd + ["-G", "MinGW Makefiles", "-DCMAKE_SH=CMAKE_SH-NOTFOUND"], stderr=sys.stderr, stdout=sys.stdout)
             # silent_call(cmake_cmd + ["-G", "MinGW Makefiles"], raise_error=True,
             #             error_msg='Please install CMake and all required dependencies first')
             logger.info("---- made it here ----")

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -126,14 +126,10 @@ def compile_cpp(
                 raise Exception('MPI version cannot be compiled by MinGW due to the miss of MPI library in it')
             logger.info("Starting to compile with CMake and MinGW.")
             # ref: https://stackoverflow.com/a/45104058/3986677
-            subprocess.check_call(cmake_cmd + ["-G", "MinGW Makefiles", "-DCMAKE_SH=CMAKE_SH-NOTFOUND"], stderr=sys.stderr, stdout=sys.stdout)
-            # silent_call(cmake_cmd + ["-G", "MinGW Makefiles"], raise_error=True,
-            #             error_msg='Please install CMake and all required dependencies first')
-            logger.info("---- made it here ----")
-            # silent_call(["mingw32-make.exe", "_lightgbm", f"-I{build_dir}", "-j4"], raise_error=True,
-            #             error_msg='Please install MinGW first')
-            subprocess.check_call(["mingw32-make.exe", "_lightgbm", f"-I{build_dir}", "-j4"], stderr=sys.stderr, stdout=sys.stdout)
-            logger.info("---- made it past mingw32-make.exe ----")
+            silent_call(cmake_cmd + ["-G", "MinGW Makefiles", "-DCMAKE_SH=CMAKE_SH-NOTFOUND"], raise_error=True,
+                        error_msg='Please install CMake and all required dependencies first')
+            silent_call(["mingw32-make.exe", "_lightgbm", f"-I{build_dir}", "-j4"], raise_error=True,
+                        error_msg='Please install MinGW first')
         else:
             status = 1
             lib_path = CURRENT_DIR / "compile" / "windows" / "x64" / "DLL" / "lib_lightgbm.dll"

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -125,7 +125,7 @@ def compile_cpp(
             if use_mpi:
                 raise Exception('MPI version cannot be compiled by MinGW due to the miss of MPI library in it')
             logger.info("Starting to compile with CMake and MinGW.")
-            subprocess.check_call(cmake_cmd + ["-G", "MinGW Makefiles"], stderr=sys.stderr, stdout=sys.stdout)
+            subprocess.check_call(cmake_cmd + ["-G", "MinGW Makefiles", "-DCMAKE_SH=\"CMAKE_SH-NOTFOUND\""], stderr=sys.stderr, stdout=sys.stdout)
             # silent_call(cmake_cmd + ["-G", "MinGW Makefiles"], raise_error=True,
             #             error_msg='Please install CMake and all required dependencies first')
             logger.info("---- made it here ----")

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -7,8 +7,8 @@ import sys
 from os import chdir
 from pathlib import Path
 from platform import system
-from shutil import copyfile, copytree, rmtree
-from typing import List, Optional, Union
+from shutil import rmtree
+from typing import List, Optional
 
 from setuptools import find_packages, setup
 from setuptools.command.install import install

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -125,10 +125,14 @@ def compile_cpp(
             if use_mpi:
                 raise Exception('MPI version cannot be compiled by MinGW due to the miss of MPI library in it')
             logger.info("Starting to compile with CMake and MinGW.")
-            silent_call(cmake_cmd + ["-G", "MinGW Makefiles"], raise_error=True,
-                        error_msg='Please install CMake and all required dependencies first')
-            silent_call(["mingw32-make.exe", "_lightgbm", f"-I{build_dir}", "-j4"], raise_error=True,
-                        error_msg='Please install MinGW first')
+            subprocess.check_call(cmake_cmd + ["-G", "MinGW Makefiles"], stderr=sys.stderr, stdout=sys.stdout)
+            # silent_call(cmake_cmd + ["-G", "MinGW Makefiles"], raise_error=True,
+            #             error_msg='Please install CMake and all required dependencies first')
+            logger.info("---- made it here ----")
+            # silent_call(["mingw32-make.exe", "_lightgbm", f"-I{build_dir}", "-j4"], raise_error=True,
+            #             error_msg='Please install MinGW first')
+            subprocess.check_call(["mingw32-make.exe", "_lightgbm", f"-I{build_dir}", "-j4"], stderr=sys.stderr, stdout=sys.stdout)
+            logger.info("---- made it past mingw32-make.exe ----")
         else:
             status = 1
             lib_path = CURRENT_DIR / "compile" / "windows" / "x64" / "DLL" / "lib_lightgbm.dll"

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -46,41 +46,6 @@ def find_lib() -> List[str]:
     return LIB_PATH
 
 
-def copy_files(integrated_opencl: bool = False, use_gpu: bool = False) -> None:
-
-    def copy_files_helper(folder_name: Union[str, Path]) -> None:
-        src = CURRENT_DIR.parent / folder_name
-        if src.is_dir():
-            dst = CURRENT_DIR / 'compile' / folder_name
-            if dst.is_dir():
-                rmtree(dst)
-            copytree(src, dst)
-        else:
-            raise Exception(f'Cannot copy {src} folder')
-
-    if not IS_SOURCE_FLAG_PATH.is_file():
-        copy_files_helper('include')
-        copy_files_helper('src')
-        for submodule in (CURRENT_DIR.parent / 'external_libs').iterdir():
-            submodule_stem = submodule.stem
-            if submodule_stem == 'compute' and not use_gpu:
-                continue
-            copy_files_helper(Path('external_libs') / submodule_stem)
-        (CURRENT_DIR / "compile" / "windows").mkdir(parents=True, exist_ok=True)
-        copyfile(CURRENT_DIR.parent / "windows" / "LightGBM.sln",
-                 CURRENT_DIR / "compile" / "windows" / "LightGBM.sln")
-        copyfile(CURRENT_DIR.parent / "windows" / "LightGBM.vcxproj",
-                 CURRENT_DIR / "compile" / "windows" / "LightGBM.vcxproj")
-        copyfile(CURRENT_DIR.parent / "LICENSE",
-                 CURRENT_DIR / "LICENSE")
-        copyfile(CURRENT_DIR.parent / "CMakeLists.txt",
-                 CURRENT_DIR / "compile" / "CMakeLists.txt")
-        if integrated_opencl:
-            (CURRENT_DIR / "compile" / "cmake").mkdir(parents=True, exist_ok=True)
-            copyfile(CURRENT_DIR.parent / "cmake" / "IntegratedOpenCL.cmake",
-                     CURRENT_DIR / "compile" / "cmake" / "IntegratedOpenCL.cmake")
-
-
 def clear_path(path: Path) -> None:
     if path.is_dir():
         for file_name in path.iterdir():
@@ -254,7 +219,6 @@ class CustomInstall(install):
                                 "please use 64-bit Python instead.")
         LOG_PATH.touch()
         if not self.precompile:
-            copy_files(integrated_opencl=self.integrated_opencl, use_gpu=self.gpu)
             compile_cpp(use_mingw=self.mingw, use_gpu=self.gpu, use_cuda=self.cuda, use_mpi=self.mpi,
                         use_hdfs=self.hdfs, boost_root=self.boost_root, boost_dir=self.boost_dir,
                         boost_include_dir=self.boost_include_dir, boost_librarydir=self.boost_librarydir,
@@ -315,7 +279,6 @@ class CustomBdistWheel(bdist_wheel):
 class CustomSdist(sdist):
 
     def run(self) -> None:
-        copy_files(integrated_opencl=True, use_gpu=True)
         IS_SOURCE_FLAG_PATH.touch()
         rmtree(CURRENT_DIR / 'lightgbm' / 'Release', ignore_errors=True)
         rmtree(CURRENT_DIR / 'lightgbm' / 'windows' / 'x64', ignore_errors=True)
@@ -332,11 +295,8 @@ if __name__ == "__main__":
     LOG_PATH = Path.home() / 'LightGBM_compilation.log'
     LOG_NOTICE = f"The full version of error log was saved into {LOG_PATH}"
     IS_SOURCE_FLAG_PATH = CURRENT_DIR / '_IS_SOURCE_PACKAGE.txt'
-    _version_src = CURRENT_DIR.parent / 'VERSION.txt'
-    _version_dst = CURRENT_DIR / 'lightgbm' / 'VERSION.txt'
-    if _version_src.is_file():
-        copyfile(_version_src, _version_dst)
-    version = _version_dst.read_text(encoding='utf-8').strip()
+    _version_file = CURRENT_DIR / 'lightgbm' / 'VERSION.txt'
+    version = _version_file.read_text(encoding='utf-8').strip()
     readme = (CURRENT_DIR / 'README.rst').read_text(encoding='utf-8')
 
     sys.path.insert(0, str(CURRENT_DIR))


### PR DESCRIPTION
Contributes to #5061.

This PR proposes replacing all existing direct invocations of `python setup.py` with a shell script, `build-python-package.sh`.

### What will the use experience be like?

For people using `pip install` or `conda install`, **this PR does not change anything**.

Anyone currently building / installing the Python package from sources here on GitHub using commands like the following:

```shell
cd python-package
python setup.py {command} [OPTIONS]
```

Would now instead run

```shell
sh ./build-python.sh {command} [OPTIONS]
```

### Why a shell script?

Most Python build tools (e.g. `wheel`, `build`, `pip wheel`, `scikit-build`, `hatchling`, etc.) assume a directory structure with all source files at or below the level of where the tool is called from. This repo contains more than just a Python package, and so it can't be directly used that way.

This project currently solves that problem via Python code in a `setup.py` file which reaches up into the parent directory and copying files at build time.

https://github.com/microsoft/LightGBM/blob/f74875ed60e696ee7d223ddb409e66f51bddbb47/python-package/setup.py#L61-L68

As described #5061, the Python packaging community is moving away from supporting such `setup.py` invocations.

I'm proposing that we use an `sh`-compatible shell script to create an isolated source directory *prior to invoking any Python build tools* for the following reasons:

* that approach has been working well for the R package for 2+ years (since #2960)
* `sh` is highly portable
* allows maximum flexibility to change the strategy for how the package is built in the future without affecting users
    - e.g., enables work in a followup PR to switch from `setup.py` to something like `scikit-build-core` (which I'm working on in #5759) or `hatchling` (like XGBoost is trying in https://github.com/dmlc/xgboost/pull/9021)
    - really important, I think, given how quickly the Python packaging tools are evolving

### How I tested this

In addition to all off the checks run in CI, I did the following:

* ran many combinations of the commands and options for this new script locally on my Mac
* checked the sdist and wheel contents using `pydistcheck`, to confirm that they have the same contents as those built on `main`, and are the same size
    - reference: #5838 