### PR TITLE
introduce random assignment prediction (fixes #5177)

### DIFF
--- a/include/LightGBM/boosting.h
+++ b/include/LightGBM/boosting.h
@@ -7,6 +7,7 @@
 
 #include <LightGBM/config.h>
 #include <LightGBM/meta.h>
+#include <LightGBM/prediction_control_parameter.h>
 
 #include <string>
 #include <map>
@@ -131,11 +132,11 @@ class LIGHTGBM_EXPORT Boosting {
   * \param output Prediction result for this record
   * \param early_stop Early stopping instance. If nullptr, no early stopping is applied and all models are evaluated.
   */
-  virtual void PredictRaw(const double* features, double* output,
-                          const PredictionEarlyStopInstance* early_stop) const = 0;
+  virtual void PredictRaw(const double* features, double* output, const PredictionEarlyStopInstance* early_stop,
+                          const PredictionControlParameter* predict_params) const = 0;
 
   virtual void PredictRawByMap(const std::unordered_map<int, double>& features, double* output,
-                               const PredictionEarlyStopInstance* early_stop) const = 0;
+                               const PredictionEarlyStopInstance* early_stop, const PredictionControlParameter* predict_params) const = 0;
 
 
   /*!
@@ -144,11 +145,11 @@ class LIGHTGBM_EXPORT Boosting {
   * \param output Prediction result for this record
   * \param early_stop Early stopping instance. If nullptr, no early stopping is applied and all models are evaluated.
   */
-  virtual void Predict(const double* features, double* output,
-                       const PredictionEarlyStopInstance* early_stop) const = 0;
+  virtual void Predict(const double* features, double* output, const PredictionEarlyStopInstance* early_stop,
+                       const PredictionControlParameter* predict_params) const = 0;
 
   virtual void PredictByMap(const std::unordered_map<int, double>& features, double* output,
-                            const PredictionEarlyStopInstance* early_stop) const = 0;
+                            const PredictionEarlyStopInstance* early_stop, const PredictionControlParameter* predict_params) const = 0;
 
 
   /*!

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -859,6 +859,12 @@ struct Config {
   // desc = **Note**: can be used only in CLI version
   std::string output_result = "LightGBM_predict_result.txt";
 
+  // [no-save]
+  // desc = used only in ``prediction`` task
+  // desc = Split features of internal nodes that enable left-right random assignment mechnisim.
+  // desc = See section "A surrogate VIMP" of the paper https://doi.org/10.1214/07-EJS039 for more details.
+  std::vector<int> random_assign_features;
+
   #ifndef __NVCC__
   #pragma endregion
 

--- a/include/LightGBM/prediction_control_parameter.h
+++ b/include/LightGBM/prediction_control_parameter.h
@@ -1,0 +1,40 @@
+
+/*!
+ * Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for license information.
+ */
+#ifndef LIGHTGBM_PREDICTION_CONTROL_PARAMETER_H_
+#define LIGHTGBM_PREDICTION_CONTROL_PARAMETER_H_
+
+
+#include <vector>
+#include <algorithm>
+
+namespace LightGBM {
+
+/*!
+* \brief Control paramters for prediction, used to implement variants of prediction algorithm
+*/
+struct PredictionControlParameter {
+  public:
+    PredictionControlParameter() {}
+    PredictionControlParameter(const std::vector<int>& ra_features) : random_assign_features(ra_features) {
+      // std::stable_sort(random_assign_features.begin(), random_assign_features.end(), std::less<int>());
+    }
+
+    /*!
+    * \brief try to enable random assignment mechanism with the split feature of current node
+    * \param split_feat_idx real index of the split feature
+    */
+    inline bool EnableRandomAssign(int split_feat_idx) const {
+      // return std::binary_search(random_assign_features.begin(), random_assign_features.end(), split_feat_idx);
+      return (std::find(random_assign_features.begin(), random_assign_features.end(), split_feat_idx) 
+              != random_assign_features.end());
+    }
+
+    std::vector<int> random_assign_features;
+};
+
+}   // namespace LightGBM
+
+#endif  // LIGHTGBM_PREDICTION_CONTROL_PARAMETER_H_

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -290,17 +290,19 @@ class GBDT : public GBDTBase {
     return num_pred_in_one_row;
   }
 
-  void PredictRaw(const double* features, double* output,
-                  const PredictionEarlyStopInstance* earlyStop) const override;
+  void PredictRaw(const double* features, double* output, const PredictionEarlyStopInstance* early_stop, 
+                  const PredictionControlParameter* predict_params) const override;
 
   void PredictRawByMap(const std::unordered_map<int, double>& features, double* output,
-                       const PredictionEarlyStopInstance* early_stop) const override;
+                       const PredictionEarlyStopInstance* early_stop,
+                       const PredictionControlParameter* predict_params) const override;
 
-  void Predict(const double* features, double* output,
-               const PredictionEarlyStopInstance* earlyStop) const override;
+  void Predict(const double* features, double* output, const PredictionEarlyStopInstance* early_stop,
+               const PredictionControlParameter* predict_params) const override;
 
-  void PredictByMap(const std::unordered_map<int, double>& features, double* output,
-                    const PredictionEarlyStopInstance* early_stop) const override;
+  void PredictByMap(const std::unordered_map<int, double>& features, double* output, 
+                    const PredictionEarlyStopInstance* early_stop,
+                    const PredictionControlParameter* predict_params) const override;
 
   void PredictLeafIndex(const double* features, double* output) const override;
 

--- a/src/boosting/gbdt_prediction.cpp
+++ b/src/boosting/gbdt_prediction.cpp
@@ -10,7 +10,9 @@
 
 namespace LightGBM {
 
-void GBDT::PredictRaw(const double* features, double* output, const PredictionEarlyStopInstance* early_stop) const {
+void GBDT::PredictRaw(const double* features, double* output,
+                      const PredictionEarlyStopInstance* early_stop,
+                      const PredictionControlParameter* predict_params) const {
   int early_stop_round_counter = 0;
   // set zero
   std::memset(output, 0, sizeof(double) * num_tree_per_iteration_);
@@ -18,7 +20,7 @@ void GBDT::PredictRaw(const double* features, double* output, const PredictionEa
   for (int i = start_iteration_for_pred_; i < end_iteration_for_pred; ++i) {
     // predict all the trees for one iteration
     for (int k = 0; k < num_tree_per_iteration_; ++k) {
-      output[k] += models_[i * num_tree_per_iteration_ + k]->Predict(features);
+      output[k] += models_[i * num_tree_per_iteration_ + k]->Predict(features, predict_params);
     }
     // check early stopping
     ++early_stop_round_counter;
@@ -31,7 +33,10 @@ void GBDT::PredictRaw(const double* features, double* output, const PredictionEa
   }
 }
 
-void GBDT::PredictRawByMap(const std::unordered_map<int, double>& features, double* output, const PredictionEarlyStopInstance* early_stop) const {
+void GBDT::PredictRawByMap(const std::unordered_map<int, double>& features,
+                           double* output,
+                           const PredictionEarlyStopInstance* early_stop,
+                           const PredictionControlParameter* predict_params) const {
   int early_stop_round_counter = 0;
   // set zero
   std::memset(output, 0, sizeof(double) * num_tree_per_iteration_);
@@ -39,7 +44,7 @@ void GBDT::PredictRawByMap(const std::unordered_map<int, double>& features, doub
   for (int i = start_iteration_for_pred_; i < end_iteration_for_pred; ++i) {
     // predict all the trees for one iteration
     for (int k = 0; k < num_tree_per_iteration_; ++k) {
-      output[k] += models_[i * num_tree_per_iteration_ + k]->PredictByMap(features);
+      output[k] += models_[i * num_tree_per_iteration_ + k]->PredictByMap(features, predict_params);
     }
     // check early stopping
     ++early_stop_round_counter;
@@ -52,8 +57,10 @@ void GBDT::PredictRawByMap(const std::unordered_map<int, double>& features, doub
   }
 }
 
-void GBDT::Predict(const double* features, double* output, const PredictionEarlyStopInstance* early_stop) const {
-  PredictRaw(features, output, early_stop);
+void GBDT::Predict(const double* features, double* output,
+                   const PredictionEarlyStopInstance* early_stop,
+                   const PredictionControlParameter* predict_params) const {
+  PredictRaw(features, output, early_stop, predict_params);
   if (average_output_) {
     for (int k = 0; k < num_tree_per_iteration_; ++k) {
       output[k] /= num_iteration_for_pred_;
@@ -64,8 +71,11 @@ void GBDT::Predict(const double* features, double* output, const PredictionEarly
   }
 }
 
-void GBDT::PredictByMap(const std::unordered_map<int, double>& features, double* output, const PredictionEarlyStopInstance* early_stop) const {
-  PredictRawByMap(features, output, early_stop);
+void GBDT::PredictByMap(const std::unordered_map<int, double>& features,
+                        double* output,
+                        const PredictionEarlyStopInstance* early_stop,
+                        const PredictionControlParameter* predict_params) const {
+  PredictRawByMap(features, output, early_stop, predict_params);
   if (average_output_) {
     for (int k = 0; k < num_tree_per_iteration_; ++k) {
       output[k] /= num_iteration_for_pred_;

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -576,6 +576,10 @@ void Config::GetMembersFromString(const std::unordered_map<std::string, std::str
 
   GetString(params, "output_result", &output_result);
 
+  if (GetString(params, "random_assign_features", &tmp_str)) {
+    random_assign_features = Common::StringToArray<int>(tmp_str, ',');
+  }
+
   GetString(params, "convert_model_language", &convert_model_language);
 
   GetString(params, "convert_model", &convert_model);


### PR DESCRIPTION
* Introduce a struct of parameters PredictionControlParameter

* Add a new field random_assign_features to class Config

* Add new GetLeaf functions that apply random assign mechanism to class Tree

Hi @guolinke, I completed my code writing following a modified implementation plan, would you please give some suggestions for my code? It's my first time creating a PR for LightGBM and any suggestions would be greatly appreciated. Since the implementation plan has been modified from that in the discussion of #5177, there is one thing I should explain before your review:

### Why add a parameter to prediction functions in Predictor/Tree instead of adding some new predict functions?
The difference between normal prediction and random assignment prediction is mainly in how to search a Tree(how to choose to go left or go right), which means they have too much repetitive code except for the code of GetLeaf functions. In the part of predict functions, they have the same logic. That's why I didn't choose to add new predict functions for class Predictor or class Tree. While considering scalability, a structure of control parameters that could be extended easily seems a perfect idea to me.