### PR TITLE
[ci] [python-package] check distributions with pydistcheck

### DIFF
--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -24,7 +24,7 @@ if [ $PY_MINOR_VER -gt 7 ]; then
     if { test "${TASK}" = "cuda" || test "${METHOD}" = "wheel"; }; then
         pydistcheck \
             --inspect \
-            --ignore 'compiled-objects-have-debug-symbols,max-allowed-size-compressed' \
+            --ignore 'compiled-objects-have-debug-symbols,distro-too-large-compressed' \
             --max-allowed-size-uncompressed '60M' \
             --max-allowed-files 800 \
             ${DIST_DIR}/* || exit -1

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -21,6 +21,9 @@ fi
 echo "pydistcheck..."
 pydistcheck \
     --inspect \
+    --max-allow-size-compressed '5M' \
+    --max-allow-size-uncompressed '15M' \
+    --max-allowed-files 800 \
     ${DIST_DIR}/*
 
 echo "done checking Python package distributions"

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -21,7 +21,7 @@ PY_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")
 if [ $PY_MINOR_VER -gt 7 ]; then
     echo "pydistcheck..."
     pip install pydistcheck
-    if [ $TASK == "CUDA" ] && [ $METHOD == "wheel" ]; then
+    if [ $TASK == "cuda" ] && [ $METHOD == "wheel" ]; then
         pydistcheck \
             --inspect \
             --ignore 'compiled-objects-have-debug-symbols,max-allowed-size-compressed' \

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -7,7 +7,6 @@ echo "checking Python package distributions in '${DIST_DIR}'"
 pip install \
     -qq \
     check-wheel-contents \
-    'pydistcheck; python_version>=3.8' \
     twine || exit -1
 
 echo "twine check..."
@@ -21,6 +20,7 @@ fi
 PY_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")
 if [ $PY_MINOR_VER -gt 7 ]; then
     echo "pydistcheck..."
+    pip install pydistcheck
     pydistcheck \
         --inspect \
         --max-allowed-size-compressed '5M' \

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -21,14 +21,14 @@ PY_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")
 if [ $PY_MINOR_VER -gt 7 ]; then
     echo "pydistcheck..."
     pip install pydistcheck
-    if [[ "${TASK}" == "cuda" ]] && [[ "${METHOD}" == "wheel" ]]; then
+    if { test "${TASK}" = "cuda" || test "${METHOD}" = "wheel"; }; then
         pydistcheck \
             --inspect \
             --ignore 'compiled-objects-have-debug-symbols,max-allowed-size-compressed' \
             --max-allowed-size-uncompressed '60M' \
             --max-allowed-files 800 \
             ${DIST_DIR}/* || exit -1
-    elif [[ $(uname -m) == "aarch64" ]]; then
+    elif { test $(uname -m) = "aarch64"; }; then
         pydistcheck \
             --inspect \
             --ignore 'compiled-objects-have-debug-symbols' \

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -21,14 +21,14 @@ PY_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")
 if [ $PY_MINOR_VER -gt 7 ]; then
     echo "pydistcheck..."
     pip install pydistcheck
-    if [ $TASK == "cuda" ] && [ $METHOD == "wheel" ]; then
+    if [[ "${TASK}" = "cuda" ]] && [[ "${METHOD}" = "wheel" ]]; then
         pydistcheck \
             --inspect \
             --ignore 'compiled-objects-have-debug-symbols,max-allowed-size-compressed' \
             --max-allowed-size-uncompressed '60M' \
             --max-allowed-files 800 \
             ${DIST_DIR}/* || exit -1
-    elif [ $ARCH == "aarch64" ]; then
+    elif [[ $(uname -m) == "aarch64" ]]; then
         pydistcheck \
             --inspect \
             --ignore 'compiled-objects-have-debug-symbols' \

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -7,6 +7,7 @@ echo "checking Python package distributions in '${DIST_DIR}'"
 pip install \
     -qq \
     check-wheel-contents \
+    pydistcheck \
     twine || exit -1
 
 echo "twine check..."
@@ -16,5 +17,10 @@ if { test "${TASK}" = "bdist" || test "${METHOD}" = "wheel"; }; then
     echo "check-wheel-contents..."
     check-wheel-contents ${DIST_DIR}/*.whl || exit -1
 fi
+
+echo "pydistcheck..."
+pydistcheck \
+    --inspect \
+    ${DIST_DIR}/*
 
 echo "done checking Python package distributions"

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -21,12 +21,29 @@ PY_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")
 if [ $PY_MINOR_VER -gt 7 ]; then
     echo "pydistcheck..."
     pip install pydistcheck
-    pydistcheck \
-        --inspect \
-        --max-allowed-size-compressed '5M' \
-        --max-allowed-size-uncompressed '15M' \
-        --max-allowed-files 800 \
-        ${DIST_DIR}/* || exit -1
+    if [ $TASK == "CUDA" ] && [ $METHOD == "wheel" ]; then
+        pydistcheck \
+            --inspect \
+            --ignore 'compiled-objects-have-debug-symbols,max-allowed-size-compressed' \
+            --max-allowed-size-uncompressed '60M' \
+            --max-allowed-files 800 \
+            ${DIST_DIR}/* || exit -1
+    elif [ $ARCH == "aarch64" ]; then
+        pydistcheck \
+            --inspect \
+            --ignore 'compiled-objects-have-debug-symbols' \
+            --max-allowed-size-compressed '5M' \
+            --max-allowed-size-uncompressed '15M' \
+            --max-allowed-files 800 \
+            ${DIST_DIR}/* || exit -1
+    else
+        pydistcheck \
+            --inspect \
+            --max-allowed-size-compressed '5M' \
+            --max-allowed-size-uncompressed '15M' \
+            --max-allowed-files 800 \
+            ${DIST_DIR}/* || exit -1
+    fi
 else
     echo "skipping pydistcheck (does not support Python 3.${PY_MINOR_VER})"
 fi

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -21,9 +21,9 @@ fi
 echo "pydistcheck..."
 pydistcheck \
     --inspect \
-    --max-allow-size-compressed '5M' \
-    --max-allow-size-uncompressed '15M' \
+    --max-allowed-size-compressed '5M' \
+    --max-allowed-size-uncompressed '15M' \
     --max-allowed-files 800 \
-    ${DIST_DIR}/*
+    ${DIST_DIR}/* || exit -1
 
 echo "done checking Python package distributions"

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -7,7 +7,7 @@ echo "checking Python package distributions in '${DIST_DIR}'"
 pip install \
     -qq \
     check-wheel-contents \
-    pydistcheck \
+    'pydistcheck; python_version>=3.8' \
     twine || exit -1
 
 echo "twine check..."
@@ -18,12 +18,17 @@ if { test "${TASK}" = "bdist" || test "${METHOD}" = "wheel"; }; then
     check-wheel-contents ${DIST_DIR}/*.whl || exit -1
 fi
 
-echo "pydistcheck..."
-pydistcheck \
-    --inspect \
-    --max-allowed-size-compressed '5M' \
-    --max-allowed-size-uncompressed '15M' \
-    --max-allowed-files 800 \
-    ${DIST_DIR}/* || exit -1
+PY_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")
+if [ $PY_MINOR_VER -gt 7 ]; then
+    echo "pydistcheck..."
+    pydistcheck \
+        --inspect \
+        --max-allowed-size-compressed '5M' \
+        --max-allowed-size-uncompressed '15M' \
+        --max-allowed-files 800 \
+        ${DIST_DIR}/* || exit -1
+else
+    echo "skipping pydistcheck (does not support Python 3.${PY_MINOR_VER})"
+fi
 
 echo "done checking Python package distributions"

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -21,7 +21,7 @@ PY_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")
 if [ $PY_MINOR_VER -gt 7 ]; then
     echo "pydistcheck..."
     pip install pydistcheck
-    if [[ "${TASK}" = "cuda" ]] && [[ "${METHOD}" = "wheel" ]]; then
+    if [[ "${TASK}" == "cuda" ]] && [[ "${METHOD}" == "wheel" ]]; then
         pydistcheck \
             --inspect \
             --ignore 'compiled-objects-have-debug-symbols,max-allowed-size-compressed' \


### PR DESCRIPTION
Contributes to #5061.

Proposes adding `pydistcheck` to the set of checks run on Python sdists and wheels (the artifacts this project publishes to PyPI).

`pydistcheck` is a linter for Python distributions, similar with `check-wheel-contents` but with a very different set of checks, including:

* inclusion of debug symbols in `lib_lightgbm.so` / `lib_lightgbm.dll`
* accidental inclusion of unnecessary files
   - see #3639 and #3685, for example
* other portability issues documented at https://pydistcheck.readthedocs.io/en/latest/check-reference.html

I believe adding this will improve our confidence in releases of the Python package.

### Notes for Reviewers

Full disclosure, `pydistcheck` is my own personal side-project: https://github.com/jameslamb/pydistcheck. I started it after a conference talk I gave last year. I've resisted introducing it into LightGBM until now because I didn't think it was appropriate to use my position as a maintainer here to promote my own project.

I'm proposing it now because I think that project is at a level of maturity that it could genuinely be helpful here in LightGBM. I used it, for example, to catch two small packaging issues in `pandas` recently: 

* https://github.com/pandas-dev/pandas/issues/51900
* https://github.com/pandas-dev/pandas/pull/51931
* https://github.com/pandas-dev/pandas/pull/51971

And because it's been very helpful during my active development on changing the packaging strategy here for #5061 (e.g. in #5837 and #5759 ). It has helped me catch several mistakes during that development already.

Thanks very much for considering it.