### PR TITLE
[R-package] Use `cat()` instead of `print()` for metrics and callbacks

### DIFF
--- a/.ci/lint_r_code.R
+++ b/.ci/lint_r_code.R
@@ -78,8 +78,7 @@ LINTERS_TO_USE <- list(
     , "true_false"           = lintr::T_and_F_symbol_linter()
     , "undesirable_function" = lintr::undesirable_function_linter(
         fun = c(
-            "cat" = "CRAN forbids the use of cat() in packages except in special cases. Use message() or warning()."
-            , "cbind" = paste0(
+            "cbind" = paste0(
                 "cbind is an unsafe way to build up a data frame. merge() or direct "
                 , "column assignment is preferred."
             )

--- a/R-package/R/callback.R
+++ b/R-package/R/callback.R
@@ -90,7 +90,7 @@ cb_print_evaluation <- function(period) {
 
         # Check if message is existing
         if (nchar(msg) > 0L) {
-          print(.merge_eval_string(env = env))
+          cat(.merge_eval_string(env = env), "\n")
         }
 
       }
@@ -208,9 +208,9 @@ cb_early_stop <- function(stopping_rounds, first_metric_only, verbose) {
       msg <- paste0(
         "Will train until there is no improvement in "
         , stopping_rounds
-        , " rounds."
+        , " rounds.\n"
       )
-      print(msg)
+      cat(msg)
     }
 
     # Internally treat everything as a maximization task
@@ -284,7 +284,7 @@ cb_early_stop <- function(stopping_rounds, first_metric_only, verbose) {
             }
 
             if (isTRUE(verbose)) {
-              print(paste0("Early stopping, best iteration is: ", best_msg[[i]]))
+              cat(paste0("Early stopping, best iteration is: ", best_msg[[i]], "\n"))
             }
 
             # Store best iteration and stop
@@ -302,7 +302,7 @@ cb_early_stop <- function(stopping_rounds, first_metric_only, verbose) {
         }
 
         if (isTRUE(verbose)) {
-          print(paste0("Did not meet early stopping, best iteration is: ", best_msg[[i]]))
+          cat(paste0("Did not meet early stopping, best iteration is: ", best_msg[[i]], "\n"))
         }
 
         # Store best iteration and stop

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3805,3 +3805,25 @@ test_that("lightgbm() correctly sets objective when passing lgb.Dataset as input
   )
   expect_equal(model$params$objective, "regression")
 })
+
+test_that("Evaluation metrics aren't printed as a single-element vector", {
+  log_txt <- capture_output({
+    data(mtcars)
+    y <- mtcars$mpg
+    x <- as.matrix(mtcars[, -1L])
+    cv_result <- lgb.cv(
+        data = lgb.Dataset(x, label = y)
+        , params = list(
+            objective = "regression"
+            , metric = "l2"
+            , min_data_in_leaf = 5L
+            , max_depth = 3L
+        )
+        , nrounds = 2L
+        , nfold = 3L
+        , verbose = 1L
+        , eval_train_metric = TRUE
+    )
+  })
+  expect_false(grepl("[1] \"[1]", log_txt, fixed = TRUE))
+})

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -3818,6 +3818,7 @@ test_that("Evaluation metrics aren't printed as a single-element vector", {
             , metric = "l2"
             , min_data_in_leaf = 5L
             , max_depth = 3L
+            , num_threads = .LGB_MAX_THREADS
         )
         , nrounds = 2L
         , nfold = 3L


### PR DESCRIPTION
This PR modifies the callbacks that print information such as evaluation metrics to use `cat()` instead of `print()`.

When using print on a `character`, since there is no "scalar" version of such class, R adds information about which element of the input vector is each - meaning: if there's only one element, it will always add `[1] ...` as part of the printed output. This is undesirable when looking at messages like evaluation metrics.