### PR TITLE
[R-package] remove unused internal variables

### DIFF
--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -494,11 +494,10 @@ Dataset <- R6::R6Class(
         if (info_len > 0L) {
 
           # Get back fields
-          ret <- NULL
-          ret <- if (field_name == "group") {
-            integer(info_len)
+          if (field_name == "group") {
+            ret <- integer(info_len)
           } else {
-            numeric(info_len)
+            ret <- numeric(info_len)
           }
 
           .Call(

--- a/R-package/R/lgb.Predictor.R
+++ b/R-package/R/lgb.Predictor.R
@@ -98,8 +98,6 @@ Predictor <- R6::R6Class(
         start_iteration <- 0L
       }
 
-      num_row <- 0L
-
       # Check if data is a file name and not a matrix
       if (identical(class(data), "character") && length(data) == 1L) {
 

--- a/R-package/R/lgb.convert_with_rules.R
+++ b/R-package/R/lgb.convert_with_rules.R
@@ -116,10 +116,6 @@ lgb.convert_with_rules <- function(data, rules = NULL) {
 
     column_classes <- .get_column_classes(df = data)
 
-    is_char <- which(column_classes == "character")
-    is_factor <- which(column_classes == "factor")
-    is_logical <- which(column_classes == "logical")
-
     is_data_table <- data.table::is.data.table(x = data)
     is_data_frame <- is.data.frame(data)
 

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -225,8 +225,6 @@ lgb.cv <- function(params = list()
       stop(sQuote("folds"), " must be a list with 2 or more elements that are vectors of indices for each CV-fold")
     }
 
-    nfold <- length(folds)
-
   } else {
 
     if (nfold <= 1L) {

--- a/R-package/tests/testthat/test_lgb.Booster.R
+++ b/R-package/tests/testthat/test_lgb.Booster.R
@@ -1341,7 +1341,7 @@ test_that("Booster's print, show, and summary work correctly", {
         .has_expected_content_for_fitted_model(log_txt)
 
         # summary()
-        log_text <- capture.output({
+        log_txt <- capture.output({
           ret <- summary(model)
         })
         .have_same_handle(ret, model)


### PR DESCRIPTION
Removes some unused internal variables in the R package code.

The project's `{lintr}` checks and `R CMD check` don't catch these, but PyCharm did 😁 

