### PR TITLE
[ci] [docs] fix broken ACM links

### DIFF
--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -9,6 +9,7 @@ threads=1
 ignore=
   pythonapi/lightgbm\..*\.html.*
   http.*amd.com/.*
+  https.*dl.acm.org/doi/.*
   https.*tandfonline.com/.*
 ignorewarnings=http-robots-denied,https-certificate-error
 checkextern=1


### PR DESCRIPTION
Since #5929 was merged, the link checks job has been failing with the following error:

> URL        https://dl.acm.org/doi/10.1145/3298689.3347033'
Name       PAL: a position-bias aware learning framework for CTR prediction in live recommender systems'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/Advanced-Topics.html, line 207, col 362
Real URL   https://dl.acm.org/doi/10.1145/3298689.3347033
Check time 0.407 seconds
Result     Error: 403 Forbidden

([build link](https://github.com/microsoft/LightGBM/actions/runs/6107046649/job/16573278047))

I checked, and it seems that page is behind cloudflare.

```shell
curl -I https://dl.acm.org/doi/10.1145/3298689.3347033
```

```text
HTTP/2 403
date: Thu, 07 Sep 2023 19:22:02 GMT
content-type: text/html; charset=UTF-8
cross-origin-embedder-policy: require-corp
cross-origin-opener-policy: same-origin
cross-origin-resource-policy: same-origin
origin-agent-cluster: ?1
permissions-policy: accelerometer=(),autoplay=(),camera=(),clipboard-read=(),clipboard-write=(),geolocation=(),gyroscope=(),hid=(),interest-cohort=(),magnetometer=(),microphone=(),payment=(),publickey-credentials-get=(),screen-wake-lock=(),serial=(),sync-xhr=(),usb=()
referrer-policy: same-origin
x-frame-options: SAMEORIGIN
cf-mitigated: challenge
cache-control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
expires: Thu, 01 Jan 1970 00:00:01 GMT
set-cookie: __cf_bm=Zm6CO4SBK5VM9M4feOCBkuT2SUCwlB3zQEsLvOhhtfk-1694114522-0-ASEE7TsSYPsG0V8M8wCl4WaJMw0ktQ4dIhJGlEilHHzIB+qiTAhGZEy5qpSlw2kMraBE2K7c0PO69iBjYzh1Sqo=; path=/; expires=Thu, 07-Sep-23 19:52:02 GMT; domain=.dl.acm.org; HttpOnly; Secure; SameSite=None
strict-transport-security: max-age=15552000
server: cloudflare
cf-ray: 8031517359141050-ORD
alt-svc: h3=":443"; ma=86400
```

But it works without issue in the browser.

This PR proposes just excluding `dl.acm.org` links from the link-checker job, just as we did in #5939 for another paywalled academic publisher behind cloudflare: https://github.com/microsoft/LightGBM/pull/5939#discussion_r1239322270

### How I tested this

Manually triggered the `Link checks` CI job pointed at this branch, saw it succeed: https://github.com/microsoft/LightGBM/actions/runs/6113950577/job/16594489046