### PR TITLE
allow new files in include/LightGBM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,7 +266,7 @@ _Pvt_Extensions
 *.out
 *.app
 /windows/LightGBM.VC.db
-lightgbm
+/lightgbm
 /testlightgbm
 
 # Created by https://www.gitignore.io/api/python


### PR DESCRIPTION
This fixes an unintended behavior in this project's `git` configuration.

The `.gitignore` rule intended to block inclusion of the LightGBM CLI (a binary file named `lightgbm`) also prevents including of any new files in `include/LightGBM`:

```shell
touch include/LightGBM/something.h
git add include/LightGBM/something.h
```

```text
The following paths are ignored by one of your .gitignore files:
include/LightGBM
hint: Use -f if you really want to add them.
hint: Turn this message off by running
hint: "git config advice.addIgnoredFile false"
```

@borchero ran into this here: https://github.com/microsoft/LightGBM/pull/6034#discussion_r1299487404

This PR fixes that by adding a leading `/` to that rule. References explaining why that works:

* https://stackoverflow.com/a/6168768/3986677
* https://git-scm.com/docs/gitignore#_pattern_format