### PR TITLE
update MSBuild solution to Windows SDK v10.0, add inet_pton define (fixes #5856)

### DIFF
--- a/windows/LightGBM.vcxproj
+++ b/windows/LightGBM.vcxproj
@@ -34,7 +34,7 @@
     <SccLocalPath>SAK</SccLocalPath>
     <SccProvider>SAK</SccProvider>
     <ProjectName>LightGBM</ProjectName>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug_mpi|x64'">
@@ -101,7 +101,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>EIGEN_MPL2_ONLY;EIGEN_DONT_PARALLELIZE</PreprocessorDefinitions>
+      <PreprocessorDefinitions>EIGEN_MPL2_ONLY;EIGEN_DONT_PARALLELIZE;WIN_HAS_INET_PTON;</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_mpi|x64'">


### PR DESCRIPTION
Fixes #5856.
Contributes to #5061.

Tonight I tried compiling LightGBM on latest `master` with `MSBUild` (using Visual Studio 2019), like this:

```pwsh
MSBuild.exe windows/LightGBM.sln /p:Configuration=DLL /p:Platform=x64 /p:PlatformToolset=v142
```

That resulted in this error:

>   C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\cstddef(12,10): fatal error C1083: Cannot open include file: 'stddef.h': No such file or directory (compiling source file ..\src\treelearner\voting_parallel_tree_learner.cpp) [C:\Users\James\repos\LightGBM\windows\LightGBM.vcxproj]

Updating the target Windows SDK version from 8.1 to 10.0 fixed that.

Then I hit the error reported in #5856. I think that happened because when building without CMake, the test introduced in #5159 isn't run, `WIN_HAS_INET_PTON` isn't defined, and then the implementation in `socket_wrapper.hpp` conflicts with the one linked in from ws2_32.

This PR proposes always defining that in the `MSBuild` configuration, since it should be only older releases of MinGW that didn't have a definition for that function.

### How I tested this

Ran that command from above on this branch, using Visual Studio 2019 on Windows 10.

Saw that LightGBM compiled successfully.
