### PR TITLE
[docs] fix broken links

### DIFF
--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -11,7 +11,7 @@ ignore=
   http.*amd.com/.*
   https.*dl.acm.org/doi/.*
   https.*tandfonline.com/.*
-ignorewarnings=http-robots-denied,https-certificate-error
+ignorewarnings=http-redirect,http-robots-denied,https-certificate-error
 checkextern=1
 
 [output]

--- a/docs/.linkcheckerrc
+++ b/docs/.linkcheckerrc
@@ -11,7 +11,7 @@ ignore=
   http.*amd.com/.*
   https.*dl.acm.org/doi/.*
   https.*tandfonline.com/.*
-ignorewarnings=http-redirect,http-robots-denied,https-certificate-error
+ignorewarnings=http-redirected,http-robots-denied,https-certificate-error
 checkextern=1
 
 [output]

--- a/docs/Experiments.rst
+++ b/docs/Experiments.rst
@@ -25,7 +25,7 @@ We used 5 datasets to conduct our comparison experiments. Details of data are li
 +-----------+-----------------------+------------------------------------------------------------------------+-------------+----------+----------------------------------------------+
 | Yahoo LTR | Learning to rank      | `link <https://webscope.sandbox.yahoo.com/catalog.php?datatype=c>`__   | 473,134     | 700      | set1.train as train, set1.test as test       |
 +-----------+-----------------------+------------------------------------------------------------------------+-------------+----------+----------------------------------------------+
-| MS LTR    | Learning to rank      | `link <http://research.microsoft.com/en-us/projects/mslr/>`__          | 2,270,296   | 137      | {S1,S2,S3} as train set, {S5} as test set    |
+| MS LTR    | Learning to rank      | `link <https://www.microsoft.com/en-us/research/project/mslr/>`__          | 2,270,296   | 137      | {S1,S2,S3} as train set, {S5} as test set    |
 +-----------+-----------------------+------------------------------------------------------------------------+-------------+----------+----------------------------------------------+
 | Expo      | Binary classification | `link <http://stat-computing.org/dataexpo/2009/>`__                    | 11,000,000  | 700      | last 1,000,000 samples were used as test set |
 +-----------+-----------------------+------------------------------------------------------------------------+-------------+----------+----------------------------------------------+

--- a/docs/Experiments.rst
+++ b/docs/Experiments.rst
@@ -25,7 +25,7 @@ We used 5 datasets to conduct our comparison experiments. Details of data are li
 +-----------+-----------------------+------------------------------------------------------------------------+-------------+----------+----------------------------------------------+
 | Yahoo LTR | Learning to rank      | `link <https://webscope.sandbox.yahoo.com/catalog.php?datatype=c>`__   | 473,134     | 700      | set1.train as train, set1.test as test       |
 +-----------+-----------------------+------------------------------------------------------------------------+-------------+----------+----------------------------------------------+
-| MS LTR    | Learning to rank      | `link <https://www.microsoft.com/en-us/research/project/mslr/>`__          | 2,270,296   | 137      | {S1,S2,S3} as train set, {S5} as test set    |
+| MS LTR    | Learning to rank      | `link <https://www.microsoft.com/en-us/research/project/mslr>`__          | 2,270,296   | 137      | {S1,S2,S3} as train set, {S5} as test set    |
 +-----------+-----------------------+------------------------------------------------------------------------+-------------+----------+----------------------------------------------+
 | Expo      | Binary classification | `link <http://stat-computing.org/dataexpo/2009/>`__                    | 11,000,000  | 700      | last 1,000,000 samples were used as test set |
 +-----------+-----------------------+------------------------------------------------------------------------+-------------+----------+----------------------------------------------+

--- a/docs/Experiments.rst
+++ b/docs/Experiments.rst
@@ -25,7 +25,7 @@ We used 5 datasets to conduct our comparison experiments. Details of data are li
 +-----------+-----------------------+------------------------------------------------------------------------+-------------+----------+----------------------------------------------+
 | Yahoo LTR | Learning to rank      | `link <https://webscope.sandbox.yahoo.com/catalog.php?datatype=c>`__   | 473,134     | 700      | set1.train as train, set1.test as test       |
 +-----------+-----------------------+------------------------------------------------------------------------+-------------+----------+----------------------------------------------+
-| MS LTR    | Learning to rank      | `link <https://www.microsoft.com/en-us/research/project/mslr>`__          | 2,270,296   | 137      | {S1,S2,S3} as train set, {S5} as test set    |
+| MS LTR    | Learning to rank      | `link <https://www.microsoft.com/en-us/research/project/mslr/>`__      | 2,270,296   | 137      | {S1,S2,S3} as train set, {S5} as test set    |
 +-----------+-----------------------+------------------------------------------------------------------------+-------------+----------+----------------------------------------------+
 | Expo      | Binary classification | `link <http://stat-computing.org/dataexpo/2009/>`__                    | 11,000,000  | 700      | last 1,000,000 samples were used as test set |
 +-----------+-----------------------+------------------------------------------------------------------------+-------------+----------+----------------------------------------------+

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -289,7 +289,7 @@ Python-package
 
 This error should be solved in latest version.
 If you still meet this error, try to remove ``lightgbm.egg-info`` folder in your Python-package and reinstall,
-or check `this thread on stackoverflow <http://stackoverflow.com/questions/18085571/pip-install-error-setup-script-specifies-an-absolute-path>`__.
+or check `this thread on stackoverflow <https://stackoverflow.com/questions/18085571/pip-install-error-setup-script-specifies-an-absolute-path>`__.
 
 2. Error messages: ``Cannot ... before construct dataset``.
 -----------------------------------------------------------

--- a/docs/GPU-Performance.rst
+++ b/docs/GPU-Performance.rst
@@ -196,7 +196,7 @@ Huan Zhang, Si Si and Cho-Jui Hsieh. `GPU Acceleration for Large-scale Tree Boos
 
 .. _link1: https://archive.ics.uci.edu/ml/datasets/HIGGS
 
-.. _link2: http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary.html
+.. _link2: https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary.html
 
 .. _link3: https://www.kaggle.com/c/bosch-production-line-performance/data
 

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -960,7 +960,7 @@ gcc
 
 .. _Boost Binaries: https://sourceforge.net/projects/boost/files/boost-binaries/
 
-.. _SWIG: http://www.swig.org/download.html
+.. _SWIG: https://www.swig.org/download.html
 
 .. _this detailed guide: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
 

--- a/docs/Parallel-Learning-Guide.rst
+++ b/docs/Parallel-Learning-Guide.rst
@@ -384,8 +384,6 @@ From the point forward, you can use any of the following methods to save the Boo
 Kubeflow
 ^^^^^^^^
 
-`Kubeflow Fairing`_ supports LightGBM distributed training. `These examples`_ show how to get started with LightGBM and Kubeflow Fairing in a hybrid cloud environment.
-
 Kubeflow users can also use the `Kubeflow XGBoost Operator`_ for machine learning workflows with LightGBM. You can see `this example`_ for more details.
 
 Kubeflow integrations for LightGBM are not maintained by LightGBM's maintainers.
@@ -527,10 +525,6 @@ See `the mars documentation`_ for usage examples.
 .. _the metrics functions from dask-ml: https://ml.dask.org/modules/api.html#dask-ml-metrics-metrics
 
 .. _these Dask examples: https://github.com/microsoft/lightgbm/tree/master/examples/python-guide/dask
-
-.. _Kubeflow Fairing: https://www.kubeflow.org/docs/components/fairing/fairing-overview
-
-.. _These examples: https://github.com/kubeflow/fairing/tree/master/examples/lightgbm
 
 .. _Kubeflow XGBoost Operator: https://github.com/kubeflow/xgboost-operator
 

--- a/docs/gcc-Tips.rst
+++ b/docs/gcc-Tips.rst
@@ -25,8 +25,6 @@ You can find more details on the experimentation below:
 
 -  `Laurae's Benchmark Master Data (Interactive) <https://public.tableau.com/views/gbt_benchmarks/Master-Data?:showVizHome=no>`__
 
--  `Kaggle Paris Meetup #12 Slides <https://drive.google.com/file/d/0B6qJBmoIxFe0ZHNCOXdoRWMxUm8/view>`__
-
 The image below compares the runtime for training with different compiler options to a baseline using LightGBM compiled with ``-O2 --mtune=core2``. All three options are faster than that baseline. The best performance was achieved with ``-O3 --mtune=native``.
 
 .. image:: ./_static/images/gcc-comparison-2.png


### PR DESCRIPTION
The `check-links` CI job is failing as a result of broken links ([recent build](https://github.com/microsoft/LightGBM/actions/runs/6682111840/job/18156925117)).

This PR fixes those errors:

<details><summary>Kubeflow Fairing is no longer supported (click me)</summary>

```text
URL        `https://www.kubeflow.org/docs/components/fairing/fairing-overview'
Name       `Kubeflow Fairing'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/Parallel-Learning-Guide.html, line 452, col 4
Real URL   https://www.kubeflow.org/docs/external-add-ons/fairing/fairing-overview
Check time 0.452 seconds
Warning    [http-redirected] Redirected to
           `https://www.kubeflow.org/docs/external-add-ons/fairing/fairing-overview'
           status: 301 Moved Permanently.
Result     Error: 404 Not Found
```

See https://github.com/kubeflow/fairing/issues/573.

And at https://github.com/kubeflow/fairing/tree/master

<img width="1423" alt="Screen Shot 2023-10-29 at 11 09 01 PM" src="https://github.com/microsoft/LightGBM/assets/7608904/3fea43ba-6d76-4dbf-bff4-1cd6054db6b4">

And https://www.kubeflow.org/docs/external-add-ons/fairing/fairing-overview

<img width="1413" alt="image" src="https://github.com/microsoft/LightGBM/assets/7608904/3c7bfc02-c1f7-4bc5-8d28-c51d2d277526">

</details>

<details><summary>Paris Kaggle Meetup slides have been removed or made private (click me)</summary>

```text
URL        `https://drive.google.com/file/d/0B6qJBmoIxFe0ZHNCOXdoRWMxUm8/view'
Name       `Kaggle Paris Meetup #12 Slides'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/gcc-Tips.html, line 124, col 8
Real URL   https://drive.google.com/file/d/0B6qJBmoIxFe0ZHNCOXdoRWMxUm8/view
Check time 0.549 seconds
Result     Error: 401 Unauthorized
```

https://drive.google.com/file/d/0B6qJBmoIxFe0ZHNCOXdoRWMxUm8/view

<img width="669" alt="image" src="https://github.com/microsoft/LightGBM/assets/7608904/c163e685-7a83-4cec-b78d-8259b837e905">

</details>

<details><summary>MSLR dataset moved (click me)</summary>

```text
URL        `http://research.microsoft.com/en-us/projects/mslr/'
Name       `link'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/Experiments.html, line 159, col 8
Real URL   https://www.microsoft.com/en-us/research/redirect/?ref=https://research.microsoft.com/en-us/projects/mslr/
Check time 62.618 seconds
Size       0B
Warning    [http-redirected] Redirected to
           `https://www.microsoft.com/en-us/research/redirect/?ref=https://research.microsoft.com/en-us/projects/mslr/'
           status: 301 Moved Permanently.
Result     Error: ReadTimeout: HTTPSConnectionPool(host='www.microsoft.com', port=443): Read timed out. (read timeout=60)
```

</details>

<details><summary>SWIG docs site requests sometimes fail (click me)</summary>

```text
URL        `http://www.swig.org/download.html'
Name       `SWIG'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/Installation-Guide.html, line 791, col 16
Real URL   http://www.swig.org/download.html
Check time 10.217 seconds
Result     Error: ConnectionError: HTTPConnectionPool(host='www.swig.org', port=80): Max retries exceeded with url: /download.html (Caused by NameResolutionError("<urllib3.connection.HTTPConnection object at 0x7fc81fd499a0>: Failed to resolve 'www.swig.org' ...
```

I suspect that that might be a result of the use of `http://` instead of `https://`... maybe that site is doing a redirection of `http://` traffic that results in failures.

</details>

While looking through this, I also saw 2 warnings about redirects from `http://` to `https://` pages.. this PR fixes those as well.

<details><summary>redirects (click me)</summary>

```text
URL        `http://stackoverflow.com/questions/18085571/pip-install-error-setup-script-specifies-an-absolute-path'
Name       `this thread on stackoverflow'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/FAQ.html, line 383, col 10
Real URL   https://stackoverflow.com/questions/18085571/pip-install-error-setup-script-specifies-an-absolute-path
Check time 0.318 seconds
Warning    [http-redirected] Redirected to
           `https://stackoverflow.com/questions/18085571/pip-install-error-setup-script-specifies-an-absolute-path'
           status: 301 Moved Permanently.
```

```text
URL        `http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary.html'
Name       `link2'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/GPU-Performance.html, line 162, col 8
Real URL   https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary.html
Check time 3.449 seconds
Size       9KB
Warning    [http-redirected] Redirected to
           `https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary.html'
           status: 301 Moved Permanently.
```

</details>

### Notes for Reviewers

✅ triggered the job on this branch and saw it succeed: https://github.com/microsoft/LightGBM/actions/runs/6766631790