### PR TITLE
WIP: [ci] remove unnecessary workarounds in R-package macOS jobs

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -96,29 +96,6 @@ if [[ $OS_NAME == "macos" ]]; then
     sudo installer \
         -pkg $(pwd)/R.pkg \
         -target / || exit 1
-
-    # Older R versions (<= 4.1.2) on newer macOS (>= 11.0.0) cannot create the necessary symlinks.
-    # See https://github.com/r-lib/actions/issues/412.
-    if [[ $(sw_vers -productVersion | head -c2) -ge "11" ]]; then
-        sudo ln \
-            -sf \
-            /Library/Frameworks/R.framework/Resources/bin/R \
-            /usr/local/bin/R
-        sudo ln \
-            -sf \
-            /Library/Frameworks/R.framework/Resources/bin/Rscript \
-            /usr/local/bin/Rscript
-    fi
-
-    # Fix "duplicate libomp versions" issue on Mac
-    # by replacing the R libomp.dylib with a symlink to the one installed with brew
-    if [[ $COMPILER == "clang" ]]; then
-        ver_arr=( ${R_MAC_VERSION//./ } )
-        R_MAJOR_MINOR="${ver_arr[0]}.${ver_arr[1]}"
-        sudo ln -sf \
-            "$(brew --cellar libomp)"/*/lib/libomp.dylib \
-            /Library/Frameworks/R.framework/Versions/${R_MAJOR_MINOR}/Resources/lib/libomp.dylib
-    fi
 fi
 
 # fix for issue where CRAN was not returning {lattice} when using R 3.6


### PR DESCRIPTION
In #6266, I'm working on making this project's shell scripts stricter, so they exit with a non-0 exit code the first time anything goes wrong (e.g. some variable they require isn't set or somme command they run fails).

This revealed that 2 workarounds in `.ci/test_r_package.sh` that are no longer necessary:

* symlinking `R` to `/usr/local/bin/R` (added in #4989)
* ensuring the R's `libomp.dylib` and Homebrew's `libomp.dylib` don't conflict with each other (added in #2530)

Those have both been unnecessary and not working for a while, as can be seen by messages like this in CI:

```text
ln: /Library/Frameworks/R.framework/Versions/4.3/Resources/lib/libomp.dylib: No such file or directory
```

([link to recent build from master](https://github.com/microsoft/LightGBM/actions/runs/7966544907/job/21747975478))

This removes those workarounds, simplifying the testing setup a bit.