### PR TITLE
[ci] fix conda env creation in 'regular' CI job (fixes #6282)

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set +x
+
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "gcc" ]]; then
     export CXX=g++-11
     export CC=gcc-11
@@ -131,7 +133,7 @@ if [[ $PYTHON_VERSION == "3.7" ]]; then
 fi
 
 # including python=version[build=*cpython] to ensure that conda doesn't fall back to pypy
-mamba create -q -y -n $CONDA_ENV \
+mamba create -v -y -n $CONDA_ENV \
     ${CONSTRAINED_DEPENDENCIES} \
     cffi \
     cloudpickle \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -321,7 +321,7 @@ matplotlib.use\(\"Agg\"\)\
     # importing the library should succeed even if all optional dependencies are not present
     mamba uninstall -n $CONDA_ENV --force --yes \
         cffi \
-        dask \
+        dask-core \
         distributed \
         joblib \
         matplotlib \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -319,7 +319,7 @@ matplotlib.use\(\"Agg\"\)\
     jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb || exit -1  # run all notebooks
 
     # importing the library should succeed even if all optional dependencies are not present
-    mamba uninstall -n $CONDA_ENV --force --yes \
+    conda uninstall -n $CONDA_ENV --force --yes \
         cffi \
         dask-core \
         distributed \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set +x
-
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "gcc" ]]; then
     export CXX=g++-11
     export CC=gcc-11
@@ -133,7 +131,7 @@ if [[ $PYTHON_VERSION == "3.7" ]]; then
 fi
 
 # including python=version[build=*cpython] to ensure that conda doesn't fall back to pypy
-mamba create -v -y -n $CONDA_ENV \
+mamba create -q -y -n $CONDA_ENV \
     ${CONSTRAINED_DEPENDENCIES} \
     cffi \
     cloudpickle \
@@ -321,7 +319,7 @@ matplotlib.use\(\"Agg\"\)\
     jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb || exit -1  # run all notebooks
 
     # importing the library should succeed even if all optional dependencies are not present
-    conda uninstall --force --yes \
+    mamba uninstall -n $CONDA_ENV --force --yes \
         cffi \
         dask \
         distributed \


### PR DESCRIPTION
Fixes #6282

We install a package `dask-core` but then in CI later uninstall one called `dask`. That might not have been caught before because `dask` was being pulled in as a transitive dependency of something else (unsure).

Anyway, now that it isn't, `conda uninstall dask` fails with the error shown in the linked issue.

This resolves it by explicitly uninstalling `dask-core`.