### PR TITLE
Keep number of threads in a global variable separate from global OMP config

### DIFF
--- a/include/LightGBM/utils/openmp_wrapper.h
+++ b/include/LightGBM/utils/openmp_wrapper.h
@@ -17,20 +17,17 @@
 #include <stdexcept>
 #include <vector>
 
+static int lgb_global_omp_threads = omp_get_max_threads();
+
 inline int OMP_NUM_THREADS() {
-  int ret = 1;
-#pragma omp parallel
-#pragma omp master
-  { ret = omp_get_num_threads(); }
-  return ret;
+  return lgb_global_omp_threads;
 }
 
 inline void OMP_SET_NUM_THREADS(int num_threads) {
-  static const int default_omp_num_threads = OMP_NUM_THREADS();
   if (num_threads > 0) {
-    omp_set_num_threads(num_threads);
+    lgb_global_omp_threads = num_threads;
   } else {
-    omp_set_num_threads(default_omp_num_threads);
+    lgb_global_omp_threads = omp_get_max_threads();
   }
 }
 


### PR DESCRIPTION
ref https://github.com/microsoft/LightGBM/issues/4705
ref https://github.com/microsoft/LightGBM/pull/6133

This PR changes the recently introduced workaround for getting the number of threads to be a global variable specific to lightgbm instead of modifying the global openmp configuration.

This is a quick workaround (compared to using a variable local to a function call) and doesn't solve the problem for good - for example, if one calls `fit` in multiple threads, the configs will overwrite each other, but at least they won't conflict with those of other software.

Ideally this new global variable should be thread-local but I see that lightgbm is also compiled with MSVC and I'm not sure if omp's thread-local pragmas are supported for that compiler so I left them out.