### PR TITLE
[python-package] avoid data_has_header check in predict()

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -967,7 +967,7 @@ class _InnerPredictor:
                 _safe_call(_LIB.LGBM_BoosterPredictForFile(
                     self._handle,
                     _c_str(str(data)),
-                    ctypes.c_int(int(data_has_header)),
+                    ctypes.c_int(data_has_header),
                     ctypes.c_int(predict_type),
                     ctypes.c_int(start_iteration),
                     ctypes.c_int(num_iteration),

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -961,14 +961,13 @@ class _InnerPredictor:
             predict_type = _C_API_PREDICT_LEAF_INDEX
         if pred_contrib:
             predict_type = _C_API_PREDICT_CONTRIB
-        int_data_has_header = 1 if data_has_header else 0
 
         if isinstance(data, (str, Path)):
             with _TempFile() as f:
                 _safe_call(_LIB.LGBM_BoosterPredictForFile(
                     self._handle,
                     _c_str(str(data)),
-                    ctypes.c_int(int_data_has_header),
+                    ctypes.c_int(int(data_has_header)),
                     ctypes.c_int(predict_type),
                     ctypes.c_int(start_iteration),
                     ctypes.c_int(num_iteration),


### PR DESCRIPTION
In the Python package, you can generate predictions on data stored in a delimited text file by passing a filepath to `Booster.predict()`.

That calls `LGBM_BoosterPredictForFile()` in the C API, which takes a boolean argument indicating whether or not the file's first row is a header with feature names.

That argument, `data_has_header`, is a boolean in `Booster.predict()`'s interface but an int in `LGBM_BoosterPredictForFile()`, leading to this conversion:

https://github.com/microsoft/LightGBM/blob/714039681a9502ce6644357d38ec9143bf5a7852/python-package/lightgbm/basic.py#L964

This PR proposes moving that conversion down into the `if-else` block corresponding to "`data` is a file", so it's cost is avoided on all other prediction paths.

I'm sure the cost of that one check is very very very very very small, but `Booster.predict()` is a latency-sensitive part of the API since it's used in model serving.