### PR TITLE
[ci] increase valgrind timeout to 6 hours

### DIFF
--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-r-valgrind:
     name: r-package (ubuntu-latest, R-devel, valgrind)
-    timeout-minutes: 300
+    timeout-minutes: 360
     runs-on: ubuntu-latest
     container: wch1/r-debug
     env:

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -1,4 +1,4 @@
-iname: docs-env
+name: docs-env
 channels:
   - nodefaults
   - conda-forge

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -13,6 +13,8 @@ dependencies:
   - r-pkgdown=1.6.1
   - r-rmarkdown=2.11
   - r-roxygen2=7.2.1
-  - scikit-learn
+  # scikit-learn pin can hopefully be changed to a floor after
+  # https://github.com/scikit-learn/scikit-learn/pull/26747
+  - scikit-learn<1.3.0
   - sphinx
   - "sphinx_rtd_theme>=0.5"

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -1,4 +1,4 @@
-name: docs-env
+iname: docs-env
 channels:
   - nodefaults
   - conda-forge
@@ -13,8 +13,6 @@ dependencies:
   - r-pkgdown=1.6.1
   - r-rmarkdown=2.11
   - r-roxygen2=7.2.1
-  # scikit-learn pin can hopefully be changed to a floor after
-  # https://github.com/scikit-learn/scikit-learn/pull/26747
-  - scikit-learn<1.3.0
+  - scikit-learn
   - sphinx
   - "sphinx_rtd_theme>=0.5"


### PR DESCRIPTION
Blocks #5952.

* upgrades the timeout on the `r-valgrind` CI job to 6 hours, to try to fix https://github.com/microsoft/LightGBM/pull/5952#issuecomment-1613764158

### Notes for Reviewers

As described in #5414, this has to be merged to `master` to be tested, since the valgrind job's configuration is only sourced from `master`.

6 hours is the absolute maximum GitHub Actions allows: https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits.

So if this doesn't work, we'll have to come up with another strategy for running the valgrind tests faster (like maybe finding a source of Linux precompiled binaries for `{lightgbm}`'s dependencies), or will have to rely on running them somewhere else (even maybe just locally on a maintainer's laptop 😬 ).