### PR TITLE
WIP: [ci] [python-package] remove unused mypy type-ignore comments

### DIFF
--- a/.ci/lint-python.sh
+++ b/.ci/lint-python.sh
@@ -30,6 +30,7 @@ echo "done running isort"
 echo "running mypy"
 mypy \
     --ignore-missing-imports \
+    --warn-unused-ignores \
     --exclude 'build/' \
     --exclude 'compile/' \
     --exclude 'docs/' \

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -4191,7 +4191,7 @@ class Booster:
         if dataset_params is None:
             dataset_params = {}
         predictor = self._to_predictor(pred_parameter=deepcopy(kwargs))
-        leaf_preds: np.ndarray = predictor.predict(  # type: ignore[assignment]
+        leaf_preds: np.ndarray = predictor.predict(
             data=data,
             start_iteration=-1,
             pred_leaf=True,
@@ -4529,7 +4529,7 @@ class Booster:
             if tmp_out_len.value != len(self.__inner_predict_buffer[data_idx]):  # type: ignore[arg-type]
                 raise ValueError(f"Wrong length of predict results for data {data_idx}")
             self.__is_predicted_cur_iter[data_idx] = True
-        result: np.ndarray = self.__inner_predict_buffer[data_idx]  # type: ignore[assignment]
+        result: np.ndarray = self.__inner_predict_buffer[data_idx]
         if self.__num_class > 1:
             num_data = result.size // self.__num_class
             result = result.reshape(num_data, self.__num_class, order='F')

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -212,7 +212,7 @@ def _load_lib() -> ctypes.CDLL:
 _LIB: ctypes.CDLL
 if environ.get('LIGHTGBM_BUILD_DOC', False):
     from unittest.mock import Mock  # isort: skip
-    _LIB = Mock(ctypes.CDLL)  # type: ignore
+    _LIB = Mock(ctypes.CDLL)
 else:
     _LIB = _load_lib()
 

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -149,11 +149,11 @@ try:
 except ImportError:
     DASK_INSTALLED = False
 
-    dask_array_from_delayed = None  # type: ignore[assignment]
-    dask_bag_from_delayed = None  # type: ignore[assignment]
+    dask_array_from_delayed = None
+    dask_bag_from_delayed = None
     delayed = None
-    default_client = None  # type: ignore[assignment]
-    wait = None  # type: ignore[assignment]
+    default_client = None
+    wait = None
 
     class Client:  # type: ignore
         """Dummy class for dask.distributed.Client."""

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1089,7 +1089,7 @@ class _DaskLGBMModel:
         )
 
         self.set_params(**model.get_params())  # type: ignore[attr-defined]
-        self._lgb_dask_copy_extra_params(model, self)  # type: ignore[attr-defined]
+        self._lgb_dask_copy_extra_params(model, self)
 
         return self
 

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -1236,7 +1236,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
 
     def predict(
         self,
-        X: _DaskMatrixLike,  # type: ignore[override]
+        X: _DaskMatrixLike,
         raw_score: bool = False,
         start_iteration: int = 0,
         num_iteration: Optional[int] = None,
@@ -1271,7 +1271,7 @@ class DaskLGBMClassifier(LGBMClassifier, _DaskLGBMModel):
 
     def predict_proba(
         self,
-        X: _DaskMatrixLike,  # type: ignore[override]
+        X: _DaskMatrixLike,
         raw_score: bool = False,
         start_iteration: int = 0,
         num_iteration: Optional[int] = None,
@@ -1442,7 +1442,7 @@ class DaskLGBMRegressor(LGBMRegressor, _DaskLGBMModel):
 
     def predict(
         self,
-        X: _DaskMatrixLike,  # type: ignore[override]
+        X: _DaskMatrixLike,
         raw_score: bool = False,
         start_iteration: int = 0,
         num_iteration: Optional[int] = None,
@@ -1617,7 +1617,7 @@ class DaskLGBMRanker(LGBMRanker, _DaskLGBMModel):
 
     def predict(
         self,
-        X: _DaskMatrixLike,  # type: ignore[override]
+        X: _DaskMatrixLike,
         raw_score: bool = False,
         start_iteration: int = 0,
         num_iteration: Optional[int] = None,

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1053,8 +1053,8 @@ class LGBMRegressor(_LGBMRegressorBase, LGBMModel):
         return self
 
     _base_doc = LGBMModel.fit.__doc__.replace("self : LGBMModel", "self : LGBMRegressor")  # type: ignore
-    _base_doc = (_base_doc[:_base_doc.find('group :')]  # type: ignore
-                 + _base_doc[_base_doc.find('eval_set :'):])  # type: ignore
+    _base_doc = (_base_doc[:_base_doc.find('group :')]
+                 + _base_doc[_base_doc.find('eval_set :'):])
     _base_doc = (_base_doc[:_base_doc.find('eval_class_weight :')]
                  + _base_doc[_base_doc.find('eval_init_score :'):])
     fit.__doc__ = (_base_doc[:_base_doc.find('eval_group :')]
@@ -1147,8 +1147,8 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
         return self
 
     _base_doc = LGBMModel.fit.__doc__.replace("self : LGBMModel", "self : LGBMClassifier")  # type: ignore
-    _base_doc = (_base_doc[:_base_doc.find('group :')]  # type: ignore
-                 + _base_doc[_base_doc.find('eval_set :'):])  # type: ignore
+    _base_doc = (_base_doc[:_base_doc.find('group :')]
+                 + _base_doc[_base_doc.find('eval_set :'):])
     fit.__doc__ = (_base_doc[:_base_doc.find('eval_group :')]
                    + _base_doc[_base_doc.find('eval_metric :'):])
 
@@ -1209,7 +1209,7 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
                          "due to the usage of customized objective function.\n"
                          "Returning raw scores instead.")
             return result
-        elif self._n_classes > 2 or raw_score or pred_leaf or pred_contrib:  # type: ignore [operator]
+        elif self._n_classes > 2 or raw_score or pred_leaf or pred_contrib:
             return result
         else:
             return np.vstack((1. - result, result)).transpose()
@@ -1305,8 +1305,8 @@ class LGBMRanker(LGBMModel):
         return self
 
     _base_doc = LGBMModel.fit.__doc__.replace("self : LGBMModel", "self : LGBMRanker")  # type: ignore
-    fit.__doc__ = (_base_doc[:_base_doc.find('eval_class_weight :')]  # type: ignore
-                   + _base_doc[_base_doc.find('eval_init_score :'):])  # type: ignore
+    fit.__doc__ = (_base_doc[:_base_doc.find('eval_class_weight :')]
+                   + _base_doc[_base_doc.find('eval_init_score :'):])
     _base_doc = fit.__doc__
     _before_feature_name, _feature_name, _after_feature_name = _base_doc.partition('feature_name :')
     fit.__doc__ = f"""{_before_feature_name}eval_at : list or tuple of int, optional (default=(1, 2, 3, 4, 5))

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1091,7 +1091,7 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
             self._class_weight = {self._class_map[k]: v for k, v in self.class_weight.items()}
 
         self._classes = self._le.classes_
-        self._n_classes = len(self._classes)  # type: ignore[arg-type]
+        self._n_classes = len(self._classes)
 
         # adjust eval metrics to match whether binary or multiclass
         # classification is being performed


### PR DESCRIPTION
Contributes to #3867.

As more of the library's code gets type annotations, as errors in those annotations are fixed, and as `mypy` itself is improved, some `# type: ignore` comments used to suppress `mypy` errors can become irrelevant.

This PR proposes running `mypy` with `--warn-unused-ignores`, which will cause `mypy` to fail if unnecessary `# type: ignore` comments are used.

This is useful because `# type: ignore` comments can sometimes cause `mypy` to stop checking down a code path, and removing unnecessary ones therefore improves the likelihood that problems can be detected by `mypy`.

This PR also fixes the following errors introduced by that check.

```text
python-package/lightgbm/basic.py:215: error: Unused "type: ignore" comment
python-package/lightgbm/sklearn.py:1056: error: Unused "type: ignore" comment
python-package/lightgbm/sklearn.py:1057: error: Unused "type: ignore" comment
python-package/lightgbm/sklearn.py:1150: error: Unused "type: ignore" comment
python-package/lightgbm/sklearn.py:1151: error: Unused "type: ignore" comment
python-package/lightgbm/sklearn.py:1212: error: Unused "type: ignore" comment
python-package/lightgbm/sklearn.py:1308: error: Unused "type: ignore" comment
python-package/lightgbm/sklearn.py:1309: error: Unused "type: ignore" comment
python-package/lightgbm/dask.py:1092: error: Unused "type: ignore" comment
```