### PR TITLE
[python-package] fix mypy error about eval result tuples

### DIFF
--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -164,7 +164,7 @@ class _RecordEvaluationCallback:
             else:
                 data_name, eval_name = item[1].split()
                 res_mean = item[2]
-                res_stdv = item[4]
+                res_stdv = item[4]  # type: ignore[misc]
                 self.eval_result[data_name][f'{eval_name}-mean'].append(res_mean)
                 self.eval_result[data_name][f'{eval_name}-stdv'].append(res_stdv)
 


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3756.
Contributes to https://github.com/microsoft/LightGBM/issues/3867.

Resolves the following error from mypy:

```text
callback.py:167: error: Tuple index out of range  [misc]
```

That's raised in code that works with eval result tuples, which can be either 4 or 5 elements. Per the discussion in https://github.com/python/mypy/issues/1178, `mypy` can't use branches like `if len(tup)` to figure out which element of a union type it must be working with.