### PR TITLE
WIP: [python-package] remove unnecessary Boost files from sdists

### DIFF
--- a/build-python.sh
+++ b/build-python.sh
@@ -280,20 +280,9 @@ create_isolated_source_dir() {
     ###################
     mkdir -p ./lightgbm-python/compile/external_libs/compute
     cp \
-        external_libs/compute/CMakeLists.txt \
-        ./lightgbm-python/compile/external_libs/compute/
-    cp \
-        -R \
-        external_libs/compute/cmake \
-        ./lightgbm-python/compile/external_libs/compute/cmake/
-    cp \
         -R \
         external_libs/compute/include \
         ./lightgbm-python/compile/external_libs/compute/include/
-    cp \
-        -R \
-        external_libs/compute/meta \
-        ./lightgbm-python/compile/external_libs/compute/meta/
 }
 
 create_isolated_source_dir


### PR DESCRIPTION
Contributes to #5061.

The OpenCL-based GPU builds of LightGBM rely on the Boost headers included in the repo

https://github.com/microsoft/LightGBM/blob/36fe73aecbd15a09635ddea98744ff4babd735f0/CMakeLists.txt#L179

but link against already-compiled Boost libraries, expected to be pre-installed.

https://github.com/microsoft/LightGBM/blob/36fe73aecbd15a09635ddea98744ff4babd735f0/CMakeLists.txt#L187

As a result, the only Boost files that need to be packaged in sdists are the headers in `external_libs/compute/include`. This PR proposes removing the other Boost files, to reduce the size of sdists and the time it takes to build them.