### PR TITLE
[ci] [R-package] allow more possibly-lost warnings from valgrind

### DIFF
--- a/.ci/test_r_package_valgrind.sh
+++ b/.ci/test_r_package_valgrind.sh
@@ -68,7 +68,7 @@ bytes_possibly_lost=$(
     | tr -d ","
 )
 echo "valgrind found ${bytes_possibly_lost} bytes possibly lost"
-if [[ ${bytes_possibly_lost} -gt 352 ]]; then
+if [[ ${bytes_possibly_lost} -gt 1056 ]]; then
     exit -1
 fi
 


### PR DESCRIPTION
Contributes to the `v4.2.0` release (#6191).

The latest `valgrind` build showed 1,056 bytes "possibly lost", all from code paths that create threads w/ `pthread_create`. (https://github.com/microsoft/LightGBM/pull/6191#issuecomment-1846240329)

In the past, CRAN has allowed some of these as false positives. (https://github.com/microsoft/LightGBM/pull/6191#issuecomment-1846502740)

This PR proposes modifying the test script for that job to acknowledge that this set of findings from `valgrind` are allowed.

### Notes for Reviewers

It would be better to suppress *specific* cases instead of do text-parsing to enforce a maximum number of "possibly lost" reported bytes... but that will take a bit more time to develop. I've documented it in #6231 and put `good first issue` on it to try to increase the likelihood that someone comes and contributes that.