### PR TITLE
[ci] fix no-response permissions

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,5 +1,9 @@
 name: No Response Bot
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -10,6 +10,8 @@ on:
   schedule:
     # "every day at 04:00 UTC"
     - cron: '0 4 * * *'
+  # Run manually by clicking a button in the UI
+  workflow_dispatch:
 
 jobs:
   noResponse:


### PR DESCRIPTION
Contributes to #6313

### How to test this

I think we'll have to merge this PR to test, since `workflow_dispatch` (the thing that lets you click a button and run it from an arbitrary branch) isn't set up for this workflow.

In this PR, I'm also proposing adding a `workflow_dispatch` trigger, so we can do that type of testing in the future if needed.

### Notes for Reviewers

Looks like the lock-bot config already uses this:

https://github.com/microsoft/LightGBM/blob/6330d6269c81dfd4c96e664b99239b8ff39ccf91/.github/workflows/lock.yml#L10-L12

And it shouldn't affect triggering-comments stuff like the `valgrind` checks, as those use a different secret:

https://github.com/microsoft/LightGBM/blob/6330d6269c81dfd4c96e664b99239b8ff39ccf91/.github/workflows/triggering_comments.yml#L11-L12