### PR TITLE
[python-package] take shallow copy of dataframe in predict (fixes #6195)

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -786,6 +786,10 @@ def _data_from_pandas(
     if len(data.shape) != 2 or data.shape[0] < 1:
         raise ValueError('Input data must be 2 dimensional and non empty.')
 
+    # take shallow copy in case we modify categorical columns
+    # whole column modifications don't change the original df
+    data = data.copy(deep=False)
+
     # determine feature names
     if feature_name == 'auto':
         feature_name = [str(col) for col in data.columns]
@@ -802,7 +806,6 @@ def _data_from_pandas(
             if list(data[col].cat.categories) != list(category):
                 data[col] = data[col].cat.set_categories(category)
     if len(cat_cols):  # cat_cols is list
-        data = data.copy(deep=False)  # not alter origin DataFrame
         data[cat_cols] = data[cat_cols].apply(lambda x: x.cat.codes).replace({-1: np.nan})
     if categorical_feature == 'auto':  # use cat cols from DataFrame
         categorical_feature = cat_cols_not_ordered


### PR DESCRIPTION
Takes a shallow copy of the dataframe in the `_data_from_pandas` function to avoid modifying it when converting categorical features to their codes. This used to always be done (implicitly) for predict until #6066, since the function is called with `feature_name='auto'` and the `copy` argument of `pandas.DataFrame.rename` is passed as the `deep` argument to `pandas.DataFrame.copy`, however that behavior wasn't obvious.

Fixes #6195.

Also updates the test that verifies the original dataframe isn't modified to now consider the case of unseen categories, which fails in the current master and should prevent #6195 from happening again.