### PR TITLE
[ci] use Python 3.11 in linting CI job

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -21,7 +21,7 @@ env:
   CONDA_ENV: test-env
   GITHUB_ACTIONS: 'true'
   OS_NAME: 'linux'
-  PYTHON_VERSION: '3.10'
+  PYTHON_VERSION: '3.11'
 
 jobs:
   test:


### PR DESCRIPTION
Contributes to #3867.

Proposes running the `lint` CI task in a Python 3.11 environment, to ensure we continue to be able to install the latest versions of that job's various dependencies together.

I'm hoping it might help with #5746, which in turn might improve `mypy`'s ability to catch bugs.