### PR TITLE
[ci] [python-package] fix mypy errors in Booster.refit()

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -4189,7 +4189,7 @@ class Booster:
         if dataset_params is None:
             dataset_params = {}
         predictor = self._to_predictor(pred_parameter=deepcopy(kwargs))
-        leaf_preds = predictor.predict(
+        leaf_preds: np.ndarray = predictor.predict(  # type: ignore[assignment]
             data=data,
             start_iteration=-1,
             pred_leaf=True,


### PR DESCRIPTION
Contributes to #3867.

Fixes the following errors from `mypy`.

```text
python-package/lightgbm/basic.py:4198: error: Item "List[Any]" of "Union[ndarray[Any, Any], Any, List[Any]]" has no attribute "shape"  [union-attr]
python-package/lightgbm/basic.py:4228: error: Item "List[Any]" of "Union[ndarray[Any, Any], Any, List[Any]]" has no attribute "reshape"  [union-attr]
```

These errors come from the fact that `mypy` thinks it's possible for `_InnerPredictor.predict()` to return a List but in the lines those errors are reported on, the code uses the output of `_InnerPredictor.predict()` as `numpy` array unconditionally.

`mypy` doesn't know that when `pred_leaf=True`, the output of that function will never be a list.