### PR TITLE
factor out uses of omp_get_num_threads() and omp_get_max_threads() outside of OpenMP wrapper

### DIFF
--- a/src/treelearner/gpu_tree_learner.cpp
+++ b/src/treelearner/gpu_tree_learner.cpp
@@ -344,7 +344,7 @@ void GPUTreeLearner::AllocateGPUMemory() {
   // for data transfer time
   auto start_time = std::chrono::steady_clock::now();
   // Now generate new data structure feature4, and copy data to the device
-  int nthreads = std::min(omp_get_max_threads(), static_cast<int>(dense_feature_group_map_.size()) / dword_features_);
+  int nthreads = std::min(OMP_NUM_THREADS(), static_cast<int>(dense_feature_group_map_.size()) / dword_features_);
   nthreads = std::max(nthreads, 1);
   std::vector<Feature4*> host4_vecs(nthreads);
   std::vector<boost::compute::buffer> host4_bufs(nthreads);

--- a/src/treelearner/linear_tree_learner.cpp
+++ b/src/treelearner/linear_tree_learner.cpp
@@ -52,7 +52,7 @@ void LinearTreeLearner::InitLinear(const Dataset* train_data, const int max_leav
   }
   XTHX_by_thread_.clear();
   XTg_by_thread_.clear();
-  int max_threads = omp_get_max_threads();
+  int max_threads = OMP_NUM_THREADS();
   for (int i = 0; i < max_threads; ++i) {
     XTHX_by_thread_.push_back(XTHX_);
     XTg_by_thread_.push_back(XTg_);


### PR DESCRIPTION
Contributes to #4705.
Contributes to #5987.

LightGBM uses OpenMP for to parallelize many operations via multi-threading.

It's C/C++ codebase uses some wrapper functions defined in a header file `openmp_wrapper.h` to get and set the number of threads to use in such operations:

https://github.com/microsoft/LightGBM/blob/f901f47141700f01294c6766bd93bcc57ddb1960/include/LightGBM/utils/openmp_wrapper.h#L20-L35

There are a few places in the code which bypass those helpers and instead directly call `omp_get_num_threads()` and `omp_get_max_threads()`.

This PR proposes switching such calls to instead use LightGBM's wrappers. That reduces the number of different code paths that multi-threading configuration goes through, therefore reducing the risk of configuration inconsistencies and issues like #4705 and #5124.