### PR TITLE
reduce verbosity of some log messages

### DIFF
--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3265,6 +3265,8 @@ test_that("lightgbm() accepts 'weight' and 'weights'", {
     , metric =  "auc"
     , early_stopping_round = nrounds
     , num_threads = .LGB_MAX_THREADS
+    # include a nonsense parameter just to trigger a WARN-level log
+    , nonsense_param = 1.0
   )
   if (!is.null(verbose_param)) {
     params[["verbose"]] <- verbose_param

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -150,7 +150,7 @@ class Booster {
     objective_fun_.reset(ObjectiveFunction::CreateObjectiveFunction(config_.objective,
                                                                     config_));
     if (objective_fun_ == nullptr) {
-      Log::Warning("Using self-defined objective function");
+      Log::Info("Using self-defined objective function");
     }
     // initialize the objective function
     if (objective_fun_ != nullptr) {
@@ -320,7 +320,7 @@ class Booster {
       objective_fun_.reset(ObjectiveFunction::CreateObjectiveFunction(config_.objective,
                                                                       config_));
       if (objective_fun_ == nullptr) {
-        Log::Warning("Using self-defined objective function");
+        Log::Info("Using self-defined objective function");
       }
       // initialize the objective function
       if (objective_fun_ != nullptr) {

--- a/src/io/dataset.cpp
+++ b/src/io/dataset.cpp
@@ -699,7 +699,7 @@ TrainingShareStates* Dataset::GetShareStates(
 
     if (col_wise_time < row_wise_time) {
       auto overhead_cost = row_wise_init_time + row_wise_time + col_wise_time;
-      Log::Warning(
+      Log::Info(
           "Auto-choosing col-wise multi-threading, the overhead of testing was "
           "%f seconds.\n"
           "You can set `force_col_wise=true` to remove the overhead.",
@@ -707,7 +707,7 @@ TrainingShareStates* Dataset::GetShareStates(
       return col_wise_state.release();
     } else {
       auto overhead_cost = col_wise_init_time + row_wise_time + col_wise_time;
-      Log::Warning(
+      Log::Info(
           "Auto-choosing row-wise multi-threading, the overhead of testing was "
           "%f seconds.\n"
           "You can set `force_row_wise=true` to remove the overhead.\n"


### PR DESCRIPTION
Running a minimal example of cross-validation in the Python package (https://github.com/microsoft/LightGBM/issues/6072#issuecomment-1703993820), I noticed some warning-level log messages that I believe should only be printed when users request more verbose logging.

```text
[LightGBM] [Warning] Using self-defined objective function
[LightGBM] [Warning] Auto-choosing col-wise multi-threading, the overhead of testing was 0.006622 seconds.
You can set `force_col_wise=true` to remove the overhead.
[LightGBM] [Info] Total Bins 25500
[LightGBM] [Info] Number of data points in the train set: 6666, number of used features: 100
[LightGBM] [Warning] Using self-defined objective function
[LightGBM] [Warning] Auto-choosing col-wise multi-threading, the overhead of testing was 0.005703 seconds.
You can set `force_col_wise=true` to remove the overhead.
[LightGBM] [Info] Total Bins 25500
[LightGBM] [Info] Number of data points in the train set: 6666, number of used features: 100
[LightGBM] [Warning] Using self-defined objective function
[LightGBM] [Warning] Auto-choosing col-wise multi-threading, the overhead of testing was 0.006084 seconds.
You can set `force_col_wise=true` to remove the overhead.
[LightGBM] [Info] Total Bins 25500
[LightGBM] [Info] Number of data points in the train set: 6666, number of used features: 100
[LightGBM] [Warning] Using self-defined objective function
[LightGBM] [Warning] Using self-defined objective function
[LightGBM] [Warning] Using self-defined objective function
```

This PR proposes changing the level for those messages.

### Notes for Reviewers

In my opinion, the following guidelines should be used to determine the level for log messages:

* `FATAL`
    - answers *"why did LightGBM raise a runtime exception?"*
* `WARNING`
    - alerts users to situations that might require their action  (e.g. an unknown parameter, ignored parameters, inefficient configuration, etc.)
    - if possible, provides guidance on what specifics actions they should take
* `INFO`
    - the default information LightGBM users should see under normal use of the project's public API
* `DEBUG`
    - low-level details describing what LightGBM is doing, to help with troubleshooting and development

Do you agree? If so, I'll add that to the contributing documentation.