### PR TITLE
[ci] [python-package] remove unused flake8 configuration

### DIFF
--- a/python-package/setup.cfg
+++ b/python-package/setup.cfg
@@ -3,16 +3,3 @@ include_package_data = True
 
 [options.packages.find]
 where = lightgbm
-
-[flake8]
-ignore =
-    # line too long
-    E501,
-    # line break occurred before a binary operator
-    W503
-exclude =
-    ./.nuget,
-    ./external_libs,
-    ./lightgbm-python,
-    ./python-package/build,
-    ./python-package/compile


### PR DESCRIPTION
As of #5871, this project no longer uses the `flake8` library. It uses `ruff` to enforce similar checks.

This PR proposes removing now-unnecessary configuration for `flake8` in `setup.cfg`.

`ruff` doesn't rely on the `[flake8]` table there, and instead gets its configuration from `pyproject.toml`.

https://github.com/microsoft/LightGBM/blob/cb4972eeefe83d1558fb3c855ea25097e570ef7f/.pre-commit-config.yaml#L21-L22

https://github.com/microsoft/LightGBM/blob/cb4972eeefe83d1558fb3c855ea25097e570ef7f/python-package/pyproject.toml#L123