### PR TITLE
[python-package] fix mypy error about pyarrow data

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -76,6 +76,7 @@ if [[ $TASK == "lint" ]]; then
         cpplint \
         mypy \
         'pre-commit>=3.6.0' \
+        'pyarrow>=14.0'
         'r-lintr>=3.1'
     source activate $CONDA_ENV
     echo "Linting Python code"

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -76,7 +76,7 @@ if [[ $TASK == "lint" ]]; then
         cpplint \
         mypy \
         'pre-commit>=3.6.0' \
-        'pyarrow>=14.0'
+        'pyarrow>=14.0' \
         'r-lintr>=3.1'
     source activate $CONDA_ENV
     echo "Linting Python code"

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -364,7 +364,7 @@ def _is_2d_collection(data: Any) -> bool:
     )
 
 
-def _is_pyarrow_array(data: Any) -> bool:
+def _is_pyarrow_array(data: Any) -> "TypeGuard[Union[pa_Array, pa_ChunkedArray]]":
     """Check whether data is a PyArrow array."""
     return isinstance(data, (pa_Array, pa_ChunkedArray))
 


### PR DESCRIPTION
Contributes to #3756.
Contributes to #3867.

Fixes the following error from `mypy`:

```text
python-package/lightgbm/basic.py:2889: error: Incompatible types in assignment (expression has type "list[float] | list[int] | ndarray[Any, Any] | Any | Any | Any | Any | None", variable has type "ndarray[Any, dtype[Any]]")  [assignment]
```

### Notes for Reviewers

For more details on how `typing.TypeGuard` helps with this, see #6106.