### PR TITLE
fix compiler warnings for CPP tests

### DIFF
--- a/tests/cpp_tests/test_byte_buffer.cpp
+++ b/tests/cpp_tests/test_byte_buffer.cpp
@@ -30,7 +30,7 @@ TEST(ByteBuffer, JustWorks) {
   EXPECT_EQ(cumulativeSize, buffer->GetSize());
   int16_t serializedInt16 = 0;
   char* int16Ptr = reinterpret_cast<char*>(&serializedInt16);
-  for (uint i = 0; i < sizeof(int16_t); i++) {
+  for (unsigned int i = 0; i < sizeof(int16_t); i++) {
     int16Ptr[i] = buffer->GetAt(cumulativeSize - (sizeof(int16_t) - i));
   }
   EXPECT_EQ(int16Val, serializedInt16);
@@ -41,7 +41,7 @@ TEST(ByteBuffer, JustWorks) {
   EXPECT_EQ(cumulativeSize, buffer->GetSize());
   int64_t serializedInt64 = 0;
   char* int64Ptr = reinterpret_cast<char*>(&serializedInt64);
-  for (uint i = 0; i < sizeof(int64_t); i++) {
+  for (unsigned int i = 0; i < sizeof(int64_t); i++) {
     int64Ptr[i] = buffer->GetAt(cumulativeSize - (sizeof(int64_t) - i));
   }
   EXPECT_EQ(int64Val, serializedInt64);
@@ -52,7 +52,7 @@ TEST(ByteBuffer, JustWorks) {
   EXPECT_EQ(cumulativeSize, buffer->GetSize());
   double serializedDouble = 0;
   char* doublePtr = reinterpret_cast<char*>(&serializedDouble);
-  for (uint i = 0; i < sizeof(double); i++) {
+  for (unsigned int i = 0; i < sizeof(double); i++) {
     doublePtr[i] = buffer->GetAt(cumulativeSize - (sizeof(double) - i));
   }
   EXPECT_EQ(doubleVal, serializedDouble);

--- a/tests/cpp_tests/test_byte_buffer.cpp
+++ b/tests/cpp_tests/test_byte_buffer.cpp
@@ -30,7 +30,7 @@ TEST(ByteBuffer, JustWorks) {
   EXPECT_EQ(cumulativeSize, buffer->GetSize());
   int16_t serializedInt16 = 0;
   char* int16Ptr = reinterpret_cast<char*>(&serializedInt16);
-  for (int i = 0; i < sizeof(int16_t); i++) {
+  for (uint i = 0; i < sizeof(int16_t); i++) {
     int16Ptr[i] = buffer->GetAt(cumulativeSize - (sizeof(int16_t) - i));
   }
   EXPECT_EQ(int16Val, serializedInt16);
@@ -41,7 +41,7 @@ TEST(ByteBuffer, JustWorks) {
   EXPECT_EQ(cumulativeSize, buffer->GetSize());
   int64_t serializedInt64 = 0;
   char* int64Ptr = reinterpret_cast<char*>(&serializedInt64);
-  for (int i = 0; i < sizeof(int64_t); i++) {
+  for (uint i = 0; i < sizeof(int64_t); i++) {
     int64Ptr[i] = buffer->GetAt(cumulativeSize - (sizeof(int64_t) - i));
   }
   EXPECT_EQ(int64Val, serializedInt64);
@@ -52,7 +52,7 @@ TEST(ByteBuffer, JustWorks) {
   EXPECT_EQ(cumulativeSize, buffer->GetSize());
   double serializedDouble = 0;
   char* doublePtr = reinterpret_cast<char*>(&serializedDouble);
-  for (int i = 0; i < sizeof(double); i++) {
+  for (uint i = 0; i < sizeof(double); i++) {
     doublePtr[i] = buffer->GetAt(cumulativeSize - (sizeof(double) - i));
   }
   EXPECT_EQ(doubleVal, serializedDouble);

--- a/tests/cpp_tests/testutils.cpp
+++ b/tests/cpp_tests/testutils.cpp
@@ -265,7 +265,7 @@ namespace LightGBM {
                      groups_ptr,
                      thread_count,
                      t);
-      threads.push_back(move(th));
+      threads.push_back(std::move(th));
     }
 
     for (auto& t : threads) t.join();


### PR DESCRIPTION
The C++ tests currently raise the following compiler warnings with `clang` 11:

```text
tests/cpp_tests/test_byte_buffer.cpp:33:21: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
  for (int i = 0; i < sizeof(int16_t); i++) {
                  ~ ^ ~~~~~~~~~~~~~~~
tests/cpp_tests/test_byte_buffer.cpp:44:21: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
  for (int i = 0; i < sizeof(int64_t); i++) {
                  ~ ^ ~~~~~~~~~~~~~~~
tests/cpp_tests/test_byte_buffer.cpp:55:21: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
  for (int i = 0; i < sizeof(double); i++) {
  

tests/cpp_tests/testutils.cpp:268:25: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
      threads.push_back(move(th));
```

([build link](https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=15284&view=logs&j=b720f717-c673-5cb6-db4e-30b527463a8e&t=3374e212-0f80-5d51-7e1c-28e6268f20d8))

This PR fixes them.