### PR TITLE
[python-package] replace np.find_common_type with np.result_type

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -699,7 +699,7 @@ def _data_from_pandas(
         _check_for_bad_pandas_dtypes(data.dtypes)
         df_dtypes = [dtype.type for dtype in data.dtypes]
         df_dtypes.append(np.float32)  # so that the target dtype considers floats
-        target_dtype = np.find_common_type(df_dtypes, [])
+        target_dtype = np.result_type(*df_dtypes)
         try:
             # most common case (no nullable dtypes)
             data = data.to_numpy(dtype=target_dtype, copy=False)


### PR DESCRIPTION
Replaces the use of `np.find_common_type` with `np.result_type` to determine the type that should be used when coercing a pandas dataframe to a numpy array.

This function was added in numpy 1.6 ([docs](https://numpy.org/doc/stable/reference/generated/numpy.result_type.html)), which is from [May 2011](https://pypi.org/project/numpy/1.6.0/) and the lowest version we support [is 1.12](https://github.com/microsoft/LightGBM/blob/8967debeb5cb03875eb96a22dbcaa5387b5abaa3/.ci/test-python-oldest.sh#L10) so there shouldn't be any compatibility issues.

Fixes #5990.