### PR TITLE
deprecate HDFS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,12 @@ if(USE_CUDA)
 endif()
 
 if(USE_HDFS)
-    message(DEPRECATION "HDFS support in LightGBM is deprecated, and will be removed in a future release. See https://github.com/microsoft/LightGBM/issues/6436.")
+    message(
+      DEPRECATION
+      "HDFS support in LightGBM is deprecated, and will be removed in a future release.\
+      See https://github.com/microsoft/LightGBM/issues/6436.
+      "
+    )
     find_package(JNI REQUIRED)
     find_path(HDFS_INCLUDE_DIR hdfs.h REQUIRED)
     find_library(HDFS_LIB NAMES hdfs REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ if(USE_CUDA)
 endif()
 
 if(USE_HDFS)
+    message(DEPRECATION "HDFS support in LightGBM is deprecated, and will be removed in a future release. See https://github.com/microsoft/LightGBM/issues/6436.")
     find_package(JNI REQUIRED)
     find_path(HDFS_INCLUDE_DIR hdfs.h REQUIRED)
     find_library(HDFS_LIB NAMES hdfs REQUIRED)

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -631,6 +631,10 @@ Use the GPU version (``device_type=gpu``) for GPU acceleration on Windows.
 Build HDFS Version
 ~~~~~~~~~~~~~~~~~~
 
+.. warning::
+   HDFS support in LightGBM is deprecated, and will be removed in a future release.
+   See https://github.com/microsoft/LightGBM/issues/6436.
+
 The HDFS version of LightGBM was tested on CDH-5.14.4 cluster.
 
 Linux

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -160,6 +160,10 @@ To use the CUDA version within Python, pass ``{"device": "cuda"}`` respectively 
 Build HDFS Version
 ~~~~~~~~~~~~~~~~~~
 
+.. warning::
+   HDFS support in LightGBM is deprecated, and will be removed in a future release.
+   See https://github.com/microsoft/LightGBM/issues/6436.
+
 .. code:: sh
 
     pip install lightgbm --config-settings=cmake.define.USE_HDFS=ON


### PR DESCRIPTION
Contributes to #6436. See that issue for much more discussion.

This proposes deprecating HDFS support, for the reasons described in #6436. I'd like to get this into the next release (#6439) and then fully **remove** this support in a future release of LightGBM.

## Notes for Reviewers

Since this is a proposal to eventually break a part of the public API, I would especially like a review on this (and #6436) from either @guolinke or @shiyu1994 .

### How I tested this

I searched for these places like this:

```shell
git grep -i hdfs
```

And tested the deprecation warning like this:

```shell
cmake -B build -S . -DUSE_HDFS=ON
```

Saw it generated correctly.

```text
CMake Deprecation Warning at CMakeLists.txt:289 (message):
  HDFS support in LightGBM is deprecated, and will be removed in a future
  release.  See https://github.com/microsoft/LightGBM/issues/6436.
```