### PR TITLE
[docs] fix broken link to contributor GitHub account

### DIFF
--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -23,7 +23,7 @@ You may also ping a member of the core team according to the relevant area of ex
 -  `@guolinke <https://github.com/guolinke>`__ **Guolin Ke** (C++ code / R-package / Python-package)
 -  `@chivee <https://github.com/chivee>`__ **Qiwei Ye** (C++ code / Python-package)
 -  `@shiyu1994 <https://github.com/shiyu1994>`__ **Yu Shi** (C++ code / Python-package)
--  `@tongwu-msft <https://github.com/tongwu-msft>`__ **Tong Wu** (C++ code / Python-package)
+-  `@tongwu-msft` **Tong Wu** (C++ code / Python-package)
 -  `@hzy46 <https://github.com/hzy46>`__ **Zhiyuan He** (C++ code / Python-package)
 -  `@btrotta <https://github.com/btrotta>`__ **Belinda Trotta** (C++ code)
 -  `@Laurae2 <https://github.com/Laurae2>`__ **Damien Soukhavong** (R-package)


### PR DESCRIPTION
The `Link Checks` CI job has been failing because apparently the GitHub account `@tongwu-msft` no longer exists.

```text
URL        `https://github.com/tongwu-msft'
Name       `@tongwu-msft'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/FAQ.html, line 150, col 8
Real URL   https://github.com/tongwu-msft
Check time 2.058 seconds
Size       40B
Result     Error: 404 Not Found
```

([build link](https://github.com/microsoft/LightGBM/actions/runs/5461860140))

<img width="1001" alt="image" src="https://github.com/microsoft/LightGBM/assets/7608904/b571b0f8-a1db-4b39-a898-b6f66c92c630">
