### PR TITLE
[python-package] simplify Dataset._compare_params_for_warning()

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2200,8 +2200,8 @@ class Dataset:
 
     @staticmethod
     def _compare_params_for_warning(
-        params: Optional[Dict[str, Any]],
-        other_params: Optional[Dict[str, Any]],
+        params: Dict[str, Any],
+        other_params: Dict[str, Any],
         ignore_keys: Set[str]
     ) -> bool:
         """Compare two dictionaries with params ignoring some keys.
@@ -2222,10 +2222,6 @@ class Dataset:
         compare_result : bool
           Returns whether two dictionaries with params are equal.
         """
-        if params is None:
-            params = {}
-        if other_params is None:
-            other_params = {}
         for k in other_params:
             if k not in ignore_keys:
                 if k not in params or params[k] != other_params[k]:

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2210,9 +2210,9 @@ class Dataset:
 
         Parameters
         ----------
-        params : dict or None
+        params : dict
             One dictionary with parameters to compare.
-        other_params : dict or None
+        other_params : dict
             Another dictionary with parameters to compare.
         ignore_keys : set
             Keys that should be ignored during comparing two dictionaries.


### PR DESCRIPTION
Contributes to #3756.

Private method `Dataset._compare_for_warning()` is used to avoid raising unnecessary warnings when creating a `Dataset` from another `Dataset`.

It's only used in one place:

https://github.com/microsoft/LightGBM/blob/63a882b7400a19485727cc808e4715897e63635a/python-package/lightgbm/basic.py#L2251-L2257

And that place only passes in results from `Dataset.get_params()`.

`Dataset.get_params()` allways returns a dictionary (never `None`)...

https://github.com/microsoft/LightGBM/blob/63a882b7400a19485727cc808e4715897e63635a/python-package/lightgbm/basic.py#L1777

... so code paths in `Dataset._compare_for_warning()` to handle `None` are unnecessary.

This PR proposes removing them.

### Notes for Reviewers

I found this by checking the statement coverage of the Python package's unit tests, like this:

```shell
sh build-python.sh install

SITE_PACKAGE_DIR=$(
    python -c "import site; print(site.getsitepackages()[0])"
)
pytest \
    --cov=${SITE_PACKAGE_DIR}/lightgbm \
    --verbose \
    tests/python_package_test/

coverage html
open ./htmlcov/index.html
```

Found through that that these `if params is None` blocks are not covered by any tests, and that was my clue that they might not be necessary at all.