### PR TITLE
[ci] update issue-locking workflow

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -18,15 +18,15 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v4
+      - uses: dessant/lock-threads@v5
         with:
           github-token: ${{ github.token }}
           # after how many days of inactivity should a closed issue/PR be locked?
-          issue-inactive-days: '90'
-          pr-inactive-days: '90'
+          issue-inactive-days: '365'
+          pr-inactive-days: '365'
           # do not close feature request issues...
           # we close those but track them in https://github.com/microsoft/LightGBM/issues/2302
-          exclude-any-issue-labels: '"feature request"'
+          exclude-any-issue-labels: 'feature request'
           # what labels should be removed prior to locking?
           remove-issue-labels: 'awaiting response,awaiting review,blocking,in progress'
           remove-pr-labels: 'awaiting response,awaiting review,blocking,in progress'
@@ -42,3 +42,4 @@ jobs:
           # what shoulld the locking status be?
           issue-lock-reason: 'resolved'
           pr-lock-reason: 'resolved'
+          process-only: 'issues, prs'


### PR DESCRIPTION
Proposes a few changes to the GitHub Actions workflow we use to close issues and labels:

* changes time-til-locking from 90 to 365 days after issues/PRs are closed
* removes extra double quotes (originally added in #6047)
* updates to `v5` of `dessant/lock-threads`

### Why now?

@dessant, the author of `lock-threads`, tagged me to tell me that extra double quotes are no longer necessary: https://github.com/dessant/lock-threads/issues/40#issuecomment-1835711406.

### Why increase the time-til-locking?

I've found that locking a PR / issue prevents GitHub from generating these annotations showing that the PR / issue was mentioned somewhere else.

<img width="834" alt="image" src="https://github.com/microsoft/LightGBM/assets/7608904/2f3dc607-4ea5-4fa1-8e0b-c051b7a80c5d">

I've found those annotations really useful, for example to discover problems in other projects that were caused by changes here.

I'd like to extend the time-til-locking so that we can see more of those annotations in the time after a release.