### PR TITLE
[python-package] fix mypy errors related to eval result tuples

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3858,7 +3858,6 @@ class Booster:
 
         return self.__inner_eval(name, data_idx, feval)
 
-
     def eval_train(
         self,
         feval: Optional[Union[_LGBM_CustomEvalFunction, List[_LGBM_CustomEvalFunction]]] = None

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -54,6 +54,7 @@ _ctypes_float_array = Union[
 _LGBM_EvalFunctionResultType = Tuple[str, float, bool]
 _LGBM_BoosterBestScoreType = Dict[str, Dict[str, float]]
 _LGBM_BoosterEvalMethodResultType = Tuple[str, str, float, bool]
+_LGBM_BoosterEvalMethodResultWithStandardDeviationType = Tuple[str, str, float, bool, float]
 _LGBM_CategoricalFeatureConfiguration = Union[List[str], List[int], "Literal['auto']"]
 _LGBM_FeatureNameConfiguration = Union[List[str], "Literal['auto']"]
 _LGBM_GroupType = Union[
@@ -3855,7 +3856,7 @@ class Booster:
             self.add_valid(data, name)
             data_idx = self.__num_dataset - 1
 
-        return self.__inner_eval(name, data_idx, feval)
+        return self.__inner_eval(data_name=name, data_idx=data_idx, feval=feval)
 
     def eval_train(
         self,
@@ -3889,7 +3890,7 @@ class Booster:
         result : list
             List with (train_dataset_name, eval_name, eval_result, is_higher_better) tuples.
         """
-        return self.__inner_eval(self._train_data_name, 0, feval)
+        return self.__inner_eval(data_name=self._train_data_name, data_idx=0, feval=feval)
 
     def eval_valid(
         self,
@@ -3923,8 +3924,10 @@ class Booster:
         result : list
             List with (validation_dataset_name, eval_name, eval_result, is_higher_better) tuples.
         """
-        return [item for i in range(1, self.__num_dataset)
-                for item in self.__inner_eval(self.name_valid_sets[i - 1], i, feval)]
+        return [
+            item for i in range(1, self.__num_dataset)
+            for item in self.__inner_eval(data_name=self.name_valid_sets[i - 1], data_idx=i, feval=feval)
+        ]
 
     def save_model(
         self,
@@ -4600,6 +4603,7 @@ class Booster:
 
     def __inner_eval(
         self,
+        *,
         data_name: str,
         data_idx: int,
         feval: Optional[Union[_LGBM_CustomEvalFunction, List[_LGBM_CustomEvalFunction]]]

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -3856,7 +3856,8 @@ class Booster:
             self.add_valid(data, name)
             data_idx = self.__num_dataset - 1
 
-        return self.__inner_eval(data_name=name, data_idx=data_idx, feval=feval)
+        return self.__inner_eval(name, data_idx, feval)
+
 
     def eval_train(
         self,
@@ -3890,7 +3891,7 @@ class Booster:
         result : list
             List with (train_dataset_name, eval_name, eval_result, is_higher_better) tuples.
         """
-        return self.__inner_eval(data_name=self._train_data_name, data_idx=0, feval=feval)
+        return self.__inner_eval(self._train_data_name, 0, feval)
 
     def eval_valid(
         self,
@@ -3924,10 +3925,8 @@ class Booster:
         result : list
             List with (validation_dataset_name, eval_name, eval_result, is_higher_better) tuples.
         """
-        return [
-            item for i in range(1, self.__num_dataset)
-            for item in self.__inner_eval(data_name=self.name_valid_sets[i - 1], data_idx=i, feval=feval)
-        ]
+        return [item for i in range(1, self.__num_dataset)
+                for item in self.__inner_eval(self.name_valid_sets[i - 1], i, feval)]
 
     def save_model(
         self,
@@ -4603,7 +4602,6 @@ class Booster:
 
     def __inner_eval(
         self,
-        *,
         data_name: str,
         data_idx: int,
         feval: Optional[Union[_LGBM_CustomEvalFunction, List[_LGBM_CustomEvalFunction]]]

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -3,7 +3,7 @@
 from collections import OrderedDict
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from .basic import (Booster, _ConfigAliases, _LGBM_BoosterEvalMethodResultType,
                     _LGBM_BoosterEvalMethodResultWithStandardDeviationType, _log_info, _log_warning)

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
-from .basic import Booster, _ConfigAliases, _LGBM_BoosterEvalMethodResultType, _LGBM_BoosterEvalMethodResultWithStandardDeviationType, _log_info, _log_warning
+from .basic import (Booster, _ConfigAliases, _LGBM_BoosterEvalMethodResultType,
+                    _LGBM_BoosterEvalMethodResultWithStandardDeviationType, _log_info, _log_warning)
 
 if TYPE_CHECKING:
     from .engine import CVBooster

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
-from .basic import Booster, _ConfigAliases, _LGBM_BoosterEvalMethodResultType, _log_info, _log_warning
+from .basic import Booster, _ConfigAliases, _LGBM_BoosterEvalMethodResultType, _LGBM_BoosterEvalMethodResultWithStandardDeviationType, _log_info, _log_warning
 
 if TYPE_CHECKING:
     from .engine import CVBooster
@@ -20,11 +20,11 @@ __all__ = [
 _EvalResultDict = Dict[str, Dict[str, List[Any]]]
 _EvalResultTuple = Union[
     _LGBM_BoosterEvalMethodResultType,
-    Tuple[str, str, float, bool, float]
+    _LGBM_BoosterEvalMethodResultWithStandardDeviationType
 ]
 _ListOfEvalResultTuples = Union[
     List[_LGBM_BoosterEvalMethodResultType],
-    List[Tuple[str, str, float, bool, float]]
+    List[_LGBM_BoosterEvalMethodResultWithStandardDeviationType]
 ]
 
 
@@ -54,7 +54,7 @@ class CallbackEnv:
     iteration: int
     begin_iteration: int
     end_iteration: int
-    evaluation_result_list: Optional[List[_LGBM_BoosterEvalMethodResultType]]
+    evaluation_result_list: Optional[_ListOfEvalResultTuples]
 
 
 def _format_eval_result(value: _EvalResultTuple, show_stdv: bool) -> str:

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -12,7 +12,8 @@ import numpy as np
 from . import callback
 from .basic import (Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _InnerPredictor,
                     _LGBM_BoosterEvalMethodResultType, _LGBM_CategoricalFeatureConfiguration,
-                    _LGBM_CustomObjectiveFunction, _LGBM_EvalFunctionResultType, _LGBM_FeatureNameConfiguration,
+                    _LGBM_CustomObjectiveFunction, _LGBM_EvalFunctionResultType, _LGBM_BoosterEvalMethodResultWithStandardDeviationType,
+                    _LGBM_FeatureNameConfiguration,
                     _log_warning)
 from .compat import SKLEARN_INSTALLED, _LGBMBaseCrossValidator, _LGBMGroupKFold, _LGBMStratifiedKFold
 
@@ -519,8 +520,8 @@ def _make_n_folds(
 
 
 def _agg_cv_result(
-    raw_results: List[List[Tuple[str, str, float, bool]]]
-) -> List[Tuple[str, str, float, bool, float]]:
+    raw_results: List[List[_LGBM_BoosterEvalMethodResultType]]
+) -> List[_LGBM_BoosterEvalMethodResultWithStandardDeviationType]:
     """Aggregate cross-validation results."""
     cvmap: Dict[str, List[float]] = OrderedDict()
     metric_type: Dict[str, bool] = {}

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -753,13 +753,12 @@ def cv(
 
     for i in range(num_boost_round):
         for cb in callbacks_before_iter:
-            empty_eval_result_list: callback._ListOfEvalResultTuples = []
             cb(callback.CallbackEnv(model=cvfolds,
                                     params=params,
                                     iteration=i,
                                     begin_iteration=0,
                                     end_iteration=num_boost_round,
-                                    evaluation_result_list=empty_eval_result_list))
+                                    evaluation_result_list=None))
         cvfolds.update(fobj=fobj)  # type: ignore[call-arg]
         res = _agg_cv_result(cvfolds.eval_valid(feval))  # type: ignore[call-arg]
         for _, key, mean, _, std in res:

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -531,7 +531,7 @@ def _agg_cv_result(
             metric_type[key] = one_line[3]
             cvmap.setdefault(key, [])
             cvmap[key].append(one_line[2])
-    return [('cv_agg', k, np.mean(v), metric_type[k], np.std(v)) for k, v in cvmap.items()]
+    return [('cv_agg', k, float(np.mean(v)), metric_type[k], float(np.std(v))) for k, v in cvmap.items()]
 
 
 def cv(
@@ -753,12 +753,13 @@ def cv(
 
     for i in range(num_boost_round):
         for cb in callbacks_before_iter:
+            empty_eval_result_list: callback._ListOfEvalResultTuples = []
             cb(callback.CallbackEnv(model=cvfolds,
                                     params=params,
                                     iteration=i,
                                     begin_iteration=0,
                                     end_iteration=num_boost_round,
-                                    evaluation_result_list=None))
+                                    evaluation_result_list=empty_eval_result_list))
         cvfolds.update(fobj=fobj)  # type: ignore[call-arg]
         res = _agg_cv_result(cvfolds.eval_valid(feval))  # type: ignore[call-arg]
         for _, key, mean, _, std in res:

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -11,10 +11,9 @@ import numpy as np
 
 from . import callback
 from .basic import (Booster, Dataset, LightGBMError, _choose_param_value, _ConfigAliases, _InnerPredictor,
-                    _LGBM_BoosterEvalMethodResultType, _LGBM_CategoricalFeatureConfiguration,
-                    _LGBM_CustomObjectiveFunction, _LGBM_EvalFunctionResultType, _LGBM_BoosterEvalMethodResultWithStandardDeviationType,
-                    _LGBM_FeatureNameConfiguration,
-                    _log_warning)
+                    _LGBM_BoosterEvalMethodResultType, _LGBM_BoosterEvalMethodResultWithStandardDeviationType,
+                    _LGBM_CategoricalFeatureConfiguration, _LGBM_CustomObjectiveFunction, _LGBM_EvalFunctionResultType,
+                    _LGBM_FeatureNameConfiguration, _log_warning)
 from .compat import SKLEARN_INSTALLED, _LGBMBaseCrossValidator, _LGBMGroupKFold, _LGBMStratifiedKFold
 
 __all__ = [


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3756.
Contributes to https://github.com/microsoft/LightGBM/issues/3867.

Resolves the following errors from `mypy`:

```text
engine.py:533: error: List comprehension has incompatible type List[Tuple[str, str, floating[Any], bool, floating[Any]]]; expected List[Tuple[str, str, float, bool, float]]  [misc]
engine.py:773: error: Argument "evaluation_result_list" to "CallbackEnv" has incompatible type "List[Tuple[str, str, float, bool, float]]"; expected "Optional[List[Tuple[str, str, float, bool]]]"  [arg-type]
```

These both came from an incorrect type hint on `lightgbm.callback.CallbackEnv.evaluation_result_list`, which failed to include the possibility of eval result tuples that included a 5th element for the across-folds standard deviation of metrics, as are calculated in `cv()`.