### PR TITLE
[ci] add tests on cv() with an init_model

### DIFF
--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1075,6 +1075,67 @@ def test_cv():
     np.testing.assert_allclose(cv_res_lambda['valid ndcg@3-mean'], cv_res_lambda_obj['valid ndcg@3-mean'])
 
 
+def test_cv_works_with_init_model(tmp_path):
+    X, y = make_synthetic_regression()
+    params = {'objective': 'regression', 'verbose': -1}
+    num_train_rounds = 2
+    lgb_train = lgb.Dataset(X, y, free_raw_data=False)
+    bst = lgb.train(
+        params=params,
+        train_set=lgb_train,
+        num_boost_round=num_train_rounds
+    )
+    preds_raw = bst.predict(X, raw_score=True)
+    model_path_txt = str(tmp_path / 'lgb.model')
+    bst.save_model(model_path_txt)
+
+    num_cv_rounds = 5
+    cv_kwargs = {
+        "num_boost_round": num_cv_rounds,
+        "nfold": 3,
+        "stratified": False,
+        "shuffle": False,
+        "seed": 708,
+        "return_cvbooster": True,
+        "params": params
+    }
+
+    # init_model from an in-memory Booster
+    cv_res = lgb.cv(
+        train_set=lgb_train,
+        init_model=bst,
+        **cv_kwargs
+    )
+    cv_bst_w_in_mem_init_model = cv_res["cvbooster"]
+    assert cv_bst_w_in_mem_init_model.current_iteration() == [num_train_rounds + num_cv_rounds] * 3
+    for booster in cv_bst_w_in_mem_init_model.boosters:
+        np.testing.assert_allclose(
+            preds_raw,
+            booster.predict(X, raw_score=True, num_iteration=num_train_rounds)
+        )
+
+    # init_model from a text file
+    cv_res = lgb.cv(
+        train_set=lgb_train,
+        init_model=model_path_txt,
+        **cv_kwargs
+    )
+    cv_bst_w_file_init_model = cv_res["cvbooster"]
+    assert cv_bst_w_file_init_model.current_iteration() == [num_train_rounds + num_cv_rounds] * 3
+    for booster in cv_bst_w_file_init_model.boosters:
+        np.testing.assert_allclose(
+            preds_raw,
+            booster.predict(X, raw_score=True, num_iteration=num_train_rounds)
+        )
+
+    # predictions should be identical
+    for i in range(3):
+        np.testing.assert_allclose(
+            cv_bst_w_in_mem_init_model.boosters[i].predict(X),
+            cv_bst_w_file_init_model.boosters[i].predict(X)
+        )
+
+
 def test_cvbooster():
     X, y = load_breast_cancer(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)


### PR DESCRIPTION
The Python package does not currently have tests covering the case where `cv()` is used with an `init_model` from an in-memory `Booster` or a model text file.

<img width="873" alt="image" src="https://user-images.githubusercontent.com/7608904/234167847-ce8d0aeb-5010-4af4-8abf-9a077a1f0a17.png">

This adds such tests:

<img width="873" alt="image" src="https://user-images.githubusercontent.com/7608904/234166380-fc2ade01-6fbc-4fef-9f9d-0fa7836ab728.png">

<details><summary>how I got those coverage summaries (click me)</summary>

```text
rm -rf ./build
mkdir build
cd build
cmake ..
make -j3
cd ..

cd ./python-package
python setup.py install --precompile
cd ..

pip install pytest-cov

SITE_PACKAGE_DIR=$(
    python -c "import site; print(site.getsitepackages()[0])"
)
pytest \
    --cov=${SITE_PACKAGE_DIR}/lightgbm \
    tests/python_package_test/

coverage html
open ./htmlcov/index.html
```

</details>