### PR TITLE
[docs] more fixes for broken links

### DIFF
--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -176,8 +176,8 @@ For C/C++ users, any OpenMP feature cannot be used before the fork happens. If a
 fork happens (example: using OpenMP for forking), OpenMP will hang inside the forked sessions. Use new processes instead
 and copy memory as required by creating new processes instead of forking (or, use Intel compilers).
 
-Cloud platform container services may cause LightGBM to hang, if they use Linux fork to run multiple containers on a 
-single instance. For example, LightGBM hangs in AWS Batch array jobs, which `use the ECS agent 
+Cloud platform container services may cause LightGBM to hang, if they use Linux fork to run multiple containers on a
+single instance. For example, LightGBM hangs in AWS Batch array jobs, which `use the ECS agent
 <https://aws.amazon.com/batch/faqs/#Features>`__ to manage multiple running jobs. Setting ``nthreads=1`` mitigates the issue.
 
 12. Why is early stopping not enabled by default in LightGBM?
@@ -220,7 +220,7 @@ If you are using any Python package that depends on ``threadpoolctl``, you also 
 
 .. code-block:: console
 
-    /root/miniconda/envs/test-env/lib/python3.8/site-packages/threadpoolctl.py:546: RuntimeWarning: 
+    /root/miniconda/envs/test-env/lib/python3.8/site-packages/threadpoolctl.py:546: RuntimeWarning:
     Found Intel OpenMP ('libiomp') and LLVM OpenMP ('libomp') loaded at
     the same time. Both libraries are known to be incompatible and this
     can cause random crashes or deadlocks on Linux when loaded in the
@@ -231,7 +231,7 @@ If you are using any Python package that depends on ``threadpoolctl``, you also 
 
 Detailed description of conflicts between multiple OpenMP instances is provided in the `following document <https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md>`__.
 
-**Solution**: Assuming you are using LightGBM Python-package and conda as a package manager, we strongly recommend using ``conda-forge`` channel as the only source of all your Python package installations because it contains built-in patches to workaround OpenMP conflicts. Some other workarounds are listed `here <https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md#workarounds-for-intel-openmp-and-llvm-openmp-case>`__.
+**Solution**: Assuming you are using LightGBM Python-package and conda as a package manager, we strongly recommend using ``conda-forge`` channel as the only source of all your Python package installations because it contains built-in patches to workaround OpenMP conflicts. Some other workarounds are listed `here <https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md#user-content-workarounds-for-intel-openmp-and-llvm-openmp-case>`__.
 
 If this is not your case, then you should find conflicting OpenMP library installations on your own and leave only one of them.
 

--- a/docs/Parallel-Learning-Guide.rst
+++ b/docs/Parallel-Learning-Guide.rst
@@ -520,7 +520,7 @@ See `the mars documentation`_ for usage examples.
 
 .. _the Dask prediction example: https://github.com/microsoft/lightgbm/tree/master/examples/python-guide/dask/prediction.py
 
-.. _the Dask worker documentation: https://distributed.dask.org/en/latest/worker.html#memory-management
+.. _the Dask worker documentation: https://distributed.dask.org/en/stable/worker-memory.html
 
 .. _the metrics functions from dask-ml: https://ml.dask.org/modules/api.html#dask-ml-metrics-metrics
 


### PR DESCRIPTION
I thought I fixed the `check-links` task in #5939 .

... but I didn't realize that that job will also fail for *warnings*.

Build link: https://github.com/microsoft/LightGBM/actions/runs/5358159570/jobs/9720047454

This fixes the following warnings:

```text
URL        `https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md#workarounds-for-intel-openmp-and-llvm-openmp-case'
Name       `here'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/FAQ.html, line 329, col 396
Real URL   https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md#workarounds-for-intel-openmp-and-llvm-openmp-case
Check time 3.620 seconds
D/L time   0.006 seconds
Size       157.11KB
Warning    [None] Anchor
           `workarounds-for-intel-openmp-and-llvm-openmp-case'
           (decoded:
           `workarounds-for-intel-openmp-and-llvm-openmp-case')
           not found. Available anchors:
           `actions-repo-tab-count', `actions-tab',
           `ajax-error-message', `blob-more-options-details',
           `blob-path', `branch-select-menu',
           `code-repo-tab-count', `code-tab',
           `context-commitish-filter-field', `fork-button',
           `insights-repo-tab-count', `insights-tab',
           `issues-repo-tab-count', `issues-tab',
           `js-flash-container',
           `js-global-screen-reader-notice',
           `js-repo-pjax-container', `jump-to-results',
           `jumpto-line-details-dialog',
           `open-source-repositories-heading',
           `product-explore-heading', `projects-repo-tab-count',
           `projects-tab', `pull-requests-repo-tab-count',
           `pull-requests-tab', `raw-url', `readme',
           `ref-list-branches', `repo-content-pjax-container',
           `repo-content-turbo-frame', `repo-network-counter',
           `repo-stars-counter-star',
           `repository-container-header',
           `repository-details-container',
           `responsive-meta-container', `security-tab',
           `site-details-dialog',
           `snippet-clipboard-copy-button',
           `snippet-clipboard-copy-button-unpositioned',
           `solutions-by-solution-heading',
           `solutions-case-studies-heading',
           `solutions-for-heading', `spoof-warning',
           `sr-footer-heading', `start-of-content', `tags-menu',
           `user-content-context',
           `user-content-incompatibility-between-intel-openmp-and-llvm-openmp-under-linux',
           `user-content-multiple-openmp-runtimes',
           `user-content-references',
           `user-content-workarounds-for-intel-openmp-and-llvm-openmp-case',
           `warn-tag-match-create-branch-dialog',
           `warn-tag-match-create-branch-dialog-header'.
```

```text
URL        `https://distributed.dask.org/en/latest/worker.html#memory-management'
Name       `the Dask worker documentation'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/Parallel-Learning-Guide.html, line 212, col 149
Real URL   https://distributed.dask.org/en/latest/worker.html#memory-management
Check time 0.662 seconds
D/L time   0.001 seconds
Size       120.19KB
Warning    [None] Anchor `memory-management' (decoded:
           `memory-management') not found. Available anchors:
           `READTHEDOCS_DATA', `__navigation',
           `api-documentation', `banner', `bd-docs-nav',
           `bd-toc-nav', `command-line-tool',
           `distributed.nanny.Nanny',
           `distributed.nanny.Nanny.close',
           `distributed.nanny.Nanny.close_gracefully',
           `distributed.nanny.Nanny.instantiate',
           `distributed.nanny.Nanny.kill',
           `distributed.nanny.Nanny.log_event',
           `distributed.nanny.Nanny.start_unsafe',
           `distributed.worker.Worker',
           `distributed.worker.Worker.batched_send',
           `distributed.worker.Worker.close',
           `distributed.worker.Worker.close_gracefully',
           `distributed.worker.Worker.data',
           `distributed.worker.Worker.digest_metric',
           `distributed.worker.Worker.execute',
           `distributed.worker.Worker.gather_dep',
           `distributed.worker.Worker.get_current_task',
           `distributed.worker.Worker.handle_stimulus',
           `distributed.worker.Worker.log_event',
           `distributed.worker.Worker.retry_busy_worker_later',
           `distributed.worker.Worker.start_unsafe',
           `distributed.worker.Worker.transfer_outgoing_bytes',
           `distributed.worker.Worker.transfer_outgoing_bytes_total',
           `distributed.worker.Worker.transfer_outgoing_count',
           `distributed.worker.Worker.transfer_outgoing_count_total',
           `distributed.worker.Worker.trigger_profile',
           `distributed.worker.Worker.worker_address',
           `documentation_options', `download-print',
           `dropdown-buttons-trigger', `id1',
           `internal-scheduling', `jb-print-docs-body',
           `jb-print-toc', `main-content', `nanny', `next-link',
           `overview', `prev-link', `print-main-content',
           `search-input', `site-navigation', `site-title',
           `storing-data', `thread-pool', `toctree-checkbox-1',
           `worker'.
Result     Valid: 200 OK
```