### PR TITLE
[docs] recommend a more efficient source installation of the python package

### DIFF
--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -333,7 +333,7 @@ So, if you want to:
 We are doing our best to provide universal wheels which have high running speed and are compatible with any hardware, OS, compiler, etc. at the same time.
 However, sometimes it's just impossible to guarantee the possibility of usage of LightGBM in any specific environment (see `Microsoft/LightGBM#1743 <https://github.com/microsoft/LightGBM/issues/1743>`__).
 
-Therefore, the first thing you should try in case of segfaults is **compiling from the source** using ``pip install --no-binary :all: lightgbm``.
+Therefore, the first thing you should try in case of segfaults is **compiling from the source** using ``pip install --no-binary lightgbm lightgbm``.
 For the OS-specific prerequisites see `this guide <https://github.com/microsoft/LightGBM/blob/master/python-package/README.rst#user-content-build-from-sources>`__.
 
 Also, feel free to post a new issue in our GitHub repository. We always look at each case individually and try to find a root cause.

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -41,7 +41,7 @@ Build from Sources
 
 .. code:: sh
 
-    pip install --no-binary :all: lightgbm
+    pip install --no-binary lightgbm lightgbm
 
 For **Linux** and **macOS** users, installation from sources requires installed `CMake`_.
 


### PR DESCRIPTION
This project's docs currently recommend running the following to force installation of a source distribution (instead of a wheel with a precompiled `lib_lightgbm`):

```shell
pip install --no-binary :all: lightgbm
```

The use of `:all:` is unnecessary... it implies "do not use ANY wheels". That means, for example, that if `numpy` isn't already installed then it will ALSO be built from source.

From `pip --help`.

> --no-binary <format_control>
    Do not use binary packages. Can be supplied multiple times, and
    each time adds to the existing value. Accepts either ":all:" to
                              disable all binary packages, ":none:" to empty the set (notice the
                              colons), or one or more package names with commas between them (no
                              colons). Note that some packages are tricky to compile and may fail
                              to install when this option is used on them.

This PR proposes instead recommending the use of `--no-binary lightgbm`, to instruct `pip` to only install `lightgbm`'s source distribution (and to otherwise use the latest available version, built or source, of all other dependencies).

### How I tested this

```shell
docker run \
    -it python:3.10 \
    pip install --no-binary ':all:' lightgbm
```

Saw in the logs that `numpy` was being built from source.

```text
Collecting numpy
  Downloading numpy-1.24.3.tar.gz (10.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10.9/10.9 MB 19.5 MB/s eta 0:00:00
  Installing build dependencies
...
```

Then ran the following

```shell
docker run \
    -it python:3.10 \
    pip install --no-binary lightgbm lightgbm
```

And saw that `pip` pulled in the `numpy` wheel.

```text
Collecting numpy
  Downloading numpy-1.24.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 17.3/17.3 MB 22.3 MB/s eta 0:00:00
```