### PR TITLE
[python-package] remove hard dependency on 'scikit-learn', fix minimal runtime dependencies

### DIFF
--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -56,6 +56,15 @@ To install all dependencies needed to use ``pandas`` in LightGBM, append ``[pand
 
     pip install 'lightgbm[pandas]'
 
+Use LightGBM with scikit-learn
+******************************
+
+To install all dependencies needed to use ``scikit-learn`` in LightGBM, append ``[scikit-learn]``.
+
+.. code:: sh
+
+    pip install 'lightgbm[scikit-learn]'
+
 Build from Sources
 ******************
 

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -16,6 +16,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering :: Artificial Intelligence"
 ]
+dependencies = [
+    "numpy",
+    "scipy"
+]
 description = "LightGBM Python Package"
 license = {file = "LICENSE"}
 maintainers = [
@@ -33,6 +37,9 @@ dask = [
 ]
 pandas = [
     "pandas>=0.24.0"
+]
+scikit-learn = [
+    "scikit-learn!=0.22.0"
 ]
 
 [project.urls]

--- a/python-package/setup.cfg
+++ b/python-package/setup.cfg
@@ -1,9 +1,5 @@
 [options]
 include_package_data = True
-install_requires =
-    numpy
-    scikit-learn!=0.22.0
-    scipy
 
 [options.packages.find]
 where = lightgbm


### PR DESCRIPTION
Today, `pip install lightgbm` absolutely requires that you're able to also install `numpy`, `scipy`, and `scikit-learn` (and therefore all of their recursive dependencies).

This PR proposes removing the hard requirement on `scikit-learn`, so that users who aren't using the `lightgbm.sklearn` interface don't have to pay the download time, disk usage, and incompatibility-risk cost of having to install `scikit-learn`.

`scikit-learn` is already used conditionally throughout the package...

https://github.com/microsoft/LightGBM/blob/2e603f860664d3aaf382059a378f3212049f1c4c/python-package/lightgbm/compat.py#L71-L73

https://github.com/microsoft/LightGBM/blob/2e603f860664d3aaf382059a378f3212049f1c4c/python-package/lightgbm/sklearn.py#L531-L533

... so this is only a change to the Python package's dependency metadata and doesn't require any changes to the library code.

While doing this, I also discovered that the changes from #5759 broke the *required dependencies*, such that `pip install lightgbm` wouldn't automatically install `numpy` and `scipy` if they weren't present. This PR fixes that as well.

### How I tested this

Built the wheel (just using `--nomp` to make compilation a little faster, it's irrelevant to this test):

```shell
docker run \
    --rm \
    -v $(pwd):/opt/lgb-build \
    -w /opt/lgb-build \
    python:3.11 \
    sh ./build-python.sh bdist_wheel --nomp
```

Confirmed that `pip install lightgbm` pulls in just `numpy` and `scipy`

```shell
docker run \
    --rm \
    -v $(pwd):/opt/lgb-build \
    -w /opt/lgb-build \
    python:3.11 \
    /bin/bash -c "pip install --find-links=./dist 'lightgbm' && pip freeze"
```

```text
lightgbm==3.3.5.99
numpy==1.25.0
scipy==1.10.1
```

Confirmed that `pip install lightgbm[scikit-learn]` works, and pulls in `numpy`, `scikit-learn`, `scipy`, and all of `scikit-learn`'s other dependencies.

```shell
docker run \
    --rm \
    -v $(pwd):/opt/lgb-build \
    -w /opt/lgb-build \
    -it python:3.11 \
    /bin/bash -c "pip install --find-links=./dist 'lightgbm[scikit-learn]' && pip freeze"
```

```text
joblib==1.2.0
lightgbm==3.3.5.99
numpy==1.25.0
scikit-learn==1.2.2
scipy==1.10.1
threadpoolctl==3.1.0
```

### Notes for Reviewers

I called this `breaking` because if anyone is currently relying on `pip install lightgbm` pulling in `scikit-learn` (e.g. they aren't specifying the `scikit-learn` dependency separately), their setup will break when upgrading to `lightgbm` 4.0. I think that's acceptable in exchange for making it possible to build a lighter-weight, less-risky-to-build, Python environment using just `lightgbm`, `numpy`, and `scipy`.

I got the idea for this by observing that `xgboost` does the same thing

https://github.com/dmlc/xgboost/blob/54da4b31856625e9cca1848e1aa8ab8bf584e5fe/python-package/pyproject.toml#L30-L33

https://github.com/dmlc/xgboost/blob/54da4b31856625e9cca1848e1aa8ab8bf584e5fe/python-package/pyproject.toml#L41