### PR TITLE
[R-package] [ci] switch vignettes from 'rmarkdown' to 'markdown'

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -127,13 +127,13 @@ if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
     Rscript --vanilla -e "install.packages('https://cran.r-project.org/src/contrib/Archive/lattice/lattice_0.20-41.tar.gz', repos = NULL, lib = '${R_LIB_PATH}')"
 fi
 
-# Manually install Depends and Imports libraries + 'knitr', 'RhpcBLASctl', 'rmarkdown', 'testthat'
+# Manually install Depends and Imports libraries + 'knitr', 'markdown', 'RhpcBLASctl', 'testthat'
 # to avoid a CI-time dependency on devtools (for devtools::install_deps())
 # NOTE: testthat is not required when running rchk
 if [[ "${TASK}" == "r-rchk" ]]; then
-    packages="c('data.table', 'jsonlite', 'knitr', 'Matrix', 'R6', 'RhpcBLASctl', 'rmarkdown')"
+    packages="c('data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'R6', 'RhpcBLASctl')"
 else
-    packages="c('data.table', 'jsonlite', 'knitr', 'Matrix', 'R6', 'RhpcBLASctl', 'rmarkdown', 'testthat')"
+    packages="c('data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'R6', 'RhpcBLASctl', 'testthat')"
 fi
 compile_from_source="both"
 if [[ $OS_NAME == "macos" ]]; then

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -124,7 +124,7 @@ Start-Process -FilePath Rtools.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT
 Write-Output "Done installing Rtools"
 
 Write-Output "Installing dependencies"
-$packages = "c('data.table', 'jsonlite', 'knitr', 'Matrix', 'processx', 'R6', 'RhpcBLASctl', 'rmarkdown', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
+$packages = "c('data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'processx', 'R6', 'RhpcBLASctl', 'testthat'), dependencies = c('Imports', 'Depends', 'LinkingTo')"
 Run-R-Code-Redirect-Stderr "options(install.packages.check.source = 'no'); install.packages($packages, repos = '$env:CRAN_MIRROR', type = 'binary', lib = '$env:R_LIB_PATH', Ncpus = parallel::detectCores())" ; Check-Output $?
 
 Write-Output "Building R package"

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -177,6 +177,8 @@ jobs:
         with:
           fetch-depth: 5
           submodules: true
+      - name: Install pandoc
+        uses: r-lib/actions/setup-pandoc@v2
       - name: install tinytex
         if: startsWith(matrix.os, 'windows')
         uses: r-lib/actions/setup-tinytex@v2

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Install packages
         shell: bash
         run: |
-          RDscript${{ matrix.r_customization }} -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'Matrix', 'RhpcBLASctl', 'rmarkdown', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
+          RDscript${{ matrix.r_customization }} -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
           sh build-cran-package.sh --r-executable=RD${{ matrix.r_customization }}
           RD${{ matrix.r_customization }} CMD INSTALL lightgbm_*.tar.gz || exit -1
       - name: Run tests with sanitizers
@@ -320,7 +320,7 @@ jobs:
         shell: bash
         run: |
           export PATH=/opt/R-devel/bin/:${PATH}
-          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'Matrix', 'RhpcBLASctl', 'rmarkdown', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
+          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
           sh build-cran-package.sh
           R CMD check --as-cran --run-donttest lightgbm_*.tar.gz || exit -1
           if grep -q -E "NOTE|WARNING|ERROR" lightgbm.Rcheck/00check.log; then

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -177,8 +177,6 @@ jobs:
         with:
           fetch-depth: 5
           submodules: true
-      - name: Install pandoc
-        uses: r-lib/actions/setup-pandoc@v2
       - name: install tinytex
         if: startsWith(matrix.os, 'windows')
         uses: r-lib/actions/setup-tinytex@v2

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install packages
         shell: bash
         run: |
-          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'Matrix', 'RhpcBLASctl', 'rmarkdown', 'roxygen2', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
+          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'roxygen2', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
           sh build-cran-package.sh || exit -1
           R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit -1
       - name: Test documentation

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -309,7 +309,7 @@ jobs:
       R_LIB_PATH=~/Rlib
       export R_LIBS=${R_LIB_PATH}
       mkdir -p ${R_LIB_PATH}
-      RDscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'Matrix', 'RhpcBLASctl', 'rmarkdown'),  lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())" || exit -1
+      RDscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl'),  lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())" || exit -1
       sh build-cran-package.sh --r-executable=RD || exit -1
       mv lightgbm_${LGB_VER}.tar.gz $(Build.ArtifactStagingDirectory)/lightgbm-${LGB_VER}-r-cran.tar.gz
     displayName: 'Build CRAN R-package'

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -46,9 +46,9 @@ Biarch: true
 VignetteBuilder: knitr
 Suggests:
     knitr,
+    markdown,
     processx,
     RhpcBLASctl,
-    rmarkdown,
     testthat
 Depends:
     R (>= 3.5)

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -428,7 +428,7 @@ docker run \
 
 # install dependencies
 RDscript${R_CUSTOMIZATION} \
-  -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'Matrix', 'RhpcBLASctl', 'rmarkdown', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
+  -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
 
 # install lightgbm
 sh build-cran-package.sh --r-executable=RD${R_CUSTOMIZATION}
@@ -459,7 +459,7 @@ docker run \
     -it \
         wch1/r-debug
 
-RDscriptvalgrind -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'Matrix', 'RhpcBLASctl', 'rmarkdown', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
+RDscriptvalgrind -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
 
 sh build-cran-package.sh \
     --r-executable=RDvalgrind

--- a/R-package/vignettes/basic_walkthrough.Rmd
+++ b/R-package/vignettes/basic_walkthrough.Rmd
@@ -3,10 +3,14 @@ title:
   "Basic Walkthrough"
 description: >
   This vignette describes how to train a LightGBM model for binary classification.
-output: rmarkdown::html_vignette
+output:
+  markdown::html_format:
+    options:
+      toc: true
+      number_sections: true
 vignette: >
   %\VignetteIndexEntry{Basic Walkthrough}
-  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEngine{knitr::knitr}
   %\VignetteEncoding{UTF-8}
 ---
 
@@ -23,7 +27,7 @@ knitr::opts_chunk$set(
 
 Welcome to the world of [LightGBM](https://lightgbm.readthedocs.io/en/latest/), a highly efficient gradient boosting implementation (Ke et al. 2017).
 
-```{r setup}
+```{r}
 library(lightgbm)
 ```
 

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -9,9 +9,9 @@ dependencies:
   - r-data.table=1.14.2
   - r-jsonlite=1.7.2
   - r-knitr=1.37
+  - r-markdown
   - r-matrix=1.4_0
   - r-pkgdown=1.6.1
-  - r-rmarkdown=2.11
   - r-roxygen2=7.2.1
   - scikit-learn
   - sphinx


### PR DESCRIPTION
Related to #1944.

Proposes switching from `{rmarkdown}` to `{markdown}` for the R package's vignettes.

### Benefits of this Change

Reduces the set of dependencies that have to build successfully to run `R CMD check --as-cran` against `{lightgbm}`, leading to:

* faster CI builds
* lower risk of CI failures
* lower risk of failed builds and disruptions on CRAN
* slightly reduced reverse-dependency burden for CRAN and maintainers of `{rmarkdown}`

<details><summary>this change results in 14 fewer packages needing to be installed in CI</summary>

R code I used (with R 4.2.3) to calculate that:

```r
CRAN_DB <- tools::CRAN_package_db()

.get_strong_deps <- function(packages) {
    ret <- tools::package_dependencies(
        packages = packages
        , db = CRAN_DB
        , which = c("Depends", "Imports", "LinkingTo")
        , recursive = TRUE
    )
    ret_vec <- c(unlist(ret), packages)
    return(sort(unique(ret_vec)))
}

# combination of the following:
#   * LightGBM's strong dependencies (recursive)
#   * LightGBM's "Suggests" dependencies
#   * strong dependencies of those "Suggests" dependencies (recursive)
#
# excluding {rmarkdown} / {markdown}
lgb_r_cmd_check_deps <- setdiff(
    .get_strong_deps(c("lightgbm", "knitr", "RhpcBLASctl", "testthat"))
    , "lightgbm"
)
length(lgb_r_cmd_check_deps)
# 47

strong_deps_for_rmarkdown <- .get_strong_deps("rmarkdown")
strong_deps_for_markdown <- .get_strong_deps("markdown")

# additional packages added by {rmarkdown}
setdiff(strong_deps_for_rmarkdown, lgb_r_cmd_check_deps)

# [1] "base64enc"   "bslib"       "cachem"      "ellipsis"   
# [5] "fastmap"     "fontawesome" "htmltools"   "jquerylib"  
# [9] "memoise"     "mime"        "rappdirs"    "rmarkdown"  
# [13] "sass"        "stringi"     "stringr"     "tinytex"

# additional packages added by {markdown}
setdiff(strong_deps_for_markdown, lgb_r_cmd_check_deps)
# [1] "commonmark" "markdown"
```

</details>

### But what are we giving up?

My understanding is the main benefits of `{rmarkdown}` over `{markdown}` are things that are not relevant to the simple documentation `{lightgbm}` produces. Things like:

* support for many more outputs formats, such as Microsoft Word documents, interactive notebooks, and 5+ formats of slide show (see https://rmarkdown.rstudio.com/lesson-9.html)
* interactivity within the RStudio IDE (see https://rmarkdown.rstudio.com/lesson-14.html)

`{markdown}`, as stated in its README (https://github.com/rstudio/markdown), aims to be simpler and lighter-weight:

> *It is a deliberate design choice to keep this markdown package lightweight...*
> *...  this package is intended for minimalists*

### How I tested this

Enabled this branch on readthedocs and built the docs there.

The build took 807 seconds ([build link](https://readthedocs.org/projects/lightgbm/builds/23038504/)), roughly the same as other builds took over the last 7 days ([build history](https://readthedocs.org/projects/lightgbm/builds/)).

Confirmed that the rendered vignette looks correct at the documentation site: https://lightgbm.readthedocs.io/en/docs-lighter-weight-vignettes/R/articles/basic_walkthrough.html.

Many of this project's R CI jobs build the vignettes and test them with `R CMD check --as-cran`, so I'm confident this change wouldn't cause issues for CRAN.

Confirmed all references to `{rmarkdown}` have been replaced by `{markdown}`:

```shell
git grep -i rmarkdown
```

### Notes for Reviewers

This PR inspired by @jangorecki's post on the `r-pkg-devel` mailing list: https://stat.ethz.ch/pipermail/r-package-devel/2024q1/010280.html. `{data.table}` recently made a similar change in pursuit of reducing the weight of their dependencies.

Related:

* https://github.com/rstudio/markdown/issues/109
* https://github.com/Rdatatable/data.table/issues/5745
* https://github.com/Rdatatable/data.table/pull/5773/