### PR TITLE
[CUDA] Set GPU device ID in threads

### DIFF
--- a/include/LightGBM/cuda/cuda_column_data.hpp
+++ b/include/LightGBM/cuda/cuda_column_data.hpp
@@ -98,6 +98,7 @@ class CUDAColumnData {
 
   void ResizeWhenCopySubrow(const data_size_t num_used_indices);
 
+  int gpu_device_id_;
   int num_threads_;
   data_size_t num_data_;
   int num_columns_;

--- a/include/LightGBM/cuda/cuda_metric.hpp
+++ b/include/LightGBM/cuda/cuda_metric.hpp
@@ -9,6 +9,7 @@
 
 #ifdef USE_CUDA
 
+#include <LightGBM/cuda/cuda_utils.h>
 #include <LightGBM/metric.h>
 
 namespace LightGBM {
@@ -19,6 +20,8 @@ class CUDAMetricInterface: public HOST_METRIC {
   explicit CUDAMetricInterface(const Config& config): HOST_METRIC(config) {
     cuda_labels_ = nullptr;
     cuda_weights_ = nullptr;
+    const int gpu_device_id = config.gpu_device_id >= 0 ? config.gpu_device_id : 0;
+    SetCUDADevice(gpu_device_id, __FILE__, __LINE__);
   }
 
   void Init(const Metadata& metadata, data_size_t num_data) override {

--- a/include/LightGBM/cuda/cuda_objective_function.hpp
+++ b/include/LightGBM/cuda/cuda_objective_function.hpp
@@ -21,7 +21,10 @@ namespace LightGBM {
 template <typename HOST_OBJECTIVE>
 class CUDAObjectiveInterface: public HOST_OBJECTIVE {
  public:
-  explicit CUDAObjectiveInterface(const Config& config): HOST_OBJECTIVE(config) {}
+  explicit CUDAObjectiveInterface(const Config& config): HOST_OBJECTIVE(config) {
+    const int gpu_device_id = config.gpu_device_id >= 0 ? config.gpu_device_id : 0;
+    SetCUDADevice(gpu_device_id, __FILE__, __LINE__);
+  }
 
   explicit CUDAObjectiveInterface(const std::vector<std::string>& strs): HOST_OBJECTIVE(strs) {}
 

--- a/include/LightGBM/cuda/cuda_utils.h
+++ b/include/LightGBM/cuda/cuda_utils.h
@@ -28,6 +28,8 @@ inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort =
 
 void SetCUDADevice(int gpu_device_id, const char* file, int line);
 
+int GetCUDADevice(const char* file, int line);
+
 template <typename T>
 void AllocateCUDAMemory(T** out_ptr, size_t size, const char* file, const int line) {
   void* tmp_ptr = nullptr;

--- a/src/cuda/cuda_utils.cpp
+++ b/src/cuda/cuda_utils.cpp
@@ -26,6 +26,12 @@ void SetCUDADevice(int gpu_device_id, const char* file, int line) {
   }
 }
 
+int GetCUDADevice(const char* file, int line) {
+  int cur_gpu_device_id = 0;
+  CUDASUCCESS_OR_FATAL_OUTER(cudaGetDevice(&cur_gpu_device_id));
+  return cur_gpu_device_id;
+}
+
 }  // namespace LightGBM
 
 #endif  // USE_CUDA

--- a/src/io/cuda/cuda_column_data.cpp
+++ b/src/io/cuda/cuda_column_data.cpp
@@ -114,38 +114,41 @@ void CUDAColumnData::Init(const int num_columns,
   feature_mfb_is_na_ = feature_mfb_is_na;
   data_by_column_.resize(num_columns_, nullptr);
   OMP_INIT_EX();
-  #pragma omp parallel for schedule(static) num_threads(num_threads_)
-  for (int column_index = 0; column_index < num_columns_; ++column_index) {
-    OMP_LOOP_EX_BEGIN();
+  #pragma omp parallel num_threads(num_threads_)
+  {
     SetCUDADevice(gpu_device_id_, __FILE__, __LINE__);
-    const int8_t bit_type = column_bit_type[column_index];
-    if (column_data[column_index] != nullptr) {
-      // is dense column
-      if (bit_type == 4) {
-        column_bit_type_[column_index] = 8;
-        InitOneColumnData<false, true, uint8_t>(column_data[column_index], nullptr, &data_by_column_[column_index]);
-      } else if (bit_type == 8) {
-        InitOneColumnData<false, false, uint8_t>(column_data[column_index], nullptr, &data_by_column_[column_index]);
-      } else if (bit_type == 16) {
-        InitOneColumnData<false, false, uint16_t>(column_data[column_index], nullptr, &data_by_column_[column_index]);
-      } else if (bit_type == 32) {
-        InitOneColumnData<false, false, uint32_t>(column_data[column_index], nullptr, &data_by_column_[column_index]);
+    #pragma omp for schedule(static)
+    for (int column_index = 0; column_index < num_columns_; ++column_index) {
+      OMP_LOOP_EX_BEGIN();
+      const int8_t bit_type = column_bit_type[column_index];
+      if (column_data[column_index] != nullptr) {
+        // is dense column
+        if (bit_type == 4) {
+          column_bit_type_[column_index] = 8;
+          InitOneColumnData<false, true, uint8_t>(column_data[column_index], nullptr, &data_by_column_[column_index]);
+        } else if (bit_type == 8) {
+          InitOneColumnData<false, false, uint8_t>(column_data[column_index], nullptr, &data_by_column_[column_index]);
+        } else if (bit_type == 16) {
+          InitOneColumnData<false, false, uint16_t>(column_data[column_index], nullptr, &data_by_column_[column_index]);
+        } else if (bit_type == 32) {
+          InitOneColumnData<false, false, uint32_t>(column_data[column_index], nullptr, &data_by_column_[column_index]);
+        } else {
+          Log::Fatal("Unknow column bit type %d", bit_type);
+        }
       } else {
-        Log::Fatal("Unknow column bit type %d", bit_type);
+        // is sparse column
+        if (bit_type == 8) {
+          InitOneColumnData<true, false, uint8_t>(nullptr, column_bin_iterator[column_index], &data_by_column_[column_index]);
+        } else if (bit_type == 16) {
+          InitOneColumnData<true, false, uint16_t>(nullptr, column_bin_iterator[column_index], &data_by_column_[column_index]);
+        } else if (bit_type == 32) {
+          InitOneColumnData<true, false, uint32_t>(nullptr, column_bin_iterator[column_index], &data_by_column_[column_index]);
+        } else {
+          Log::Fatal("Unknow column bit type %d", bit_type);
+        }
       }
-    } else {
-      // is sparse column
-      if (bit_type == 8) {
-        InitOneColumnData<true, false, uint8_t>(nullptr, column_bin_iterator[column_index], &data_by_column_[column_index]);
-      } else if (bit_type == 16) {
-        InitOneColumnData<true, false, uint16_t>(nullptr, column_bin_iterator[column_index], &data_by_column_[column_index]);
-      } else if (bit_type == 32) {
-        InitOneColumnData<true, false, uint32_t>(nullptr, column_bin_iterator[column_index], &data_by_column_[column_index]);
-      } else {
-        Log::Fatal("Unknow column bit type %d", bit_type);
-      }
+      OMP_LOOP_EX_END();
     }
-    OMP_LOOP_EX_END();
   }
   OMP_THROW_EX();
   feature_to_column_ = feature_to_column;
@@ -180,25 +183,28 @@ void CUDAColumnData::CopySubrow(
     AllocateCUDAMemory<data_size_t>(&cuda_used_indices_, num_used_indices_size, __FILE__, __LINE__);
     data_by_column_.resize(num_columns_, nullptr);
     OMP_INIT_EX();
-    #pragma omp parallel for schedule(static) num_threads(num_threads_)
-    for (int column_index = 0; column_index < num_columns_; ++column_index) {
-      OMP_LOOP_EX_BEGIN();
+    #pragma omp parallel num_threads(num_threads_)
+    {
       SetCUDADevice(gpu_device_id_, __FILE__, __LINE__);
-      const uint8_t bit_type = column_bit_type_[column_index];
-      if (bit_type == 8) {
-        uint8_t* column_data = nullptr;
-        AllocateCUDAMemory<uint8_t>(&column_data, num_used_indices_size, __FILE__, __LINE__);
-        data_by_column_[column_index] = reinterpret_cast<void*>(column_data);
-      } else if (bit_type == 16) {
-        uint16_t* column_data = nullptr;
-        AllocateCUDAMemory<uint16_t>(&column_data, num_used_indices_size, __FILE__, __LINE__);
-        data_by_column_[column_index] = reinterpret_cast<void*>(column_data);
-      } else if (bit_type == 32) {
-        uint32_t* column_data = nullptr;
-        AllocateCUDAMemory<uint32_t>(&column_data, num_used_indices_size, __FILE__, __LINE__);
-        data_by_column_[column_index] = reinterpret_cast<void*>(column_data);
+      #pragma omp for schedule(static)
+      for (int column_index = 0; column_index < num_columns_; ++column_index) {
+        OMP_LOOP_EX_BEGIN();
+        const uint8_t bit_type = column_bit_type_[column_index];
+        if (bit_type == 8) {
+          uint8_t* column_data = nullptr;
+          AllocateCUDAMemory<uint8_t>(&column_data, num_used_indices_size, __FILE__, __LINE__);
+          data_by_column_[column_index] = reinterpret_cast<void*>(column_data);
+        } else if (bit_type == 16) {
+          uint16_t* column_data = nullptr;
+          AllocateCUDAMemory<uint16_t>(&column_data, num_used_indices_size, __FILE__, __LINE__);
+          data_by_column_[column_index] = reinterpret_cast<void*>(column_data);
+        } else if (bit_type == 32) {
+          uint32_t* column_data = nullptr;
+          AllocateCUDAMemory<uint32_t>(&column_data, num_used_indices_size, __FILE__, __LINE__);
+          data_by_column_[column_index] = reinterpret_cast<void*>(column_data);
+        }
+        OMP_LOOP_EX_END();
       }
-      OMP_LOOP_EX_END();
     }
     OMP_THROW_EX();
     InitCUDAMemoryFromHostMemory<void*>(&cuda_data_by_column_, data_by_column_.data(), data_by_column_.size(), __FILE__, __LINE__);
@@ -220,28 +226,31 @@ void CUDAColumnData::ResizeWhenCopySubrow(const data_size_t num_used_indices) {
   DeallocateCUDAMemory<data_size_t>(&cuda_used_indices_, __FILE__, __LINE__);
   AllocateCUDAMemory<data_size_t>(&cuda_used_indices_, num_used_indices_size, __FILE__, __LINE__);
   OMP_INIT_EX();
-  #pragma omp parallel for schedule(static) num_threads(num_threads_)
-  for (int column_index = 0; column_index < num_columns_; ++column_index) {
-    OMP_LOOP_EX_BEGIN();
+  #pragma omp parallel num_threads(num_threads_)
+  {
     SetCUDADevice(gpu_device_id_, __FILE__, __LINE__);
-    const uint8_t bit_type = column_bit_type_[column_index];
-    if (bit_type == 8) {
-      uint8_t* column_data = reinterpret_cast<uint8_t*>(data_by_column_[column_index]);
-      DeallocateCUDAMemory<uint8_t>(&column_data, __FILE__, __LINE__);
-      AllocateCUDAMemory<uint8_t>(&column_data, num_used_indices_size, __FILE__, __LINE__);
-      data_by_column_[column_index] = reinterpret_cast<void*>(column_data);
-    } else if (bit_type == 16) {
-      uint16_t* column_data = reinterpret_cast<uint16_t*>(data_by_column_[column_index]);
-      DeallocateCUDAMemory<uint16_t>(&column_data, __FILE__, __LINE__);
-      AllocateCUDAMemory<uint16_t>(&column_data, num_used_indices_size, __FILE__, __LINE__);
-      data_by_column_[column_index] = reinterpret_cast<void*>(column_data);
-    } else if (bit_type == 32) {
-      uint32_t* column_data = reinterpret_cast<uint32_t*>(data_by_column_[column_index]);
-      DeallocateCUDAMemory<uint32_t>(&column_data, __FILE__, __LINE__);
-      AllocateCUDAMemory<uint32_t>(&column_data, num_used_indices_size, __FILE__, __LINE__);
-      data_by_column_[column_index] = reinterpret_cast<void*>(column_data);
+    #pragma omp for schedule(static)
+    for (int column_index = 0; column_index < num_columns_; ++column_index) {
+      OMP_LOOP_EX_BEGIN();
+      const uint8_t bit_type = column_bit_type_[column_index];
+      if (bit_type == 8) {
+        uint8_t* column_data = reinterpret_cast<uint8_t*>(data_by_column_[column_index]);
+        DeallocateCUDAMemory<uint8_t>(&column_data, __FILE__, __LINE__);
+        AllocateCUDAMemory<uint8_t>(&column_data, num_used_indices_size, __FILE__, __LINE__);
+        data_by_column_[column_index] = reinterpret_cast<void*>(column_data);
+      } else if (bit_type == 16) {
+        uint16_t* column_data = reinterpret_cast<uint16_t*>(data_by_column_[column_index]);
+        DeallocateCUDAMemory<uint16_t>(&column_data, __FILE__, __LINE__);
+        AllocateCUDAMemory<uint16_t>(&column_data, num_used_indices_size, __FILE__, __LINE__);
+        data_by_column_[column_index] = reinterpret_cast<void*>(column_data);
+      } else if (bit_type == 32) {
+        uint32_t* column_data = reinterpret_cast<uint32_t*>(data_by_column_[column_index]);
+        DeallocateCUDAMemory<uint32_t>(&column_data, __FILE__, __LINE__);
+        AllocateCUDAMemory<uint32_t>(&column_data, num_used_indices_size, __FILE__, __LINE__);
+        data_by_column_[column_index] = reinterpret_cast<void*>(column_data);
+      }
+      OMP_LOOP_EX_END();
     }
-    OMP_LOOP_EX_END();
   }
   OMP_THROW_EX();
   DeallocateCUDAMemory<void*>(&cuda_data_by_column_, __FILE__, __LINE__);


### PR DESCRIPTION
This is to fix the issue proposed in #6018. As reported in the issue, currently illegal memory access may arise when using a `gpu_device_id > 0` for `cuda` tree learner. This is because some CUDA memory is allocated in threads. Though the device ID is set in the main thread, it is not set in the newly created threads. The allocated CUDA memory in those threads may reside in GPU 0 by default, which is different with the `gpu_device_id`. Accessing to such memory on `gpu_device_id` may cause illegal memory access.

Here's one example,
https://github.com/microsoft/LightGBM/blob/20975badd7ea3083c89f08a1f4dfda1a9789f6bc/src/io/cuda/cuda_column_data.cpp#L120-L137