### PR TITLE
[c++] support building with Ninja on Linux

### DIFF
--- a/cmake/IntegratedOpenCL.cmake
+++ b/cmake/IntegratedOpenCL.cmake
@@ -59,16 +59,31 @@ set(BOOST_BASE "${PROJECT_BINARY_DIR}/Boost")
 set(BOOST_INCLUDE "${BOOST_BASE}/source" CACHE PATH "")
 set(BOOST_LIBRARY "${BOOST_BASE}/source/stage/lib" CACHE PATH "")
 if(WIN32)
+  if(MSVC)
+    if(${MSVC_VERSION} GREATER 1929)
+      message(FATAL_ERROR "Unrecognized MSVC version number: ${MSVC_VERSION}")
+    elseif(${MSVC_VERSION} GREATER 1919)
+      set(MSVC_TOOLCHAIN_ID "142")
+    elseif(${MSVC_VERSION} GREATER 1909)
+      set(MSVC_TOOLCHAIN_ID "141")
+    elseif(${MSVC_VERSION} GREATER 1899)
+      set(MSVC_TOOLCHAIN_ID "140")
+    else()
+      message(FATAL_ERROR "Unrecognized MSVC version number: ${MSVC_VERSION}")
+    endif()
+    list(
+      APPEND
+        BOOST_BUILD_BYPRODUCTS
+          ${BOOST_LIBRARY}/libboost_filesystem-vc${MSVC_TOOLCHAIN_ID}-mt-x64-${BOOST_VERSION_UNDERSCORE}.lib
+          ${BOOST_LIBRARY}/libboost_system-vc${MSVC_TOOLCHAIN_ID}-mt-x64-${BOOST_VERSION_UNDERSCORE}.lib
+          ${BOOST_LIBRARY}/libboost_chrono-vc${MSVC_TOOLCHAIN_ID}-mt-x64-${BOOST_VERSION_UNDERSCORE}.lib
+    )
+  else()
+    message(FATAL_ERROR "Integrated OpenCL build is not yet available for MinGW")
+  endif()
   set(BOOST_BOOTSTRAP "${BOOST_BASE}/source/bootstrap.bat")
   set(BOOST_BUILD "${BOOST_BASE}/source/b2.exe")
   set(BOOST_FLAGS "")
-  list(
-    APPEND
-    BOOST_BUILD_BYPRODUCTS
-      ${BOOST_LIBRARY}/libboost_filesystem-vc${MSVC_TOOLCHAIN_ID}-mt-x64-${BOOST_VERSION_UNDERSCORE}.lib
-      ${BOOST_LIBRARY}/libboost_system-vc${MSVC_TOOLCHAIN_ID}-mt-x64-${BOOST_VERSION_UNDERSCORE}.lib
-      ${BOOST_LIBRARY}/libboost_chrono-vc${MSVC_TOOLCHAIN_ID}-mt-x64-${BOOST_VERSION_UNDERSCORE}.lib
-  )
 else()
   set(BOOST_BOOTSTRAP "${BOOST_BASE}/source/bootstrap.sh")
   set(BOOST_BUILD "${BOOST_BASE}/source/b2")
@@ -174,22 +189,5 @@ ExternalProject_Add(
 )
 list(APPEND INTEGRATED_OPENCL_INCLUDES ${BOOST_INCLUDE})
 list(APPEND INTEGRATED_OPENCL_LIBRARIES ${BOOST_BUILD_BYPRODUCTS})
-if(WIN32)
-  if(MSVC)
-    if(${MSVC_VERSION} GREATER 1929)
-      message(FATAL_ERROR "Unrecognized MSVC version number: ${MSVC_VERSION}")
-    elseif(${MSVC_VERSION} GREATER 1919)
-      set(MSVC_TOOLCHAIN_ID "142")
-    elseif(${MSVC_VERSION} GREATER 1909)
-      set(MSVC_TOOLCHAIN_ID "141")
-    elseif(${MSVC_VERSION} GREATER 1899)
-      set(MSVC_TOOLCHAIN_ID "140")
-    else()
-      message(FATAL_ERROR "Unrecognized MSVC version number: ${MSVC_VERSION}")
-    endif()
-  else()
-    message(FATAL_ERROR "Integrated OpenCL build is not yet available for MinGW")
-  endif()
-endif()
 
 set(BUILD_SHARED_LIBS ON CACHE BOOL "" FORCE)

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -133,6 +133,20 @@ On Linux LightGBM can be built using **CMake** and **gcc** or **Clang**.
 
 Also, you may want to read `gcc Tips <./gcc-Tips.rst>`__.
 
+Using ``Ninja``
+^^^^^^^^^^^^^^^
+
+On Linux, LightGBM can also be built with `Ninja <https://ninja-build.org/>`__ instead of ``make``.
+
+.. code:: sh
+
+     git clone --recursive https://github.com/microsoft/LightGBM
+     cd LightGBM
+     mkdir build
+     cd build
+     cmake -G 'Ninja' ..
+     ninja -j2
+
 macOS
 ~~~~~
 


### PR DESCRIPTION
Contributes to #5061.

Adds support for building with `Ninja` instead of `make` on Linux.

This is necessary (or at least, very very helpful) for integrating `scikit-build-core` as the backend for building the Python package (as I'm working on in #5759).

### What is `Ninja`?

`Ninja` is an open-source alternative to `make`, originally developed to support building Google Chrome on Linux (["Google man open sources Chrome build system"](https://www.theregister.com/2011/02/08/google_ninja_build_system_open_sourced/)).

It's often much faster than `make`, in exchange for being simpler (i.e. supporting a stricter, harder-to-customize API).

Because of its build speeds, `Ninja` is the strongly-preferred default build tool for macOS and Linux in `scikit-build-core`. See https://github.com/scikit-build/scikit-build-core.

### How do these changes relate to supporting it?

Try the following on a Linux system, using latest `master` (https://github.com/microsoft/LightGBM/commit/36fe73aecbd15a09635ddea98744ff4babd735f0).

```shell
rm -rf ./build
mkdir ./build
cd ./build
cmake \
    -G 'Ninja' \
    -D__INTEGRATE_OPENCL=ON \
    ..

ninja -j2 _lightgbm
```

You'll see the following error.

> ninja: error: 'Boost/source/stage/lib/libboost_filesystem.a', needed by '/home/jlamb/repos/LightGBM/lib_lightgbm.so', missing and no known rule to make it

This is because of the use of `ExternalProject_Add(... BUILD_COMMAND ...)` in the CMake script used to build the integrated-OpenCL wheels. Unlike with `make`, the `Ninja` CMake generator requires that you explicitly list the outputs of such commands, so the generated `.ninja` files will contain the appropriate references to them. See the following for documentation on that:

* https://cmake.org/cmake/help/latest/module/ExternalProject.html
* https://stackoverflow.com/a/65803911/3986677

This PR modifies that script by adding an explicit list of the expected output files.

### Should we add new CI jobs?

I don't think that's necessary. Once #5759 is merged, the Python-package tests on Linux and macOS will be testing compilation with `Ninja`.

### Notes for Reviewers

Thanks for your time and consideration. I know the progress towards fixing #5061 has been slow and has involved a lot of building/packaging changes. I really appreciate your thoughtful reviews.