### PR TITLE
[ci] use `mamba` instead of `conda` in macOS and Linux CI jobs

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -37,7 +37,7 @@ fi
 CONDA_PYTHON_REQUIREMENT="python=$PYTHON_VERSION[build=*cpython]"
 
 if [[ $TASK == "if-else" ]]; then
-    conda create -q -y -n $CONDA_ENV ${CONDA_PYTHON_REQUIREMENT} numpy
+    mamba create -q -y -n $CONDA_ENV ${CONDA_PYTHON_REQUIREMENT} numpy
     source activate $CONDA_ENV
     mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build && cmake .. && make lightgbm -j4 || exit -1
     cd $BUILD_DIRECTORY/tests/cpp_tests && ../../lightgbm config=train.conf convert_model_language=cpp convert_model=../../src/boosting/gbdt_prediction.cpp && ../../lightgbm config=predict.conf output_result=origin.pred || exit -1
@@ -67,7 +67,7 @@ fi
 
 if [[ $TASK == "lint" ]]; then
     cd ${BUILD_DIRECTORY}
-    conda create -q -y -n $CONDA_ENV \
+    mamba create -q -y -n $CONDA_ENV \
         ${CONDA_PYTHON_REQUIREMENT} \
         cmakelint \
         cpplint \
@@ -87,10 +87,10 @@ fi
 
 if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     cd $BUILD_DIRECTORY/docs
-    conda env create \
+    mamba env create \
         -n $CONDA_ENV \
         --file ./env.yml || exit -1
-    conda install \
+    mamba install \
         -q \
         -y \
         -n $CONDA_ENV \
@@ -128,7 +128,7 @@ if [[ $PYTHON_VERSION == "3.7" ]]; then
 fi
 
 # including python=version[build=*cpython] to ensure that conda doesn't fall back to pypy
-conda create -q -y -n $CONDA_ENV \
+mamba create -q -y -n $CONDA_ENV \
     ${CONSTRAINED_DEPENDENCIES} \
     cloudpickle \
     joblib \
@@ -304,7 +304,7 @@ matplotlib.use\(\"Agg\"\)\
 ' plot_example.py  # prevent interactive window mode
     sed -i'.bak' 's/graph.render(view=True)/graph.render(view=False)/' plot_example.py
     # requirements for examples
-    conda install -q -y -n $CONDA_ENV \
+    mamba install -q -y -n $CONDA_ENV \
         h5py \
         ipywidgets \
         notebook
@@ -314,7 +314,7 @@ matplotlib.use\(\"Agg\"\)\
     jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb || exit -1  # run all notebooks
 
     # importing the library should succeed even if all optional dependencies are not present
-    conda uninstall --force --yes \
+    mamba uninstall --force --yes \
         dask \
         distributed \
         joblib \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -37,7 +37,7 @@ fi
 CONDA_PYTHON_REQUIREMENT="python=$PYTHON_VERSION[build=*cpython]"
 
 if [[ $TASK == "if-else" ]]; then
-    mamba create -q -y -n $CONDA_ENV ${CONDA_PYTHON_REQUIREMENT} numpy
+    ${CONDA_EXE:-conda} create -q -y -n $CONDA_ENV ${CONDA_PYTHON_REQUIREMENT} numpy
     source activate $CONDA_ENV
     mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build && cmake .. && make lightgbm -j4 || exit -1
     cd $BUILD_DIRECTORY/tests/cpp_tests && ../../lightgbm config=train.conf convert_model_language=cpp convert_model=../../src/boosting/gbdt_prediction.cpp && ../../lightgbm config=predict.conf output_result=origin.pred || exit -1
@@ -67,7 +67,7 @@ fi
 
 if [[ $TASK == "lint" ]]; then
     cd ${BUILD_DIRECTORY}
-    mamba create -q -y -n $CONDA_ENV \
+    ${CONDA_EXE:-conda} create -q -y -n $CONDA_ENV \
         ${CONDA_PYTHON_REQUIREMENT} \
         cmakelint \
         cpplint \
@@ -87,10 +87,10 @@ fi
 
 if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     cd $BUILD_DIRECTORY/docs
-    mamba env create \
+    ${CONDA_EXE:-conda} env create \
         -n $CONDA_ENV \
         --file ./env.yml || exit -1
-    mamba install \
+    ${CONDA_EXE:-conda} install \
         -q \
         -y \
         -n $CONDA_ENV \
@@ -128,7 +128,7 @@ if [[ $PYTHON_VERSION == "3.7" ]]; then
 fi
 
 # including python=version[build=*cpython] to ensure that conda doesn't fall back to pypy
-mamba create -q -y -n $CONDA_ENV \
+${CONDA_EXE:-conda} create -q -y -n $CONDA_ENV \
     ${CONSTRAINED_DEPENDENCIES} \
     cloudpickle \
     joblib \
@@ -304,7 +304,7 @@ matplotlib.use\(\"Agg\"\)\
 ' plot_example.py  # prevent interactive window mode
     sed -i'.bak' 's/graph.render(view=True)/graph.render(view=False)/' plot_example.py
     # requirements for examples
-    mamba install -q -y -n $CONDA_ENV \
+    ${CONDA_EXE:-conda} install -q -y -n $CONDA_ENV \
         h5py \
         ipywidgets \
         notebook
@@ -314,7 +314,7 @@ matplotlib.use\(\"Agg\"\)\
     jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb || exit -1  # run all notebooks
 
     # importing the library should succeed even if all optional dependencies are not present
-    mamba uninstall --force --yes \
+    ${CONDA_EXE:-conda} uninstall --force --yes \
         dask \
         distributed \
         joblib \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -37,7 +37,7 @@ fi
 CONDA_PYTHON_REQUIREMENT="python=$PYTHON_VERSION[build=*cpython]"
 
 if [[ $TASK == "if-else" ]]; then
-    ${CONDA_EXE:-conda} create -q -y -n $CONDA_ENV ${CONDA_PYTHON_REQUIREMENT} numpy
+    mamba create -q -y -n $CONDA_ENV ${CONDA_PYTHON_REQUIREMENT} numpy
     source activate $CONDA_ENV
     mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build && cmake .. && make lightgbm -j4 || exit -1
     cd $BUILD_DIRECTORY/tests/cpp_tests && ../../lightgbm config=train.conf convert_model_language=cpp convert_model=../../src/boosting/gbdt_prediction.cpp && ../../lightgbm config=predict.conf output_result=origin.pred || exit -1
@@ -67,7 +67,7 @@ fi
 
 if [[ $TASK == "lint" ]]; then
     cd ${BUILD_DIRECTORY}
-    ${CONDA_EXE:-conda} create -q -y -n $CONDA_ENV \
+    mamba create -q -y -n $CONDA_ENV \
         ${CONDA_PYTHON_REQUIREMENT} \
         cmakelint \
         cpplint \
@@ -87,10 +87,10 @@ fi
 
 if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     cd $BUILD_DIRECTORY/docs
-    ${CONDA_EXE:-conda} env create \
+    mamba env create \
         -n $CONDA_ENV \
         --file ./env.yml || exit -1
-    ${CONDA_EXE:-conda} install \
+    mamba install \
         -q \
         -y \
         -n $CONDA_ENV \
@@ -128,7 +128,7 @@ if [[ $PYTHON_VERSION == "3.7" ]]; then
 fi
 
 # including python=version[build=*cpython] to ensure that conda doesn't fall back to pypy
-${CONDA_EXE:-conda} create -q -y -n $CONDA_ENV \
+mamba create -q -y -n $CONDA_ENV \
     ${CONSTRAINED_DEPENDENCIES} \
     cloudpickle \
     joblib \
@@ -304,7 +304,7 @@ matplotlib.use\(\"Agg\"\)\
 ' plot_example.py  # prevent interactive window mode
     sed -i'.bak' 's/graph.render(view=True)/graph.render(view=False)/' plot_example.py
     # requirements for examples
-    ${CONDA_EXE:-conda} install -q -y -n $CONDA_ENV \
+    mamba install -q -y -n $CONDA_ENV \
         h5py \
         ipywidgets \
         notebook
@@ -314,7 +314,7 @@ matplotlib.use\(\"Agg\"\)\
     jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb || exit -1  # run all notebooks
 
     # importing the library should succeed even if all optional dependencies are not present
-    ${CONDA_EXE:-conda} uninstall --force --yes \
+    mamba uninstall --force --yes \
         dask \
         distributed \
         joblib \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -314,7 +314,7 @@ matplotlib.use\(\"Agg\"\)\
     jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb || exit -1  # run all notebooks
 
     # importing the library should succeed even if all optional dependencies are not present
-    mamba uninstall --force --yes \
+    conda uninstall --force --yes \
         dask \
         distributed \
         joblib \

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -74,6 +74,7 @@ jobs:
           export LGB_VER=$(head -n 1 VERSION.txt)
           export CONDA=${HOME}/miniforge
           export PATH=${CONDA}/bin:${PATH}
+          export CONDA_EXE=mamba
           $GITHUB_WORKSPACE/.ci/setup.sh || exit -1
           $GITHUB_WORKSPACE/.ci/test.sh || exit -1
   test-oldest-versions:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -74,7 +74,6 @@ jobs:
           export LGB_VER=$(head -n 1 VERSION.txt)
           export CONDA=${HOME}/miniforge
           export PATH=${CONDA}/bin:${PATH}
-          export CONDA_EXE=mamba
           $GITHUB_WORKSPACE/.ci/setup.sh || exit -1
           $GITHUB_WORKSPACE/.ci/test.sh || exit -1
   test-oldest-versions:


### PR DESCRIPTION
# Motivation

In #6034, the Python package `bdist` build on macOS times out after an hour as the environment for testing cannot be solved in time. This is the result from using conda with its slow solver. Replacing `conda` with `mamba` causes the same CI job to complete successfully in under 20 minutes.

This PR allows to optionally use `mamba` rather than `conda` to allow certain CI jobs to take advantage of `mamba`'s faster solver. The optional usage alleviates the need to build new docker images for the CI for the time being.