### PR TITLE
[cmake] [c++] require CMake 3.18+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,6 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.1.0")
     message(FATAL_ERROR "Insufficient AppleClang version")
   endif()
-  cmake_minimum_required(VERSION 3.16)
 elseif(MSVC)
   if(MSVC_VERSION LESS 1900)
     message(
@@ -83,7 +82,6 @@ elseif(MSVC)
       "The compiler ${CMAKE_CXX_COMPILER} doesn't support required C++11 features. Please use a newer MSVC."
     )
   endif()
-  cmake_minimum_required(VERSION 3.8)
 endif()
 
 if(USE_SWIG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,17 +27,7 @@ if(APPLE)
   option(APPLE_OUTPUT_DYLIB "Output dylib shared library" OFF)
 endif()
 
-if(__INTEGRATE_OPENCL)
-  cmake_minimum_required(VERSION 3.11)
-elseif(USE_SWIG)
-  cmake_minimum_required(VERSION 3.8)
-elseif(USE_GPU OR APPLE)
-  cmake_minimum_required(VERSION 3.2)
-elseif(USE_CUDA)
-  cmake_minimum_required(VERSION 3.16)
-else()
-  cmake_minimum_required(VERSION 3.0)
-endif()
+cmake_minimum_required(VERSION 3.18)
 
 project(lightgbm LANGUAGES C CXX)
 

--- a/docs/GPU-Windows.rst
+++ b/docs/GPU-Windows.rst
@@ -279,7 +279,7 @@ Installing CMake requires one download first and then a lot of configuration for
    :target: ./_static/images/screenshot-downloading-cmake.png
    :alt: A screenshot of the binary distributions of C Make for downloading on 64 bit Windows.
 
--  Download `CMake`_ (3.8 or higher)
+-  Download `CMake`_
 
 -  Install CMake
 

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -69,7 +69,7 @@ The ``.exe`` file will be in ``LightGBM-master/windows/x64/Release`` folder.
 From Command Line
 *****************
 
-1. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
+1. Install `Git for Windows`_, `CMake`_ and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
 
 2. Run the following commands:
 
@@ -167,7 +167,7 @@ Install Using ``Homebrew``
 Build from GitHub
 *****************
 
-1. Install `CMake`_ (3.16 or higher):
+1. Install `CMake`_ :
 
    .. code:: sh
 
@@ -193,7 +193,7 @@ Build from GitHub
 gcc
 ^^^
 
-1. Install `CMake`_ (3.2 or higher):
+1. Install `CMake`_ :
 
    .. code:: sh
 
@@ -266,7 +266,7 @@ The ``.exe`` file will be in ``LightGBM-master/windows/x64/Release`` folder.
 From Command Line
 -----------------
 
-1. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
+1. Install `Git for Windows`_, `CMake`_ and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
 
 2. Run the following commands:
 
@@ -331,7 +331,7 @@ Apple Clang
 
 Only **Apple Clang** version 8.1 or higher is supported.
 
-1. Install `CMake`_ (3.16 or higher):
+1. Install `CMake`_ :
 
    .. code:: sh
 
@@ -351,7 +351,7 @@ Only **Apple Clang** version 8.1 or higher is supported.
 gcc
 ***
 
-1. Install `CMake`_ (3.2 or higher):
+1. Install `CMake`_ :
 
    .. code:: sh
 
@@ -414,7 +414,7 @@ From Command Line
 
 1. You need to install `MS MPI`_ first. Both ``msmpisdk.msi`` and ``msmpisetup.exe`` are needed.
 
-2. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
+2. Install `Git for Windows`_, `CMake`_ and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
 
 3. Run the following commands:
 
@@ -465,7 +465,7 @@ Apple Clang
 
 Only **Apple Clang** version 8.1 or higher is supported.
 
-1. Install `CMake`_ (3.16 or higher):
+1. Install `CMake`_ :
 
    .. code:: sh
 
@@ -497,7 +497,7 @@ Only **Apple Clang** version 8.1 or higher is supported.
 gcc
 ***
 
-1. Install `CMake`_ (3.2 or higher):
+1. Install `CMake`_ :
 
    .. code:: sh
 
@@ -547,7 +547,7 @@ The following dependencies should be installed before compilation:
 
    The following Debian packages should provide necessary Boost libraries: ``libboost-dev``, ``libboost-system-dev``, ``libboost-filesystem-dev``.
 
--  **CMake** 3.2 or later.
+-  **CMake**
 
 To build LightGBM GPU version, run the following commands:
 
@@ -575,7 +575,7 @@ If you use **MinGW**, the build procedure is similar to the build on Linux. Refe
 
 Following procedure is for the **MSVC** (Microsoft Visual C++) build.
 
-1. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is installed).
+1. Install `Git for Windows`_, `CMake`_ and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is installed).
 
 2. Install **OpenCL** for Windows. The installation depends on the brand (NVIDIA, AMD, Intel) of your GPU card.
 
@@ -637,7 +637,7 @@ The following dependencies should be installed before compilation:
 
 -  **CUDA** 11.0 or later libraries. Please refer to `this detailed guide`_. Pay great attention to the minimum required versions of host compilers listed in the table from that guide and use only recommended versions of compilers.
 
--  **CMake** 3.16 or later.
+-  **CMake**
 
 To build LightGBM CUDA version, run the following commands:
 
@@ -700,7 +700,7 @@ On Windows a Java wrapper of LightGBM can be built using **Java**, **SWIG**, **C
 VS Build Tools
 **************
 
-1. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
+1. Install `Git for Windows`_, `CMake`_ and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
 
 2. Install `SWIG`_ and **Java** (also make sure that ``JAVA_HOME`` is set properly).
 
@@ -779,7 +779,7 @@ Apple Clang
 
 Only **Apple Clang** version 8.1 or higher is supported.
 
-1. Install `CMake`_ (3.16 or higher):
+1. Install `CMake`_ :
 
    .. code:: sh
 
@@ -805,7 +805,7 @@ Only **Apple Clang** version 8.1 or higher is supported.
 gcc
 ***
 
-1. Install `CMake`_ (3.2 or higher):
+1. Install `CMake`_ :
 
    .. code:: sh
 
@@ -839,7 +839,7 @@ Windows
 
 On Windows, C++ unit tests of LightGBM can be built using **CMake** and **VS Build Tools**.
 
-1. Install `Git for Windows`_, `CMake`_ (3.8 or higher) and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
+1. Install `Git for Windows`_, `CMake`_ and `VS Build Tools`_ (**VS Build Tools** is not needed if **Visual Studio** (2015 or newer) is already installed).
 
 2. Run the following commands:
 
@@ -884,7 +884,7 @@ Apple Clang
 
 Only **Apple Clang** version 8.1 or higher is supported.
 
-1. Install `CMake`_ (3.16 or higher):
+1. Install `CMake`_ :
 
    .. code:: sh
 
@@ -904,7 +904,7 @@ Only **Apple Clang** version 8.1 or higher is supported.
 gcc
 ***
 
-1. Install `CMake`_ (3.2 or higher):
+1. Install `CMake`_ :
 
    .. code:: sh
 

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -63,7 +63,7 @@ build-backend = "scikit_build_core.build"
 # based on https://github.com/scikit-build/scikit-build-core#configuration
 [tool.scikit-build]
 
-cmake.minimum-version = "3.15"
+cmake.minimum-version = "3.18"
 ninja.minimum-version = "1.11"
 ninja.make-fallback = true
 cmake.args = [


### PR DESCRIPTION
Fixes #5642.

Might help with the following:

* #5775
* #5785
* #5955
* #6249
* #6252

Proposes the following:

* moving this project's minimum `CMake` version up to `v3.18`
* removing `CMake` version ranges from docs

### Benefits of this change

This should reduce the risk of build failures with newer compilers, operating systems, architectures.

I'm especially hoping it'll help with M1/M2/M3 macOS support and supporting newer versions of CUDA.

Per the `CMake` docs ([link](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-settings)):

> *The `cmake_minimum_required(VERSION)` command implicitly invokes the [`cmake_policy(VERSION)`](https://cmake.org/cmake/help/latest/command/cmake_policy.html#version) command to specify that the current project code is written for the given range of CMake versions. ... All policies introduced in later versions will be unset. This effectively requests **behavior preferred as of a given CMake version** and tells newer CMake versions to warn about their new policies.*

*(my emphasis)*

So even on systems with newer versions of `CMake` installed, having `cmake_minimum_required(VERSION 3.0)` binds them to how `CMake` behaved as of that release. The last `CMake` 3.x release was 5+ years ago ([v3.0.2](https://github.com/Kitware/CMake/releases/tag/v3.0.2)).

This change resolves this warning currently seen in many of LightGBM's supported platforms:

```text
  CMake Deprecation Warning at CMakeLists.txt:35 (cmake_minimum_required):
    Compatibility with CMake < 3.5 will be removed from a future version of
    CMake.

    Update the VERSION argument <min> value or use a ...<max> suffix to tell
    CMake that the project does not need compatibility with older versions.
```

([example macOS sdist build this was observed on](https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=15640&view=logs&j=382e14e0-e893-5ccd-73ac-68042457c8d8&t=ec0ccacd-3b6a-5b68-6d60-e287382faccd))

### Why `3.18`?

From https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html

> *Your CMake version should be newer than your compiler. It should be newer than the libraries you are using (especially Boost*

And from https://cliutils.gitlab.io/modern-cmake/chapters/intro/dodonot.html

> **What minimum to choose**
>
> - *3.12: C++20*
> - *3.17/3.18: CUDA*
> - *3.19: First to support Apple Silicon*

I'm mainly recommending v3.18 to support the CUDA builds here.

Other evidence it could be ok:

* XGBoost has been using `CMake >= 3.18.0` for about 9 months: https://github.com/dmlc/xgboost/pull/8853
* XGBoost used `CMake >= 3.14.0` for the 3 years prior to that: https://github.com/dmlc/xgboost/pull/7060
* it should be very easy for Windows and macOS users to update to newer versions, via `conda`, `pip`, official binaries from KitWare, and many other options from https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html
* PyPI has `CMake` wheels for a wide range of platforms ([link](https://pypi.org/project/cmake/#files)), and when building the Python package, `scikit-build-core` will automatically get one of those if the local `CMake` version isn't sufficiently new
* the distro-provided `CMake` is v3.22.1 on Ubuntu 22.04 ([link](https://pkgs.org/download/cmake)), so any downstream project building on GitHub Actions `ubuntu-latest` ([GHA docs](https://github.com/actions/runner-images/tree/4b8f0f965c7b328d10ac63e209feb33a4e3676a9#available-images)) will be unaffected