### PR TITLE
add CMakeLists options to disable building CLI, installing headers

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -199,7 +199,12 @@ if [[ $TASK == "gpu" ]]; then
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit -1
         sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
-        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--gpu || exit -1
+        pip install \
+            --user \
+            -v \
+            --install-option=--gpu \
+            $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz \
+        || exit -1
         pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
@@ -222,7 +227,12 @@ elif [[ $TASK == "cuda" ]]; then
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit -1
         sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
-        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--cuda || exit -1
+        pip install \
+            --user \
+            -v \
+            --install-option=--cuda \
+            $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz \
+        || exit -1
         pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
@@ -240,7 +250,12 @@ elif [[ $TASK == "mpi" ]]; then
     if [[ $METHOD == "pip" ]]; then
         cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit -1
         sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
-        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz -v --install-option=--mpi || exit -1
+        pip install \
+            --user \
+            -v \
+            --install-option=--mpi \
+            $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz \
+        || exit -1
         pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,11 @@ set(
   "Semicolon separated list of sanitizer names, e.g., 'address;leak'. \
 Supported sanitizers are address, leak, undefined and thread."
 )
+option(BUILD_CLI "Build the 'lightbgm' command-line interface in addition to lib_lightgbm" ON)
 option(BUILD_CPP_TEST "Build C++ tests with Google Test" OFF)
 option(BUILD_STATIC_LIB "Build static library" OFF)
+option(INSTALL_HEADERS "Install headers to CMAKE_INSTALL_PREFIX (e.g. '/usr/local/include')" ON)
+option(__BUILD_FOR_PYTHON "Set to ON if building lib_lightgbm for use with the Python package" OFF)
 option(__BUILD_FOR_R "Set to ON if building lib_lightgbm for use with the R package" OFF)
 option(__INTEGRATE_OPENCL "Set to ON if building LightGBM with the OpenCL ICD Loader and its dependencies included" OFF)
 
@@ -53,6 +56,14 @@ if(__INTEGRATE_OPENCL)
   set(__INTEGRATE_OPENCL ON CACHE BOOL "" FORCE)
   set(USE_GPU OFF CACHE BOOL "" FORCE)
   message(STATUS "Building library with integrated OpenCL components")
+endif()
+
+if(__BUILD_FOR_PYTHON OR __BUILD_FOR_R)
+    # the Python and R package don't require the CLI
+    set(BUILD_CLI OFF)
+    # installing the R and Python package shouldn't place LightGBM's headers
+    # outside of where the package is installed
+    set(INSTALL_HEADERS OFF)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -421,8 +432,10 @@ endif()
 
 add_library(lightgbm_objs OBJECT ${SOURCES})
 
-add_executable(lightgbm src/main.cpp src/application/application.cpp)
-target_link_libraries(lightgbm PRIVATE lightgbm_objs)
+if(BUILD_CLI)
+    add_executable(lightgbm src/main.cpp src/application/application.cpp)
+    target_link_libraries(lightgbm PRIVATE lightgbm_objs)
+endif()
 
 set(API_SOURCES "src/c_api.cpp")
 # Only build the R part of the library if building for
@@ -544,19 +557,25 @@ if(USE_CUDA)
   # each target that contains or depends on cuda source.
   set_target_properties(lightgbm_objs PROPERTIES CUDA_ARCHITECTURES OFF)
   set_target_properties(_lightgbm PROPERTIES CUDA_ARCHITECTURES OFF)
-  set_target_properties(lightgbm PROPERTIES CUDA_ARCHITECTURES OFF)
+  if(BUILD_CLI)
+    set_target_properties(lightgbm PROPERTIES CUDA_ARCHITECTURES OFF)
+  endif()
 
   set_target_properties(lightgbm_objs PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
   # Device linking is not supported for object libraries.
   # Thus we have to specify them on final targets.
-  set_target_properties(lightgbm PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+  if(BUILD_CLI)
+    set_target_properties(lightgbm PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+  endif()
   set_target_properties(_lightgbm PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
   # histograms are list of object libraries. Linking object library to other
   # object libraries only gets usage requirements, the linked objects won't be
   # used. Thus we have to call target_link_libraries on final targets here.
-  target_link_libraries(lightgbm PRIVATE ${histograms})
+  if(BUILD_CLI)
+    target_link_libraries(lightgbm PRIVATE ${histograms})
+  endif()
   target_link_libraries(_lightgbm PRIVATE ${histograms})
 endif()
 
@@ -619,11 +638,20 @@ if(BUILD_CPP_TEST)
   target_link_libraries(testlightgbm PRIVATE lightgbm_objs lightgbm_capi_objs GTest::GTest)
 endif()
 
+if(BUILD_CLI)
+    install(
+      TARGETS lightgbm
+      RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+    )
+endif()
+
 install(
-  TARGETS lightgbm _lightgbm
+  TARGETS _lightgbm
   RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
   LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
   ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
 )
 
-install(DIRECTORY ${LightGBM_HEADER_DIR}/LightGBM DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+if(INSTALL_HEADERS)
+    install(DIRECTORY ${LightGBM_HEADER_DIR}/LightGBM DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+endif()

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -91,7 +91,7 @@ def compile_cpp(
 
     logger.info("Starting to compile the library.")
 
-    cmake_cmd = ["cmake", str(CURRENT_DIR / "compile")]
+    cmake_cmd = ["cmake", str(CURRENT_DIR / "compile"), "-D__BUILD_FOR_PYTHON=ON"]
     if integrated_opencl:
         use_gpu = False
         cmake_cmd.append("-D__INTEGRATE_OPENCL=ON")


### PR DESCRIPTION
Contributes to #5061.

Proposes adding 3 options to `CMakeLists.txt`:

* `__BUILD_FOR_PYTHON` = indicate that lib_lightgbm is being built for use in a Python wheel
* `BUILD_CLI` = do / do not compile the `lightgbm` CLI when running `make` or `make install`
* `INSTALL_HEADERS` = do/do not move LightGBM's headers into `CMAKE_INSTALL_PREFIX` (e.g. `/usr/local/include/LightGBM/*.h`)

### Benefits of this change

Prevents unnecessary compilation of the CLI when building the Python package with `scikit-build-core`.

Prevents unnecessary generation of Makefile code for targets that won't ever be used by the R and Python packages.

### More Details

LightGBM's `CMakeLists.txt` generates Makefile(s) where `make` / `make install` has 3 effects:

* compile `lib_lightgbm.{dll/so}` + install it
* compile `lightgbm` (the CLI) + install it
* install LightGBM's header files to the default system location for headers

When building for the R and Python packages, the steps about the CLI and installing headers aren't required. LightGBM currently avoids those in those contexts by running `make _lightgbm` instead of `make` or `make install`.

https://github.com/microsoft/LightGBM/blob/1c873af9c069ac09afae37a9787ee4f7f0f0ad68/python-package/setup.py#L174

https://github.com/microsoft/LightGBM/blob/1c873af9c069ac09afae37a9787ee4f7f0f0ad68/R-package/src/install.libs.R#L138

To address #5061, in #5759 I'm proposing that LightGBM use `scikit-build-core` (https://github.com/scikit-build/scikit-build-core) as its build backend.

As of this writing, that project unconditionally runs `make install` on the `CMake`-generated makefiles ([docs link](https://github.com/scikit-build/scikit-build-core/blob/4bc101dd5e7cb49ca33bb978fb955286899a45b1/README.md#L50)). With that tool, there's no way to say "just build the `_lightgbm` target".

This PR's changes make it possible to use LightGBM's `CMakeLists.txt` in a way that `make` and `make install` only build the shared library.
