### PR TITLE
[ci] remove R 3.6 macOS CI jobs

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -133,7 +133,7 @@ else
     packages="c('data.table', 'jsonlite', 'knitr', 'Matrix', 'R6', 'RhpcBLASctl', 'rmarkdown', 'testthat')"
 fi
 compile_from_source="both"
-if [[ $OS_NAME == "macos" ]]; then
+if [[ $OS_NAME == "macos" ]] && [[ "${R_MAJOR_VERSION}" != "3" ]]; then
     packages+=", type = 'binary'"
     compile_from_source="never"
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -133,7 +133,7 @@ else
     packages="c('data.table', 'jsonlite', 'knitr', 'Matrix', 'R6', 'RhpcBLASctl', 'rmarkdown', 'testthat')"
 fi
 compile_from_source="both"
-if [[ $OS_NAME == "macos" ]] && [[ "${R_MAJOR_VERSION}" != "3" ]]; then
+if [[ $OS_NAME == "macos" ]]; then
     packages+=", type = 'binary'"
     compile_from_source="never"
 fi

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -17,7 +17,7 @@ fi
 R_MAJOR_VERSION=( ${R_VERSION//./ } )
 if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
     export R_MAC_VERSION=3.6.3
-    export R_MAC_PKG_URL=${CRAN_MIRROR}/bin/macosx/R-${R_MAC_VERSION}.pkg
+    export R_MAC_PKG_URL=${CRAN_MIRROR}/bin/macosx/R-${R_MAC_VERSION}.nn.pkg
     export R_LINUX_VERSION="3.6.3-1bionic"
     export R_APT_REPO="bionic-cran35/"
 elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -66,19 +66,7 @@ jobs:
           - os: macOS-latest
             task: r-package
             compiler: gcc
-            r_version: 3.6
-            build_type: cmake
-            container: null
-          - os: macOS-latest
-            task: r-package
-            compiler: gcc
             r_version: 4.2
-            build_type: cmake
-            container: null
-          - os: macOS-latest
-            task: r-package
-            compiler: clang
-            r_version: 3.6
             build_type: cmake
             container: null
           - os: macOS-latest


### PR DESCRIPTION
Removes the R 3.6 macOS jobs.

See "Motivation" and https://github.com/microsoft/LightGBM/pull/5859#discussion_r1177331016 for why.

Reasons I think this is ok:

* we still have CI jobs testing the R package against R 3.6 on Windows and Linux
* R 3.6 compatibility isn't required by CRAN any more
* the last release in the 3.6 series, 3.6.3, came out 3+ years ago ([release history](https://cran.r-project.org/bin/windows/base/old/))

### Motivation

Starting recently, I've noticed that the macOS R 3.6 jobs have been failing with the following error.

> installer: Error - the package path specified was invalid: '/Users/runner/work/LightGBM/LightGBM/R.pkg'.

([example build link](https://github.com/microsoft/LightGBM/actions/runs/4803699366/jobs/8548454888))

It looks like RStudio's CRAN changed the download link for the R 3.6 mac installer to `R-3.6.3.nn.pkg`.

<img width="1053" alt="Screen Shot 2023-04-25 at 10 56 09 PM" src="https://user-images.githubusercontent.com/7608904/234466333-b734fbe0-d9a8-4988-b958-bab1e49422ee.png">

https://cran.rstudio.com/bin/macosx/
