### PR TITLE
[ci] reduce hard-coding of host architecture

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ARCH=$(uname -m)
+
 if [[ $OS_NAME == "macos" ]]; then
     if  [[ $COMPILER == "clang" ]]; then
         brew install libomp
@@ -21,7 +23,7 @@ if [[ $OS_NAME == "macos" ]]; then
     curl \
         -sL \
         -o miniforge.sh \
-        https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh
+        https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-${ARCH}.sh
 else  # Linux
     if [[ $IN_UBUNTU_BASE_CONTAINER == "true" ]]; then
         # fixes error "unable to initialize frontend: Dialog"
@@ -133,7 +135,6 @@ else  # Linux
             cmake
     fi
     if [[ $SETUP_CONDA != "false" ]]; then
-        ARCH=$(uname -m)
         curl \
             -sL \
             -o miniforge.sh \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ARCH=$(uname -m)
+
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "gcc" ]]; then
     export CXX=g++-11
     export CC=gcc-11
@@ -169,14 +171,19 @@ elif [[ $TASK == "bdist" ]]; then
         mv \
             ./dist/*.whl \
             ./dist/tmp.whl || exit 1
+        if [[ $ARCH == "x86_64" ]]; then
+            PLATFORM="macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64"
+        else
+            echo "ERROR: macos wheels not supported yet on architecture '${ARCH}'"
+            exit 1
+        fi
         mv \
             ./dist/tmp.whl \
-            dist/lightgbm-$LGB_VER-py3-none-macosx_10_15_x86_64.macosx_11_6_x86_64.macosx_12_5_x86_64.whl || exit 1
+            dist/lightgbm-$LGB_VER-py3-none-$PLATFORM.whl || exit 1
         if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
             cp dist/lightgbm-$LGB_VER-py3-none-macosx*.whl $BUILD_ARTIFACTSTAGINGDIRECTORY || exit 1
         fi
     else
-        ARCH=$(uname -m)
         if [[ $ARCH == "x86_64" ]]; then
             PLATFORM="manylinux_2_28_x86_64"
         else

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ARCH=$(uname -m)
+
 # set up R environment
 CRAN_MIRROR="https://cran.rstudio.com"
 R_LIB_PATH=~/Rlib
@@ -22,7 +24,7 @@ if [[ "${R_MAJOR_VERSION}" == "3" ]]; then
     export R_APT_REPO="bionic-cran35/"
 elif [[ "${R_MAJOR_VERSION}" == "4" ]]; then
     export R_MAC_VERSION=4.3.1
-    export R_MAC_PKG_URL=${CRAN_MIRROR}/bin/macosx/big-sur-x86_64/base/R-${R_MAC_VERSION}-x86_64.pkg
+    export R_MAC_PKG_URL=${CRAN_MIRROR}/bin/macosx/big-sur-${ARCH}/base/R-${R_MAC_VERSION}-${ARCH}.pkg
     export R_LINUX_VERSION="4.3.1-1.2204.0"
     export R_APT_REPO="jammy-cran40/"
 else
@@ -70,11 +72,11 @@ if [[ $OS_NAME == "linux" ]]; then
     fi
     if [[ $INSTALL_CMAKE_FROM_RELEASES == "true" ]]; then
         curl -O -L \
-            https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-x86_64.sh \
+            https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-${ARCH}.sh \
         || exit 1
 
         sudo mkdir /opt/cmake || exit 1
-        sudo sh cmake-3.25.1-linux-x86_64.sh --skip-license --prefix=/opt/cmake || exit 1
+        sudo sh cmake-3.25.1-linux-${ARCH}.sh --skip-license --prefix=/opt/cmake || exit 1
         sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake || exit 1
     fi
 fi

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -315,7 +315,7 @@ jobs:
   all-r-package-jobs-successful:
     if: always()
     runs-on: ubuntu-latest
-    needs: [test, test-r-debian-clang]
+    needs: [test, test-r-sanitizers, test-r-debian-clang]
     steps:
     - name: Note that all tests succeeded
       uses: re-actors/alls-green@v1.2.2


### PR DESCRIPTION
Contributes to #5328.
Contributes to #5035.

There are a couple of hard-coded `x86_64` references in CI scripts. This updates those to instead be whatever `uname -m` evaluates to. Doing this in a separate PR to keep the diff smaller for 