### PR TITLE
[ci] Fix R 3.6 tests, dask tests, compatibility with dask>=2024.3.1

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 if [[ $OS_NAME == "macos" ]]; then
+    brew update-reset && brew update
     if  [[ $COMPILER == "clang" ]]; then
         brew install libomp
         if [[ $AZURE == "true" ]]; then

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 if [[ $OS_NAME == "macos" ]]; then
-    brew update-reset && brew update
+    brew update-reset
+    brew update
     if  [[ $COMPILER == "clang" ]]; then
         brew install libomp
         if [[ $AZURE == "true" ]]; then

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 if [[ $OS_NAME == "macos" ]]; then
-    brew update-reset --auto-update
-    brew update --auto-update
     if  [[ $COMPILER == "clang" ]]; then
         brew install libomp
         if [[ $AZURE == "true" ]]; then

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ $OS_NAME == "macos" ]]; then
-    brew update-reset
-    brew update
+    brew update-reset --auto-update
+    brew update --auto-update
     if  [[ $COMPILER == "clang" ]]; then
         brew install libomp
         if [[ $AZURE == "true" ]]; then

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -126,9 +126,9 @@ fi
 # older versions of Dask are incompatible with pandas>=2.0, but not all conda packages' metadata accurately reflects that
 #
 # ref: https://github.com/microsoft/LightGBM/issues/6030
-CONSTRAINED_DEPENDENCIES="'dask-core>=2023.5.0' 'distributed>=2023.5.0' 'pandas>=2.0'"
+CONSTRAINED_DEPENDENCIES="'dask>=2023.5.0' 'distributed>=2023.5.0' 'pandas>=2.0'"
 if [[ $PYTHON_VERSION == "3.7" ]]; then
-    CONSTRAINED_DEPENDENCIES="'dask-core' 'distributed' 'pandas<2.0'"
+    CONSTRAINED_DEPENDENCIES="'dask' 'distributed' 'pandas<2.0'"
 fi
 
 # including python=version[build=*cpython] to ensure that conda doesn't fall back to pypy
@@ -322,7 +322,7 @@ matplotlib.use\(\"Agg\"\)\
     # importing the library should succeed even if all optional dependencies are not present
     conda uninstall -n $CONDA_ENV --force --yes \
         cffi \
-        dask-core \
+        dask \
         distributed \
         joblib \
         matplotlib \

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -81,6 +81,8 @@ fi
 
 # Installing R precompiled for Mac OS 10.11 or higher
 if [[ $OS_NAME == "macos" ]]; then
+    brew update-reset --auto-update
+    brew update --auto-update
     if [[ $R_BUILD_TYPE == "cran" ]]; then
         brew install automake || exit 1
     fi

--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -91,7 +91,11 @@ if ($env:R_MAJOR_VERSION -eq "3") {
 $env:R_LIB_PATH = "$env:BUILD_SOURCESDIRECTORY/RLibrary" -replace '[\\]', '/'
 $env:R_LIBS = "$env:R_LIB_PATH"
 $env:PATH = "$env:RTOOLS_BIN;" + "$env:RTOOLS_MINGW_BIN;" + "$env:R_LIB_PATH/R/bin/x64;"+ $env:PATH
-$env:CRAN_MIRROR = "https://cran.rstudio.com"
+if ([version]$env:R_VERSION -lt [version]"4.0") {
+  $env:CRAN_MIRROR = "https://cran-archive.r-project.org"
+} else {
+  $env:CRAN_MIRROR = "https://cran.rstudio.com"
+}
 $env:MIKTEX_EXCEPTION_PATH = "$env:TEMP\miktex"
 
 # don't fail builds for long-running examples unless they're very long.

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -275,7 +275,6 @@ jobs:
         clang-version:
           - 16
           - 17
-          - 18
     runs-on: ubuntu-latest
     container: rhub/debian-clang-devel
     env:

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -315,7 +315,7 @@ jobs:
   all-r-package-jobs-successful:
     if: always()
     runs-on: ubuntu-latest
-    needs: [test, test-r-sanitizers, test-r-debian-clang]
+    needs: [test, test-r-debian-clang]
     steps:
     - name: Note that all tests succeeded
       uses: re-actors/alls-green@v1.2.2

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -164,7 +164,17 @@ try:
     from dask.distributed import Client, Future, default_client, wait
 
     DASK_INSTALLED = True
-except ImportError:
+# catching 'ValueError' here because of this:
+# https://github.com/microsoft/LightGBM/issues/6365#issuecomment-2002330003
+#
+# That's potentially risky as dask does some significant import-time processing,
+# like loading configuration from environment variables and files, and catching
+# ValueError here might hide issues with that config-loading.
+#
+# But in exchange, it's less likely that 'import lightgbm' will fail for
+# dask-related reasons, which is beneficial for any workloads that are using
+# lightgbm but not its Dask functionality.
+except (ImportError, ValueError):
     DASK_INSTALLED = False
 
     dask_array_from_delayed = None  # type: ignore[assignment]

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -213,13 +213,17 @@ def _create_data(objective, n_samples=1_000, output="array", chunk_size=500, **k
 
 
 def _r2_score(dy_true, dy_pred):
-    numerator = ((dy_true - dy_pred) ** 2).sum(axis=0, dtype=np.float64)
-    denominator = ((dy_true - dy_true.mean(axis=0)) ** 2).sum(axis=0, dtype=np.float64)
-    return (1 - numerator / denominator).compute()
+    y_true = dy_true.compute()
+    y_pred = dy_pred.compute()
+    numerator = ((y_true - y_pred) ** 2).sum(axis=0)
+    denominator = ((y_true - y_true.mean(axis=0)) ** 2).sum(axis=0)
+    return 1 - numerator / denominator
 
 
 def _accuracy_score(dy_true, dy_pred):
-    return da.average(dy_true == dy_pred).compute()
+    y_true = dy_true.compute()
+    y_pred = dy_pred.compute()
+    return (y_true == y_pred).mean()
 
 
 def _constant_metric(y_true, y_pred):


### PR DESCRIPTION
Fixes multiple CI-blocking issues that have all come up in the last few days:

* RStudio no longer hosting R 3.6 (https://github.com/microsoft/LightGBM/pull/6353#issuecomment-1983746071)
* `dask.dataframe` now requiring `dask-expr` (#6365)
* basictex / mactex being updated and mirrors now longer hosting the old version: #6366
* installation of `clang-18` failing in the `r-debian-clang-devel` CI jobs (#6369)
* `r-sanitizers` jobs failing with install-time segfaults (#6367)