### PR TITLE
[docs] fix broken links in docs

### DIFF
--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -9,6 +9,7 @@ threads=1
 ignore=
   pythonapi/lightgbm\..*\.html.*
   http.*amd.com/.*
+  https.*tandfonline.com/.*
 ignorewarnings=http-robots-denied,https-certificate-error
 checkextern=1
 

--- a/docs/Parallel-Learning-Guide.rst
+++ b/docs/Parallel-Learning-Guide.rst
@@ -544,6 +544,6 @@ See `the mars documentation`_ for usage examples.
 
 .. _the lightgbm_ray documentation: https://docs.ray.io/en/latest/tune/api_docs/integration.html#lightgbm-tune-integration-lightgbm
 
-.. _Mars: https://docs.pymars.org/en/latest/index.html
+.. _Mars: https://mars-project.readthedocs.io/en/latest/
 
-.. _the mars documentation: https://docs.pymars.org/en/latest/user_guide/learn/lightgbm.html
+.. _the mars documentation: https://mars-project.readthedocs.io/en/latest/user_guide/learn/lightgbm.html


### PR DESCRIPTION
The `check-links` CI job has been broken for a while. ([most recent build link](https://github.com/microsoft/LightGBM/actions/runs/5343076586/jobs/9685687417)).

This PR fixes the 3 errors:

```text
URL        `https://www.tandfonline.com/doi/abs/10.1080/01621459.1958.10501479'
Name       `Fisher (1958)'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/Advanced-Topics.html, line 120, col 1
Real URL   https://www.tandfonline.com/doi/abs/10.1080/01621459.1958.10501479
Check time 0.230 seconds
Result     Error: 403 Forbidden
```

```text
URL        `https://docs.pymars.org/en/latest/index.html'
Name       `Mars'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/Parallel-Learning-Guide.html, line 543, col 4
Real URL   https://docs.pymars.org/en/latest/index.html
Check time 0.718 seconds
Result     Error: ConnectionError: HTTPSConnectionPool(host='docs.pymars.org', port=443): Max retries exceeded with url: /en/latest/index.html (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7f316bf6ee50>: Failed to resolve 'd...
```

```text
URL        `https://docs.pymars.org/en/latest/user_guide/learn/lightgbm.html'
Name       `the mars documentation'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/Parallel-Learning-Guide.html, line 544, col 8
Real URL   https://docs.pymars.org/en/latest/user_guide/learn/lightgbm.html
Check time 4.392 seconds
Result     Error: ConnectionError: HTTPSConnectionPool(host='docs.pymars.org', port=443): Max retries exceeded with url: /en/latest/user_guide/learn/lightgbm.html (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7f316bf6e6a0>: ...
```