### PR TITLE
[docs] document how to use a custom objective function via the C API

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -127,7 +127,9 @@ Core Parameters
 
       -  ``custom``
 
-      -  **Note**: Not supported in CLI version; must be passed through parameters explicitly
+      -  **Note**: Not supported in CLI version
+
+      -  must be passed through parameters explicitly in the C API
 
 -  ``boosting`` :raw-html:`<a id="boosting" title="Permalink to this parameter" href="#boosting">&#x1F517;&#xFE0E;</a>`, default = ``gbdt``, type = enum, options: ``gbdt``, ``rf``, ``dart``, aliases: ``boosting_type``, ``boost``
 

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -123,6 +123,12 @@ Core Parameters
 
       -  label should be ``int`` type, and larger number represents the higher relevance (e.g. 0:bad, 1:fair, 2:good, 3:perfect)
 
+    -  custom
+
+      - ``custom``
+
+      - **Note**: Not supported in CLI version; must be set explicitly when using the C API (for Python and R APIs, pass the custom objective directly into the train method)
+
 -  ``boosting`` :raw-html:`<a id="boosting" title="Permalink to this parameter" href="#boosting">&#x1F517;&#xFE0E;</a>`, default = ``gbdt``, type = enum, options: ``gbdt``, ``rf``, ``dart``, aliases: ``boosting_type``, ``boost``
 
    -  ``gbdt``, traditional Gradient Boosting Decision Tree, aliases: ``gbrt``

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -123,11 +123,11 @@ Core Parameters
 
       -  label should be ``int`` type, and larger number represents the higher relevance (e.g. 0:bad, 1:fair, 2:good, 3:perfect)
 
-    -  custom
+   -  custom objective function (gradients and hessians not computed directly by LightGBM)
 
-      - ``custom``
+      -  ``custom``
 
-      - **Note**: Not supported in CLI version; must be set explicitly when using the C API (for Python and R APIs, pass the custom objective directly into the train method)
+      -  **Note**: Not supported in CLI version; must be passed through parameters explicitly
 
 -  ``boosting`` :raw-html:`<a id="boosting" title="Permalink to this parameter" href="#boosting">&#x1F517;&#xFE0E;</a>`, default = ``gbdt``, type = enum, options: ``gbdt``, ``rf``, ``dart``, aliases: ``boosting_type``, ``boost``
 

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -158,7 +158,7 @@ struct Config {
   // descl2 = ``rank_xendcg``, `XE_NDCG_MART <https://arxiv.org/abs/1911.09798>`__ ranking objective function, aliases: ``xendcg``, ``xe_ndcg``, ``xe_ndcg_mart``, ``xendcg_mart``
   // descl2 = ``rank_xendcg`` is faster than and achieves the similar performance as ``lambdarank``
   // descl2 = label should be ``int`` type, and larger number represents the higher relevance (e.g. 0:bad, 1:fair, 2:good, 3:perfect)
-  // desc = custom
+  // desc = custom objective function (gradients and hessians not computed directly by LightGBM)
   // descl2 = ``custom``
   // descl2 = **Note**: Not supported in CLI version; must be set explicitly when using the C API (for Python and R APIs, pass the custom objective directly into the train method)
   std::string objective = "regression";

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -160,7 +160,7 @@ struct Config {
   // descl2 = label should be ``int`` type, and larger number represents the higher relevance (e.g. 0:bad, 1:fair, 2:good, 3:perfect)
   // desc = custom objective function (gradients and hessians not computed directly by LightGBM)
   // descl2 = ``custom``
-  // descl2 = **Note**: Not supported in CLI version; must be set explicitly when using the C API (for Python and R APIs, pass the custom objective directly into the train method)
+  // descl2 = **Note**: Not supported in CLI version; must be passed through parameters explicitly
   std::string objective = "regression";
 
   // [no-automatically-extract]

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -158,6 +158,9 @@ struct Config {
   // descl2 = ``rank_xendcg``, `XE_NDCG_MART <https://arxiv.org/abs/1911.09798>`__ ranking objective function, aliases: ``xendcg``, ``xe_ndcg``, ``xe_ndcg_mart``, ``xendcg_mart``
   // descl2 = ``rank_xendcg`` is faster than and achieves the similar performance as ``lambdarank``
   // descl2 = label should be ``int`` type, and larger number represents the higher relevance (e.g. 0:bad, 1:fair, 2:good, 3:perfect)
+  // desc = custom
+  // descl2 = ``custom``
+  // descl2 = **Note**: Not supported in CLI version; must be set explicitly when using the C API (for Python and R APIs, pass the custom objective directly into the train method)
   std::string objective = "regression";
 
   // [no-automatically-extract]

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -160,7 +160,8 @@ struct Config {
   // descl2 = label should be ``int`` type, and larger number represents the higher relevance (e.g. 0:bad, 1:fair, 2:good, 3:perfect)
   // desc = custom objective function (gradients and hessians not computed directly by LightGBM)
   // descl2 = ``custom``
-  // descl2 = **Note**: Not supported in CLI version; must be passed through parameters explicitly
+  // descl2 = **Note**: Not supported in CLI version
+  // descl2 = must be passed through parameters explicitly in the C API
   std::string objective = "regression";
 
   // [no-automatically-extract]

--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -344,6 +344,7 @@ bool GBDT::TrainOneIter(const score_t* gradients, const score_t* hessians) {
     hessians = hessians_pointer_;
   } else {
     // use customized objective function
+    // the check below fails unless objective=custom is provided in the parameters on Booster creation
     CHECK(objective_function_ == nullptr);
     if (data_sample_strategy_->IsHessianChange()) {
       // need to copy customized gradients when using GOSS


### PR DESCRIPTION
Follow-up to #6393.

Clarifies that `objective=custom` must be provided via `parameters` in the C API if you want to use a custom objective function and provide gradients/hessians manually.