### PR TITLE
[ci] stop relying on cran.microsoft.com in CI jobs

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -120,12 +120,8 @@ fi
 
 # fix for issue where CRAN was not returning {lattice} when using R 3.6
 # "Warning: dependency ‘lattice’ is not available"
-#
-# refs for that MRAN snapshot:
-# * https://cran.r-project.org/web/packages/checkpoint/readme/README.html
-# * https://help.codeocean.com/en/articles/3087704-using-mran-snapshots-to-install-archived-r-packages
 if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
-    Rscript --vanilla -e "install.packages('lattice', repos = 'https://cran.microsoft.com/snapshot/2020-04-23/', lib = '${R_LIB_PATH}')"
+    Rscript --vanilla -e "install.packages('https://cran.r-project.org/src/contrib/Archive/lattice/lattice_0.20-41.tar.gz', repos = NULL, lib = '${R_LIB_PATH}')"
 fi
 
 # Manually install Depends and Imports libraries + 'knitr', 'RhpcBLASctl', 'rmarkdown', 'testthat'


### PR DESCRIPTION
#5903 proposed using an MRAN snapshot to install an old version of `{lattice}` on R 3.6 CI jobs (fixing #5898).

That worked for a few days, but those jobs are again failing today ([click here for an example build](https://github.com/microsoft/LightGBM/actions/runs/5167025882/jobs/9315250012?pr=5818)).

> Warning: unable to access index for repository https://cran.microsoft.com/snapshot/2020-04-23/src/contrib:
  cannot open URL 'https://cran.microsoft.com/snapshot/2020-04-23/src/contrib/PACKAGES'

Probably because cran.microsoft.com is unavailable. Looks like Microsoft is permanently taking down MRAN and cran.microsoft.com at the end of the month 🙃 

From https://techcommunity.microsoft.com/t5/azure-sql-blog/microsoft-r-application-network-retirement/ba-p/3707161

> *the retirement process, the [Microsoft R Application Network](https://mran.microsoft.com/) (MRAN) website and CRAN Time Machine will be retired on July 1, 2023.*
>
> ...
>
> *using a CRAN repository located at https://cran.microsoft.com/ will return an error after July 1, 2023*

This PR proposes fixing those failing builds and protecting this project from the impending permanent shutdown by switching from MRAN to old sources hosted on the main CRAN server.