### PR TITLE
[c++] remove unused variable 'need_connect_cnt'

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -315,7 +315,7 @@ jobs:
   all-r-package-jobs-successful:
     if: always()
     runs-on: ubuntu-latest
-    needs: [test, test-r-debian-clang]
+    needs: [test, test-r-sanitizers, test-r-debian-clang]
     steps:
     - name: Note that all tests succeeded
       uses: re-actors/alls-green@v1.2.2

--- a/src/network/linkers_socket.cpp
+++ b/src/network/linkers_socket.cpp
@@ -171,13 +171,9 @@ void Linkers::Construct() {
       need_connect[i] = 1;
     }
   }
-  int need_connect_cnt = 0;
   int incoming_cnt = 0;
   for (auto it = need_connect.begin(); it != need_connect.end(); ++it) {
     int machine_rank = it->first;
-    if (machine_rank >= 0 && machine_rank != rank_) {
-      ++need_connect_cnt;
-    }
     if (machine_rank < rank_) {
       ++incoming_cnt;
     }


### PR DESCRIPTION
`clang++` complains about this variable in `linkers_socket.cpp` being unused.

```text
.../src/network/linkers_socket.cpp:174:7: warning: variable 'need_connect_cnt' set but not used [-Wunused-but-set-variable]
  int need_connect_cnt = 0;
```

That looks correct to me, based on the output of this:

```shell
git grep need_connect_cnt
```

Seems that that variable is being incremented but not used for anything. I suspect that's left over from some previous refactoring.

This proposes removing that unused variable.