### PR TITLE
[ci] add bot to lock inactive issues and PRs

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,44 @@
+name: 'Lock Inactive Threads'
+
+on:
+  schedule:
+    # midnight UTC, every Wednesday
+    - cron: '0 0 * * 3'
+  # allow manual triggering from GitHub UI
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v4
+        with:
+          github-token: ${{ github.token }}
+          #--------#
+          # issues #
+          #--------#
+          # after how many days of inactivity should a closed issue/PR be locked?
+          issue-inactive-days: '180'
+          pr-inactive-days: '180'
+          # what labels should be removed prior to locking?
+          remove-issue-labels: 'awaiting response,awaiting review,blocking,in progress'
+          remove-pr-labels: 'awaiting response,awaiting review,blocking,in progress'
+          # what message should be posted prior to locking?
+          issue-comment: |
+            This issue has been automatically locked since there has not been any recent activity since it was closed.
+            To start a new related discussion, open a new issue at https://github.com/microsoft/LightGBM/issues
+            including a reference to this.
+          pr-comment: |
+            This pull request has been automatically locked since there has not been any recent activity since it was closed.
+            To start a new related discussion, open a new issue at https://github.com/microsoft/LightGBM/issues
+            including a reference to this.
+          # what shoulld the locking status be?
+          issue-lock-reason: 'resolved'
+          pr-lock-reason: 'resolved'

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -21,12 +21,12 @@ jobs:
       - uses: dessant/lock-threads@v4
         with:
           github-token: ${{ github.token }}
-          #--------#
-          # issues #
-          #--------#
           # after how many days of inactivity should a closed issue/PR be locked?
-          issue-inactive-days: '180'
-          pr-inactive-days: '180'
+          issue-inactive-days: '90'
+          pr-inactive-days: '90'
+          # do not close feature request issues...
+          # we close those but track them in https://github.com/microsoft/LightGBM/issues/2302
+          exclude-any-issue-labels: 'feature request'
           # what labels should be removed prior to locking?
           remove-issue-labels: 'awaiting response,awaiting review,blocking,in progress'
           remove-pr-labels: 'awaiting response,awaiting review,blocking,in progress'


### PR DESCRIPTION
Proposes adding a bot that runs once a week and does the following for any closed issues and PRs that have not had any new activity in the previous 90 days, and which don't have the `feature request` label...

* removes any of the following labels:
   - `awaiting response`
   - `awaiting review`
   - `blocking`
   - `in progress`
* posts a comment encouraging anyone looking at it to open a new issue
* locks conversation on the issue/PR (so only maintainers can post further comments)

### Benefit of this change

Keeps focus on active conversations and PRs, that everyone looking at the repo can see.

Prevents the situation where people ask questions by commenting on old, closed discussions like this: https://github.com/microsoft/LightGBM/pull/4803#issuecomment-1675428818. In those situations, only people who were already subscribed to that particular conversation are notified.

### Notes for Reviewers

We used to run a bot for this purpose in LightGBM, but it was turned off over 2 years ago, in #4251.

At the time, I recommended that we might switch from https://github.com/dessant/lock-threads-app (archived in 2021) to https://github.com/dessant/lock-threads (active): https://github.com/microsoft/LightGBM/pull/4251#issuecomment-831640982

But then we just never did that... I got busy with other things and forgot 😅 

This PR proposes finally doing that. https://github.com/dessant/lock-threads is actively maintained ([most recent rerlease in June 2023](https://github.com/dessant/lock-threads/releases/tag/v4.0.1)), and importantly doesn't require any new permissions changes in the repo, since it is able to run as a GitHub Actions workflow.