### PR TITLE
[ci] fix sh-compatibility issue in build-cran-package.sh

### DIFF
--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -132,7 +132,7 @@ cd "${TEMP_R_DIR}"
     using_windows_and_r3=$(
         Rscript -e 'cat(.Platform$OS.type == "windows" && R.version[["major"]] < 4)'
     )
-    if [[ ${using_windows_and_r3} == "TRUE" ]]; then
+    if test "${using_windows_and_r3}" = "TRUE"; then
         LGB_CXX_STD="C++11"
     fi
     sed -i.bak -e "s/~~CXXSTD~~/${LGB_CXX_STD}/" DESCRIPTION


### PR DESCRIPTION
`build-cran-package.sh` is used to prepare a CRAN-style source distribution of this project's R package.

It's intentionally an `sh` and not `bash` script, to attempt to be as portable as possible.

I noticed tonight that that script is currently using one `bash` feature that isn't supported in at least some implementations of `sh`... `[[` for an `if` condition.

See https://github.com/microsoft/LightGBM/actions/runs/6301758829/job/17107497663#step:7:7057.

> build-cran-package.sh: 135: [[: not found

Or run the following from the root of this repo to reproduce it.

```shell
docker run \
    --rm \
    -v $(pwd):/opt/LightGBM \
    -w /opt/LightGBM \
    -it ghcr.io/r-hub/containers/ubuntu-clang:latest \
    sh build-cran-package.sh --no-build-vignettes
```

This PR fixes that.