### PR TITLE
[ci] prevent lock-threads from locking issues with label 'feature request'

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -26,16 +26,16 @@ jobs:
           pr-inactive-days: '90'
           # do not close feature request issues...
           # we close those but track them in https://github.com/microsoft/LightGBM/issues/2302
-          exclude-any-issue-labels: 'feature request'
+          exclude-any-issue-labels: '"feature request"'
           # what labels should be removed prior to locking?
           remove-issue-labels: 'awaiting response,awaiting review,blocking,in progress'
           remove-pr-labels: 'awaiting response,awaiting review,blocking,in progress'
           # what message should be posted prior to locking?
-          issue-comment: |
+          issue-comment: >
             This issue has been automatically locked since there has not been any recent activity since it was closed.
             To start a new related discussion, open a new issue at https://github.com/microsoft/LightGBM/issues
             including a reference to this.
-          pr-comment: |
+          pr-comment: >
             This pull request has been automatically locked since there has not been any recent activity since it was closed.
             To start a new related discussion, open a new issue at https://github.com/microsoft/LightGBM/issues
             including a reference to this.


### PR DESCRIPTION
#6037 reintroduced a bot for locking discussion on long-inactive closed PRs and issues, to encourage discussions to stay in highly-visible places.

This PR fixes two bugs in that configuration:

* ensures that bot-posted comments have correct text wrapping
* ensures that issues with the label `feature request` are not locked
    - *since we close such issues, link to them from #2302, and encourage contributors to comment on them if they want to re-open the discussion and work on them*

### Text wrapping

What the bot currently produces:

<img width="842" alt="image" src="https://github.com/microsoft/LightGBM/assets/7608904/281a4340-7c8f-4821-9a5a-22c899c3eb89">

What I want it to look like:

<img width="857" alt="image" src="https://github.com/microsoft/LightGBM/assets/7608904/0741c00f-67fa-47bb-af17-fa70c596a198">

Notice that there isn't an unnecessary line break after the link to the issues page. That'll make the text look a bit better when screens are resized.

To learn how switching from `|` to `>` in the configuration achieves that, see https://yaml-multiline.info/.

### `feature request` label

As described in https://github.com/microsoft/LightGBM/pull/6037#issuecomment-1679578288, the bot is locking some issues with label `feature request`, e.g. https://github.com/microsoft/LightGBM/issues/3200#issuecomment-1679573601.

Looks to me like `lock-threads` requires that labels passed into its `exclude-any-issue-labels` configuration be double-quoted if they contain spaces.

That's because that feature works by directly appending a `-label:` search body using GitHub's code search API ([docs](https://docs.github.com/en/free-pro-team@latest/rest/search/search?apiVersion=2022-11-28#search-code)):

https://github.com/dessant/lock-threads/blob/be8aa5be94131386884a6da4189effda9b14aa21/src/index.js#L143-L146

```javascript
query += ` -label:${excludeAnyLabels.join(',')}`;
```

I tested this in the GitHub UI, and can see the effect.

<img width="1173" alt="Screen Shot 2023-08-17 at 5 59 26 PM" src="https://github.com/microsoft/LightGBM/assets/7608904/bda1abc7-ae76-4c96-a34c-f55555256b41">

https://github.com/microsoft/LightGBM/issues?q=is%3Aissue+is%3Aclosed+-label%3Afeature+request

With quoting around that label, the search matches the expected issues.

<img width="1133" alt="Screen Shot 2023-08-17 at 6 02 29 PM" src="https://github.com/microsoft/LightGBM/assets/7608904/03a53861-47c4-4e3f-a61e-e8d2efc7ab4b">

https://github.com/microsoft/LightGBM/issues?q=is%3Aissue+is%3Aclosed+-label%3A%22feature+request%22

Thanks to this comment from @alessbell for the hint: https://github.com/dessant/lock-threads/issues/40#issuecomment-1430378288.

### Notes for Reviewers

I've manually unlocked all of the closed issues with label `feature request` that were incorrectly locked after merging #6037.