### PR TITLE
[ci] fix installation of clang-18 (fixes #6306)

### DIFF
--- a/.ci/install-clang-devel.sh
+++ b/.ci/install-clang-devel.sh
@@ -27,6 +27,9 @@ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 # ref: https://apt.llvm.org/
 add-apt-repository -y "deb http://apt.llvm.org/unstable/ llvm-toolchain main"
 add-apt-repository -y "deb-src http://apt.llvm.org/unstable/ llvm-toolchain main"
+add-apt-repository -y "deb http://apt.llvm.org/unstable/ llvm-toolchain-${CLANG_VERSION} main" || true
+add-apt-repository -y "deb-src http://apt.llvm.org/unstable/ llvm-toolchain-${CLANG_VERSION} main" || true
+apt-get update -y
 
 apt-get install -y --no-install-recommends \
     clang-${CLANG_VERSION} \


### PR DESCRIPTION
Fixes #6306

These modifications are based on the "Debian" section at https://apt.llvm.org/.