### PR TITLE
[python-package] prevent build-python.sh from modifying already-installed dependencies

### DIFF
--- a/build-python.sh
+++ b/build-python.sh
@@ -360,11 +360,13 @@ fi
 
 if test "${INSTALL}" = true; then
     echo "--- installing lightgbm ---"
-    # ref for use of '--find-links': https://stackoverflow.com/a/52481267/3986677
     cd ../dist
+    # remove existing installation
+    # (useful when building the dev version multiple times, where the version number doesn't change)
+    pip uninstall --yes lightgbm
+    # ref for use of '--find-links': https://stackoverflow.com/a/52481267/3986677
     pip install \
         ${PIP_INSTALL_ARGS} \
-        --force-reinstall \
         --no-cache-dir \
         --find-links=. \
         lightgbm


### PR DESCRIPTION
The recommended workflow for building the Python package from source here uses the `build-python.sh` script, like this:

```shell
cmake -B build -S .
cmake --build build --target _lightgbm -j4
sh ./build-python.sh install --precompile
```

The version for the library from any two unreleased commits is the same (e.g. `4.3.0.99`). To ensure that `pip` does not give up on successive runs and say "oh `lightgbm==4.3.0.99` is already installed, I'm not installing this wheel", in #5907 we added `--force-reinstall` to the `pip install dist/*` in `build-python.sh`.

That has the unfortunate side-effect of also force-reinstalling *all of `lightgbm`'s strong runtime dependencies* (`numpy` and `scipy`). That's undesirable for 2 reasons:

* it's surprising to get your environment's `numpy` version upgraded by installing `lightgbm`, even when `lightgbm` is compatible with the version of `numpy` you already have
* in a `conda` environment, this can result in a `numpy` conda package being replaced by a `numpy` wheel, which can cause a variety of linking and loading problems

This PR proposes avoiding that, by instead having `build-python.sh install` run `pip uninstall --yes lightgbm`.

### How I tested this

In a conda environment without `lightgbm` installed, but with `scipy` and `numpy` installed, ran the following.

```shell
cmake -B build -S .
cmake --build build --target _lightgbm -j4
sh ./build-python.sh install --precompile
```

Saw this in the logs, confirming that it didn't change my `numpy` or `scipy` versions.

```text
Requirement already satisfied: numpy in /Users/jlamb/miniforge3/envs/lgb-dev/lib/python3.11/site-packages (from lightgbm) (1.26.4)
Requirement already satisfied: scipy in /Users/jlamb/miniforge3/envs/lgb-dev/lib/python3.11/site-packages (from lightgbm) (1.12.0)
```