### PR TITLE
[ci] put ceiling on graphviz in Python 3.7 jobs

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -126,9 +126,9 @@ fi
 # older versions of Dask are incompatible with pandas>=2.0, but not all conda packages' metadata accurately reflects that
 #
 # ref: https://github.com/microsoft/LightGBM/issues/6030
-CONSTRAINED_DEPENDENCIES="'dask>=2023.5.0' 'distributed>=2023.5.0' 'pandas>=2.0'"
+CONSTRAINED_DEPENDENCIES="'dask>=2023.5.0' 'distributed>=2023.5.0' 'pandas>=2.0' python-graphviz"
 if [[ $PYTHON_VERSION == "3.7" ]]; then
-    CONSTRAINED_DEPENDENCIES="'dask' 'distributed' 'pandas<2.0'"
+    CONSTRAINED_DEPENDENCIES="'dask' 'distributed' 'python-graphviz<9.0' 'pandas<2.0'"
 fi
 
 # including python=version[build=*cpython] to ensure that conda doesn't fall back to pypy
@@ -143,7 +143,6 @@ mamba create -q -y -n $CONDA_ENV \
     pyarrow \
     pytest \
     ${CONDA_PYTHON_REQUIREMENT} \
-    python-graphviz \
     scikit-learn \
     scipy || exit 1
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -128,7 +128,7 @@ fi
 # ref: https://github.com/microsoft/LightGBM/issues/6030
 CONSTRAINED_DEPENDENCIES="'dask>=2023.5.0' 'distributed>=2023.5.0' 'pandas>=2.0' python-graphviz"
 if [[ $PYTHON_VERSION == "3.7" ]]; then
-    CONSTRAINED_DEPENDENCIES="'dask' 'distributed' 'python-graphviz<9.0' 'pandas<2.0'"
+    CONSTRAINED_DEPENDENCIES="'dask' 'distributed' 'python-graphviz<0.20.2' 'pandas<2.0'"
 fi
 
 # including python=version[build=*cpython] to ensure that conda doesn't fall back to pypy


### PR DESCRIPTION
Python 3.7 CI jobs are failing with this error:

```text
../../../.local/lib/python3.7/site-packages/lightgbm/compat.py:62: in <module>
    import graphviz  # noqa: F401
../../../miniforge/envs/test-env/lib/python3.7/site-packages/graphviz/__init__.py:31: in <module>
    from .backend import (DOT_BINARY, UNFLATTEN_BINARY,
../../../miniforge/envs/test-env/lib/python3.7/site-packages/graphviz/backend/__init__.py:5: in <module>
    from .mixins import Render, Pipe, Unflatten, View
../../../miniforge/envs/test-env/lib/python3.7/site-packages/graphviz/backend/mixins.py:8: in <module>
    from . import piping
../../../miniforge/envs/test-env/lib/python3.7/site-packages/graphviz/backend/piping.py:5: in <module>
    from .. import _tools
E     File "/Users/runner/miniforge/envs/test-env/lib/python3.7/site-packages/graphviz/_tools.py", line 23
E       def attach(object: typing.Any, /, name: str) -> typing.Callable:
E                                      ^
E   SyntaxError: invalid syntax
```

Example recent build from `master`: ([build link](https://github.com/microsoft/LightGBM/actions/runs/8320417902/job/22765116084)).

`python-graphviz` has a floor of `python>=3.8` since https://github.com/xflr6/graphviz/pull/202, but I guess that hasn't extended to the `conda-forge` package. That results in a newer version of `python-graphviz` being pulled into a Python 3.7 environment which contains invalid syntax for Python 3.7.

This PR proposes putting a ceiling on `python-graphviz` in LightGBM's Python 3.7 CI jobs.

### Notes for Reviewers

Looks like this is the result of the latest `python-graphviz` release on conda-forge about 4 hours ago: https://github.com/conda-forge/python-graphviz-feedstock/pull/55.

I don't think conda-forge will be interested in a repodata patch to prevent this from happening, so I'm not planning to propose one. Based on this evidence:

* https://github.com/microsoft/LightGBM/issues/5969#issuecomment-1630131940
* https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-python.html
  - *"Conda supports Python 3.8, 3.9, 3.10, 3.11 and 3.12."*
* https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/478#pullrequestreview-1523437604

I did put up https://github.com/conda-forge/python-graphviz-feedstock/pull/56 proposing adding a `python>=3.8` floor  on conda-forge, so maybe if that's merged we could eventually remove this ceiling in CI scripts.

If this ceiling on `python-graphviz` causes problems in the future, I'd support turning off the plotting tests for Python 3.7 environments.