### PR TITLE
[python-package] add 'pandas' extra

### DIFF
--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -36,6 +36,28 @@ For **macOS** (we provide wheels for 3 newest macOS versions) users:
 
 - For version smaller than 2.1.2, **gcc-7** with **OpenMP** is required.
 
+Use LightGBM with Dask
+**********************
+
+.. warning::
+
+    Dask-package is only tested on Linux.
+
+To install all dependencies needed to use ``lightgbm.dask``, append ``[dask]``.
+
+.. code:: sh
+
+    pip install 'lightgbm[dask]'
+
+Use LightGBM with pandas
+************************
+
+To install all dependencies needed to use ``pandas`` in LightGBM, append ``[pandas]``.
+
+.. code:: sh
+
+    pip install 'lightgbm[pandas]'
+
 Build from Sources
 ******************
 
@@ -243,21 +265,6 @@ Then install the Python package using that library.
 .. code:: sh
 
   sh ./build-python.sh install --precompile
-
-Install Dask-package
-''''''''''''''''''''
-
-.. warning::
-
-    Dask-package is only tested on Linux.
-
-To install all additional dependencies required for Dask-package, you can append ``[dask]`` to LightGBM package name:
-
-.. code:: sh
-
-    pip install lightgbm[dask]
-
-Or replace ``sh ./build-python.sh install`` with ``pip install -e .[dask]`` if you are installing the package from source files.
 
 Troubleshooting
 ---------------

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -26,6 +26,15 @@ readme = "README.rst"
 requires-python = ">=3.6"
 version = "3.3.5.99"
 
+[project.optional-dependencies]
+dask = [
+    "dask[array,dataframe,distributed]>=2.0.0",
+    "pandas>=0.24.0"
+]
+pandas = [
+    "pandas>=0.24.0"
+]
+
 [project.urls]
 homepage = "https://github.com/microsoft/LightGBM"
 documentation = "https://lightgbm.readthedocs.io/en/latest/"

--- a/python-package/setup.cfg
+++ b/python-package/setup.cfg
@@ -5,13 +5,6 @@ install_requires =
     scikit-learn!=0.22.0
     scipy
 
-[options.extras_require]
-dask =
-    dask[array]>=2.0.0
-    dask[dataframe]>=2.0.0
-    dask[distributed]>=2.0.0
-    pandas
-
 [options.packages.find]
 where = lightgbm
 


### PR DESCRIPTION
While working on #5936, I discovered that `lightgbm` is incompatible with `pandas<0.24.0`. This PR proposes adding a `[pandas]` extra to the Python package to track that floor, so users can run `pip install 'lightgbm[pandas]'` to be guaranteed to either get a compatible version or a big, loud, clear error.

Other changes:

* moves configuration for extras to `pyproject.toml`
    - #5759 broke `pip install 'lightgbm[dask]'`, sorry 😬
* moves docs for the extras up under "Install from PyPI" section in the docs
* consolidates the three `dask` dependencies into one

### How I found that version floor

<details><summary>details (click me)</summary>

`lightgbm` can only be used with `pandas` if `CategoricalDType` can be imported...

https://github.com/microsoft/LightGBM/blob/ac57d5a45a3ff3a04fbbcb8fb24f0c60072471e2/python-package/lightgbm/compat.py#L6-L17

... which was introduced in `pandas==0.21.0`: https://github.com/pandas-dev/pandas/pull/16015.

`lightgbm` also relies on `pd.DataFrame.to_numpy()` and `pd.Series.to_numpy()`...

https://github.com/microsoft/LightGBM/blob/ac57d5a45a3ff3a04fbbcb8fb24f0c60072471e2/python-package/lightgbm/basic.py#L704

https://github.com/microsoft/LightGBM/blob/ac57d5a45a3ff3a04fbbcb8fb24f0c60072471e2/python-package/lightgbm/basic.py#L711

https://github.com/microsoft/LightGBM/blob/ac57d5a45a3ff3a04fbbcb8fb24f0c60072471e2/python-package/lightgbm/basic.py#L2594

https://github.com/microsoft/LightGBM/blob/ac57d5a45a3ff3a04fbbcb8fb24f0c60072471e2/python-package/lightgbm/basic.py#L2601

https://github.com/microsoft/LightGBM/blob/ac57d5a45a3ff3a04fbbcb8fb24f0c60072471e2/python-package/lightgbm/basic.py#L2964-L2965

... which was introduced in `pandas==0.24.0`: https://github.com/pandas-dev/pandas/pull/23623

</details>

### How I discovered that extras were broken (and then tested that this fixes them)

<details><summary>details (click me)</summary>

```shell
# build the wheel
sh ./build-python.sh bdist_wheel

# try to install
pip install \
    --find-links=./dist \
    'lightgbm[pandas]'
```

On `master`:

```text
WARNING: lightgbm 3.3.5.99 does not provide the extra 'pandas'
```

On this branch:

```text
Looking in links: ./dist
Processing ./dist/lightgbm-3.3.5.99-py3-none-macosx_12_0_x86_64.whl
Collecting pandas>=0.24.0
  Downloading pandas-2.0.2-cp39-cp39-macosx_10_9_x86_64.whl (11.8 MB)
...
```

</details>