### PR TITLE
[ci] use an MRAN snapshot for R 3.6 Linux jobs (fixes #5898)

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -120,8 +120,12 @@ fi
 
 # fix for issue where CRAN was not returning {lattice} when using R 3.6
 # "Warning: dependency ‘lattice’ is not available"
+#
+# refs for that MRAN snapshot:
+# * https://cran.r-project.org/web/packages/checkpoint/readme/README.html
+# * https://help.codeocean.com/en/articles/3087704-using-mran-snapshots-to-install-archived-r-packages
 if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
-    Rscript --vanilla -e "install.packages('lattice', repos = 'https://mran.microsoft.com', lib = '${R_LIB_PATH}')"
+    Rscript --vanilla -e "install.packages('lattice', repos = 'https://cran.microsoft.com/snapshot/2020-04-23/', lib = '${R_LIB_PATH}')"
 fi
 
 # Manually install Depends and Imports libraries + 'knitr', 'RhpcBLASctl', 'rmarkdown', 'testthat'

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -44,6 +44,12 @@ if ($env:TASK -eq "swig") {
 conda init powershell
 conda activate
 conda config --set always_yes yes --set changeps1 no
+
+# ref:
+# * https://stackoverflow.com/a/62897729/3986677
+# * https://github.com/microsoft/LightGBM/issues/5899
+conda install -c conda-forge brotlipy
+
 conda update -q -y conda
 conda create -q -y -n $env:CONDA_ENV `
   cloudpickle `

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -48,7 +48,7 @@ conda config --set always_yes yes --set changeps1 no
 # ref:
 # * https://stackoverflow.com/a/62897729/3986677
 # * https://github.com/microsoft/LightGBM/issues/5899
-conda install -c conda-forge brotlipy
+conda install brotlipy
 
 conda update -q -y conda
 conda create -q -y -n $env:CONDA_ENV `


### PR DESCRIPTION
Fixes #5898.
Fixes #5899.

Proposes switching to an MRAN snapshot ([link](https://mran.microsoft.com/documents/rro/reproducibility)) of CRAN for R 3.6 CI jobs. This ensures that the packages installed are from a frozen moment in time...which should reduce the risk of CI failures caused by trying to install new versions of `{lightgbm}`'s dependencies using old versions of R and old operating systems.

This is most important for Linux, as CRAN doesn't host precompiled binaries for Linux (only Windows and macOS).