### PR TITLE
[python-package] make it possible to build wheels without internet connection (fixes #5979)

### DIFF
--- a/build-python.sh
+++ b/build-python.sh
@@ -48,6 +48,9 @@
 #                                   Compile with MinGW.
 #     --mpi
 #                                   Compile MPI version.
+#     --no-isolation
+#                                   Assume all build and install dependencies are already installed,
+#                                   don't go to the internet to get them.
 #     --nomp
 #                                   Compile version without OpenMP support.
 #     --precompile
@@ -159,8 +162,11 @@ while [ $# -gt 0 ]; do
     --mpi)
         BUILD_ARGS="${BUILD_ARGS} --config-setting=cmake.define.USE_MPI=ON"
         ;;
+    --no-isolation)
+        BUILD_ARGS="${BUILD_ARGS} --no-isolation"
+        ;;
     --nomp)
-        BUILD_ARGS="${BUILD_ARGS} --config-setting=cmake.define.USE_OPENMP=OFF"
+        PIP_INSTALL_ARGS="${PIP_INSTALL_ARGS} --no-build-isolation"
         ;;
     --precompile)
         PRECOMPILE="true"
@@ -337,6 +343,7 @@ if test "${BUILD_SDIST}" = true; then
     python -m build \
         --sdist \
         --outdir ../dist \
+        ${BUILD_ARGS} \
         .
 fi
 

--- a/build-python.sh
+++ b/build-python.sh
@@ -164,9 +164,10 @@ while [ $# -gt 0 ]; do
         ;;
     --no-isolation)
         BUILD_ARGS="${BUILD_ARGS} --no-isolation"
+        PIP_INSTALL_ARGS="${PIP_INSTALL_ARGS} --no-build-isolation"
         ;;
     --nomp)
-        PIP_INSTALL_ARGS="${PIP_INSTALL_ARGS} --no-build-isolation"
+        BUILD_ARGS="${BUILD_ARGS} --config-setting=cmake.define.USE_OPENMP=OFF"
         ;;
     --precompile)
         PRECOMPILE="true"

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -256,7 +256,14 @@ If you get any errors during installation or due to any other reasons, you may w
 Build Wheel File
 ****************
 
-You can use ``sh ./build-python.sh install bdist_wheel`` instead of ``sh ./build-python.sh install`` to build wheel file and use it for installation later. This might be useful for systems with restricted or completely without network access.
+You can use ``sh ./build-python.sh install bdist_wheel`` to build a wheel file but not install it.
+
+That script requires some dependencies like ``build``, ``scikit-build-core``, and ``wheel``.
+In environments with restricted or no internt access, install those tools and then pass ``--no-isolation``.
+
+.. code:: sh
+
+  sh ./build-pythoon.sh bdist_wheel --no-isolation
 
 Build With MSBuild
 ******************


### PR DESCRIPTION
Fixes #5979.

Makes it possible to build wheels with `build-python.sh` in environments without internet access.

That's relevant to repackaging like the creation of FreeBSD ports described in #5979.

### How I tested this

On my Mac laptop...

... installed build dependencies

```shell
pip install \
    build \
    scikit-build-core \
    wheel
```

... turned off wifi and build a wheel

```shell
sh ./build-python.sh \
    --no-isolation \
    bdist_wheel
```