### PR TITLE
[python-package] fix libpath.py

### DIFF
--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -16,7 +16,7 @@ def find_lib_path() -> List[str]:
        List of all found library paths to LightGBM.
     """
     curr_path = Path(__file__).absolute()
-    dll_path = [curr_path,
+    dll_path = [curr_path.parents[0],
                 curr_path.parents[1],
                 curr_path.parents[0] / 'bin',
                 curr_path.parents[0] / 'lib']

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -16,8 +16,7 @@ def find_lib_path() -> List[str]:
        List of all found library paths to LightGBM.
     """
     curr_path = Path(__file__).absolute()
-    dll_path = [curr_path.parents[0],
-                curr_path.parents[1],
+    dll_path = [curr_path.parents[1],
                 curr_path.parents[0] / 'bin',
                 curr_path.parents[0] / 'lib']
     if system() in ('Windows', 'Microsoft'):


### PR DESCRIPTION
This is to fix a mistake in libpath.py, which causes a wrong candidate library path, as shown by the first one below:
```bash
$ python python-package/lightgbm/libpath.py
/home/shiyu/Test-LightGBM/cuda-obj/LightGBM/python-package/lightgbm/libpath.py/lib_lightgbm.so
/home/shiyu/Test-LightGBM/cuda-obj/LightGBM/python-package/lib_lightgbm.so
/home/shiyu/Test-LightGBM/cuda-obj/LightGBM/python-package/lightgbm/bin/lib_lightgbm.so
/home/shiyu/Test-LightGBM/cuda-obj/LightGBM/python-package/lightgbm/lib/lib_lightgbm.so
```
With this fix, it becomes
```bash
/home/shiyu/Test-LightGBM/cuda-obj/LightGBM/python-package/lightgbm/lib_lightgbm.so
/home/shiyu/Test-LightGBM/cuda-obj/LightGBM/python-package/lib_lightgbm.so
/home/shiyu/Test-LightGBM/cuda-obj/LightGBM/python-package/lightgbm/bin/lib_lightgbm.so
/home/shiyu/Test-LightGBM/cuda-obj/LightGBM/python-package/lightgbm/lib/lib_lightgbm.so
```