### PR TITLE
Bump min python version to 3.7

### DIFF
--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -28,7 +28,7 @@ maintainers = [
 ]
 name = "lightgbm"
 readme = "README.rst"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 version = "4.0.0"
 
 [project.optional-dependencies]


### PR DESCRIPTION
The dependency scikit-build-core>=0.4.4 requires python >=3.7. 

Attempting to install with `pip install lightgbm` will fail in python 3.6 env since it will attempt to install lighgbm=4.0.0 but then fail to find a package matching scikit-build-core>=0.4.4 (since none are compatible with python 3.6)