### PR TITLE
Docs changes to Binary Classification Example

### DIFF
--- a/examples/binary_classification/README.md
+++ b/examples/binary_classification/README.md
@@ -3,8 +3,9 @@ Binary Classification Example
 
 Here is an example for LightGBM to run binary classification task.
 
-***You must follow the [installation instructions](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html)
-for the following commands to work. The `lightgbm` binary must be built and available at the root of this project.***
+> **Note**
+>
+> Follow the [Installation Guide](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html) to make `lightgbm` binary available.
 
 Training
 --------
@@ -12,16 +13,22 @@ Training
 Run the following command in this folder:
 
 ```bash
-"../../lightgbm" config=train.conf
+lightgbm config=train.conf
 ```
+
+> **Note**
+>
+> Use `train_linear.conf` for [fit piecewise linear gradient boosting tree](https://lightgbm.readthedocs.io/en/latest/Parameters.html#linear_tree).
 
 Prediction
 ----------
 
-You should finish training first.
+> **Note**
+>
+> Finish the [training](#training) step first.
 
 Run the following command in this folder:
 
 ```bash
-"../../lightgbm" config=predict.conf
+lightgbm config=predict.conf
 ```

--- a/examples/binary_classification/predict.conf
+++ b/examples/binary_classification/predict.conf
@@ -1,5 +1,9 @@
+# task type
+# supported values:
+# - train
+# - predict
 task = predict
 
 data = binary.test
 
-input_model= LightGBM_model.txt
+input_model = LightGBM_model.txt

--- a/examples/binary_classification/train.conf
+++ b/examples/binary_classification/train.conf
@@ -1,7 +1,8 @@
 # task type, support train and predict
 task = train
 
-# boosting type, support gbdt for now, alias: boosting, boost
+# boosting type, support gbdt for now
+# alias: boosting, boost
 boosting_type = gbdt
 
 # application type, support following application
@@ -23,13 +24,11 @@ metric = binary_logloss,auc
 # frequency for metric output
 metric_freq = 1
 
-# true if need output metric for training data, alias: tranining_metric, train_metric
+# true if need output metric for training data
+# alias: training_metric, train_metric
 is_training_metric = true
 
-# column in data to use as label
-label_column = 0
-
-# number of bins for feature bucket, 255 is a recommend setting, it can save memories, and also has good accuracy. 
+# number of bins for feature bucket, 255 is a recommend setting, it can save memory, and also has good accuracy. 
 max_bin = 255
 
 # training data
@@ -42,13 +41,16 @@ data = binary.train
 # alias: valid, test, test_data, 
 valid_data = binary.test
 
-# number of trees(iterations), alias: num_tree, num_iteration, num_iterations, num_round, num_rounds
+# number of trees(iterations)
+# alias: num_tree, num_iteration, num_iterations, num_round, num_rounds
 num_trees = 100
 
-# shrinkage rate , alias: shrinkage_rate
+# shrinkage rate
+# alias: shrinkage_rate
 learning_rate = 0.1
 
-# number of leaves for one tree, alias: num_leaf
+# number of leaves for one tree
+# alias: num_leaf
 num_leaves = 63
 
 # type of tree learner, support following types:
@@ -80,7 +82,8 @@ min_data_in_leaf = 50
 # minimal sum Hessians for one leaf, use this to deal with over-fit
 min_sum_hessian_in_leaf = 5.0
 
-# save memory and faster speed for sparse feature, alias: is_sparse
+# save memory and faster speed for sparse feature
+# alias: is_sparse
 is_enable_sparse = true
 
 # when data is bigger than memory size, set this to true. otherwise set false will have faster speed
@@ -95,19 +98,21 @@ is_save_binary_file = false
 output_model = LightGBM_model.txt
 
 # support continuous train from trained gbdt model
-# input_model= trained_model.txt
+# input_model = trained_model.txt
 
 # output prediction file for predict task
-# output_result= prediction.txt
+# output_result = prediction.txt
 
-
-# number of machines in distributed training, alias: num_machine
+# number of machines in distributed training
+# alias: num_machine
 num_machines = 1
 
-# local listening port in distributed training, alias: local_port
+# local listening port in distributed training
+# alias: local_port
 local_listen_port = 12400
 
-# machines list file for distributed training, alias: mlist
+# machines list file for distributed training
+# alias: mlist
 machine_list_file = mlist.txt
 
 # force splits

--- a/examples/binary_classification/train_linear.conf
+++ b/examples/binary_classification/train_linear.conf
@@ -1,7 +1,8 @@
 # task type, support train and predict
 task = train
 
-# boosting type, support gbdt for now, alias: boosting, boost
+# boosting type, support gbdt for now
+# alias: boosting, boost
 boosting_type = gbdt
 
 # application type, support following application
@@ -11,6 +12,8 @@ boosting_type = gbdt
 # alias: application, app
 objective = binary
 
+# fit piecewise linear gradient boosting tree
+# alias: linear_trees
 linear_tree = true
 
 # eval metrics, support multi metric, delimited by ',' , support following metrics
@@ -25,10 +28,11 @@ metric = binary_logloss,auc
 # frequency for metric output
 metric_freq = 1
 
-# true if need output metric for training data, alias: tranining_metric, train_metric
+# true if need output metric for training data
+# alias: training_metric, train_metric
 is_training_metric = true
 
-# number of bins for feature bucket, 255 is a recommend setting, it can save memories, and also has good accuracy. 
+# number of bins for feature bucket, 255 is a recommend setting, it can save memory, and also has good accuracy. 
 max_bin = 255
 
 # training data
@@ -41,13 +45,16 @@ data = binary.train
 # alias: valid, test, test_data, 
 valid_data = binary.test
 
-# number of trees(iterations), alias: num_tree, num_iteration, num_iterations, num_round, num_rounds
+# number of trees(iterations)
+# alias: num_tree, num_iteration, num_iterations, num_round, num_rounds
 num_trees = 100
 
-# shrinkage rate , alias: shrinkage_rate
+# shrinkage rate
+# alias: shrinkage_rate
 learning_rate = 0.1
 
-# number of leaves for one tree, alias: num_leaf
+# number of leaves for one tree
+# alias: num_leaf
 num_leaves = 63
 
 # type of tree learner, support following types:
@@ -58,7 +65,7 @@ num_leaves = 63
 # alias: tree
 tree_learner = serial
 
-# number of threads for multi-threading. One thread will use each CPU. The default is set to CPU count. 
+# number of threads for multi-threading. One thread will use each CPU. The default is the CPU count. 
 # num_threads = 8
 
 # feature sub-sample, will random select 80% feature to train on each iteration 
@@ -79,7 +86,8 @@ min_data_in_leaf = 50
 # minimal sum Hessians for one leaf, use this to deal with over-fit
 min_sum_hessian_in_leaf = 5.0
 
-# save memory and faster speed for sparse feature, alias: is_sparse
+# save memory and faster speed for sparse feature
+# alias: is_sparse
 is_enable_sparse = true
 
 # when data is bigger than memory size, set this to true. otherwise set false will have faster speed
@@ -94,19 +102,21 @@ is_save_binary_file = false
 output_model = LightGBM_model.txt
 
 # support continuous train from trained gbdt model
-# input_model= trained_model.txt
+# input_model = trained_model.txt
 
 # output prediction file for predict task
-# output_result= prediction.txt
+# output_result = prediction.txt
 
-
-# number of machines in distributed training, alias: num_machine
+# number of machines in distributed training
+# alias: num_machine
 num_machines = 1
 
-# local listening port in distributed training, alias: local_port
+# local listening port in distributed training
+# alias: local_port
 local_listen_port = 12400
 
-# machines list file for distributed training, alias: mlist
+# machines list file for distributed training
+# alias: mlist
 machine_list_file = mlist.txt
 
 # force splits


### PR DESCRIPTION
Improve the docs of the Binary Classification Example:

- Reformatted and added comments in the two train configuration files consistent (e.g., doing `diff` on command line can show what the difference is)
- Added a note about `train_linear.conf` that was part of the example yet with no reference in `README` (which I found quite surprising as a newbie in this project)
- Used GitHub-flavoured Markdown to make notes (so they stand out properly IMHO)

These are the changes I found helpful while reviewing the example (that I would've done on a side for further learning but I thought I'd propose them to be included in the project for others).

HTH ❤️