### PR TITLE
[ci] ignore ruff-format changes in git blame (fixes #6304)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# introduce ruff-format (#6308)
+6330d6269c81dfd4c96e664b99239b8ff39ccf91
+# enable ruff format on tests and examples (#6317)
+1b792e716682254c33ddb5eb845357e84018636d
+# enable ruff-format on main library Python code (#6336)
+dd31208ab7a7aea86762830697b00666f843ded9


### PR DESCRIPTION
Fixes #6304.

Adds the recent `ruff-format` commits to a `.git-blame-ignore-revs` file, so those changes that touched a LOT of lines are ignored in the `git blame`.

For details on that, see https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

### How I tested this

Look at the blame view on this branch: https://github.com/microsoft/LightGBM/blame/git-blame-ignore/python-package/lightgbm/basic.py.

<img width="791" alt="Screen Shot 2024-02-27 at 10 03 17 PM" src="https://github.com/microsoft/LightGBM/assets/7608904/b7ff81bf-294a-466c-bf63-e893a390ae60">

Scrolled through there and did not see any of the formatting changes in the blame.