### PR TITLE
[c++] virtual destructor for gradient discretizer

### DIFF
--- a/src/treelearner/gradient_discretizer.hpp
+++ b/src/treelearner/gradient_discretizer.hpp
@@ -30,7 +30,7 @@ class GradientDiscretizer {
     stochastic_rounding_ = stochastic_rounding;
   }
 
-  ~GradientDiscretizer() {}
+  virtual ~GradientDiscretizer() {}
 
   virtual void DiscretizeGradients(
     const data_size_t num_data,


### PR DESCRIPTION
This is to fix the compilation warning.
```
/Applications/Xcode_11.7.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:2338:5: warning: delete called on non-final 'LightGBM::GradientDiscretizer' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
    delete __ptr;
    ^
/Applications/Xcode_11.7.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:2651:7: note: in instantiation of member function 'std::__1::default_delete<LightGBM::GradientDiscretizer>::operator()' requested here
      __ptr_.second()(__tmp);
      ^
/Users/runner/work/1/s/lightgbm-python/src/treelearner/serial_tree_learner.cpp:65:27: note: in instantiation of member function 'std::__1::unique_ptr<LightGBM::GradientDiscretizer, std::__1::default_delete<LightGBM::GradientDiscretizer> >::reset' requested here
    gradient_discretizer_.reset(new GradientDiscretizer(config_->num_grad_quant_bins, config_->num_iterations, config_->seed, is_constant_hessian, config_->stochastic_rounding));
                          ^
1 warning generated.

```
See https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=14888&view=logs&j=52ea7a35-6bb0-5680-4def-de74fd7388e2&t=3a5da3c1-f658-52cd-3d24-edc674c4d20e for example.