### PR TITLE
[CUDA] fix typo in error message

### DIFF
--- a/src/treelearner/cuda/cuda_single_gpu_tree_learner.hpp
+++ b/src/treelearner/cuda/cuda_single_gpu_tree_learner.hpp
@@ -155,7 +155,7 @@ class CUDASingleGPUTreeLearner: public SerialTreeLearner {
     #pragma warning(disable : 4702)
     explicit CUDASingleGPUTreeLearner(const Config* tree_config, const bool /*boosting_on_cuda*/) : SerialTreeLearner(tree_config) {
       Log::Fatal("CUDA Tree Learner was not enabled in this build.\n"
-                 "Please recompile with CMake option -DUSE_CUDAP=1");
+                 "Please recompile with CMake option -DUSE_CUDA=1");
     }
 };
 


### PR DESCRIPTION
Per the report in #6205.

Fixes a typo in an error message from the CUDA version of the library.