### PR TITLE
fix errors from MSVC '/permissive-' mode (fixes #6230)

### DIFF
--- a/include/LightGBM/arrow.h
+++ b/include/LightGBM/arrow.h
@@ -16,6 +16,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <stdexcept>
 
 /* -------------------------------------- C DATA INTERFACE ------------------------------------- */
 // The C data interface is taken from


### PR DESCRIPTION
Fixes #6230

Add stdexcept header file to fix `error C2039: 'invalid_argument': is not a member of 'std'` under option /permissive-.
