### PR TITLE
[python-package] fix mypy error from Dataset.pandas_categorical

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1593,7 +1593,7 @@ class Dataset:
         self.used_indices: Optional[List[int]] = None
         self._need_slice = True
         self._predictor: Optional[_InnerPredictor] = None
-        self.pandas_categorical = None
+        self.pandas_categorical: Optional[List[List]] = None
         self._params_back_up = None
         self.version = 0
         self._start_row = 0  # Used when pushing rows one by one.


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3756.
Contributes to https://github.com/microsoft/LightGBM/issues/3867.

Resolves the following error from mypy:

```text
basic.py:1862: error: Incompatible types in assignment (expression has type "List[List[Any]]", variable has type "None")  [assignment]
```