### PR TITLE
[ci] remove workflow_dispatch from no-response configuration

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -10,8 +10,6 @@ on:
   schedule:
     # "every day at 04:00 UTC"
     - cron: '0 4 * * *'
-  # Run manually by clicking a button in the UI
-  workflow_dispatch:
 
 jobs:
   noResponse:


### PR DESCRIPTION
I just learned that GitHub Action `lee-dohm/no-response` doesn't support `workflow_dispatch` events: https://github.com/microsoft/LightGBM/issues/6313#issuecomment-1953111798

This reverts that addition from #6323.