### PR TITLE
[cmake] [swig] use CMake's built-in file-copying mechanisms instead of 'cp'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,7 +545,7 @@ if(USE_SWIG)
           "${CMAKE_COMMAND}"
           -E
           copy_if_different
-          "${PROJECT_SOURCE_DIR}/*.dylib"
+          "${PROJECT_SOURCE_DIR}/lib_lightgbm.dylib"
           com/microsoft/ml/lightgbm/osx/x86_64
         COMMAND
           "${CMAKE_COMMAND}"
@@ -564,7 +564,7 @@ if(USE_SWIG)
           "${CMAKE_COMMAND}"
           -E
           copy_if_different
-          "${PROJECT_SOURCE_DIR}/*.so"
+          "${PROJECT_SOURCE_DIR}/lib_lightgbm.so"
           com/microsoft/ml/lightgbm/linux/x86_64
         COMMAND "${Java_JAR_EXECUTABLE}" -cf lightgbmlib.jar com
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,7 +525,13 @@ if(USE_SWIG)
               "${CMAKE_COMMAND}"
               -E
               copy_if_different
-              "${PROJECT_SOURCE_DIR}/Release/*.dll"
+              "${PROJECT_SOURCE_DIR}/Release/lib_lightgbm.dll"
+              com/microsoft/ml/lightgbm/windows/x86_64
+            COMMAND
+              "${CMAKE_COMMAND}"
+              -E
+              copy_if_different
+              "${PROJECT_SOURCE_DIR}/Release/lib_lightgbm_swig.dll"
               com/microsoft/ml/lightgbm/windows/x86_64
             COMMAND "${Java_JAR_EXECUTABLE}" -cf lightgbmlib.jar com
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,7 +521,12 @@ if(USE_SWIG)
             TARGET _lightgbm_swig
             POST_BUILD
             COMMAND "${Java_JAVAC_EXECUTABLE}" -d . java/*.java
-            COMMAND cp "${PROJECT_SOURCE_DIR}/Release/*.dll" com/microsoft/ml/lightgbm/windows/x86_64
+            COMMAND
+              "${CMAKE_COMMAND}"
+              -E
+              copy_if_different
+              "${PROJECT_SOURCE_DIR}/Release/*.dll"
+              com/microsoft/ml/lightgbm/windows/x86_64
             COMMAND "${Java_JAR_EXECUTABLE}" -cf lightgbmlib.jar com
         )
     endif()
@@ -530,9 +535,16 @@ if(USE_SWIG)
         TARGET _lightgbm_swig
         POST_BUILD
         COMMAND "${Java_JAVAC_EXECUTABLE}" -d . java/*.java
-        COMMAND cp "${PROJECT_SOURCE_DIR}/*.dylib" com/microsoft/ml/lightgbm/osx/x86_64
         COMMAND
-          cp
+          "${CMAKE_COMMAND}"
+          -E
+          copy_if_different
+          "${PROJECT_SOURCE_DIR}/*.dylib"
+          com/microsoft/ml/lightgbm/osx/x86_64
+        COMMAND
+          "${CMAKE_COMMAND}"
+          -E
+          copy_if_different
           "${PROJECT_SOURCE_DIR}/lib_lightgbm_swig.jnilib"
           com/microsoft/ml/lightgbm/osx/x86_64/lib_lightgbm_swig.dylib
         COMMAND "${Java_JAR_EXECUTABLE}" -cf lightgbmlib.jar com
@@ -542,7 +554,12 @@ if(USE_SWIG)
         TARGET _lightgbm_swig
         POST_BUILD
         COMMAND "${Java_JAVAC_EXECUTABLE}" -d . java/*.java
-        COMMAND cp "${PROJECT_SOURCE_DIR}/*.so" com/microsoft/ml/lightgbm/linux/x86_64
+        COMMAND
+          "${CMAKE_COMMAND}"
+          -E
+          copy_if_different
+          "${PROJECT_SOURCE_DIR}/*.so"
+          com/microsoft/ml/lightgbm/linux/x86_64
         COMMAND "${Java_JAR_EXECUTABLE}" -cf lightgbmlib.jar com
     )
   endif()


### PR DESCRIPTION
As described in #5972, the use of `COMMAND cp` in this project's `CMake` code leads to errors when the project is built in environments where `cp` is not available (for example, the Windows `CMD` shell by default).

This proposes replacing all of those uses with `COMMAND cmake -e copy_if_different`, so that `cp` isn't strictly required to build LightGBM.