### PR TITLE
[ci] fix wheel renaming in test.sh

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -150,7 +150,7 @@ if [[ $TASK == "sdist" ]]; then
     sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
     pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz -v || exit -1
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
-        cp $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz $BUILD_ARTIFACTSTAGINGDIRECTORY
+        cp $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz $BUILD_ARTIFACTSTAGINGDIRECTORY || exit -1
     fi
     pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
     exit 0
@@ -159,10 +159,10 @@ elif [[ $TASK == "bdist" ]]; then
         cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel || exit -1
         sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
         mv \
-            dist/lightgbm-$LGB_VER-py3-none-macosx*.whl \
-            dist/lightgbm-$LGB_VER-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl
+            ./dist/*.whl \
+            dist/lightgbm-$LGB_VER-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl || exit -1
         if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
-            cp dist/lightgbm-$LGB_VER-py3-none-macosx*.whl $BUILD_ARTIFACTSTAGINGDIRECTORY
+            cp dist/lightgbm-$LGB_VER-py3-none-macosx*.whl $BUILD_ARTIFACTSTAGINGDIRECTORY || exit -1
         fi
     else
         ARCH=$(uname -m)
@@ -174,10 +174,10 @@ elif [[ $TASK == "bdist" ]]; then
         cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --integrated-opencl || exit -1
         mv \
             ./dist/*.whl \
-            ./dist/lightgbm-$LGB_VER-py3-none-$PLATFORM.whl
+            ./dist/lightgbm-$LGB_VER-py3-none-$PLATFORM.whl || exit -1
         sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
         if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
-            cp dist/lightgbm-$LGB_VER-py3-none-$PLATFORM.whl $BUILD_ARTIFACTSTAGINGDIRECTORY
+            cp dist/lightgbm-$LGB_VER-py3-none-$PLATFORM.whl $BUILD_ARTIFACTSTAGINGDIRECTORY || exit -1
         fi
         # Make sure we can do both CPU and GPU; see tests/python_package_test/test_dual.py
         export LIGHTGBM_TEST_DUAL_CPU_GPU=1

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -35,7 +35,7 @@ if ($env:TASK -eq "swig") {
   mkdir $env:BUILD_SOURCESDIRECTORY/build; cd $env:BUILD_SOURCESDIRECTORY/build
   cmake -A x64 -DUSE_SWIG=ON .. ; cmake --build . --target ALL_BUILD --config Release ; Check-Output $?
   if ($env:AZURE -eq "true") {
-    cp $env:BUILD_SOURCESDIRECTORY/build/lightgbmlib.jar $env:BUILD_ARTIFACTSTAGINGDIRECTORY/lightgbmlib_win.jar
+    cp $env:BUILD_SOURCESDIRECTORY/build/lightgbmlib.jar $env:BUILD_ARTIFACTSTAGINGDIRECTORY/lightgbmlib_win.jar ; Check-Output $?
   }
   Exit 0
 }


### PR DESCRIPTION
Since #5837, CI jobs on macOS are failing to rename the macOS wheels.

> mv: rename dist/lightgbm-3.3.5.99-py3-none-macosx*.whl to dist/lightgbm-3.3.5.99-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl: No such file or directory

([build link](https://github.com/microsoft/LightGBM/actions/runs/4920451551/jobs/8789262420#step:3:652))

This is because the logic in `build-python.sh` doesn't pass `--plat-name=macosx` through when building wheels. Doing that (and adding more logic to detect that it's on macOS) isn't necessary.

In all of LightGBM's CI scripts, we rename wheels manually anyway, like this

https://github.com/microsoft/LightGBM/blob/1c873af9c069ac09afae37a9787ee4f7f0f0ad68/.ci/test.sh#L161-L163

And in #5759, `scikit-build-core` will generate wheels with the correct platform tag.

So this, for now, just:

1. makes the logic in test scripts a bit less specific about which platform tag it's looking for during the rename step
2. makes all this renaming logic stricter (i.e. more likely to cause a big loud CI failure if this breaks again in the future)

Sorry 😅 