### PR TITLE
[ci] [docs] update some docs and CI dependencies

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -72,9 +72,9 @@ if [[ $TASK == "lint" ]]; then
     cd ${BUILD_DIRECTORY}
     mamba create -q -y -n $CONDA_ENV \
         ${CONDA_PYTHON_REQUIREMENT} \
-        cmakelint \
-        cpplint \
-        mypy \
+        'cmakelint>=1.4.2' \
+        'cpplint>=1.6.0' \
+        'mypy>=1.8.0' \
         'pre-commit>=3.6.0' \
         'pyarrow>=14.0' \
         'r-lintr>=3.1'
@@ -97,8 +97,8 @@ if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
         -q \
         -y \
         -n $CONDA_ENV \
-            doxygen \
-            'rstcheck>=6.0.0' || exit 1
+            'doxygen>=1.10.0' \
+            'rstcheck>=6.2.0' || exit 1
     source activate $CONDA_ENV
     # check reStructuredText formatting
     cd $BUILD_DIRECTORY/python-package

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -3,7 +3,7 @@ channels:
   - nodefaults
   - conda-forge
 dependencies:
-  - breathe=4.35
+  - breathe
   - python=3.11
   - r-base=4.3.2
   - r-data.table=1.14.10

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - breathe>=4.35
-  - python=3.11
+  - python=3.10
   - r-base=4.3.2
   - r-data.table=1.14.10
   - r-jsonlite=1.8.8

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -3,16 +3,16 @@ channels:
   - nodefaults
   - conda-forge
 dependencies:
-  - breathe
-  - python=3.9
-  - r-base=4.1.3
-  - r-data.table=1.14.2
-  - r-jsonlite=1.7.2
-  - r-knitr=1.37
-  - r-markdown
-  - r-matrix=1.4_0
-  - r-pkgdown=1.6.1
-  - r-roxygen2=7.2.1
-  - scikit-learn
-  - sphinx
-  - "sphinx_rtd_theme>=0.5"
+  - breathe=4.35
+  - python=3.11
+  - r-base=4.3.2
+  - r-data.table=1.14.10
+  - r-jsonlite=1.8.8
+  - r-knitr=1.45
+  - r-markdown=1.12
+  - r-matrix=1.6_4
+  - r-pkgdown=2.0.7
+  - r-roxygen2=7.3.1
+  - scikit-learn>=1.4.0
+  - sphinx=7.2.6
+  - sphinx_rtd_theme=2.0

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -14,5 +14,5 @@ dependencies:
   - r-pkgdown=2.0.7
   - r-roxygen2=7.3.1
   - scikit-learn>=1.4.0
-  - sphinx>=7.0
+  - sphinx>=6.0
   - sphinx_rtd_theme>=2.0

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -3,7 +3,7 @@ channels:
   - nodefaults
   - conda-forge
 dependencies:
-  - breathe
+  - breathe>=4.35
   - python=3.11
   - r-base=4.3.2
   - r-data.table=1.14.10

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -14,5 +14,5 @@ dependencies:
   - r-pkgdown=2.0.7
   - r-roxygen2=7.3.1
   - scikit-learn>=1.4.0
-  - sphinx=7.2.6
-  - sphinx_rtd_theme=2.0
+  - sphinx>=7.0
+  - sphinx_rtd_theme>=2.0


### PR DESCRIPTION
Proposes updating the following dependencies to their latest versions:

* libraries (and Python and R versions) used to create the docs hosted at https://lightgbm.readthedocs.io/en/latest/
* static analyzers like `cpplint` and `mypy`

### Benefits of these changes

* faster conda environment solves = faster builds
* extends further into the future the time til we have to upgrade these language versions on readthedocs again

## Notes for Reviewers

Even though the latest release of `sphinx` is the 7.x series, I'm proposing using `sphinx>=6.0` because LightGBM'ss docs rely on `breathe`, and as of this writing the `breathe` conda-forge package has a ceiling of `breathe<7.0`.

* https://github.com/breathe-doc/breathe/issues/943
* https://github.com/conda-forge/breathe-feedstock/blob/5d9908bf915d15abbb4fe6d768a694f53e305d72/recipe/meta.yaml#L28

Despite that ceiling not being present for wheels on PyPI:

* https://github.com/breathe-doc/breathe/pull/885

```shell
# this happily installs breather 4.35 and sphinx 7.2.6 together
docker run \
  --rm \
  -it python:3.10 \
   /bin/bash -c "pip install 'breathe>=4.35' 'sphinx>7.0'"
```