### PR TITLE
remove unnecessary allocations in HistogramSumReducer

### DIFF
--- a/include/LightGBM/bin.h
+++ b/include/LightGBM/bin.h
@@ -63,8 +63,7 @@ inline static void Int32HistogramSumReducer(const char* src, char* dst, int type
   const int64_t* src_ptr = reinterpret_cast<const int64_t*>(src);
   int64_t* dst_ptr = reinterpret_cast<int64_t*>(dst);
   const comm_size_t steps = (len + (type_size * 2) - 1) / (type_size * 2);
-  const int num_threads = OMP_NUM_THREADS();
-  #pragma omp parallel for schedule(static) num_threads(num_threads)
+  #pragma omp parallel for schedule(static) num_threads(OMP_NUM_THREADS())
   for (comm_size_t i = 0; i < steps; ++i) {
     dst_ptr[i] += src_ptr[i];
   }
@@ -74,8 +73,7 @@ inline static void Int16HistogramSumReducer(const char* src, char* dst, int type
   const int32_t* src_ptr = reinterpret_cast<const int32_t*>(src);
   int32_t* dst_ptr = reinterpret_cast<int32_t*>(dst);
   const comm_size_t steps = (len + (type_size * 2) - 1) / (type_size * 2);
-  const int num_threads = OMP_NUM_THREADS();
-  #pragma omp parallel for schedule(static) num_threads(num_threads)
+  #pragma omp parallel for schedule(static) num_threads(OMP_NUM_THREADS())
   for (comm_size_t i = 0; i < steps; ++i) {
     dst_ptr[i] += src_ptr[i];
   }


### PR DESCRIPTION
Contributes to #4705.

`Int32HistogramSumReducer` and `Int16HistogramSumReducer` allocate an `int` and assign to it the value of `OMP_NUM_THREADS()`,  then only use that value immediately after, for one OpenMP for loop.

This PR proposes just directly passing `OMP_NUM_THREADS()` to the configuration for those OpenMP `for` loop pragmas, to avoid the unnecessary allocation.

This also resolves the following compiler warnings that show up on `clang` when OpenMP support is disabled:

```text
LightGBM/include/LightGBM/bin.h:66:13: warning: unused variable 'num_threads' [-Wunused-variable]
  const int num_threads = OMP_NUM_THREADS();
            ^
LightGBM/include/LightGBM/bin.h:77:13: warning: unused variable 'num_threads' [-Wunused-variable]
  const int num_threads = OMP_NUM_THREADS();
            ^
2 warnings generated.
```

### How I tested this

LightGBM's CI covers the cases where OpenMP is available. I ran the following locally to confirm that this suppresses the compiler warnings when building without OpenMP support.

```shell
rm -rf ./build
mkdir ./build
cd ./build
cmake -DUSE_OPENMP=off ..
make -j3 _lightgbm
```