### PR TITLE
[ci] fix build python

### DIFF
--- a/build-python.sh
+++ b/build-python.sh
@@ -354,6 +354,7 @@ if test "${INSTALL}" = true; then
     echo "--- installing lightgbm ---"
     # ref for use of '--find-links': https://stackoverflow.com/a/52481267/3986677
     cd ../dist
+<<<<<<< Updated upstream
     if test "${BUILD_SDIST}" = true; then
         pip install \
             ${PIP_INSTALL_ARGS} \
@@ -370,6 +371,20 @@ if test "${INSTALL}" = true; then
             --find-links=. \
             lightgbm-*.whl
     fi
+=======
+    LGB_VER=$(head -n 1 ../VERSION.txt)
+    if test "${BUILD_SDIST}" = true; then
+        SUFFIX="tar.gz"
+    elif test "${BUILD_WHEEL}" = true; then
+        SUFFIX="whl"
+    fi
+    pip install \
+        ${PIP_INSTALL_ARGS} \
+        --force-reinstall \
+        --no-cache-dir \
+        --find-links=. \
+        lightgbm-${LGB_VER}-*.${SUFFIX}
+>>>>>>> Stashed changes
     cd ../
 fi
 

--- a/build-python.sh
+++ b/build-python.sh
@@ -354,12 +354,22 @@ if test "${INSTALL}" = true; then
     echo "--- installing lightgbm ---"
     # ref for use of '--find-links': https://stackoverflow.com/a/52481267/3986677
     cd ../dist
-    pip install \
-        ${PIP_INSTALL_ARGS} \
-        --force-reinstall \
-        --no-cache-dir \
-        --find-links=. \
-        lightgbm-*.tar.gz
+    if test "${BUILD_SDIST}" = true; then
+        pip install \
+            ${PIP_INSTALL_ARGS} \
+            --force-reinstall \
+            --no-cache-dir \
+            --find-links=. \
+            lightgbm-*.tar.gz
+    fi
+    if test "${BUILD_WHEEL}" = true; then
+        pip install \
+            ${PIP_INSTALL_ARGS} \
+            --force-reinstall \
+            --no-cache-dir \
+            --find-links=. \
+            lightgbm-*.whl
+    fi
     cd ../
 fi
 

--- a/build-python.sh
+++ b/build-python.sh
@@ -354,24 +354,6 @@ if test "${INSTALL}" = true; then
     echo "--- installing lightgbm ---"
     # ref for use of '--find-links': https://stackoverflow.com/a/52481267/3986677
     cd ../dist
-<<<<<<< Updated upstream
-    if test "${BUILD_SDIST}" = true; then
-        pip install \
-            ${PIP_INSTALL_ARGS} \
-            --force-reinstall \
-            --no-cache-dir \
-            --find-links=. \
-            lightgbm-*.tar.gz
-    fi
-    if test "${BUILD_WHEEL}" = true; then
-        pip install \
-            ${PIP_INSTALL_ARGS} \
-            --force-reinstall \
-            --no-cache-dir \
-            --find-links=. \
-            lightgbm-*.whl
-    fi
-=======
     LGB_VER=$(head -n 1 ../VERSION.txt)
     if test "${BUILD_SDIST}" = true; then
         SUFFIX="tar.gz"
@@ -384,7 +366,6 @@ if test "${INSTALL}" = true; then
         --no-cache-dir \
         --find-links=. \
         lightgbm-${LGB_VER}-*.${SUFFIX}
->>>>>>> Stashed changes
     cd ../
 fi
 

--- a/build-python.sh
+++ b/build-python.sh
@@ -359,7 +359,7 @@ if test "${INSTALL}" = true; then
         --force-reinstall \
         --no-cache-dir \
         --find-links=. \
-        lightgbm
+        lightgbm-*.tar.gz
     cd ../
 fi
 

--- a/build-python.sh
+++ b/build-python.sh
@@ -365,7 +365,7 @@ if test "${INSTALL}" = true; then
         --force-reinstall \
         --no-cache-dir \
         --find-links=. \
-        lightgbm-${LGB_VER}-*.${SUFFIX}
+        lightgbm-${LGB_VER}*.${SUFFIX}
     cd ../
 fi
 


### PR DESCRIPTION
The python package installation from source with `build-python.sh` will always install the latest released version.
https://github.com/microsoft/LightGBM/blob/20975badd7ea3083c89f08a1f4dfda1a9789f6bc/build-python.sh#L362
Change this to install the built tar.gz file.