### PR TITLE
[ci] [python-package] tell mypy 'auto' has a special meaning for feature_name and categorical_feature

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -12,7 +12,7 @@ from os import SEEK_END, environ
 from os.path import getsize
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import scipy.sparse

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -12,13 +12,16 @@ from os import SEEK_END, environ
 from os.path import getsize
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 import scipy.sparse
 
 from .compat import PANDAS_INSTALLED, concat, dt_DataTable, pd_CategoricalDtype, pd_DataFrame, pd_Series
 from .libpath import find_lib_path
+
+if TYPE_CHECKING:
+    from typing import Literal
 
 __all__ = [
     'Booster',
@@ -49,8 +52,8 @@ _ctypes_float_array = Union[
 _LGBM_EvalFunctionResultType = Tuple[str, float, bool]
 _LGBM_BoosterBestScoreType = Dict[str, Dict[str, float]]
 _LGBM_BoosterEvalMethodResultType = Tuple[str, str, float, bool]
-_LGBM_CategoricalFeatureConfiguration = Union[List[str], List[int], str]
-_LGBM_FeatureNameConfiguration = Union[List[str], str]
+_LGBM_CategoricalFeatureConfiguration = Union[List[str], List[int], "Literal['auto']"]
+_LGBM_FeatureNameConfiguration = Union[List[str], "Literal['auto']"]
 _LGBM_GroupType = Union[
     List[float],
     List[int],
@@ -687,8 +690,6 @@ def _data_from_pandas(
                 feature_name = list(data.columns)
             if categorical_feature == 'auto':  # use cat cols from DataFrame
                 categorical_feature = cat_cols_not_ordered
-            else:  # use cat cols specified by user
-                categorical_feature = list(categorical_feature)
         if feature_name == 'auto':
             feature_name = list(data.columns)
         _check_for_bad_pandas_dtypes(data.dtypes)

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -691,7 +691,7 @@ def _data_from_pandas(
             if categorical_feature == 'auto':  # use cat cols from DataFrame
                 categorical_feature = cat_cols_not_ordered
             else:  # use cat cols specified by user
-                categorical_feature = list(categorical_feature)
+                categorical_feature = list(categorical_feature)  # type: ignore[assignment]
         if feature_name == 'auto':
             feature_name = list(data.columns)
         _check_for_bad_pandas_dtypes(data.dtypes)

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -690,6 +690,8 @@ def _data_from_pandas(
                 feature_name = list(data.columns)
             if categorical_feature == 'auto':  # use cat cols from DataFrame
                 categorical_feature = cat_cols_not_ordered
+            else:  # use cat cols specified by user
+                categorical_feature = list(categorical_feature)
         if feature_name == 'auto':
             feature_name = list(data.columns)
         _check_for_bad_pandas_dtypes(data.dtypes)


### PR DESCRIPTION
Contributes to #3756.
Contributes to #3867.

Fixes the following error from `mypy`.

```text
python-package/lightgbm/basic.py:691: error: Incompatible types in assignment (expression has type "List[object]", variable has type "Union[List[str], List[int], str, None]")  [assignment]
```

For arguments `feature_name` and `categorical_feature`, the Python package supports passing 3 possible non-`None` values:

* list of strings (column names)
* list of ints (0-based positional indexes of the columns)
* string `"auto"` (interpreted as "figure it out automatically" for `pandas` inputs, and as `None` otherwise)

Using the `typing.Literal` annotation, added in Python 3.8, `mypy` is able to understand that if these arguments are not `None` or a list, they must be *literally `"auto"`*, not any arbitrary string (as the current type hint of `str` implies).

This helps it to understand that, for example...

```python
if categorical_feature != "auto" and categorical_feature is not None:
    # categorical_feature MUST be a list at this point
```

### Notes for Reviewers

For more details on the `Literal` type, see https://mypy.readthedocs.io/en/stable/literal_types.html#literal-types.

For an explanation of how string-literal type hints can be used to prevent runtime users, see https://mypy.readthedocs.io/en/stable/runtime_troubles.html.