### PR TITLE
[python-package] Add `progress_bar` callback using tqdm

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -134,7 +134,8 @@ conda create -q -y -n $CONDA_ENV \
     ${CONDA_PYTHON_REQUIREMENT} \
     python-graphviz \
     scikit-learn \
-    scipy || exit -1
+    scipy \
+    tqdm || exit -1
 
 source activate $CONDA_ENV
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -135,7 +135,8 @@ conda create -q -y -n $CONDA_ENV \
     python-graphviz \
     scikit-learn \
     scipy \
-    tqdm || exit -1
+    tqdm \
+    types-tqdm || exit -1
 
 source activate $CONDA_ENV
 

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -56,7 +56,8 @@ conda create -q -y -n $env:CONDA_ENV `
   "python=$env:PYTHON_VERSION[build=*cpython]" `
   python-graphviz `
   scikit-learn `
-  scipy ; Check-Output $?
+  scipy `
+  tqdm ; Check-Output $?
 
 if ($env:TASK -ne "bdist") {
   conda activate $env:CONDA_ENV

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -57,7 +57,8 @@ conda create -q -y -n $env:CONDA_ENV `
   python-graphviz `
   scikit-learn `
   scipy `
-  tqdm ; Check-Output $?
+  tqdm `
+  types-tqdm ; Check-Output $?
 
 if ($env:TASK -ne "bdist") {
   conda activate $env:CONDA_ENV

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,7 @@ autodoc_mock_imports = [
     'pandas',
     'scipy',
     'scipy.sparse',
+    'tqdm'
 ]
 try:
     import sklearn  # noqa: F401

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -6,7 +6,7 @@ Contributors: https://github.com/microsoft/LightGBM/graphs/contributors.
 from pathlib import Path
 
 from .basic import Booster, Dataset, Sequence, register_logger
-from .callback import early_stopping, log_evaluation, record_evaluation, reset_parameter
+from .callback import early_stopping, log_evaluation, record_evaluation, reset_parameter, progress_bar
 from .engine import CVBooster, cv, train
 
 try:
@@ -32,5 +32,5 @@ __all__ = ['Dataset', 'Booster', 'CVBooster', 'Sequence',
            'train', 'cv',
            'LGBMModel', 'LGBMRegressor', 'LGBMClassifier', 'LGBMRanker',
            'DaskLGBMRegressor', 'DaskLGBMClassifier', 'DaskLGBMRanker',
-           'log_evaluation', 'record_evaluation', 'reset_parameter', 'early_stopping',
+           'log_evaluation', 'record_evaluation', 'reset_parameter', 'early_stopping', 'progress_bar',
            'plot_importance', 'plot_split_value_histogram', 'plot_metric', 'plot_tree', 'create_tree_digraph']

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -6,7 +6,7 @@ Contributors: https://github.com/microsoft/LightGBM/graphs/contributors.
 from pathlib import Path
 
 from .basic import Booster, Dataset, Sequence, register_logger
-from .callback import early_stopping, log_evaluation, record_evaluation, reset_parameter, progress_bar
+from .callback import early_stopping, log_evaluation, progress_bar, record_evaluation, reset_parameter
 from .engine import CVBooster, cv, train
 
 try:

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -427,27 +427,6 @@ def early_stopping(stopping_rounds: int, first_metric_only: bool = False, verbos
     return _EarlyStoppingCallback(stopping_rounds=stopping_rounds, first_metric_only=first_metric_only, verbose=verbose, min_delta=min_delta)
 
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-    _tqdm_module_name_str = Literal[
-            "auto",
-            "autonotebook",
-            "std",
-            "notebook",
-            "asyncio",
-            "keras",
-            "dask",
-            "tk",
-            "gui",
-            "rich",
-            "contrib.slack",
-            "contrib.discord",
-            "contrib.telegram",
-            "contrib.bells",
-        ]
-else:
-    _tqdm_module_name_str = str
-
 class _ProgressBarCallback:
     """Internal class to handle progress bar."""
     tqdm_cls: "Type[tqdm.std.tqdm]"
@@ -455,8 +434,7 @@ class _ProgressBarCallback:
 
     def __init__(
         self,
-        tqdm_cls: _tqdm_module_name_str
-        | "Type[tqdm.std.tqdm]" = "auto",
+        tqdm_cls: str | Type["tqdm.std.tqdm"] = "auto",
         early_stopping_callback: Any | None = None,
         **tqdm_kwargs: Any,
     ) -> None:
@@ -534,9 +512,29 @@ class _ProgressBarCallback:
         self.pbar.update()
         self.pbar.refresh()
 
+if sys.version_info >= (3, 8):
+    from typing import Literal, overload
+    
+    @overload
+    def progress_bar(tqdm_cls: Literal[
+            "auto",
+            "autonotebook",
+            "std",
+            "notebook",
+            "asyncio",
+            "keras",
+            "dask",
+            "tk",
+            "gui",
+            "rich",
+            "contrib.slack",
+            "contrib.discord",
+            "contrib.telegram",
+            "contrib.bells",
+        ], early_stopping_callback: _EarlyStoppingCallback | None = None, **tqdm_kwargs: Any) -> _ProgressBarCallback:
+        ...
 
-def progress_bar(tqdm_cls: _tqdm_module_name_str
-    | "Type[tqdm.std.tqdm]" = "auto",
+def progress_bar(tqdm_cls: str | Type["tqdm.std.tqdm"] = "auto",
     early_stopping_callback: _EarlyStoppingCallback | None = None,
     **tqdm_kwargs: Any,
 ) -> _ProgressBarCallback:

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -454,6 +454,8 @@ class _ProgressBarCallback:
                 callbacks = [early_stopping_callback, ProgressBarCallback(early_stopping_callback=early_stopping_callback)]
                 estimator.fit(X_train, y_train, eval_set=[(X_test, y_test)], callbacks=callbacks)
         """
+        self.order = 40
+        self.before_iteration = False
         if isinstance(tqdm_cls, str):
             try:
                 tqdm_module = importlib.import_module(f"tqdm.{tqdm_cls}")

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -7,7 +7,8 @@ import importlib
 import warnings
 from collections import OrderedDict
 from functools import partial
-from typing import Any, Callable, Dict, List, Literal, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Tuple, Type, Union
+import sys
 
 from .basic import _ConfigAliases, _LGBM_BoosterEvalMethodResultType, _log_info, _log_warning
 
@@ -426,14 +427,9 @@ def early_stopping(stopping_rounds: int, first_metric_only: bool = False, verbos
     return _EarlyStoppingCallback(stopping_rounds=stopping_rounds, first_metric_only=first_metric_only, verbose=verbose, min_delta=min_delta)
 
 
-class _ProgressBarCallback:
-    """Internal class to handle progress bar."""
-    tqdm_cls: "Type[tqdm.std.tqdm]"
-    pbar: "tqdm.std.tqdm" | None
-
-    def __init__(
-        self,
-        tqdm_cls: Literal[
+if sys.version_info >= (3, 8):
+    from typing import Literal
+    _tqdm_module_name_str = Literal[
             "auto",
             "autonotebook",
             "std",
@@ -449,6 +445,17 @@ class _ProgressBarCallback:
             "contrib.telegram",
             "contrib.bells",
         ]
+else:
+    _tqdm_module_name_str = str
+
+class _ProgressBarCallback:
+    """Internal class to handle progress bar."""
+    tqdm_cls: "Type[tqdm.std.tqdm]"
+    pbar: "tqdm.std.tqdm" | None
+
+    def __init__(
+        self,
+        tqdm_cls: _tqdm_module_name_str
         | "Type[tqdm.std.tqdm]" = "auto",
         early_stopping_callback: Any | None = None,
         **tqdm_kwargs: Any,
@@ -528,22 +535,7 @@ class _ProgressBarCallback:
         self.pbar.refresh()
 
 
-def progress_bar(tqdm_cls: Literal[
-    "auto",
-    "autonotebook",
-    "std",
-    "notebook",
-    "asyncio",
-    "keras",
-    "dask",
-    "tk",
-    "gui",
-    "rich",
-    "contrib.slack",
-    "contrib.discord",
-    "contrib.telegram",
-    "contrib.bells",
-]
+def progress_bar(tqdm_cls: _tqdm_module_name_str
     | "Type[tqdm.std.tqdm]" = "auto",
     early_stopping_callback: _EarlyStoppingCallback | None = None,
     **tqdm_kwargs: Any,

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -513,6 +513,17 @@ class _ProgressBarCallback:
         # update pbar
         self.pbar.update()
         self.pbar.refresh()
+    
+    # do not pickle tqdm instance
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state["pbar"] = None
+        # class should be picklable
+        return state
+    
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self.pbar = None
 
 if sys.version_info >= (3, 8):
     from typing import Literal, overload

--- a/tests/python_package_test/test_callback.py
+++ b/tests/python_package_test/test_callback.py
@@ -81,7 +81,7 @@ def test_progress_bar_binary():
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
     gbm = lgb.LGBMClassifier(n_estimators=50, verbose=-1)
     callback = lgb.progress_bar()
-    gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], callbacks=[lgb.early_stopping(5), callback])
+    gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], callbacks=[callback])
     
     assert issubclass(callback.tqdm_cls, tqdm.std.tqdm)
     assert isinstance(callback.pbar, tqdm.std.tqdm)

--- a/tests/python_package_test/test_callback.py
+++ b/tests/python_package_test/test_callback.py
@@ -4,6 +4,7 @@ from sklearn.model_selection import train_test_split
 import tqdm
 
 import lightgbm as lgb
+import lightgbm.callback
 
 from .utils import SERIALIZERS, load_breast_cancer, pickle_and_unpickle_object
 
@@ -93,9 +94,9 @@ def test_progress_bar_early_stopping_binary():
     X, y = load_breast_cancer(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
     gbm = lgb.LGBMClassifier(n_estimators=50, verbose=-1)
-    early_stopping = lgb.early_stopping(5)
-    callback = lgb.progress_bar(early_stopping=early_stopping)
-    gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], callbacks=[early_stopping, callback])
+    early_stopping_callback = lgb.early_stopping(5)
+    callback = lgb.progress_bar(early_stopping_callback=early_stopping_callback)
+    gbm.fit(X_train, y_train, eval_set=[(X_test, y_test)], callbacks=[early_stopping_callback, callback])
     
     assert issubclass(callback.tqdm_cls, tqdm.std.tqdm)
     assert isinstance(callback.pbar, tqdm.std.tqdm)

--- a/tests/python_package_test/test_callback.py
+++ b/tests/python_package_test/test_callback.py
@@ -65,7 +65,7 @@ def test_progress_bar_callback_is_picklable(serializer):
     callback_from_disk = pickle_and_unpickle_object(obj=callback, serializer=serializer)
     callback(lightgbm.callback.CallbackEnv(model=None,
                          params={},
-                         iteration=1,
+                         iteration=0,
                          begin_iteration=0,
                          end_iteration=100,
                          evaluation_result_list=[]))

--- a/tests/python_package_test/test_callback.py
+++ b/tests/python_package_test/test_callback.py
@@ -55,3 +55,17 @@ def test_reset_parameter_callback_is_picklable(serializer):
     assert callback_from_disk.before_iteration is True
     assert callback.kwargs == callback_from_disk.kwargs
     assert callback.kwargs == params
+
+@pytest.mark.parametrize('serializer', SERIALIZERS)
+def test_progress_bar_callback_is_picklable(serializer):
+    rounds = 5
+    callback = lgb.progress_bar()
+    callback_from_disk = pickle_and_unpickle_object(obj=callback, serializer=serializer)
+    assert callback_from_disk.order == 30
+    assert callback_from_disk.before_iteration is False
+    assert callback.stopping_rounds == callback_from_disk.stopping_rounds
+    assert callback.stopping_rounds == rounds
+
+def test_progress_bar_warn_override() -> None:
+    with pytest.warns(UserWarning):
+        lgb.progress_bar(total=100)

--- a/tests/python_package_test/test_callback.py
+++ b/tests/python_package_test/test_callback.py
@@ -63,13 +63,12 @@ def test_reset_parameter_callback_is_picklable(serializer):
 def test_progress_bar_callback_is_picklable(serializer):
     callback = lgb.progress_bar()
     callback_from_disk = pickle_and_unpickle_object(obj=callback, serializer=serializer)
-    callback.CallbackEnv(model=None,
+    callback(lightgbm.callback.CallbackEnv(model=None,
                          params={},
                          iteration=1,
                          begin_iteration=0,
                          end_iteration=100,
-                         evaluation_result_list=[])
-    callback.pbar = tqdm.tqdm(total=100)
+                         evaluation_result_list=[]))
     assert callback_from_disk.order == 40
     assert callback_from_disk.before_iteration is False
 

--- a/tests/python_package_test/test_callback.py
+++ b/tests/python_package_test/test_callback.py
@@ -60,13 +60,17 @@ def test_reset_parameter_callback_is_picklable(serializer):
 
 @pytest.mark.parametrize('serializer', SERIALIZERS)
 def test_progress_bar_callback_is_picklable(serializer):
-    rounds = 5
     callback = lgb.progress_bar()
     callback_from_disk = pickle_and_unpickle_object(obj=callback, serializer=serializer)
-    assert callback_from_disk.order == 30
+    callback.CallbackEnv(model=None,
+                         params={},
+                         iteration=1,
+                         begin_iteration=0,
+                         end_iteration=100,
+                         evaluation_result_list=[])
+    callback.pbar = tqdm.tqdm(total=100)
+    assert callback_from_disk.order == 40
     assert callback_from_disk.before_iteration is False
-    assert callback.stopping_rounds == callback_from_disk.stopping_rounds
-    assert callback.stopping_rounds == rounds
 
 def test_progress_bar_warn_override() -> None:
     with pytest.warns(UserWarning):


### PR DESCRIPTION
Use tqdm to display training progress and metrics and, if necessary, early_stopping results. tqdm does not need to be installed and is compatible with the existing code.

Example:
```python
X_train, X_test, y_train, y_test = train_test_split(...)
gbm = lgb.LGBMRegressor()
early_stopping_callback = lgb.early_stopping(stopping_rounds=50)
callback = lgb.progress_bar("rich", early_stopping_callback=early_stopping_callback)
gbm.fit(
    X_train,
    y_train,
    eval_set=[(X_test, y_test)],
    callbacks=[early_stopping_callback, callback],
)
```

![image](https://user-images.githubusercontent.com/55338215/236421472-eccce05b-64dc-4a04-b983-02fb03319ee3.png)

```python
X_train, X_test, y_train, y_test = train_test_split(...)
gbm = lgb.LGBMRegressor()
early_stopping_callback = lgb.early_stopping(stopping_rounds=50)
callback = lgb.progress_bar(early_stopping_callback=early_stopping_callback)
gbm.fit(
    X_train,
    y_train,
    eval_set=[(X_test, y_test)],
    callbacks=[early_stopping_callback, callback],
)
```

![image](https://user-images.githubusercontent.com/55338215/236422916-59ae2c4a-5ca3-45e9-ac00-2babd8f261b5.png)
I tried `sys.stderr.flush()` and so on, but the output was inevitably broken when using `tqdm.std.tqdm`.