### PR TITLE
upgrade CMake in dockerfile-cli (fixes #6420)

### DIFF
--- a/docker/dockerfile-cli
+++ b/docker/dockerfile-cli
@@ -8,7 +8,7 @@ ENV \
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
-        cmake \
+        curl \
         build-essential \
         gcc \
         g++ \
@@ -16,12 +16,17 @@ RUN apt-get update -y && \
         libomp-dev && \
     rm -rf /var/lib/apt/lists/*
 
+RUN curl -L -o cmake.sh https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-linux-x86_64.sh && \
+    chmod +x cmake.sh && \
+    sh ./cmake.sh --prefix=/usr/local --skip-license && \
+    rm cmake.sh
+
 RUN git clone \
         --recursive \
         --branch stable \
         --depth 1 \
         https://github.com/Microsoft/LightGBM && \
-    cd ./Lightgbm && \
+    cd ./LightGBM && \
     cmake -B build -S . && \
     cmake --build build -j4 && \
     cmake --install build && \


### PR DESCRIPTION
```
$ docker build -t lightgbm-cli -f dockerfile-cli .

14.05 CMake Error at CMakeLists.txt:30 (cmake_minimum_required):
14.05   CMake 3.18 or higher is required.  You are running version 3.16.3
```

This PR upgrades CMake to the newest version.