### PR TITLE
[python-package] ignore pip cache dir in build-python.sh

### DIFF
--- a/build-python.sh
+++ b/build-python.sh
@@ -357,6 +357,7 @@ if test "${INSTALL}" = true; then
     pip install \
         ${PIP_INSTALL_ARGS} \
         --force-reinstall \
+        --no-cache-dir \
         --find-links=. \
         lightgbm
     cd ../


### PR DESCRIPTION
Follow-up to #5907.

Tells `pip install` in `sh ./build-python.sh install` to:

* not consult the `pip` cache dir (the place `pip` puts `.tar.gz` and `.whl` files it downloads) when installing
* not add the just-locally-build sdist/wheel to that cache dir

This ensures that `build-python.sh install` will overwrite an existing installation of `lightgbm`, even if it had been run previously in the same environment.