### PR TITLE
[ci] use newer h5py in AppVeyor jobs (fixes #5995)

### DIFF
--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -124,7 +124,7 @@ if (($env:TASK -eq "regular") -or (($env:APPVEYOR -eq "true") -and ($env:TASK -e
   cd $env:BUILD_SOURCESDIRECTORY/examples/python-guide
   @("import matplotlib", "matplotlib.use('Agg')") + (Get-Content "plot_example.py") | Set-Content "plot_example.py"
   (Get-Content "plot_example.py").replace('graph.render(view=True)', 'graph.render(view=False)') | Set-Content "plot_example.py"  # prevent interactive window mode
-  conda install -q -y -n $env:CONDA_ENV h5py ipywidgets notebook
+  conda install -q -y -n $env:CONDA_ENV "h5py>3.0" ipywidgets notebook
   foreach ($file in @(Get-ChildItem *.py)) {
     @("import sys, warnings", "warnings.showwarning = lambda message, category, filename, lineno, file=None, line=None: sys.stdout.write(warnings.formatwarning(message, category, filename, lineno, line))") + (Get-Content $file) | Set-Content $file
     python $file ; Check-Output $?

--- a/R-package/tests/testthat/test_dataset.R
+++ b/R-package/tests/testthat/test_dataset.R
@@ -446,7 +446,7 @@ test_that("lgb.Dataset: should be able to use and retrieve long feature names", 
   # set one feature to a value longer than the default buffer size used
   # in LGBM_DatasetGetFeatureNames_R
   feature_names <- names(iris)
-  long_name <- paste0(rep("a", 1000L), collapse = "")
+  long_name <- strrep("a", 1000L)
   feature_names[1L] <- long_name
   names(iris) <- feature_names
   # check that feature name survived the trip from R to C++ and back


### PR DESCRIPTION
Fixes #5995.

Attempts to force `conda` to use a newer version of `h5py` in tests, to avoid the errors in the linked issue related to the combination of newer `numpy` and older `h5py` being incompatible.

Also fixes the following error caused by the new release of `{lintr}` a few hours ago:

> [1] Total linting issues found: 1
[[1]]
/home/runner/work/LightGBM/LightGBM/R-package/tests/testthat/test_dataset.R:449:16: warning: [paste] strrep(x, times) is better than paste0(rep(x, times), collapse = "").
  long_name <- paste0(rep("a", 1000L), collapse = "")
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

([failed R linting job](https://github.com/microsoft/LightGBM/actions/runs/5613432576/job/15209447243?pr=5996))