### PR TITLE
[ci] remove brew update-reset again (fixes #5670)

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -77,7 +77,6 @@ fi
 
 # Installing R precompiled for Mac OS 10.11 or higher
 if [[ $OS_NAME == "macos" ]]; then
-    brew update-reset && brew update
     if [[ $R_BUILD_TYPE == "cran" ]]; then
         brew install automake || exit -1
     fi


### PR DESCRIPTION
Fixes #5670 (again).

Fixes the macOS R-package CI jobs by removing a `brew update-reset` (again).

History:

* #4160
* #4161
* #5670
* #5671
* #5807
* https://github.com/microsoft/LightGBM/issues/5670#issuecomment-1590437347