### PR TITLE
[R-package] use safer pattern for error formatting (fixes #6212)

### DIFF
--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -40,7 +40,7 @@ void LGBM_R_save_exception_msg(const std::string &err);
   catch(std::exception& ex) { LGBM_R_save_exception_msg(ex); } \
   catch(std::string& ex) { LGBM_R_save_exception_msg(ex); } \
   catch(...) { Rf_error("unknown exception"); } \
-  Rf_error(R_errmsg_buffer); \
+  Rf_error("%s", R_errmsg_buffer); \
   return R_NilValue; /* <- won't be reached */
 
 #define CHECK_CALL(x) \


### PR DESCRIPTION
Fixes #6212.

Resolves warning `-Wformat-security` raised with R-devel as of a few days ago and `clang-15`:

> lightgbm_R.cpp:159:3: warning: format string is not a string literal (potentially insecure) [-Wformat-security]

See https://github.com/microsoft/LightGBM/issues/6212#issuecomment-1829182030 for more details informing the changes in this PR.

### Why not just suppress this warning?

CRAN has in the past not allowed compiler flags or pragmas in code that suppress warnings.

* https://github.com/microsoft/LightGBM/blob/2ee3ec84b70df1a9e249d3b3bff9458fe3726cd4/build-cran-package.sh#L140-L143
* #3433

I couldn't find that stated explicitly in the CRAN policy (https://cran.r-project.org/web/packages/policies.html) or Writing R Extensions (https://cran.r-project.org/doc/manuals/R-exts.html), although there are some valid things there that note that warning-control flags can be compiler-specific and therefore add maintenance complexity to achieve portability. e.g. from https://cran.r-project.org/doc/manuals/R-exts.html#Portable-C-and-C_002b_002b-code

> *When writing a Makevars file for a package you intend to distribute, take care to ensure that it is not specific to your compiler: flags such as `-O2 -Wall -pedantic` (and all other `-W `flags: for the Oracle compilers these were used to pass arguments to compiler phases) are all specific to GCC (and compilers such as clang which aim to be options-compatible with it).*

So unless there's some other performance, safety, or correctness issue I'm unaware of, I think the fix in this PR is a good approach to satisfying `clang-15` and therefore the CRAN checks.

### Notes for Reviewers

@shiyu1994 @guolinke @jmoralez this PR will unblock LightGBM's CI.

@david-cortes if you have other opinions on the approach I took here I'd welcome them.