### PR TITLE
[ci] [python-package] fix mypy error in Dataset.set_categorical_feature()

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2478,7 +2478,7 @@ class Dataset:
             else:
                 if self.categorical_feature != 'auto':
                     _log_warning('categorical_feature in Dataset is overridden.\n'
-                                 f'New categorical_feature is {sorted(list(categorical_feature))}')
+                                 f'New categorical_feature is {list(categorical_feature)}')
                 self.categorical_feature = categorical_feature
                 return self._free_handle()
         else:


### PR DESCRIPTION
Contributes to #3867.

Fixes the following error from `mypy`:

```text
python-package/lightgbm/basic.py:2480: error: Value of type variable "SupportsRichComparisonT" of "sorted" cannot be "object"  [type-var]
```