### PR TITLE
[docs] remove language about CUDA version being experimental (fixes #6340)

### DIFF
--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -624,9 +624,8 @@ Build CUDA Version
 
 The `original GPU build <#build-gpu-version>`__ of LightGBM (``device_type=gpu``) is based on OpenCL.
 
-The CUDA-based build (``device_type=cuda``) is a separate implementation and requires an NVIDIA graphics card with compute capability 6.0 and higher. It should be considered experimental, and we suggest using it only when it is impossible to use OpenCL version (for example, on IBM POWER microprocessors).
-
-**Note**: only Linux is supported, other operating systems are not supported yet.
+The CUDA-based build (``device_type=cuda``) is a separate implementation. with compute capability 6.0 and higher.
+Use this version in Linux environments with an NVIDIA GPU with compute capability 6.0 or higher.
 
 Linux
 ^^^^^
@@ -653,6 +652,17 @@ To build LightGBM CUDA version, run the following commands:
 **Note**: glibc >= 2.14 is required.
 
 **Note**: In some rare cases you may need to install OpenMP runtime library separately (use your package manager and search for ``lib[g|i]omp`` for doing this).
+
+macOS
+^^^^^
+
+The CUDA version is not supported on macOS.
+
+Windows
+^^^^^^^
+
+The CUDA version is not supported on Windows.
+Use the GPU version (``device_type=gpu``) for GPU acceleration on Windows.
 
 Build HDFS Version
 ~~~~~~~~~~~~~~~~~~

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -624,7 +624,7 @@ Build CUDA Version
 
 The `original GPU build <#build-gpu-version>`__ of LightGBM (``device_type=gpu``) is based on OpenCL.
 
-The CUDA-based build (``device_type=cuda``) is a separate implementation. with compute capability 6.0 and higher.
+The CUDA-based build (``device_type=cuda``) is a separate implementation.
 Use this version in Linux environments with an NVIDIA GPU with compute capability 6.0 or higher.
 
 Linux

--- a/docs/_static/js/script.js
+++ b/docs/_static/js/script.js
@@ -28,7 +28,7 @@ $(function() {
             '#build-threadless-version-not-recommended',
             '#build-mpi-version',
             '#build-gpu-version',
-            '#build-cuda-version-experimental',
+            '#build-cuda-version',
             '#build-hdfs-version',
             '#build-java-wrapper',
             '#build-c-unit-tests'

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -153,7 +153,7 @@ Build CUDA Version
 
 All requirements from `Build from Sources section <#build-from-sources>`__ apply for this installation option as well, and `CMake`_ (version 3.16 or higher) is strongly required.
 
-**CUDA** library (version 10.0 or higher) is needed: details for installation can be found in `Installation Guide <https://github.com/microsoft/LightGBM/blob/master/docs/Installation-Guide.rst#build-cuda-version-experimental>`__.
+**CUDA** library (version 10.0 or higher) is needed: details for installation can be found in `Installation Guide <https://github.com/microsoft/LightGBM/blob/master/docs/Installation-Guide.rst#build-cuda-version>`__.
 
 To use the CUDA version within Python, pass ``{"device": "cuda"}`` respectively in parameters.
 


### PR DESCRIPTION
Fixes #6340.

Removes language in the docs about the CUDA version being considered "experimental".

Also fixes some links in docs to point to the correct section of the installation guide.