### PR TITLE
[c++] remove unnecessary include in CLI

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,9 @@
 
 #include <iostream>
 
-#include "network/linkers.h"
+#ifdef USE_MPI
+  #include "network/linkers.h"
+#endif
 
 int main(int argc, char** argv) {
   bool success = false;


### PR DESCRIPTION
The CLI's main implementation file, `src/main.cpp`, only needs `LightGBM::Linkers` methods when compiled for use with MPI (`-DUSE_MPI`).

This proposes guarding the relevant includes with `#ifdef USE_MPI`, to make compilation a little faster for non-MPI use cases.