### PR TITLE
[python-package] use dataclass for CallbackEnv

### DIFF
--- a/.ci/test-python-oldest.sh
+++ b/.ci/test-python-oldest.sh
@@ -7,6 +7,7 @@
 #
 echo "installing lightgbm's dependencies"
 pip install \
+  'dataclasses' \
   'numpy==1.12.0' \
   'pandas==0.24.0' \
   'scikit-learn==0.18.2' \

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 """Library with training routines of LightGBM."""
-import collections
 import copy
 import json
+from collections import OrderedDict, defaultdict
 from operator import attrgetter
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
@@ -293,7 +293,7 @@ def train(
             booster.best_iteration = earlyStopException.best_iteration + 1
             evaluation_result_list = earlyStopException.best_score
             break
-    booster.best_score = collections.defaultdict(collections.OrderedDict)
+    booster.best_score = defaultdict(OrderedDict)
     for dataset_name, eval_name, score, _ in evaluation_result_list:
         booster.best_score[dataset_name][eval_name] = score
     if not keep_training_booster:
@@ -526,7 +526,7 @@ def _agg_cv_result(
     raw_results: List[List[Tuple[str, str, float, bool]]]
 ) -> List[Tuple[str, str, float, bool, float]]:
     """Aggregate cross-validation results."""
-    cvmap: Dict[str, List[float]] = collections.OrderedDict()
+    cvmap: Dict[str, List[float]] = OrderedDict()
     metric_type: Dict[str, bool] = {}
     for one_result in raw_results:
         for one_line in one_result:
@@ -717,7 +717,7 @@ def cv(
              .set_feature_name(feature_name) \
              .set_categorical_feature(categorical_feature)
 
-    results = collections.defaultdict(list)
+    results = defaultdict(list)
     cvfolds = _make_n_folds(full_data=train_set, folds=folds, nfold=nfold,
                             params=params, seed=seed, fpreproc=fpreproc,
                             stratified=stratified, shuffle=shuffle,

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence"
 ]
 dependencies = [
+    "dataclasses ; python_version < '3.7'",
     "numpy",
     "scipy"
 ]


### PR DESCRIPTION
Contributes #3756.
Contributes to #3867.

Proposes converting `CallbackEnv` in the Python package to a dataclass.

Also proposes removing uses of `import collections` in favor of importing only exactly what LightGBM needs from that module.

Restating the benefits I mentioned when I last tried this in #5765, `dataclasses` are preferable to `namedtuple` in the following ways:

* easier to set type annotations + default values than named tuples
    - makes it easier for both human developers and and tools like `mypy` to understand the expected types of properties
* possible to attach other methods or computed properties with `@property` (just like normal classes)

I realized today that "use `dataclassses`" and "drop Python 3.6 support" don't have to be coupled... I was wrong to suggest that coupling in #5765 and https://github.com/microsoft/LightGBM/pull/6022#discussion_r1285248720.

This proposes taking on the `dataclasses` package as a required dependency **only for Python 3.6**.  For details on that mechanism, see PEP 508 and PEP 631:

* https://peps.python.org/pep-0508/
* https://peps.python.org/pep-0631/

That package still exists on PyPI exactly for cases like this... it's intended to be used to continue to provide `dataclasses` support for Python 3.6: https://pypi.org/project/dataclasses/.