### PR TITLE
[ci] ensure correct R version is used on GitHub Actions (fixes #5640)

### DIFF
--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -212,7 +212,7 @@ if ($env:TOOLCHAIN -ne "MSVC") {
   $checks_cnt = $checks.Matches.length
 }
 if ($checks_cnt -eq 0) {
-  Write-Output "MM_PREFETCH preprocessor definition wasn't used. Check the build logs."
+  Write-Output "Wrong R version was found (expected '$R_WINDOWS_VERSION'). Check the build logs."
   Check-Output $False
 }
 

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -205,7 +205,7 @@ if ($env:COMPILER -ne "MSVC") {
 
 # Checking that the correct R version was used
 if ($env:TOOLCHAIN -ne "MSVC") {
-  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "using R version $env:R_WINDOWS_VERSION"
+  $checks = Select-String -Path "${LOG_FILE_NAME}" -Pattern "using R version $env:R_WINDOWS_VERSION"
   $checks_cnt = $checks.Matches.length
 } else {
   $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "R version passed into FindLibR.* $env:R_WINDOWS_VERSION"

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -205,14 +205,14 @@ if ($env:COMPILER -ne "MSVC") {
 
 # Checking that the correct R version was used
 if ($env:TOOLCHAIN -ne "MSVC") {
-  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "using R version 9.$R_WINDOWS_VERSION"
+  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "using R version 9.$env:R_WINDOWS_VERSION"
   $checks_cnt = $checks.Matches.length
 } else {
-  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "R version passed into FindLibR.* 9.$R_WINDOWS_VERSION"
+  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "R version passed into FindLibR.* 9.$env:R_WINDOWS_VERSION"
   $checks_cnt = $checks.Matches.length
 }
 if ($checks_cnt -eq 0) {
-  Write-Output "Wrong R version was found (expected '$R_WINDOWS_VERSION'). Check the build logs."
+  Write-Output "Wrong R version was found (expected '$env:R_WINDOWS_VERSION'). Check the build logs."
   Check-Output $False
 }
 

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -203,6 +203,19 @@ if ($env:COMPILER -ne "MSVC") {
   }
 }
 
+# Checking that the correct R version was used
+if ($env:TOOLCHAIN -ne "MSVC") {
+  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "using R version 9.$R_WINDOWS_VERSION"
+  $checks_cnt = $checks.Matches.length
+} else {
+  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "R version passed into FindLibR.* 9.$R_WINDOWS_VERSION"
+  $checks_cnt = $checks.Matches.length
+}
+if ($checks_cnt -eq 0) {
+  Write-Output "MM_PREFETCH preprocessor definition wasn't used. Check the build logs."
+  Check-Output $False
+}
+
 # Checking that we actually got the expected compiler. The R package has some logic
 # to fail back to MinGW if MSVC fails, but for CI builds we need to check that the correct
 # compiler was used.

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -205,10 +205,10 @@ if ($env:COMPILER -ne "MSVC") {
 
 # Checking that the correct R version was used
 if ($env:TOOLCHAIN -ne "MSVC") {
-  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "using R version 9.$env:R_WINDOWS_VERSION"
+  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "using R version $env:R_WINDOWS_VERSION"
   $checks_cnt = $checks.Matches.length
 } else {
-  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "R version passed into FindLibR.* 9.$env:R_WINDOWS_VERSION"
+  $checks = Select-String -Path "${INSTALL_LOG_FILE_NAME}" -Pattern "R version passed into FindLibR.* $env:R_WINDOWS_VERSION"
   $checks_cnt = $checks.Matches.length
 }
 if ($checks_cnt -eq 0) {


### PR DESCRIPTION
Fixes #5640.

Adds checks to the Windows R-package CI jobs to ensure that we're alerted if the jobs accidentally start relying on an unexpected version of R, e.g. the version installed by GitHub Actions in its images.

## How I tested this

Started by intentionally breaking this, to be sure it will loudly break builds.

> Wrong R version was found (expected '3.6.3'). Check the build logs.

([build link](https://github.com/microsoft/LightGBM/actions/runs/6231183789/job/16912352494?pr=6107))

Then pushed changes to fix it, and saw them succeed.

([build link](https://github.com/microsoft/LightGBM/actions/runs/6243354759/job/16948642319?pr=6107))
