### PR TITLE
refactor: change namespace in modified json11.

### DIFF
--- a/include/LightGBM/tree_learner.h
+++ b/include/LightGBM/tree_learner.h
@@ -14,7 +14,7 @@
 
 namespace LightGBM {
 
-using json11::Json;
+using json11_internal_lightgbm::Json;
 
 /*! \brief forward declaration */
 class Tree;

--- a/include/LightGBM/utils/common.h
+++ b/include/LightGBM/utils/common.h
@@ -58,7 +58,7 @@ namespace LightGBM {
 
 namespace Common {
 
-using json11::Json;
+using json11_internal_lightgbm::Json;
 
 /*!
 * Imbues the stream with the C locale.

--- a/include/LightGBM/utils/json11.h
+++ b/include/LightGBM/utils/json11.h
@@ -60,7 +60,7 @@
 #include <utility>
 #include <vector>
 
-namespace json11 {
+namespace json11_internal_lightgbm {
 
 enum JsonParse { STANDARD, COMMENTS };
 
@@ -223,4 +223,4 @@ class JsonValue {
   virtual ~JsonValue() {}
 };
 
-}  // namespace json11
+}  // namespace json11_internal_lightgbm

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -29,7 +29,7 @@
 
 namespace LightGBM {
 
-using json11::Json;
+using json11_internal_lightgbm::Json;
 
 /*!
 * \brief GBDT algorithm implementation. including Training, prediction, bagging.

--- a/src/io/dataset_loader.cpp
+++ b/src/io/dataset_loader.cpp
@@ -15,7 +15,7 @@
 
 namespace LightGBM {
 
-using json11::Json;
+using json11_internal_lightgbm::Json;
 
 DatasetLoader::DatasetLoader(const Config& io_config, const PredictFunction& predict_fun, int num_class, const char* filename)
   :config_(io_config), random_(config_.data_random_seed), predict_fun_(predict_fun), num_class_(num_class) {

--- a/src/io/json11.cpp
+++ b/src/io/json11.cpp
@@ -27,7 +27,7 @@
 #include <cstdlib>
 #include <limits>
 
-namespace json11 {
+namespace json11_internal_lightgbm {
 
 static const int max_depth = 200;
 
@@ -160,7 +160,7 @@ class Value : public JsonValue {
   }
 
   const T m_value;
-  void dump(string *out) const override { json11::dump(m_value, out); }
+  void dump(string *out) const override { json11_internal_lightgbm::dump(m_value, out); }
 };
 
 class JsonDouble final : public Value<Json::NUMBER, double> {
@@ -777,4 +777,4 @@ bool Json::has_shape(const shape &types, string *err) const {
   return true;
 }
 
-}  // namespace json11
+}  // namespace json11_internal_lightgbm

--- a/src/treelearner/gpu_tree_learner.h
+++ b/src/treelearner/gpu_tree_learner.h
@@ -36,7 +36,7 @@
 
 namespace LightGBM {
 
-using json11::Json;
+using json11_internal_lightgbm::Json;
 
 /*!
 * \brief GPU-based parallel learning algorithm.

--- a/src/treelearner/serial_tree_learner.h
+++ b/src/treelearner/serial_tree_learner.h
@@ -37,7 +37,7 @@
 
 namespace LightGBM {
 
-using json11::Json;
+using json11_internal_lightgbm::Json;
 
 /*! \brief forward declaration */
 class CostEfficientGradientBoosting;


### PR DESCRIPTION
The LightGBM library includes code from the json11 library (https://github.com/dropbox/json11), with some minor changes for internal use.

When attempting to integrate the LightGBM library into another project that already relies on the unmodified json11 library, it doesn't compile due to multiple definition of methods. 

Using a single version of json11 for everything doesn't work because some method signatures were changed in https://github.com/microsoft/LightGBM/pull/2975/commits/346db12e706a46541c2b079c158b72cde95f08ac.

This problem can be easily resolved by changing the namespace, and since this project is the one using a modified version of json11, I think that the change should be implemented here.
