### PR TITLE
[R-package] remove unreachable code

### DIFF
--- a/R-package/R/lgb.Booster.R
+++ b/R-package/R/lgb.Booster.R
@@ -1462,7 +1462,6 @@ lgb.get.eval.result <- function(booster, data_name, eval_name, iters = NULL, is_
       , toString(eval_names)
       , "]"
     ))
-    stop("lgb.get.eval.result: wrong eval name")
   }
 
   result <- booster$record_evals[[data_name]][[eval_name]][[.EVAL_KEY()]]


### PR DESCRIPTION
A new version of `{lintr}` was released today ([CRAN link](https://cran.r-project.org/web/packages/lintr/)) and it caught an unreachable line of code in the R package!

> R-package/R/lgb.Booster.R:1465:5: warning: [unreachable_code] Code and comments coming after a return() or stop() should be removed.
>    stop("lgb.get.eval.result: wrong eval name")

This PR fixes that.

### Notes

Not sure exactly which `{lintr}` change resulted in this being caught, but I think it's https://github.com/r-lib/lintr/pull/2129. Thanks @MEO265 and @MichaelChirico!