### PR TITLE
[ci] ensure shell script exit codes are in range 0-255

### DIFF
--- a/.ci/append_comment.sh
+++ b/.ci/append_comment.sh
@@ -14,12 +14,12 @@ set -e
 
 if [ -z "$GITHUB_ACTIONS" ]; then
   echo "Must be run inside GitHub Actions CI"
-  exit -1
+  exit 1
 fi
 
 if [ $# -ne 2 ]; then
   echo "Usage: $0 <COMMENT_ID> <BODY>"
-  exit -1
+  exit 1
 fi
 
 comment_id=$1

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -7,14 +7,14 @@ echo "checking Python package distributions in '${DIST_DIR}'"
 pip install \
     -qq \
     check-wheel-contents \
-    twine || exit -1
+    twine || exit 1
 
 echo "twine check..."
-twine check --strict ${DIST_DIR}/* || exit -1
+twine check --strict ${DIST_DIR}/* || exit 1
 
 if { test "${TASK}" = "bdist" || test "${METHOD}" = "wheel"; }; then
     echo "check-wheel-contents..."
-    check-wheel-contents ${DIST_DIR}/*.whl || exit -1
+    check-wheel-contents ${DIST_DIR}/*.whl || exit 1
 fi
 
 PY_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")
@@ -27,7 +27,7 @@ if [ $PY_MINOR_VER -gt 7 ]; then
             --ignore 'compiled-objects-have-debug-symbols,distro-too-large-compressed' \
             --max-allowed-size-uncompressed '100M' \
             --max-allowed-files 800 \
-            ${DIST_DIR}/* || exit -1
+            ${DIST_DIR}/* || exit 1
     elif { test $(uname -m) = "aarch64"; }; then
         pydistcheck \
             --inspect \
@@ -35,14 +35,14 @@ if [ $PY_MINOR_VER -gt 7 ]; then
             --max-allowed-size-compressed '5M' \
             --max-allowed-size-uncompressed '15M' \
             --max-allowed-files 800 \
-            ${DIST_DIR}/* || exit -1
+            ${DIST_DIR}/* || exit 1
     else
         pydistcheck \
             --inspect \
             --max-allowed-size-compressed '5M' \
             --max-allowed-size-uncompressed '15M' \
             --max-allowed-files 800 \
-            ${DIST_DIR}/* || exit -1
+            ${DIST_DIR}/* || exit 1
     fi
 else
     echo "skipping pydistcheck (does not support Python 3.${PY_MINOR_VER})"

--- a/.ci/install-clang-devel.sh
+++ b/.ci/install-clang-devel.sh
@@ -27,6 +27,7 @@ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 # ref: https://apt.llvm.org/
 add-apt-repository -y "deb http://apt.llvm.org/unstable/ llvm-toolchain main"
 add-apt-repository -y "deb-src http://apt.llvm.org/unstable/ llvm-toolchain main"
+apt-get update -y
 
 apt-get install -y --no-install-recommends \
     clang-${CLANG_VERSION} \

--- a/.ci/install-clang-devel.sh
+++ b/.ci/install-clang-devel.sh
@@ -27,7 +27,6 @@ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 # ref: https://apt.llvm.org/
 add-apt-repository -y "deb http://apt.llvm.org/unstable/ llvm-toolchain main"
 add-apt-repository -y "deb-src http://apt.llvm.org/unstable/ llvm-toolchain main"
-apt-get update -y
 
 apt-get install -y --no-install-recommends \
     clang-${CLANG_VERSION} \

--- a/.ci/install_opencl.ps1
+++ b/.ci/install_opencl.ps1
@@ -12,7 +12,7 @@ if (Test-Path "$installer") {
   Write-Output "Unable to download OpenCL platform installer"
   Write-Output "Setting EXIT"
   $host.SetShouldExit(-1)
-  Exit -1
+  exit 1
 }
 
 # Install OpenCL platform from installer executable
@@ -26,7 +26,7 @@ if ($property -eq $null) {
   Get-Content "opencl.log"
   Write-Output "Setting EXIT"
   $host.SetShouldExit(-1)
-  Exit -1
+  exit 1
 } else {
   Write-Output "Successfully installed OpenCL CPU platform"
   Write-Output "Current OpenCL drivers:"

--- a/.ci/lint-cpp.sh
+++ b/.ci/lint-cpp.sh
@@ -4,7 +4,7 @@ echo "running cpplint"
 cpplint \
     --filter=-build/c++11,-build/include_subdir,-build/header_guard,-whitespace/line_length \
     --recursive ./src ./include ./R-package ./swig ./tests \
-|| exit -1
+|| exit 1
 echo "done running cpplint"
 
 echo "running cmakelint"
@@ -16,7 +16,7 @@ cmakelint \
     --linelength=120 \
     --filter=-convention/filename,-package/stdargs,-readability/wonkycase \
     ${cmake_files} \
-|| exit -1
+|| exit 1
 echo "done running cmakelint"
 
 echo "checking that all OpenMP pragmas specify num_threads()"
@@ -39,6 +39,6 @@ if test "${PROBLEMATIC_LINES}" != ""; then
     get_omp_pragmas_without_num_threads
     echo "Found '#pragma omp parallel' not using explicit num_threads() configuration. Fix those."
     echo "For details, see https://www.openmp.org/spec-html/5.0/openmpse14.html#x54-800002.6"
-    exit -1
+    exit 1
 fi
 echo "done checking OpenMP pragmas"

--- a/.ci/lint-python.sh
+++ b/.ci/lint-python.sh
@@ -4,7 +4,7 @@ echo "running ruff"
 ruff check \
     --config=./python-package/pyproject.toml \
     . \
-|| exit -1
+|| exit 1
 echo "done running ruff"
 
 echo "running isort"
@@ -12,7 +12,7 @@ isort \
     --check-only \
     --settings-path=./python-package/pyproject.toml \
     . \
-|| exit -1
+|| exit 1
 echo "done running isort"
 
 echo "running mypy"

--- a/.ci/rerun_workflow.sh
+++ b/.ci/rerun_workflow.sh
@@ -16,12 +16,12 @@ set -e
 
 if [ -z "$GITHUB_ACTIONS" ]; then
   echo "Must be run inside GitHub Actions CI"
-  exit -1
+  exit 1
 fi
 
 if [ $# -ne 3 ]; then
   echo "Usage: $0 <WORKFLOW_ID> <PR_NUMBER> <PR_BRANCH>"
-  exit -1
+  exit 1
 fi
 
 workflow_id=$1

--- a/.ci/set_commit_status.sh
+++ b/.ci/set_commit_status.sh
@@ -18,12 +18,12 @@ set -e
 
 if [ -z "$GITHUB_ACTIONS" ]; then
   echo "Must be run inside GitHub Actions CI"
-  exit -1
+  exit 1
 fi
 
 if [ $# -ne 3 ]; then
   echo "Usage: $0 <NAME> <STATUS> <SHA>"
-  exit -1
+  exit 1
 fi
 
 name=$1

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -4,10 +4,10 @@ if [[ $OS_NAME == "macos" ]]; then
     if  [[ $COMPILER == "clang" ]]; then
         brew install libomp
         if [[ $AZURE == "true" ]]; then
-            sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer || exit -1
+            sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer || exit 1
         fi
     else  # gcc
-        sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer || exit -1
+        sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer || exit 1
         if [[ $TASK != "mpi" ]]; then
             brew install gcc
         fi
@@ -49,7 +49,7 @@ else  # Linux
             locales-all \
             netcat \
             unzip \
-            zip || exit -1
+            zip || exit 1
         if [[ $COMPILER == "clang" ]]; then
             sudo apt-get install --no-install-recommends -y \
                 clang \
@@ -82,7 +82,7 @@ else  # Linux
             sudo yum update -y
             sudo yum install -y \
                 openmpi-devel \
-            || exit -1
+            || exit 1
         fi
     fi
     if [[ $TASK == "gpu" ]]; then
@@ -98,7 +98,7 @@ else  # Linux
                 boost-devel \
                 ocl-icd-devel \
                 opencl-headers \
-            || exit -1
+            || exit 1
         fi
     fi
     if [[ $TASK == "gpu" || $TASK == "bdist" ]]; then
@@ -111,7 +111,7 @@ else  # Linux
             sudo yum install -y \
                 ocl-icd-devel \
                 opencl-headers \
-            || exit -1
+            || exit 1
         fi
     fi
     if [[ $TASK == "cuda" ]]; then

--- a/.ci/test-python-oldest.sh
+++ b/.ci/test-python-oldest.sh
@@ -14,11 +14,11 @@ pip install \
   'pyarrow==6.0.1' \
   'scikit-learn==0.18.2' \
   'scipy==0.19.0' \
-|| exit -1
+|| exit 1
 echo "done installing lightgbm's dependencies"
 
 echo "installing lightgbm"
-pip install --no-deps dist/*.whl || exit -1
+pip install --no-deps dist/*.whl || exit 1
 echo "done installing lightgbm"
 
 echo "installed package versions:"
@@ -31,22 +31,22 @@ echo "checking that examples run without error"
 echo ""
 echo "--- advanced_example.py ---"
 echo ""
-python ./examples/python-guide/advanced_example.py || exit -1
+python ./examples/python-guide/advanced_example.py || exit 1
 
 echo ""
 echo "--- logistic_regression.py ---"
 echo ""
-python ./examples/python-guide/logistic_regression.py || exit -1
+python ./examples/python-guide/logistic_regression.py || exit 1
 
 echo ""
 echo "--- simple_example.py ---"
 echo ""
-python ./examples/python-guide/simple_example.py || exit -1
+python ./examples/python-guide/simple_example.py || exit 1
 
 echo ""
 echo "--- sklearn_example.py ---"
 echo ""
-python ./examples/python-guide/sklearn_example.py || exit -1
+python ./examples/python-guide/sklearn_example.py || exit 1
 
 echo ""
 echo "done testing on oldest supported Python version"

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -17,7 +17,7 @@ if [[ $IN_UBUNTU_BASE_CONTAINER == "true" ]]; then
 fi
 
 if [[ "${TASK}" == "r-package" ]] || [[ "${TASK}" == "r-rchk" ]]; then
-    bash ${BUILD_DIRECTORY}/.ci/test_r_package.sh || exit -1
+    bash ${BUILD_DIRECTORY}/.ci/test_r_package.sh || exit 1
     exit 0
 fi
 
@@ -32,8 +32,8 @@ if [[ "$TASK" == "cpp-tests" ]]; then
         extra_cmake_opts=""
     fi
     cmake -DBUILD_CPP_TEST=ON -DUSE_OPENMP=OFF -DUSE_DEBUG=ON $extra_cmake_opts ..
-    make testlightgbm -j4 || exit -1
-    ./../testlightgbm || exit -1
+    make testlightgbm -j4 || exit 1
+    ./../testlightgbm || exit 1
     exit 0
 fi
 
@@ -42,10 +42,10 @@ CONDA_PYTHON_REQUIREMENT="python=$PYTHON_VERSION[build=*cpython]"
 if [[ $TASK == "if-else" ]]; then
     mamba create -q -y -n $CONDA_ENV ${CONDA_PYTHON_REQUIREMENT} numpy
     source activate $CONDA_ENV
-    mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build && cmake .. && make lightgbm -j4 || exit -1
-    cd $BUILD_DIRECTORY/tests/cpp_tests && ../../lightgbm config=train.conf convert_model_language=cpp convert_model=../../src/boosting/gbdt_prediction.cpp && ../../lightgbm config=predict.conf output_result=origin.pred || exit -1
-    cd $BUILD_DIRECTORY/build && make lightgbm -j4 || exit -1
-    cd $BUILD_DIRECTORY/tests/cpp_tests && ../../lightgbm config=predict.conf output_result=ifelse.pred && python test.py || exit -1
+    mkdir $BUILD_DIRECTORY/build && cd $BUILD_DIRECTORY/build && cmake .. && make lightgbm -j4 || exit 1
+    cd $BUILD_DIRECTORY/tests/cpp_tests && ../../lightgbm config=train.conf convert_model_language=cpp convert_model=../../src/boosting/gbdt_prediction.cpp && ../../lightgbm config=predict.conf output_result=origin.pred || exit 1
+    cd $BUILD_DIRECTORY/build && make lightgbm -j4 || exit 1
+    cd $BUILD_DIRECTORY/tests/cpp_tests && ../../lightgbm config=predict.conf output_result=ifelse.pred && python test.py || exit 1
     exit 0
 fi
 
@@ -56,11 +56,11 @@ if [[ $TASK == "swig" ]]; then
     else
         cmake -DUSE_SWIG=ON ..
     fi
-    make -j4 || exit -1
+    make -j4 || exit 1
     if [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "gcc" ]]; then
-        objdump -T $BUILD_DIRECTORY/lib_lightgbm.so > $BUILD_DIRECTORY/objdump.log || exit -1
-        objdump -T $BUILD_DIRECTORY/lib_lightgbm_swig.so >> $BUILD_DIRECTORY/objdump.log || exit -1
-        python $BUILD_DIRECTORY/helpers/check_dynamic_dependencies.py $BUILD_DIRECTORY/objdump.log || exit -1
+        objdump -T $BUILD_DIRECTORY/lib_lightgbm.so > $BUILD_DIRECTORY/objdump.log || exit 1
+        objdump -T $BUILD_DIRECTORY/lib_lightgbm_swig.so >> $BUILD_DIRECTORY/objdump.log || exit 1
+        python $BUILD_DIRECTORY/helpers/check_dynamic_dependencies.py $BUILD_DIRECTORY/objdump.log || exit 1
     fi
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
         cp $BUILD_DIRECTORY/build/lightgbmlib.jar $BUILD_ARTIFACTSTAGINGDIRECTORY/lightgbmlib_$OS_NAME.jar
@@ -80,11 +80,11 @@ if [[ $TASK == "lint" ]]; then
         ruff
     source activate $CONDA_ENV
     echo "Linting Python code"
-    sh ${BUILD_DIRECTORY}/.ci/lint-python.sh || exit -1
+    sh ${BUILD_DIRECTORY}/.ci/lint-python.sh || exit 1
     echo "Linting R code"
-    Rscript ${BUILD_DIRECTORY}/.ci/lint_r_code.R ${BUILD_DIRECTORY} || exit -1
+    Rscript ${BUILD_DIRECTORY}/.ci/lint_r_code.R ${BUILD_DIRECTORY} || exit 1
     echo "Linting C++ code"
-    sh ${BUILD_DIRECTORY}/.ci/lint-cpp.sh || exit -1
+    sh ${BUILD_DIRECTORY}/.ci/lint-cpp.sh || exit 1
     exit 0
 fi
 
@@ -92,33 +92,33 @@ if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     cd $BUILD_DIRECTORY/docs
     mamba env create \
         -n $CONDA_ENV \
-        --file ./env.yml || exit -1
+        --file ./env.yml || exit 1
     mamba install \
         -q \
         -y \
         -n $CONDA_ENV \
             doxygen \
-            'rstcheck>=6.0.0' || exit -1
+            'rstcheck>=6.0.0' || exit 1
     source activate $CONDA_ENV
     # check reStructuredText formatting
     cd $BUILD_DIRECTORY/python-package
-    rstcheck --report-level warning $(find . -type f -name "*.rst") || exit -1
+    rstcheck --report-level warning $(find . -type f -name "*.rst") || exit 1
     cd $BUILD_DIRECTORY/docs
-    rstcheck --report-level warning --ignore-directives=autoclass,autofunction,autosummary,doxygenfile $(find . -type f -name "*.rst") || exit -1
+    rstcheck --report-level warning --ignore-directives=autoclass,autofunction,autosummary,doxygenfile $(find . -type f -name "*.rst") || exit 1
     # build docs
-    make html || exit -1
+    make html || exit 1
     if [[ $TASK == "check-links" ]]; then
         # check docs for broken links
         pip install --user linkchecker
-        linkchecker --config=.linkcheckerrc ./_build/html/*.html || exit -1
+        linkchecker --config=.linkcheckerrc ./_build/html/*.html || exit 1
         exit 0
     fi
     # check the consistency of parameters' descriptions and other stuff
     cp $BUILD_DIRECTORY/docs/Parameters.rst $BUILD_DIRECTORY/docs/Parameters-backup.rst
     cp $BUILD_DIRECTORY/src/io/config_auto.cpp $BUILD_DIRECTORY/src/io/config_auto-backup.cpp
-    python $BUILD_DIRECTORY/helpers/parameter_generator.py || exit -1
-    diff $BUILD_DIRECTORY/docs/Parameters-backup.rst $BUILD_DIRECTORY/docs/Parameters.rst || exit -1
-    diff $BUILD_DIRECTORY/src/io/config_auto-backup.cpp $BUILD_DIRECTORY/src/io/config_auto.cpp || exit -1
+    python $BUILD_DIRECTORY/helpers/parameter_generator.py || exit 1
+    diff $BUILD_DIRECTORY/docs/Parameters-backup.rst $BUILD_DIRECTORY/docs/Parameters.rst || exit 1
+    diff $BUILD_DIRECTORY/src/io/config_auto-backup.cpp $BUILD_DIRECTORY/src/io/config_auto.cpp || exit 1
     exit 0
 fi
 
@@ -144,7 +144,7 @@ mamba create -q -y -n $CONDA_ENV \
     ${CONDA_PYTHON_REQUIREMENT} \
     python-graphviz \
     scikit-learn \
-    scipy || exit -1
+    scipy || exit 1
 
 source activate $CONDA_ENV
 
@@ -152,30 +152,30 @@ cd $BUILD_DIRECTORY
 
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     # fix "OMP: Error #15: Initializing libiomp5.dylib, but found libomp.dylib already initialized." (OpenMP library conflict due to conda's MKL)
-    for LIBOMP_ALIAS in libgomp.dylib libiomp5.dylib libomp.dylib; do sudo ln -sf "$(brew --cellar libomp)"/*/lib/libomp.dylib $CONDA_PREFIX/lib/$LIBOMP_ALIAS || exit -1; done
+    for LIBOMP_ALIAS in libgomp.dylib libiomp5.dylib libomp.dylib; do sudo ln -sf "$(brew --cellar libomp)"/*/lib/libomp.dylib $CONDA_PREFIX/lib/$LIBOMP_ALIAS || exit 1; done
 fi
 
 if [[ $TASK == "sdist" ]]; then
-    cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit -1
-    sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
-    pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz -v || exit -1
+    cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit 1
+    sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit 1
+    pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz -v || exit 1
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
-        cp $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz $BUILD_ARTIFACTSTAGINGDIRECTORY || exit -1
+        cp $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz $BUILD_ARTIFACTSTAGINGDIRECTORY || exit 1
     fi
-    pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
+    pytest $BUILD_DIRECTORY/tests/python_package_test || exit 1
     exit 0
 elif [[ $TASK == "bdist" ]]; then
     if [[ $OS_NAME == "macos" ]]; then
-        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel || exit 1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit 1
         mv \
             ./dist/*.whl \
-            ./dist/tmp.whl || exit -1
+            ./dist/tmp.whl || exit 1
         mv \
             ./dist/tmp.whl \
-            dist/lightgbm-$LGB_VER-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl || exit -1
+            dist/lightgbm-$LGB_VER-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl || exit 1
         if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
-            cp dist/lightgbm-$LGB_VER-py3-none-macosx*.whl $BUILD_ARTIFACTSTAGINGDIRECTORY || exit -1
+            cp dist/lightgbm-$LGB_VER-py3-none-macosx*.whl $BUILD_ARTIFACTSTAGINGDIRECTORY || exit 1
         fi
     else
         ARCH=$(uname -m)
@@ -184,44 +184,44 @@ elif [[ $TASK == "bdist" ]]; then
         else
             PLATFORM="manylinux2014_$ARCH"
         fi
-        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --integrated-opencl || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --integrated-opencl || exit 1
         mv \
             ./dist/*.whl \
-            ./dist/tmp.whl || exit -1
+            ./dist/tmp.whl || exit 1
         mv \
             ./dist/tmp.whl \
-            ./dist/lightgbm-$LGB_VER-py3-none-$PLATFORM.whl || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+            ./dist/lightgbm-$LGB_VER-py3-none-$PLATFORM.whl || exit 1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit 1
         if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
-            cp dist/lightgbm-$LGB_VER-py3-none-$PLATFORM.whl $BUILD_ARTIFACTSTAGINGDIRECTORY || exit -1
+            cp dist/lightgbm-$LGB_VER-py3-none-$PLATFORM.whl $BUILD_ARTIFACTSTAGINGDIRECTORY || exit 1
         fi
         # Make sure we can do both CPU and GPU; see tests/python_package_test/test_dual.py
         export LIGHTGBM_TEST_DUAL_CPU_GPU=1
     fi
-    pip install --user $BUILD_DIRECTORY/dist/*.whl || exit -1
-    pytest $BUILD_DIRECTORY/tests || exit -1
+    pip install --user $BUILD_DIRECTORY/dist/*.whl || exit 1
+    pytest $BUILD_DIRECTORY/tests || exit 1
     exit 0
 fi
 
 if [[ $TASK == "gpu" ]]; then
     sed -i'.bak' 's/std::string device_type = "cpu";/std::string device_type = "gpu";/' $BUILD_DIRECTORY/include/LightGBM/config.h
-    grep -q 'std::string device_type = "gpu"' $BUILD_DIRECTORY/include/LightGBM/config.h || exit -1  # make sure that changes were really done
+    grep -q 'std::string device_type = "gpu"' $BUILD_DIRECTORY/include/LightGBM/config.h || exit 1  # make sure that changes were really done
     if [[ $METHOD == "pip" ]]; then
-        cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit 1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit 1
         pip install \
             --user \
             -v \
             --config-settings=cmake.define.USE_GPU=ON \
             $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz \
-        || exit -1
-        pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
+        || exit 1
+        pytest $BUILD_DIRECTORY/tests/python_package_test || exit 1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
-        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --gpu || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
-        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER*.whl -v || exit -1
-        pytest $BUILD_DIRECTORY/tests || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --gpu || exit 1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit 1
+        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER*.whl -v || exit 1
+        pytest $BUILD_DIRECTORY/tests || exit 1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         mkdir $BUILD_DIRECTORY/build
@@ -230,26 +230,26 @@ if [[ $TASK == "gpu" ]]; then
     fi
 elif [[ $TASK == "cuda" ]]; then
     sed -i'.bak' 's/std::string device_type = "cpu";/std::string device_type = "cuda";/' $BUILD_DIRECTORY/include/LightGBM/config.h
-    grep -q 'std::string device_type = "cuda"' $BUILD_DIRECTORY/include/LightGBM/config.h || exit -1  # make sure that changes were really done
+    grep -q 'std::string device_type = "cuda"' $BUILD_DIRECTORY/include/LightGBM/config.h || exit 1  # make sure that changes were really done
     # by default ``gpu_use_dp=false`` for efficiency. change to ``true`` here for exact results in ci tests
     sed -i'.bak' 's/gpu_use_dp = false;/gpu_use_dp = true;/' $BUILD_DIRECTORY/include/LightGBM/config.h
-    grep -q 'gpu_use_dp = true' $BUILD_DIRECTORY/include/LightGBM/config.h || exit -1  # make sure that changes were really done
+    grep -q 'gpu_use_dp = true' $BUILD_DIRECTORY/include/LightGBM/config.h || exit 1  # make sure that changes were really done
     if [[ $METHOD == "pip" ]]; then
-        cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit 1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit 1
         pip install \
             --user \
             -v \
             --config-settings=cmake.define.USE_CUDA=ON \
             $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz \
-        || exit -1
-        pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
+        || exit 1
+        pytest $BUILD_DIRECTORY/tests/python_package_test || exit 1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
-        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --cuda || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
-        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER*.whl -v || exit -1
-        pytest $BUILD_DIRECTORY/tests || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --cuda || exit 1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit 1
+        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER*.whl -v || exit 1
+        pytest $BUILD_DIRECTORY/tests || exit 1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         mkdir $BUILD_DIRECTORY/build
@@ -258,21 +258,21 @@ elif [[ $TASK == "cuda" ]]; then
     fi
 elif [[ $TASK == "mpi" ]]; then
     if [[ $METHOD == "pip" ]]; then
-        cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit 1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit 1
         pip install \
             --user \
             -v \
             --config-settings=cmake.define.USE_MPI=ON \
             $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz \
-        || exit -1
-        pytest $BUILD_DIRECTORY/tests/python_package_test || exit -1
+        || exit 1
+        pytest $BUILD_DIRECTORY/tests/python_package_test || exit 1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
-        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --mpi || exit -1
-        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit -1
-        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER*.whl -v || exit -1
-        pytest $BUILD_DIRECTORY/tests || exit -1
+        cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --mpi || exit 1
+        sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit 1
+        pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER*.whl -v || exit 1
+        pytest $BUILD_DIRECTORY/tests || exit 1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         mkdir $BUILD_DIRECTORY/build
@@ -285,10 +285,10 @@ else
     cmake ..
 fi
 
-make _lightgbm -j4 || exit -1
+make _lightgbm -j4 || exit 1
 
-cd $BUILD_DIRECTORY && sh ./build-python.sh install --precompile --user || exit -1
-pytest $BUILD_DIRECTORY/tests || exit -1
+cd $BUILD_DIRECTORY && sh ./build-python.sh install --precompile --user || exit 1
+pytest $BUILD_DIRECTORY/tests || exit 1
 
 if [[ $TASK == "regular" ]]; then
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
@@ -296,8 +296,8 @@ if [[ $TASK == "regular" ]]; then
             cp $BUILD_DIRECTORY/lib_lightgbm.so $BUILD_ARTIFACTSTAGINGDIRECTORY/lib_lightgbm.dylib
         else
             if [[ $COMPILER == "gcc" ]]; then
-                objdump -T $BUILD_DIRECTORY/lib_lightgbm.so > $BUILD_DIRECTORY/objdump.log || exit -1
-                python $BUILD_DIRECTORY/helpers/check_dynamic_dependencies.py $BUILD_DIRECTORY/objdump.log || exit -1
+                objdump -T $BUILD_DIRECTORY/lib_lightgbm.so > $BUILD_DIRECTORY/objdump.log || exit 1
+                python $BUILD_DIRECTORY/helpers/check_dynamic_dependencies.py $BUILD_DIRECTORY/objdump.log || exit 1
             fi
             cp $BUILD_DIRECTORY/lib_lightgbm.so $BUILD_ARTIFACTSTAGINGDIRECTORY/lib_lightgbm.so
         fi
@@ -313,10 +313,10 @@ matplotlib.use\(\"Agg\"\)\
         h5py \
         ipywidgets \
         notebook
-    for f in *.py **/*.py; do python $f || exit -1; done  # run all examples
+    for f in *.py **/*.py; do python $f || exit 1; done  # run all examples
     cd $BUILD_DIRECTORY/examples/python-guide/notebooks
     sed -i'.bak' 's/INTERACTIVE = False/assert False, \\"Interactive mode disabled\\"/' interactive_plot_example.ipynb
-    jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb || exit -1  # run all notebooks
+    jupyter nbconvert --ExecutePreprocessor.timeout=180 --to notebook --execute --inplace *.ipynb || exit 1  # run all notebooks
 
     # importing the library should succeed even if all optional dependencies are not present
     conda uninstall -n $CONDA_ENV --force --yes \
@@ -328,6 +328,6 @@ matplotlib.use\(\"Agg\"\)\
         psutil \
         pyarrow \
         python-graphviz \
-        scikit-learn || exit -1
-    python -c "import lightgbm" || exit -1
+        scikit-learn || exit 1
+    python -c "import lightgbm" || exit 1
 fi

--- a/.ci/test_r_package_valgrind.sh
+++ b/.ci/test_r_package_valgrind.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-RDscriptvalgrind -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com')" || exit -1
+RDscriptvalgrind -e "install.packages(c('R6', 'data.table', 'jsonlite', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com')" || exit 1
 sh build-cran-package.sh \
   --r-executable=RDvalgrind \
   --no-build-vignettes \
-  || exit -1
+  || exit 1
 
-RDvalgrind CMD INSTALL --preclean --install-tests lightgbm_*.tar.gz || exit -1
+RDvalgrind CMD INSTALL --preclean --install-tests lightgbm_*.tar.gz || exit 1
 
 cd R-package/tests
 
@@ -18,7 +18,7 @@ RDvalgrind \
   --vanilla \
   -d "valgrind --tool=memcheck --leak-check=full --track-origins=yes" \
   -f testthat.R \
-  > ${ALL_LOGS_FILE} 2>&1 || exit -1
+  > ${ALL_LOGS_FILE} 2>&1 || exit 1
 
 cat ${ALL_LOGS_FILE}
 
@@ -33,7 +33,7 @@ bytes_definitely_lost=$(
 )
 echo "valgrind found ${bytes_definitely_lost} bytes definitely lost"
 if [[ ${bytes_definitely_lost} -gt 0 ]]; then
-    exit -1
+    exit 1
 fi
 
 bytes_indirectly_lost=$(
@@ -44,7 +44,7 @@ bytes_indirectly_lost=$(
 )
 echo "valgrind found ${bytes_indirectly_lost} bytes indirectly lost"
 if [[ ${bytes_indirectly_lost} -gt 0 ]]; then
-    exit -1
+    exit 1
 fi
 
 # one error caused by a false positive between valgrind and openmp is allowed
@@ -71,7 +71,7 @@ bytes_possibly_lost=$(
 )
 echo "valgrind found ${bytes_possibly_lost} bytes possibly lost"
 if [[ ${bytes_possibly_lost} -gt 1056 ]]; then
-    exit -1
+    exit 1
 fi
 
 invalid_reads=$(
@@ -80,7 +80,7 @@ invalid_reads=$(
 )
 if [[ ${invalid_reads} -gt 0 ]]; then
     echo "valgrind found invalid reads: ${invalid_reads}"
-    exit -1
+    exit 1
 fi
 
 invalid_writes=$(
@@ -89,5 +89,5 @@ invalid_writes=$(
 )
 if [[ ${invalid_writes} -gt 0 ]]; then
     echo "valgrind found invalid writes: ${invalid_writes}"
-    exit -1
+    exit 1
 fi

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -2,7 +2,7 @@ function Check-Output {
   param( [bool]$success )
   if (!$success) {
     $host.SetShouldExit(-1)
-    Exit -1
+    exit 1
   }
 }
 

--- a/.ci/trigger_dispatch_run.sh
+++ b/.ci/trigger_dispatch_run.sh
@@ -16,12 +16,12 @@ set -e
 
 if [ -z "$GITHUB_ACTIONS" ]; then
   echo "Must be run inside GitHub Actions CI"
-  exit -1
+  exit 1
 fi
 
 if [ $# -ne 3 ]; then
   echo "Usage: $0 <PR_URL> <COMMENT_ID> <DISPATCH_NAME>"
-  exit -1
+  exit 1
 fi
 
 pr_url=$1

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -92,8 +92,8 @@ jobs:
             export CONDA=\$HOME/miniforge
             export PATH=\$CONDA/bin:\$PATH
             nvidia-smi
-            $ROOT_DOCKER_FOLDER/.ci/setup.sh || exit -1
-            $ROOT_DOCKER_FOLDER/.ci/test.sh || exit -1
+            $ROOT_DOCKER_FOLDER/.ci/setup.sh || exit 1
+            $ROOT_DOCKER_FOLDER/.ci/test.sh || exit 1
             EOF
             cuda_version="${{ matrix.cuda_version }}"
             cuda_major=${cuda_version%%.*}

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -29,5 +29,5 @@ jobs:
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           export CONDA=${HOME}/miniforge
           export PATH=${CONDA}/bin:${HOME}/.local/bin:${PATH}
-          $GITHUB_WORKSPACE/.ci/setup.sh || exit -1
-          $GITHUB_WORKSPACE/.ci/test.sh || exit -1
+          $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
+          $GITHUB_WORKSPACE/.ci/test.sh || exit 1

--- a/.github/workflows/optional_checks.yml
+++ b/.github/workflows/optional_checks.yml
@@ -26,5 +26,5 @@ jobs:
                 trigger_phrase=${i#*;}
                 python "$GITHUB_WORKSPACE/.ci/get_workflow_status.py" "$trigger_phrase" \
                 || { echo "The last reported status from workflow \"$workflow_name\" is failure. Commit fixes and rerun the workflow."; \
-                exit -1; }
+                exit 1; }
             done

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -74,8 +74,8 @@ jobs:
           export LGB_VER=$(head -n 1 VERSION.txt)
           export CONDA=${HOME}/miniforge
           export PATH=${CONDA}/bin:${PATH}
-          $GITHUB_WORKSPACE/.ci/setup.sh || exit -1
-          $GITHUB_WORKSPACE/.ci/test.sh || exit -1
+          $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
+          $GITHUB_WORKSPACE/.ci/test.sh || exit 1
   test-oldest-versions:
     name: Python - oldest supported versions (ubuntu-latest)
     runs-on: ubuntu-latest

--- a/.github/workflows/r_configure.yml
+++ b/.github/workflows/r_configure.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: true
       - name: Update configure
         shell: bash
-        run: ./R-package/recreate-configure.sh || exit -1
+        run: ./R-package/recreate-configure.sh || exit 1
       - name: Push changes
         run: |
           git config --global user.name "GitHub Actions Bot"

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           RDscript${{ matrix.r_customization }} -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
           sh build-cran-package.sh --r-executable=RD${{ matrix.r_customization }}
-          RD${{ matrix.r_customization }} CMD INSTALL lightgbm_*.tar.gz || exit -1
+          RD${{ matrix.r_customization }} CMD INSTALL lightgbm_*.tar.gz || exit 1
       - name: Run tests with sanitizers
         shell: bash
         run: |
@@ -303,7 +303,7 @@ jobs:
           export PATH=/opt/R-devel/bin/:${PATH}
           Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
           sh build-cran-package.sh
-          R CMD check --as-cran --run-donttest lightgbm_*.tar.gz || exit -1
+          R CMD check --as-cran --run-donttest lightgbm_*.tar.gz || exit 1
           echo ""
           echo "install logs:"
           echo ""
@@ -311,7 +311,7 @@ jobs:
           echo ""
           if grep -q -E "NOTE|WARNING|ERROR" lightgbm.Rcheck/00check.log; then
               echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
-              exit -1
+              exit 1
           fi
   all-r-package-jobs-successful:
     if: always()

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -47,8 +47,8 @@ jobs:
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           export CONDA=${HOME}/miniforge
           export PATH=${CONDA}/bin:$HOME/.local/bin:${PATH}
-          $GITHUB_WORKSPACE/.ci/setup.sh || exit -1
-          $GITHUB_WORKSPACE/.ci/test.sh || exit -1
+          $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
+          $GITHUB_WORKSPACE/.ci/test.sh || exit 1
   r-check-docs:
     name: r-package-check-docs
     timeout-minutes: 60
@@ -67,12 +67,12 @@ jobs:
         shell: bash
         run: |
           Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'roxygen2', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
-          sh build-cran-package.sh || exit -1
-          R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit -1
+          sh build-cran-package.sh || exit 1
+          R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit 1
       - name: Test documentation
         shell: bash --noprofile --norc {0}
         run: |
-          Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit -1
+          Rscript --vanilla -e "roxygen2::roxygenize('R-package/', load = 'installed')" || exit 1
           num_doc_files_changed=$(
               git diff --name-only | grep --count -E "\.Rd|NAMESPACE"
           )
@@ -83,7 +83,7 @@ jobs:
               echo "    R CMD INSTALL --with-keep.source lightgbm_*.tar.gz"
               echo "    Rscript -e \"roxygen2::roxygenize('R-package/', load = 'installed')\""
               echo ""
-              exit -1
+              exit 1
           fi
   all-static-analysis-jobs-successful:
     if: always()

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -189,12 +189,12 @@ jobs:
       export CONDA=\$HOME/miniforge
       export PATH=\$CONDA/bin:/opt/rh/llvm-toolset-7.0/root/usr/bin:\$PATH
       export LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:\$LD_LIBRARY_PATH
-      $ROOT_DOCKER_FOLDER/.ci/setup.sh || exit -1
-      $ROOT_DOCKER_FOLDER/.ci/test.sh || exit -1
+      $ROOT_DOCKER_FOLDER/.ci/setup.sh || exit 1
+      $ROOT_DOCKER_FOLDER/.ci/test.sh || exit 1
       EOF
       IMAGE_URI="lightgbm/vsts-agent:manylinux2014_aarch64"
-      docker pull "${IMAGE_URI}" || exit -1
-      PLATFORM=$(docker inspect --format='{{.Os}}/{{.Architecture}}' "${IMAGE_URI}") || exit -1
+      docker pull "${IMAGE_URI}" || exit 1
+      PLATFORM=$(docker inspect --format='{{.Os}}/{{.Architecture}}' "${IMAGE_URI}") || exit 1
       echo "detected image platform: ${PLATFORM}"
       docker run \
         --platform "${PLATFORM}" \
@@ -309,8 +309,8 @@ jobs:
       R_LIB_PATH=~/Rlib
       export R_LIBS=${R_LIB_PATH}
       mkdir -p ${R_LIB_PATH}
-      RDscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl'),  lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())" || exit -1
-      sh build-cran-package.sh --r-executable=RD || exit -1
+      RDscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl'),  lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())" || exit 1
+      sh build-cran-package.sh --r-executable=RD || exit 1
       mv lightgbm_${LGB_VER}.tar.gz $(Build.ArtifactStagingDirectory)/lightgbm-${LGB_VER}-r-cran.tar.gz
     displayName: 'Build CRAN R-package'
   - task: PublishBuildArtifacts@1

--- a/R-package/recreate-configure.sh
+++ b/R-package/recreate-configure.sh
@@ -28,7 +28,7 @@ sed -i.bak -e "s/~~VERSION~~/${LGB_VERSION}/" ${TMP_CONFIGURE_AC}
 autoconf \
     --output configure \
     ${TMP_CONFIGURE_AC} \
-    || exit -1
+    || exit 1
 
 rm ${TMP_CONFIGURE_AC}
 

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -43,7 +43,7 @@ while [ $# -gt 0 ]; do
       ;;
     *)
       echo "invalid argument '${1}'"
-      exit -1
+      exit 1
       ;;
   esac
   shift

--- a/build-python.sh
+++ b/build-python.sh
@@ -180,7 +180,7 @@ while [ $# -gt 0 ]; do
         ;;
     *)
         echo "invalid argument '${1}'"
-        exit -1
+        exit 1
         ;;
   esac
   shift

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -16,9 +16,9 @@ conda update -q -y conda
 
 conda env create \
     --name docs-env \
-    --file env.yml || exit -1
+    --file env.yml || exit 1
 
 source activate docs-env
-make clean html || exit -1
+make clean html || exit 1
 
 echo "Done building docs. Open docs/_build/html/index.html in a web browser to view them."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -270,13 +270,13 @@ def generate_r_docs(app: Sphinx) -> None:
     export TAR=/bin/tar
     cd {CURR_PATH.parent}
     export R_LIBS="$CONDA_PREFIX/lib/R/library"
-    sh build-cran-package.sh || exit -1
-    R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit -1
+    sh build-cran-package.sh || exit 1
+    R CMD INSTALL --with-keep.source lightgbm_*.tar.gz || exit 1
     cp -R \
         {CURR_PATH.parent / "R-package" / "pkgdown"} \
         {CURR_PATH.parent / "lightgbm_r" / "pkgdown"}
     cd {CURR_PATH.parent / "lightgbm_r"}
-    Rscript -e "roxygen2::roxygenize(load = 'installed')" || exit -1
+    Rscript -e "roxygen2::roxygenize(load = 'installed')" || exit 1
     Rscript -e "pkgdown::build_site( \
             lazy = FALSE \
             , install = FALSE \
@@ -287,7 +287,7 @@ def generate_r_docs(app: Sphinx) -> None:
             , preview = FALSE \
             , new_process = TRUE \
         )
-        " || exit -1
+        " || exit 1
     cd {CURR_PATH.parent}
     """
     try:


### PR DESCRIPTION
This PR proposes replacing uses of `exit -1` in shell scripts with `exit 1`.

### Benefits of this change

Removes reliance on shells correctly handling `exit -1` (which is technically not recommended by e.g. `bash`) in the project's scripts.

### Notes for Reviewers

From the `bash` docs ([link](https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html))

> *Exit statuses fall between 0 and 255*

And from the `shellcheck` docs ([SC2242](https://www.shellcheck.net/wiki/SC2242)) 

> Note in particular that exit -1 is equivalent to exit 255, but that exit 1 is the more canonical way of expressing the first possible error code.

This change resolves the following error from `shellcheck`:

```text
SC2242 (error): Can only exit with status 0-255. Other data should be written to stdout/stderr.
```