### PR TITLE
[python-package] remove unused type alias

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -262,7 +262,6 @@ else:
 
 
 _NUMERIC_TYPES = (int, float, bool)
-_ArrayLike = Union[List, np.ndarray, pd_Series]
 
 
 def _safe_call(ret: int) -> None:


### PR DESCRIPTION
Contributes to #3756

Not sure when this happened, but type alias `basic._ArrayLike` is no longer used anywhere in the library.

```shell
git grep _ArrayLike
```

This proposes removing it.