### PR TITLE
[ci] [python-package] add more linting checks

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -126,7 +126,7 @@ class _MissingType(Enum):
 
 class _DummyLogger:
     def info(self, msg: str) -> None:
-        print(msg)
+        print(msg)  # noqa: T201
 
     def warning(self, msg: str) -> None:
         warnings.warn(msg, stacklevel=3)
@@ -467,11 +467,10 @@ class _ConfigAliases:
                 ctypes.c_int64(actual_len),
                 ctypes.byref(tmp_out_len),
                 ptr_string_buffer))
-        aliases = json.loads(
+        return json.loads(
             string_buffer.value.decode('utf-8'),
             object_hook=lambda obj: {k: [k] + v for k, v in obj.items()}
         )
-        return aliases
 
     @classmethod
     def get(cls, *args) -> Set[str]:
@@ -3209,8 +3208,7 @@ class Booster:
 
     def __deepcopy__(self, _) -> "Booster":
         model_str = self.model_to_string(num_iteration=-1)
-        booster = Booster(model_str=model_str)
-        return booster
+        return Booster(model_str=model_str)
 
     def __getstate__(self) -> Dict[str, Any]:
         this = self.__dict__.copy()

--- a/python-package/lightgbm/plotting.py
+++ b/python-package/lightgbm/plotting.py
@@ -693,11 +693,7 @@ def create_tree_digraph(
 
     model = booster.dump_model()
     tree_infos = model['tree_info']
-    if 'feature_names' in model:
-        feature_names = model['feature_names']
-    else:
-        feature_names = None
-
+    feature_names = model.get('feature_names', None)
     monotone_constraints = model.get('monotone_constraints', None)
 
     if tree_index < len(tree_infos):
@@ -722,7 +718,7 @@ def create_tree_digraph(
             )[0]
         example_case = example_case[0]
 
-    graph = _to_graphviz(
+    return _to_graphviz(
         tree_info=tree_info,
         show_info=show_info,
         feature_names=feature_names,
@@ -733,8 +729,6 @@ def create_tree_digraph(
         max_category_values=max_category_values,
         **kwargs
     )
-
-    return graph
 
 
 def plot_tree(

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -111,7 +111,13 @@ select = [
     # pycodestyle
     "E",
     # pyflakes
-    "F"
+    "F",
+    # flake8-return: unnecessary assignment before return
+    "RET504",
+    # flake8-simplify: use dict.get() instead of an if-else block
+    "SIM401",
+    # flake8-print
+    "T",
 ]
 
 # this should be set to the oldest version of python LightGBM supports
@@ -120,13 +126,17 @@ target-version = "py37"
 [tool.ruff.per-file-ignores]
 "examples/*" = [
     # pydocstyle
-    "D"
+    "D",
+    # flake8-print
+    "T"
 ]
 "tests/*" = [
     # (flake8-bugbear) Found useless expression
     "B018",
     # pydocstyle
-    "D"
+    "D",
+    # flake8-print
+    "T"
 ]
 
 [tool.ruff.pydocstyle]

--- a/tests/distributed/_test_distributed.py
+++ b/tests/distributed/_test_distributed.py
@@ -25,7 +25,7 @@ def _find_random_open_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(('', 0))
         port = s.getsockname()[1]
-    return port
+    return port  # noqa: RET504
 
 
 def _generate_n_ports(n: int) -> Generator[int, None, None]:
@@ -47,8 +47,7 @@ def create_data(task: str, n_samples: int = 1_000) -> np.ndarray:
         X, y = make_blobs(n_samples, centers=centers, random_state=42)
     elif task == 'regression':
         X, y = make_regression(n_samples, n_features=4, n_informative=2, random_state=42)
-    dataset = np.hstack([y.reshape(-1, 1), X])
-    return dataset
+    return np.hstack([y.reshape(-1, 1), X])
 
 
 class DistributedMockup:
@@ -149,8 +148,7 @@ class DistributedMockup:
         result = subprocess.run(cmd)
         if result.returncode != 0:
             raise RuntimeError('Error in prediction')
-        y_pred = np.loadtxt(str(TESTS_DIR / 'predictions.txt'))
-        return y_pred
+        return np.loadtxt(str(TESTS_DIR / 'predictions.txt'))
 
     def write_train_config(self, i: int) -> None:
         """Create a file train{i}.conf with the required configuration to train.

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1720,8 +1720,7 @@ def generate_trainset_for_monotone_constraints_tests(x3_to_category=True):
     categorical_features = []
     if x3_to_category:
         categorical_features = [2]
-    trainset = lgb.Dataset(x, label=y, categorical_feature=categorical_features, free_raw_data=False)
-    return trainset
+    return lgb.Dataset(x, label=y, categorical_feature=categorical_features, free_raw_data=False)
 
 
 @pytest.mark.skipif(getenv('TASK', '') == 'cuda', reason='Monotone constraints are not yet supported by CUDA version')

--- a/tests/python_package_test/utils.py
+++ b/tests/python_package_test/utils.py
@@ -192,4 +192,4 @@ def pickle_and_unpickle_object(obj, serializer):
             filepath=tmp_file.name,
             serializer=serializer
         )
-    return obj_from_disk
+    return obj_from_disk  # noqa: RET504


### PR DESCRIPTION
Proposes adding a few more linting rules for Python code in this project, to further standardize how the code looks.

* `flake8-print`: encourages the use of the configured logger over `print()` and `pprint()`
* `flake8-return` (just one of the checks): avoid unnecessary assignment immediately before a `return()`
* `flake8-simplify` (just one of the checks): use `dict.get(key. default)` instead of an `if-else` loop

This PR adds those checks to the project's linting config, and modifies the project's code to address these specific warnings:

```text
python-package/lightgbm/basic.py:129:9: T201 `print` found
python-package/lightgbm/basic.py:474:16: RET504 [*] Unnecessary assignment to `aliases` before `return` statement
python-package/lightgbm/basic.py:3213:16: RET504 [*] Unnecessary assignment to `booster` before `return` statement
python-package/lightgbm/plotting.py:737:12: RET504 [*] Unnecessary assignment to `graph` before `return` statement
python-package/lightgbm/plotting.py:696:5: SIM401 [*] Use `feature_names = model.get('feature_names', None)` instead of an `if` block
tests/distributed/_test_distributed.py:28:12: RET504 [*] Unnecessary assignment to `port` before `return` statement
tests/distributed/_test_distributed.py:51:12: RET504 [*] Unnecessary assignment to `dataset` before `return` statement
tests/distributed/_test_distributed.py:153:16: RET504 [*] Unnecessary assignment to `y_pred` before `return` statement
tests/python_package_test/test_engine.py:1724:12: RET504 [*] Unnecessary assignment to `trainset` before `return` statement
tests/python_package_test/utils.py:195:12: RET504 [*] Unnecessary assignment to `obj_from_disk` before `return` statement
```

Docs for these checks can be found at https://beta.ruff.rs/docs/rules.