### PR TITLE
[docs] ensure pkgdown site index accurately reflects R-package public API (fixes #6444)

### DIFF
--- a/R-package/pkgdown/_pkgdown.yml
+++ b/R-package/pkgdown/_pkgdown.yml
@@ -70,6 +70,7 @@ reference:
     - '`lgb.Dataset.set.categorical`'
     - '`lgb.Dataset.set.reference`'
     - '`lgb.convert_with_rules`'
+    - '`lgb.slice.Dataset`'
   - title: Machine Learning
     desc: Train models with LightGBM and then use them to make predictions on new data
     contents:
@@ -77,6 +78,7 @@ reference:
     - '`lgb.train`'
     - '`predict.lgb.Booster`'
     - '`lgb.cv`'
+    - '`lgb.configure_fast_predict`'
   - title: Saving / Loading Models
     desc: Save and load LightGBM models
     contents:
@@ -84,6 +86,9 @@ reference:
     - '`lgb.save`'
     - '`lgb.load`'
     - '`lgb.model.dt.tree`'
+    - '`lgb.drop_serialized`'
+    - '`lgb.make_serializable`'
+    - '`lgb.restore_handle`'
   - title: Model Interpretation
     desc: Analyze your models
     contents:
@@ -92,3 +97,10 @@ reference:
     - '`lgb.interprete`'
     - '`lgb.plot.importance`'
     - '`lgb.plot.interpretation`'
+    - '`print.lgb.Booster`'
+    - '`summary.lgb.Booster`'
+  - title: Multithreading Control
+    desc: Manage degree of parallelism used by LightGBM
+    contents:
+    - '`getLGBMThreads`'
+    - '`setLGBMThreads`'

--- a/R-package/pkgdown/_pkgdown.yml
+++ b/R-package/pkgdown/_pkgdown.yml
@@ -63,7 +63,6 @@ reference:
     - '`dimnames.lgb.Dataset`'
     - '`get_field`'
     - '`set_field`'
-    - '`slice`'
     - '`lgb.Dataset`'
     - '`lgb.Dataset.construct`'
     - '`lgb.Dataset.create.valid`'


### PR DESCRIPTION
Fixes #6444.

Fixes LightGBM's documentation builds. These were failing because `{pkgdown}`, the tool used to generate the R docs site, now raises errors under the following conditions:

* objects mentioned in its config don't exist in the library
* site index is missing any objects exported by the library

### How I tested this

Enabled readthedocs builds and saw them succeed:

* build link: https://readthedocs.org/projects/lightgbm/builds/24286998/
* docs: https://lightgbm.readthedocs.io/en/docs-pkgdown-docs/R/reference/