### PR TITLE
[python-package] make LGBMDeprecationWarning inherit from FutureWarning

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -556,7 +556,8 @@ class LightGBMError(Exception):
 
 
 # DeprecationWarning is not shown by default, so let's create our own with higher level
-class LGBMDeprecationWarning(UserWarning):
+# ref: https://peps.python.org/pep-0565/#additional-use-case-for-futurewarning
+class LGBMDeprecationWarning(DeprecationWarning):
     """Custom deprecation warning."""
 
     pass

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -557,7 +557,7 @@ class LightGBMError(Exception):
 
 # DeprecationWarning is not shown by default, so let's create our own with higher level
 # ref: https://peps.python.org/pep-0565/#additional-use-case-for-futurewarning
-class LGBMDeprecationWarning(DeprecationWarning):
+class LGBMDeprecationWarning(FutureWarning):
     """Custom deprecation warning."""
 
     pass


### PR DESCRIPTION
Contributes to #6435 .

`LGBMDeprecationWarning` was added 7 years ago, in #1046. That was done because Python's builtin `DeprecationWarning` is not shown by default.

PEP 565, accepted in November 2017, offers a different prescription for this.

> *For library and framework authors that want to ensure their API compatibility warnings are more reliably seen by their users, the recommendation is to use a custom warning class that derives from `DeprecationWarning` in Python 3.7+, and from FutureWarning in earlier versions.*

([PEP-565](https://peps.python.org/pep-0565/#additional-use-case-for-futurewarning))

This change will also ensure such warnings show up in tests of anything using `lightgbm` which use `pytest` to run their tests.

From the `pytest` docs:

> *By default pytest will display `DeprecationWarning` and `PendingDeprecationWarning` warnings from user code and third-party libraries, as recommended by [PEP 565](https://www.python.org/dev/peps/pep-0565). This helps users keep their code modern and avoid breakages when deprecated warnings are effectively removed.*

(["DeprecationWarning and PendingDeprecationWarning"](https://docs.pytest.org/en/7.1.x/how-to/capture-warnings.html#deprecationwarning-and-pendingdeprecationwarning))