### PR TITLE
[python-package] [ci] fix mypy errors in Booster.__inner_predict()

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3110,7 +3110,7 @@ class Booster:
                 ctypes.byref(out_num_class)))
             self.__num_class = out_num_class.value
             # buffer for inner predict
-            self.__inner_predict_buffer = [None]
+            self.__inner_predict_buffer: List[Optional[np.ndarray]] = [None]
             self.__is_predicted_cur_iter = [False]
             self.__get_eval_info()
             self.pandas_categorical = train_set.pandas_categorical
@@ -4518,16 +4518,16 @@ class Booster:
         # avoid to predict many time in one iteration
         if not self.__is_predicted_cur_iter[data_idx]:
             tmp_out_len = ctypes.c_int64(0)
-            data_ptr = self.__inner_predict_buffer[data_idx].ctypes.data_as(ctypes.POINTER(ctypes.c_double))
+            data_ptr = self.__inner_predict_buffer[data_idx].ctypes.data_as(ctypes.POINTER(ctypes.c_double))  # type: ignore[union-attr]
             _safe_call(_LIB.LGBM_BoosterGetPredict(
                 self.handle,
                 ctypes.c_int(data_idx),
                 ctypes.byref(tmp_out_len),
                 data_ptr))
-            if tmp_out_len.value != len(self.__inner_predict_buffer[data_idx]):
+            if tmp_out_len.value != len(self.__inner_predict_buffer[data_idx]):  # type: ignore[arg-type]
                 raise ValueError(f"Wrong length of predict results for data {data_idx}")
             self.__is_predicted_cur_iter[data_idx] = True
-        result = self.__inner_predict_buffer[data_idx]
+        result: np.ndarray = self.__inner_predict_buffer[data_idx]  # type: ignore[assignment]
         if self.__num_class > 1:
             num_data = result.size // self.__num_class
             result = result.reshape(num_data, self.__num_class, order='F')


### PR DESCRIPTION
Contributes to #3867.

Fixes the following errors `mypy`:

```text
python-package/lightgbm/basic.py:4517: error: No overload variant of "__setitem__" of "list" matches argument types "int", "ndarray[Any, dtype[floating[_64Bit]]]"  [call-overload]
python-package/lightgbm/basic.py:4517: note: Possible overload variants:
python-package/lightgbm/basic.py:4517: note:     def __setitem__(self, SupportsIndex, None, /) -> None
python-package/lightgbm/basic.py:4517: note:     def __setitem__(self, slice, Iterable[None], /) -> None
python-package/lightgbm/basic.py:4521: error: "None" has no attribute "ctypes"  [attr-defined]
python-package/lightgbm/basic.py:4527: error: Argument 1 to "len" has incompatible type "None"; expected "Sized"  [arg-type]
python-package/lightgbm/basic.py:4532: error: "None" has no attribute "size"  [attr-defined]
python-package/lightgbm/basic.py:4533: error: "None" has no attribute "reshape"  [attr-defined]
python-package/lightgbm/basic.py:4534: error: Incompatible return value type (got "Optional[Any]", expected "ndarray[Any, Any]")  [return-value]
```