### PR TITLE
[python-package] mark EarlyStopException as part of public API

### DIFF
--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -32,5 +32,5 @@ __all__ = ['Dataset', 'Booster', 'CVBooster', 'Sequence',
            'train', 'cv',
            'LGBMModel', 'LGBMRegressor', 'LGBMClassifier', 'LGBMRanker',
            'DaskLGBMRegressor', 'DaskLGBMClassifier', 'DaskLGBMRanker',
-           'log_evaluation', 'record_evaluation', 'reset_parameter', 'early_stopping',
+           'log_evaluation', 'record_evaluation', 'reset_parameter', 'early_stopping', 'EarlyStopException',
            'plot_importance', 'plot_split_value_histogram', 'plot_metric', 'plot_tree', 'create_tree_digraph']

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -6,7 +6,7 @@ Contributors: https://github.com/microsoft/LightGBM/graphs/contributors.
 from pathlib import Path
 
 from .basic import Booster, Dataset, Sequence, register_logger
-from .callback import early_stopping, EarlyStopException, log_evaluation, record_evaluation, reset_parameter
+from .callback import EarlyStopException, early_stopping, log_evaluation, record_evaluation, reset_parameter
 from .engine import CVBooster, cv, train
 
 try:

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -6,7 +6,7 @@ Contributors: https://github.com/microsoft/LightGBM/graphs/contributors.
 from pathlib import Path
 
 from .basic import Booster, Dataset, Sequence, register_logger
-from .callback import early_stopping, log_evaluation, record_evaluation, reset_parameter
+from .callback import early_stopping, EarlyStopException, log_evaluation, record_evaluation, reset_parameter
 from .engine import CVBooster, cv, train
 
 try:

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -30,7 +30,11 @@ _ListOfEvalResultTuples = Union[
 
 
 class EarlyStopException(Exception):
-    """Exception of early stopping."""
+    """Exception of early stopping.
+
+    Raise this from a callback passed in via keyword argument ``callbacks``
+    in ``cv()`` or ``train()`` to trigger early stopping.
+    """
 
     def __init__(self, best_iteration: int, best_score: _ListOfEvalResultTuples) -> None:
         """Create early stopping exception.
@@ -39,6 +43,7 @@ class EarlyStopException(Exception):
         ----------
         best_iteration : int
             The best iteration stopped.
+            0-based... pass ``best_iteration=2`` to indicate that the third iteration was the best one.
         best_score : list of (eval_name, metric_name, eval_result, is_higher_better) tuple or (eval_name, metric_name, eval_result, is_higher_better, stdv) tuple
             Scores for each metric, on each validation set, as of the best iteration.
         """

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from .engine import CVBooster
 
 __all__ = [
+    'EarlyStopException',
     'early_stopping',
     'log_evaluation',
     'record_evaluation',


### PR DESCRIPTION
Doing some research for another contribution, I found that several large projects rely on importing `lightgbm.callback.EarlyStopException`, and using it to trigger early stopping in LightGBM.

* `autogluon`: https://github.com/autogluon/autogluon/blob/f77a7b4ea2f6140685e73ef41f3b533cea272391/tabular/src/autogluon/tabular/models/lgb/callbacks.py#L8
* `FLAML`: https://github.com/microsoft/FLAML/blob/4886cb56891af6ccf3e6d694bd97f571623fa6f8/flaml/automl/model.py#L1430

This PR proposes formally marking that class (and by extension, that mechanism of triggering early stopping) as a part of the public API, to prevent it from being removed or altered in a non-backward-compatible way in the future.