### PR TITLE
[python-package] ignore mypy errors related to ctypes string buffers

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2948,7 +2948,7 @@ class Dataset:
         reserved_string_buffer_size = 255
         required_string_buffer_size = ctypes.c_size_t(0)
         string_buffers = [ctypes.create_string_buffer(reserved_string_buffer_size) for _ in range(num_feature)]
-        ptr_string_buffers = (ctypes.c_char_p * num_feature)(*map(ctypes.addressof, string_buffers))
+        ptr_string_buffers = (ctypes.c_char_p * num_feature)(*map(ctypes.addressof, string_buffers))  # type: ignore[misc]
         _safe_call(_LIB.LGBM_DatasetGetFeatureNames(
             self._handle,
             ctypes.c_int(num_feature),
@@ -2962,7 +2962,7 @@ class Dataset:
         # if buffer length is not long enough, reallocate buffers
         if reserved_string_buffer_size < actual_string_buffer_size:
             string_buffers = [ctypes.create_string_buffer(actual_string_buffer_size) for _ in range(num_feature)]
-            ptr_string_buffers = (ctypes.c_char_p * num_feature)(*map(ctypes.addressof, string_buffers))
+            ptr_string_buffers = (ctypes.c_char_p * num_feature)(*map(ctypes.addressof, string_buffers))  # type: ignore[misc]
             _safe_call(_LIB.LGBM_DatasetGetFeatureNames(
                 self._handle,
                 ctypes.c_int(num_feature),
@@ -4628,7 +4628,7 @@ class Booster:
         reserved_string_buffer_size = 255
         required_string_buffer_size = ctypes.c_size_t(0)
         string_buffers = [ctypes.create_string_buffer(reserved_string_buffer_size) for _ in range(num_feature)]
-        ptr_string_buffers = (ctypes.c_char_p * num_feature)(*map(ctypes.addressof, string_buffers))
+        ptr_string_buffers = (ctypes.c_char_p * num_feature)(*map(ctypes.addressof, string_buffers))  # type: ignore[misc]
         _safe_call(_LIB.LGBM_BoosterGetFeatureNames(
             self._handle,
             ctypes.c_int(num_feature),
@@ -4642,7 +4642,7 @@ class Booster:
         # if buffer length is not long enough, reallocate buffers
         if reserved_string_buffer_size < actual_string_buffer_size:
             string_buffers = [ctypes.create_string_buffer(actual_string_buffer_size) for _ in range(num_feature)]
-            ptr_string_buffers = (ctypes.c_char_p * num_feature)(*map(ctypes.addressof, string_buffers))
+            ptr_string_buffers = (ctypes.c_char_p * num_feature)(*map(ctypes.addressof, string_buffers))  # type: ignore[misc]
             _safe_call(_LIB.LGBM_BoosterGetFeatureNames(
                 self._handle,
                 ctypes.c_int(num_feature),
@@ -4852,7 +4852,7 @@ class Booster:
                 string_buffers = [
                     ctypes.create_string_buffer(reserved_string_buffer_size) for _ in range(self.__num_inner_eval)
                 ]
-                ptr_string_buffers = (ctypes.c_char_p * self.__num_inner_eval)(*map(ctypes.addressof, string_buffers))
+                ptr_string_buffers = (ctypes.c_char_p * self.__num_inner_eval)(*map(ctypes.addressof, string_buffers))  # type: ignore[misc]
                 _safe_call(_LIB.LGBM_BoosterGetEvalNames(
                     self._handle,
                     ctypes.c_int(self.__num_inner_eval),
@@ -4868,7 +4868,7 @@ class Booster:
                     string_buffers = [
                         ctypes.create_string_buffer(actual_string_buffer_size) for _ in range(self.__num_inner_eval)
                     ]
-                    ptr_string_buffers = (ctypes.c_char_p * self.__num_inner_eval)(*map(ctypes.addressof, string_buffers))
+                    ptr_string_buffers = (ctypes.c_char_p * self.__num_inner_eval)(*map(ctypes.addressof, string_buffers))  # type: ignore[misc]
                     _safe_call(_LIB.LGBM_BoosterGetEvalNames(
                         self._handle,
                         ctypes.c_int(self.__num_inner_eval),


### PR DESCRIPTION
Contributes to #3867.

A few places in the Python package pre-allocate C char arrays with `ctypes.create_string_buffer()`, then pass a C array of pointers to those buffers through LightGBM's C API.

`mypy` is not happy about the way that's done:

```text
python-package/lightgbm/basic.py:2951: error: Array constructor argument 1 of type "map[int]" is not convertible to the array element type "Iterable[c_char_p]"  [misc]
python-package/lightgbm/basic.py:2965: error: Array constructor argument 1 of type "map[int]" is not convertible to the array element type "Iterable[c_char_p]"  [misc]
python-package/lightgbm/basic.py:4631: error: Array constructor argument 1 of type "map[int]" is not convertible to the array element type "Iterable[c_char_p]"  [misc]
python-package/lightgbm/basic.py:4645: error: Array constructor argument 1 of type "map[int]" is not convertible to the array element type "Iterable[c_char_p]"  [misc]
python-package/lightgbm/basic.py:4855: error: Array constructor argument 1 of type "map[int]" is not convertible to the array element type "Iterable[c_char_p]"  [misc]
python-package/lightgbm/basic.py:4871: error: Array constructor argument 1 of type "map[int]" is not convertible to the array element type "Iterable[c_char_p]"  [misc]
```

The way the package does this appears to follow all of the guidance from `ctypes` in https://docs.python.org/3/library/ctypes.html#arrays, so I suspect this might be an issue with the `ctypes` type hints or maybe `mypy`'s type inference. I reported that at https://github.com/python/mypy/issues/6212#issuecomment-1809628303.

This PR proposes just ignoring those issues with `#type: ignore` comments.