### PR TITLE
[python-package] fix mypy errors in Dataset construction

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -23,6 +23,7 @@ from .libpath import find_lib_path
 
 if TYPE_CHECKING:
     from typing import Literal
+
     # typing.TypeGuard was only introduced in Python 3.10
     try:
         from typing import TypeGuard


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/3756.
Contributes to https://github.com/microsoft/LightGBM/issues/3867.

Fixes the following errors from `mypy`

```text
basic.py:1922: error: Argument 1 to "__init_from_list_np2d" of "Dataset" has incompatible type "list[Any] | list[Sequence] | list[ndarray[Any, Any]]"; expected "list[ndarray[Any, Any]]"  [arg-type]
basic.py:1924: error: Argument 1 to "__init_from_seqs" of "Dataset" has incompatible type "list[Any] | list[Sequence] | list[ndarray[Any, Any]]"; expected "list[Sequence]"  [arg-type]
basic.py:2874: error: Argument 1 to "_yield_row_from_seqlist" of "Dataset" has incompatible type "list[Any] | list[Sequence] | list[ndarray[Any, Any]]"; expected "list[Sequence]"  [arg-type]
```

These errors all come from the fact that you can't use an expression like

```python
if isinstance(l, list) and all(isinstance(x, np.ndarray) for x in l):
    # ...
```

To help `mypy` understand which type from a union like `Union[List[np.ndarray], List[Sequence]]` a particular code block is working with.

As described in https://mypy.readthedocs.io/en/stable/type_narrowing.html#typeguards-with-parameters, in Python 3.10 `mypy` introduced a feature to do exactly that. If you set up a function like `f(l) -> typing.TypeGuard[List[np.ndarray]]`, that tells the type checker:

* `f()` returns a `bool`
* if `f(l)` returns `True`, then `l` must be a `List[np.ndarray]`

This PR proposes adding such guards to `lightgbm`. This will help type checkers (like `mypy` in this project's CI and others in users' IDEs) to catch errors deeper in the code paths involving lists of `numpy` arrays and lists of `Sequence` objects.