### PR TITLE
[python-package] ensure 'build-python.sh' always reinstalls (fixes #5906)

### DIFF
--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -101,9 +101,9 @@ elseif ($env:TASK -eq "bdist") {
 } elseif (($env:APPVEYOR -eq "true") -and ($env:TASK -eq "python")) {
   cd $env:BUILD_SOURCESDIRECTORY
   if ($env:COMPILER -eq "MINGW") {
-    sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install --mingw ; Check-Output $?
+    sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install --user --mingw ; Check-Output $?
   } else {
-    sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install ; Check-Output $?
+    sh $env:BUILD_SOURCESDIRECTORY/build-python.sh install --user; Check-Output $?
   }
 }
 

--- a/build-python.sh
+++ b/build-python.sh
@@ -333,6 +333,7 @@ if test "${INSTALL}" = true; then
     cd ../dist
     pip install \
         ${PIP_INSTALL_ARGS} \
+        --force-reinstall \
         --find-links=. \
         lightgbm
     cd ../


### PR DESCRIPTION
Fixes #5906.

On `master`, `build-python.sh install` will not update the installed version of `lightgbm` if that version has already been installed. For example:

```shell
sh build-python.sh install
sh build-python.sh install
# Requirement already satisfied: lightgbm in  ../mambaforge/lib/python3.9/site-packages (3.3.5.99)
```

This PR proposes modifying `build-python.sh` such that it'll always install the version it's just built, regardless of what's already installed. I think that is closer to what is expected when building from sources cloned from GitHub, and it also makes local development a bit more reliable and convenient (no need to `pip uninstall` each time you rebuild).

### Notes for Reviewers

The relevant code for installing with `--precompile` doesn't need to change, as `python setup.py install` will always reinstall over an existing version.

https://github.com/microsoft/LightGBM/blob/ad487fee57945f45041ff21038dfeaaee4e10e52/build-python.sh#L307