### PR TITLE
[docs] fix broken links

### DIFF
--- a/docs/GPU-Windows.rst
+++ b/docs/GPU-Windows.rst
@@ -602,9 +602,9 @@ And open an issue in GitHub `here`_ with that log.
 
 .. _Boost: https://www.boost.org/users/history/
 
-.. _Prebuilt Boost x86_64: https://www.rpmfind.net/linux/fedora/linux/releases/36/Everything/x86_64/os/Packages/m/mingw64-boost-static-1.75.0-6.fc36.noarch.rpm
+.. _Prebuilt Boost x86_64: https://www.rpmfind.net/linux/fedora/linux/releases/38/Everything/x86_64/os/Packages/m/mingw64-boost-static-1.78.0-4.fc38.noarch.rpm
 
-.. _Prebuilt Boost i686: https://www.rpmfind.net/linux/fedora/linux/releases/36/Everything/x86_64/os/Packages/m/mingw32-boost-static-1.75.0-6.fc36.noarch.rpm
+.. _Prebuilt Boost i686: https://www.rpmfind.net/linux/fedora/linux/releases/38/Everything/x86_64/os/Packages/m/mingw32-boost-static-1.78.0-4.fc38.noarch.rpm
 
 .. _7zip: https://www.7-zip.org/download.html
 

--- a/docs/Parallel-Learning-Guide.rst
+++ b/docs/Parallel-Learning-Guide.rst
@@ -514,7 +514,7 @@ See `the mars documentation`_ for usage examples.
 
 .. _SynapseML: https://aka.ms/spark
 
-.. _this SynapseML example: https://github.com/microsoft/SynapseML/blob/master/notebooks/features/lightgbm/LightGBM%20-%20Overview.ipynb
+.. _this SynapseML example: https://github.com/microsoft/SynapseML/tree/master/docs/Explore%20Algorithms/LightGBM
 
 .. _the Dask Array documentation: https://docs.dask.org/en/latest/array.html
 


### PR DESCRIPTION
Fixes broken links in the project's documentation, detected by the `link-checks` CI job: https://github.com/microsoft/LightGBM/actions/runs/5948642832/job/16132829498.

```text
URL        `https://www.rpmfind.net/linux/fedora/linux/releases/36/Everything/x86_64/os/Packages/m/mingw64-boost-static-1.75.0-6.fc36.noarch.rpm'
Name       `Prebuilt Boost x86_64'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/GPU-Windows.html, line 180, col 14
Real URL   https://www.rpmfind.net/linux/fedora/linux/releases/36/Everything/x86_64/os/Packages/m/mingw64-boost-static-1.75.0-6.fc36.noarch.rpm
Result     Error: 404 Not Found

URL        `https://www.rpmfind.net/linux/fedora/linux/releases/36/Everything/x86_64/os/Packages/m/mingw32-boost-static-1.75.0-6.fc36.noarch.rpm'
Name       `Prebuilt Boost i686'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/GPU-Windows.html, line 180, col 213
Real URL   https://www.rpmfind.net/linux/fedora/linux/releases/36/Everything/x86_64/os/Packages/m/mingw32-boost-static-1.75.0-6.fc36.noarch.rpm
Result     Error: 404 Not Found

URL        `https://github.com/microsoft/SynapseML/blob/master/notebooks/features/lightgbm/LightGBM%20-%20Overview.ipynb'
Name       `this SynapseML example'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/Parallel-Learning-Guide.html, line 176, col 8
Real URL   https://github.com/microsoft/SynapseML/blob/master/notebooks/features/lightgbm/LightGBM%20-%20Overview.ipynb
Result     Error: 404 Not Found
```

Looks like our friends at SynapseML did their annual "completely re-arrange all the docs" PR 😂 

https://github.com/microsoft/SynapseML/pull/2021

And some older releases of Fedora Boost packages were removed from rpmfind.net.

### How I tested this

✅  manually triggered the `check-links` job targeting this branch: https://github.com/microsoft/LightGBM/actions/runs/5952346174