### PR TITLE
ignore unknown parameters when loading from model file

### DIFF
--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -183,7 +183,7 @@ class GBDT : public GBDTBase {
       const auto value_str = pair[1].substr(1, pair[1].size() - 2);
       auto iter = param_types.find(param);
       if (iter == param_types.end()) {
-        Log::Warning("Type for param: '%s' not found. This doesn't affect inference.", param.c_str());
+        Log::Warning("Ignoring unrecognized parameter '%s' found in model string.", param.c_str());
         continue;
       }
       std::string param_type = iter->second;

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -183,7 +183,7 @@ class GBDT : public GBDTBase {
       const auto value_str = pair[1].substr(1, pair[1].size() - 2);
       auto iter = param_types.find(param);
       if (iter == param_types.end()) {
-        Log::Warning("Type for param: %s not found. This doesn't affect inference.", param.c_str());
+        Log::Warning("Type for param: '%s' not found. This doesn't affect inference.", param.c_str());
         continue;
       }
       std::string param_type = iter->second;

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -179,15 +179,20 @@ class GBDT : public GBDTBase {
       const auto pair = Common::Split(line.c_str(), ":");
       if (pair[1] == " ]")
         continue;
+      const auto param = pair[0].substr(1);
+      const auto value_str = pair[1].substr(1, pair[1].size() - 2);
+      auto iter = param_types.find(param);
+      if (iter == param_types.end()) {
+        Log::Warning("Type for param: %s not found. This doesn't affect inference.", param.c_str());
+        continue;
+      }
+      std::string param_type = iter->second;
       if (first) {
         first = false;
         str_buf << "\"";
       } else {
         str_buf << ",\"";
       }
-      const auto param = pair[0].substr(1);
-      const auto value_str = pair[1].substr(1, pair[1].size() - 2);
-      const auto param_type = param_types.at(param);
       str_buf << param << "\": ";
       if (param_type == "string") {
         str_buf << "\"" << value_str << "\"";

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1496,7 +1496,7 @@ def test_parameters_are_loaded_from_model_file(tmp_path, capsys):
     with model_file.open('wt') as f:
         f.writelines(model_contents)
     bst = lgb.Booster(model_file=model_file)
-    expected_msg = "[LightGBM] [Warning] Type for param: 'max_conflict_rate' not found. This doesn't affect inference."
+    expected_msg = "[LightGBM] [Warning] Ignoring unrecognized parameter 'max_conflict_rate' found in model string."
     stdout = capsys.readouterr().out
     assert expected_msg in stdout
     set_params = {k: bst.params[k] for k in params.keys()}


### PR DESCRIPTION
Issues a warning when a parameter type is not found when loading a booster from a model file instead of raising an error.

Fixes #6082