### PR TITLE
[ci] [python-package] fix mypy error about dask._predict_part()

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -836,6 +836,7 @@ def _predict_part(
     **kwargs: Any
 ) -> _DaskPart:
 
+    result: _DaskPart
     if part.shape[0] == 0:
         result = np.array([])
     elif pred_proba:


### PR DESCRIPTION
Contributes to #3867.

Fixes the following error from `mypy`.

```text
python-package/lightgbm/dask.py:840: error: Need type annotation for "result"  [var-annotated]
```