### PR TITLE
[ci] [python-package] fix mypy error about return_cvbooster in cv()

### DIFF
--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -545,7 +545,7 @@ def cv(
     callbacks: Optional[List[Callable]] = None,
     eval_train_metric: bool = False,
     return_cvbooster: bool = False
-) -> Dict[str, Any]:
+) -> Dict[str, Union[List[float], CVBooster]]:
     """Perform the cross-validation with given parameters.
 
     Parameters
@@ -651,7 +651,7 @@ def cv(
         {'metric1-mean': [values], 'metric1-stdv': [values],
         'metric2-mean': [values], 'metric2-stdv': [values],
         ...}.
-        If ``return_cvbooster=True``, also returns trained boosters via ``cvbooster`` key.
+        If ``return_cvbooster=True``, also returns trained boosters wrapped in a ``CVBooster`` object via ``cvbooster`` key.
     """
     if not isinstance(train_set, Dataset):
         raise TypeError(f"cv() only accepts Dataset object, train_set has type '{type(train_set).__name__}'.")
@@ -763,6 +763,6 @@ def cv(
             break
 
     if return_cvbooster:
-        results['cvbooster'] = cvfolds
+        results['cvbooster'] = cvfolds  # type: ignore[assignment]
 
     return dict(results)


### PR DESCRIPTION
Contributes to #3867.

Fixes the following error from `mypy`.

```text
python-package/lightgbm/engine.py:766: error: Incompatible types in assignment (expression has type "CVBooster", target has type "List[float]")  [assignment]
```

That error is raised because `mypy` (correctly) infers that the return value for `cv()` is a `Dict[str, List[float]]` here:

https://github.com/microsoft/LightGBM/blob/f74875ed60e696ee7d223ddb409e66f51bddbb47/python-package/lightgbm/engine.py#L704

https://github.com/microsoft/LightGBM/blob/f74875ed60e696ee7d223ddb409e66f51bddbb47/python-package/lightgbm/engine.py#L746-L748

But then it tries to add an item that is a `CVBooster` here:

https://github.com/microsoft/LightGBM/blob/f74875ed60e696ee7d223ddb409e66f51bddbb47/python-package/lightgbm/engine.py#L765-L766

I think just `#type: ignore`-ing this error is preferable to other possible fixes like:

* changing the type of `results` to `Dict[str, Any]` (which would reduce `mypy`'s ability to catch issues in the main update loop in `cv()`
* changing that return statement to something like `return {**results, 'cvbooster': cvfolds}`, which would add to the peak memory usage for running `cv()` by temporarily copying `results`