### PR TITLE
[cmake] [c++] use .dylib extension unconditionally on macOS

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -49,11 +49,7 @@ if [[ $TASK == "if-else" ]]; then
 fi
 
 if [[ $TASK == "swig" ]]; then
-    if [[ $OS_NAME == "macos" ]]; then
-        cmake -B build -S . -DUSE_SWIG=ON -DAPPLE_OUTPUT_DYLIB=ON
-    else
-        cmake -B build -S . -DUSE_SWIG=ON
-    fi
+    cmake -B build -S . -DUSE_SWIG=ON
     cmake --build build -j4 || exit 1
     if [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "gcc" ]]; then
         objdump -T $BUILD_DIRECTORY/lib_lightgbm.so > $BUILD_DIRECTORY/objdump.log || exit 1
@@ -283,7 +279,7 @@ pytest $BUILD_DIRECTORY/tests || exit 1
 if [[ $TASK == "regular" ]]; then
     if [[ $PRODUCES_ARTIFACTS == "true" ]]; then
         if [[ $OS_NAME == "macos" ]]; then
-            cp $BUILD_DIRECTORY/lib_lightgbm.so $BUILD_ARTIFACTSTAGINGDIRECTORY/lib_lightgbm.dylib
+            cp $BUILD_DIRECTORY/lib_lightgbm.dylib $BUILD_ARTIFACTSTAGINGDIRECTORY/lib_lightgbm.dylib
         else
             if [[ $COMPILER == "gcc" ]]; then
                 objdump -T $BUILD_DIRECTORY/lib_lightgbm.so > $BUILD_DIRECTORY/objdump.log || exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,6 @@ option(__BUILD_FOR_PYTHON "Set to ON if building lib_lightgbm for use with the P
 option(__BUILD_FOR_R "Set to ON if building lib_lightgbm for use with the R package" OFF)
 option(__INTEGRATE_OPENCL "Set to ON if building LightGBM with the OpenCL ICD Loader and its dependencies included" OFF)
 
-if(APPLE)
-  option(APPLE_OUTPUT_DYLIB "Output dylib shared library" OFF)
-endif()
-
 cmake_minimum_required(VERSION 3.18)
 
 project(lightgbm LANGUAGES C CXX)
@@ -406,14 +402,6 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 
 include_directories(${LightGBM_HEADER_DIR})
-
-if(APPLE)
-  if(APPLE_OUTPUT_DYLIB)
-    set(CMAKE_SHARED_LIBRARY_SUFFIX ".dylib")
-  else()
-    set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
-  endif()
-endif()
 
 if(USE_MPI)
   include_directories(${MPI_CXX_INCLUDE_PATH})

--- a/R-package/.Rbuildignore
+++ b/R-package/.Rbuildignore
@@ -8,6 +8,7 @@ AUTOCONF_UBUNTU_VERSION
 ^docs$
 ^.*\.dll
 \.drone\.yml
+^.*\.dylib
 \.git
 \.gitkeep$
 ^.*\.history

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -221,7 +221,7 @@ CRAN does not prepare precompiled binaries for Linux, and as of this writing nei
 
 ### Installing from a Pre-compiled lib_lightgbm <a name="lib_lightgbm"></a>
 
-Previous versions of LightGBM offered the ability to first compile the C++ library (`lib_lightgbm.so` or `lib_lightgbm.dll`) and then build an R package that wraps it.
+Previous versions of LightGBM offered the ability to first compile the C++ library (`lib_lightgbm.{dll,dylib,so}`) and then build an R package that wraps it.
 
 As of version 3.0.0, this is no longer supported. If building from source is difficult for you, please [open an issue](https://github.com/microsoft/LightGBM/issues).
 

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -184,7 +184,7 @@ R_version_string <- paste(
 )
 r_version_arg <- sprintf("-DCMAKE_R_VERSION='%s'", R_version_string)
 # ensure CMake build respects how R is configured (`R CMD config SHLIB_EXT`)
-shlib_ext_arg <- sprintf("-DCMAKE_SHARED_LIBRARY_SUFFIX='%s'", SHLIB_EXT)
+shlib_ext_arg <- sprintf("-DCMAKE_SHARED_LIBRARY_SUFFIX_CXX='%s'", SHLIB_EXT)
 cmake_args <- c(cmake_args, r_version_arg, shlib_ext_arg)
 
 # the checks below might already run `cmake -G`. If they do, set this flag

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -183,7 +183,9 @@ R_version_string <- paste(
   , sep = "."
 )
 r_version_arg <- sprintf("-DCMAKE_R_VERSION='%s'", R_version_string)
-cmake_args <- c(cmake_args, r_version_arg)
+# ensure CMake build respects how R is configured (`R CMD config SHLIB_EXT`)
+shlib_ext_arg <- sprintf("-DCMAKE_SHARED_LIBRARY_SUFFIX='%s'", SHLIB_EXT)
+cmake_args <- c(cmake_args, r_version_arg, shlib_ext_arg)
 
 # the checks below might already run `cmake -G`. If they do, set this flag
 # to TRUE to avoid re-running it later

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -167,7 +167,7 @@ cd "${TEMP_R_DIR}"
 
     # When building an R package with 'configure', it seems
     # you're guaranteed to get a shared library called
-    #  <packagename>.so/dll. The package source code expects
+    #  <packagename>.so/dll/dylib. The package source code expects
     # 'lib_lightgbm.so', not 'lightgbm.so', to comply with the way
     # this project has historically handled installation
     echo "Changing lib_lightgbm to lightgbm"

--- a/build-python.sh
+++ b/build-python.sh
@@ -317,12 +317,15 @@ if test "${INSTALL}" = true; then
         echo 'requires = ["setuptools"]' >> ./pyproject.toml
         echo 'build-backend = "setuptools.build_meta"' >> ./pyproject.toml
         echo "" >> ./pyproject.toml
-        echo "recursive-include lightgbm *.dll *.so" > ./MANIFEST.in
+        echo "recursive-include lightgbm *.dll *.dylib *.so" > ./MANIFEST.in
         echo "" >> ./MANIFEST.in
         mkdir -p ./lightgbm/lib
         if test -f ../lib_lightgbm.so; then
             echo "found pre-compiled lib_lightgbm.so"
             cp ../lib_lightgbm.so ./lightgbm/lib/lib_lightgbm.so
+        elif test -f ../lib_lightgbm.dylib; then
+            echo "found pre-compiled lib_lightgbm.dylib"
+            cp ../lib_lightgbm.dylib ./lightgbm/lib/lib_lightgbm.dylib
         elif test -f ../Release/lib_lightgbm.dll; then
             echo "found pre-compiled Release/lib_lightgbm.dll"
             cp ../Release/lib_lightgbm.dll ./lightgbm/lib/lib_lightgbm.dll

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -763,7 +763,7 @@ Only **Apple Clang** version 8.1 or higher is supported.
 
      git clone --recursive https://github.com/microsoft/LightGBM
      cd LightGBM
-     cmake -B build -S . -DUSE_SWIG=ON -DAPPLE_OUTPUT_DYLIB=ON
+     cmake -B build -S . -DUSE_SWIG=ON
      cmake --build build -j4
 
 gcc
@@ -788,7 +788,7 @@ gcc
      git clone --recursive https://github.com/microsoft/LightGBM
      cd LightGBM
      export CXX=g++-7 CC=gcc-7  # replace "7" with version of gcc installed on your machine
-     cmake -B build -S . -DUSE_SWIG=ON -DAPPLE_OUTPUT_DYLIB=ON
+     cmake -B build -S . -DUSE_SWIG=ON
      cmake --build build -j4
 
 Also, you may want to read `gcc Tips <./gcc-Tips.rst>`__.

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -25,7 +25,7 @@ def find_lib_path() -> List[str]:
         dll_path.append(curr_path.parents[1] / "Release")
         dll_path.append(curr_path.parents[1] / "windows" / "x64" / "DLL")
         dll_path = [p / "lib_lightgbm.dll" for p in dll_path]
-    elif system() == 'Darwin':
+    elif system() == "Darwin":
         dll_path = [p / "lib_lightgbm.dylib" for p in dll_path]
     else:
         dll_path = [p / "lib_lightgbm.so" for p in dll_path]

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -25,6 +25,8 @@ def find_lib_path() -> List[str]:
         dll_path.append(curr_path.parents[1] / "Release")
         dll_path.append(curr_path.parents[1] / "windows" / "x64" / "DLL")
         dll_path = [p / "lib_lightgbm.dll" for p in dll_path]
+    elif system() == 'Darwin':
+        dll_path = [p / "lib_lightgbm.dylib" for p in dll_path]
     else:
         dll_path = [p / "lib_lightgbm.so" for p in dll_path]
     lib_path = [str(p) for p in dll_path if p.is_file()]


### PR DESCRIPTION
## Short Description

Proposes the following changes to CMake-based builds of LightGBM:

* remove `APPLE_OUTPUT_DYLIB` CMake option
* always produce `lib_lightgbm.dylib` on macOS

## Benefits of these changes

* simplifies CMake configuration
* improves the probability of `lib_lightgbm` working correctly with tools that use string matching on file extensions to guess file format (instead of examining the [magic bytes](https://en.wikipedia.org/wiki/List_of_file_signatures)) 
   - _for example, I think this makes it more likely that CMake `find_library()` calls or custom `find_*()` CMake scripts in other projects would be able to find `lib_lightgbm` on macOS_
* might help with some of the mac-specific packaging work I'm focusing on (e.g. #5328)

## Notes for Reviewers

### This is just changing the file *name*, not the actual *format*

The shared library LightGBM currently produces on macOS is actually in mach-o format, not ELF. The CMake customization removed in this PR literally just changes the file name.

```shell
cmake -B build -S .
cmake --build build --target _lightgbm -j4
file ./lib_lightgbm.so
# ./lib_lightgbm.so: Mach-O 64-bit dynamically linked shared library arm64
```

### I couldn't find a strong reason that LightGBM needs to produce a lib_lightgbm.so on macOS

Looks like that was first added in https://github.com/microsoft/LightGBM/commit/70c31c075dbea597c141b2230d261caa3e13f82c back in December 2016. @guolinke do you remember why?

The `APPLE_OUTPUT_DYLIB` option was then added in #204.

### Why call this "breaking"?

Changing this filename could cause the following types of problems for applications depending on LightGBM on macOS:

* any scripts expecting to find `lib_lightgbm.so` will no longer find it
* setting a path to a `lib_lightgbm.so` in environment variable `LD_PRELOAD` will no longer work
* RPATHs or similar embedded in binaries will not find LightGBM

In my opinion, these are worthwhile costs in exchange for the benefits.

### How were these particular changes identified?

I searched like this:

```shell
git grep -E '\.so'
git grep -E 'lightgbm.*so'
```

I believe I've caught all the places that need to be changed. Thankfully this project has pretty good CI coverage on macOS (including Python, R, and SWIG), so I think we can be confident that this is working whenever CI for all macOS jobs passes.