### PR TITLE
[docs] add vaex-ml to list of external repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ lightgbm-transform (feature transformation binding): https://github.com/microsof
 
 `postgresml` (LightGBM training and prediction in SQL, via a Postgres extension): https://github.com/postgresml/postgresml
 
+`vaex` (Python DataFrame library with its own interface to LightGBM): https://github.com/vaexio/vaex
+
 Support
 -------
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ lightgbm-transform (feature transformation binding): https://github.com/microsof
 
 `postgresml` (LightGBM training and prediction in SQL, via a Postgres extension): https://github.com/postgresml/postgresml
 
-`vaex` (Python DataFrame library with its own interface to LightGBM): https://github.com/vaexio/vaex
+`vaex-ml` (Python DataFrame library with its own interface to LightGBM): https://github.com/vaexio/vaex
 
 Support
 -------


### PR DESCRIPTION
`vaex` is a popular Python DataFrame library, offering the ability to work with larger-than-memory datasets on disk (similar to Dask DataFrame or sqlite).

Noticed based on @ddelange's commits referencing #5196 that `vaex` ships an integration to LightGBM, as part of a package called `vaex-ml`.

https://github.com/vaexio/vaex/blob/15245cf4332d4423ac58bd737aee27d911a1b252/packages/vaex-ml/vaex/ml/lightgbm.py#L21

This proposes adding that project to the list of external repositories in the documentation here.

cc @JovanVeljanoski , the original author of this from https://github.com/vaexio/vaex/pull/254