### PR TITLE
[ci] use lowercase library names in linker flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,7 +566,7 @@ endif()
 
 if(WIN32)
     if(MINGW OR CYGWIN)
-      target_link_libraries(lightgbm_objs PUBLIC Ws2_32 IPHLPAPI)
+      target_link_libraries(lightgbm_objs PUBLIC ws2_32 iphlpapi)
     endif()
 endif()
 

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -19,7 +19,7 @@ PKG_LIBS = \
     ${SHLIB_OPENMP_CXXFLAGS} \
     ${SHLIB_PTHREAD_FLAGS} \
     -lws2_32 \
-    -lIphlpapi
+    -liphlpapi
 
 OBJECTS = \
     boosting/boosting.o \


### PR DESCRIPTION
This change should improve compatibility and consistency with other projects and build tools, and prevent any potential issues arising from the inconsistent capitalization of the library names.