### PR TITLE
[ci] simplify CI configurations, parallelize compilation, test CUDA on Ubuntu 22.04

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,42 +1,42 @@
-version: 4.3.0.99.{build}
+# version: 4.3.0.99.{build}
 
-image: Visual Studio 2015
-platform: x64
-configuration:  # a trick to construct a build matrix with multiple Python versions
-  - '3.8'
+# image: Visual Studio 2015
+# platform: x64
+# configuration:  # a trick to construct a build matrix with multiple Python versions
+#   - '3.8'
 
-# only build pull requests and
-# commits to 'master' or any branch starting with 'release'
-branches:
-  only:
-    - master
-    - /^release/
+# # only build pull requests and
+# # commits to 'master' or any branch starting with 'release'
+# branches:
+#   only:
+#     - master
+#     - /^release/
 
-environment:
-  matrix:
-    - COMPILER: MSVC
-      TASK: python
-    - COMPILER: MINGW
-      TASK: python
+# environment:
+#   matrix:
+#     - COMPILER: MSVC
+#       TASK: python
+#     - COMPILER: MINGW
+#       TASK: python
 
-clone_depth: 5
+# clone_depth: 5
 
-install:
-  - git submodule update --init --recursive  # get `external_libs` folder
-  - set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH%
-  - set PYTHON_VERSION=%CONFIGURATION%
-  - set CONDA_ENV="test-env"
-  - ps: |
-      $env:MINICONDA = "C:\Miniconda3-x64"
-      $env:PATH = "$env:MINICONDA;$env:MINICONDA\Scripts;$env:PATH"
-      $env:BUILD_SOURCESDIRECTORY = "$env:APPVEYOR_BUILD_FOLDER"
+# install:
+#   - git submodule update --init --recursive  # get `external_libs` folder
+#   - set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH%
+#   - set PYTHON_VERSION=%CONFIGURATION%
+#   - set CONDA_ENV="test-env"
+#   - ps: |
+#       $env:MINICONDA = "C:\Miniconda3-x64"
+#       $env:PATH = "$env:MINICONDA;$env:MINICONDA\Scripts;$env:PATH"
+#       $env:BUILD_SOURCESDIRECTORY = "$env:APPVEYOR_BUILD_FOLDER"
 
-build: false
+# build: false
 
-test_script:
-  - conda config --remove channels defaults
-  - conda config --add channels nodefaults
-  - conda config --add channels conda-forge
-  - conda config --set channel_priority strict
-  - conda init powershell
-  - powershell.exe -ExecutionPolicy Bypass -File %APPVEYOR_BUILD_FOLDER%\.ci\test_windows.ps1
+# test_script:
+#   - conda config --remove channels defaults
+#   - conda config --add channels nodefaults
+#   - conda config --add channels conda-forge
+#   - conda config --set channel_priority strict
+#   - conda init powershell
+#   - powershell.exe -ExecutionPolicy Bypass -File %APPVEYOR_BUILD_FOLDER%\.ci\test_windows.ps1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,42 +1,43 @@
-# version: 4.3.0.99.{build}
+version: 4.3.0.99.{build}
 
-# image: Visual Studio 2015
-# platform: x64
-# configuration:  # a trick to construct a build matrix with multiple Python versions
-#   - '3.8'
+image: Visual Studio 2015
+platform: x64
+configuration:  # a trick to construct a build matrix with multiple Python versions
+  - '3.8'
 
-# # only build pull requests and
-# # commits to 'master' or any branch starting with 'release'
-# branches:
-#   only:
-#     - master
-#     - /^release/
+# only build pull requests and
+# commits to 'master' or any branch starting with 'release'
+branches:
+  only:
+    - master
+    - /^release/
 
-# environment:
-#   matrix:
-#     - COMPILER: MSVC
-#       TASK: python
-#     - COMPILER: MINGW
-#       TASK: python
+environment:
+  matrix:
+    - COMPILER: MSVC
+      TASK: python
+    - COMPILER: MINGW
+      TASK: python
 
-# clone_depth: 5
+clone_depth: 5
 
-# install:
-#   - git submodule update --init --recursive  # get `external_libs` folder
-#   - set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH%
-#   - set PYTHON_VERSION=%CONFIGURATION%
-#   - set CONDA_ENV="test-env"
-#   - ps: |
-#       $env:MINICONDA = "C:\Miniconda3-x64"
-#       $env:PATH = "$env:MINICONDA;$env:MINICONDA\Scripts;$env:PATH"
-#       $env:BUILD_SOURCESDIRECTORY = "$env:APPVEYOR_BUILD_FOLDER"
+install:
+  - git submodule update --init --recursive  # get `external_libs` folder
+  - set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH%
+  - set PYTHON_VERSION=%CONFIGURATION%
+  - set CONDA_ENV="test-env"
+  - ps: |
+      $env:CMAKE_BUILD_PARALLEL_LEVEL = 4
+      $env:MINICONDA = "C:\Miniconda3-x64"
+      $env:PATH = "$env:MINICONDA;$env:MINICONDA\Scripts;$env:PATH"
+      $env:BUILD_SOURCESDIRECTORY = "$env:APPVEYOR_BUILD_FOLDER"
 
-# build: false
+build: false
 
-# test_script:
-#   - conda config --remove channels defaults
-#   - conda config --add channels nodefaults
-#   - conda config --add channels conda-forge
-#   - conda config --set channel_priority strict
-#   - conda init powershell
-#   - powershell.exe -ExecutionPolicy Bypass -File %APPVEYOR_BUILD_FOLDER%\.ci\test_windows.ps1
+test_script:
+  - conda config --remove channels defaults
+  - conda config --add channels nodefaults
+  - conda config --add channels conda-forge
+  - conda config --set channel_priority strict
+  - conda init powershell
+  - powershell.exe -ExecutionPolicy Bypass -File %APPVEYOR_BUILD_FOLDER%\.ci\test_windows.ps1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,6 @@ install:
       $env:MINICONDA = "C:\Miniconda3-x64"
       $env:PATH = "$env:MINICONDA;$env:MINICONDA\Scripts;$env:PATH"
       $env:BUILD_SOURCESDIRECTORY = "$env:APPVEYOR_BUILD_FOLDER"
-      $env:LGB_VER = (Get-Content $env:APPVEYOR_BUILD_FOLDER\VERSION.txt).trim()
 
 build: false
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -10,6 +10,8 @@ SANITIZERS=${SANITIZERS:-""}
 
 ARCH=$(uname -m)
 
+LGB_VER=$(head -n 1 ${BUILD_DIRECTORY}/VERSION.txt)
+
 if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "gcc" ]]; then
     export CXX=g++-11
     export CC=gcc-11

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -6,6 +6,8 @@ function Check-Output {
   }
 }
 
+$env:LGB_VER = (Get-Content $env:BUILD_SOURCESDIRECTORY\VERSION.txt).trim()
+
 # unify environment variable for Azure DevOps and AppVeyor
 if (Test-Path env:APPVEYOR) {
   $env:APPVEYOR = "true"

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -111,7 +111,7 @@ jobs:
               --env TASK=${{ matrix.task }} \
               -v "$GITHUB_WORKSPACE":"${{ env.root_docker_folder }}" \
               ${{ matrix.image }} \
-              /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
+              /bin/bash ${{ env.root_docker_folder }}/docker-script.sh
   all-cuda-jobs-successful:
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -94,11 +94,26 @@ jobs:
           submodules: true
       - name: Setup and run tests
         run: |
-            export CONDA=\$HOME/miniforge
-            export PATH=\$CONDA/bin:\$PATH
-            nvidia-smi
-            $GITHUB_WORKSPACE/.ci/setup.sh
-            $GITHUB_WORKSPACE/.ci/test.sh
+          export CONDA=\$HOME/miniforge
+          export PATH=\$CONDA/bin:\$PATH
+          # install latest git
+          apt-get update
+          apt-get install --no-install-recommends -y \
+              ca-certificates \
+              gnupg-agent \
+              software-properties-common
+
+          add-apt-repository ppa:git-core/ppa -y
+          apt-get update
+          apt-get install --no-install-recommends -y \
+              git
+
+          # check GPU usage
+          nvidia-smi
+
+          # build and test
+          $GITHUB_WORKSPACE/.ci/setup.sh
+          $GITHUB_WORKSPACE/.ci/test.sh
   all-cuda-jobs-successful:
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -100,6 +100,7 @@ jobs:
       - name: clean up previous build directory
         run: |
           rm -rf $GITHUB_WORKSPACE/
+          rm -rf /github/home/miniforge/
           mkdir -p $GITHUB_WORKSPACE/
           echo "--- ghw ---"
           ls -alF $GITHUB_WORKSPACE

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -8,50 +8,63 @@ on:
     branches:
     - master
     - release/*
-
+  # Run manually by clicking a button in the UI
+  workflow_dispatch:
+    inputs:
+      restart_docker:
+        description: 'Restart nvidia-docker on the runner before building?'
+        required: true
+        type: boolean
+        default: false
 # automatically cancel in-progress builds if another commit is pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # # this works because all these jobs run on a single runner
-  # setup-docker:
-  #   name: setup-docker
-  #   timeout-minutes: 10
-  #   steps:
-  #     - name: Setup or update software on host machine
-  #       run: |
-  #           # install core packages
-  #           sudo apt-get update
-  #           sudo apt-get install --no-install-recommends -y \
-  #               apt-transport-https \
-  #               ca-certificates \
-  #               curl \
-  #               gnupg-agent \
-  #               lsb-release \
-  #               software-properties-common
-  #           # install latest git
-  #           sudo add-apt-repository ppa:git-core/ppa -y
-  #           sudo apt-get update
-  #           sudo apt-get install --no-install-recommends -y \
-  #               git
-  #           # set up nvidia-docker
-  #           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  #           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" -y
-  #           curl -sL https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
-  #           curl -sL https://nvidia.github.io/nvidia-docker/$(. /etc/os-release;echo $ID$VERSION_ID)/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-  #           sudo apt-get update
-  #           sudo apt-get install --no-install-recommends -y \
-  #               containerd.io \
-  #               docker-ce \
-  #               docker-ce-cli \
-  #               nvidia-docker2
-  #           sudo chmod a+rw /var/run/docker.sock
-  #           sudo systemctl restart docker
+  # Optionally reinstall + restart docker on the runner before building.
+  # This is safe as long as only 1 of these jobs runs at a time.
+  restart-docker:
+    name: setup-docker
+    timeout-minutes: 30
+    steps:
+      - name: Setup or update software on host machine
+        if: ${{ inputs.restart_docker }}
+        run: |
+            # install core packages
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends -y \
+                apt-transport-https \
+                ca-certificates \
+                curl \
+                gnupg-agent \
+                lsb-release \
+                software-properties-common
+            # install latest git
+            sudo add-apt-repository ppa:git-core/ppa -y
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends -y \
+                git
+            # set up nvidia-docker
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+            sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" -y
+            curl -sL https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
+            curl -sL https://nvidia.github.io/nvidia-docker/$(. /etc/os-release;echo $ID$VERSION_ID)/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends -y \
+                containerd.io \
+                docker-ce \
+                docker-ce-cli \
+                nvidia-docker2
+            sudo chmod a+rw /var/run/docker.sock
+            sudo systemctl restart docker
+      - name: mark job successful
+        run: |
+          exit 0
   test:
     name: ${{ matrix.task }} ${{ matrix.cuda_version }} ${{ matrix.method }} (linux, ${{ matrix.compiler }}, Python ${{ matrix.python_version }})
     runs-on: [self-hosted, linux]
+    needs: [restart-docker]
     container:
       image: ${{ matrix.image }}
       env:
@@ -73,18 +86,18 @@ jobs:
             cuda_version: "11.8.0"
             image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu18.04
             task: cuda
-          # - method: source
-          #   compiler: gcc
-          #   python_version: "3.9"
-          #   cuda_version: "12.2.0"
-          #   image: nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu20.04
-          #   task: cuda
-          # - method: pip
-          #   compiler: clang
-          #   python_version: "3.10"
-          #   cuda_version: "11.8.0"
-          #   image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu18.04
-          #   task: cuda
+          - method: source
+            compiler: gcc
+            python_version: "3.9"
+            cuda_version: "12.2.0"
+            image: nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu20.04
+            task: cuda
+          - method: pip
+            compiler: clang
+            python_version: "3.10"
+            cuda_version: "11.8.0"
+            image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu18.04
+            task: cuda
     steps:
       - name: Install latest git
         run: |
@@ -96,17 +109,6 @@ jobs:
           apt-get update
           apt-get install --no-install-recommends -y \
               git
-      # - name: clean up previous build directory
-      #   run: |
-      #     rm -rf $GITHUB_WORKSPACE/
-      #     rm -rf /github/home/miniforge/
-      #     mkdir -p $GITHUB_WORKSPACE/
-      #     echo "--- ghw ---"
-      #     ls -alF $GITHUB_WORKSPACE
-      #     echo "--- home ---"
-      #     ls -alF /home
-      #     echo "--- /github/home ---"
-      #     ls -alF /github/home
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -114,8 +116,8 @@ jobs:
           submodules: true
       - name: Setup and run tests
         run: |
-          export CONDA=/tmp/miniforge
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
+          export CONDA=/tmp/miniforge
           export PATH=$CONDA/bin:$PATH
 
           # check GPU usage

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -16,6 +16,7 @@ on:
         required: true
         type: boolean
         default: false
+
 # automatically cancel in-progress builds if another commit is pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +26,7 @@ jobs:
   # Optionally reinstall + restart docker on the runner before building.
   # This is safe as long as only 1 of these jobs runs at a time.
   restart-docker:
-    name: setup-docker
+    name: set up docker
     runs-on: [self-hosted, linux]
     timeout-minutes: 30
     steps:
@@ -87,19 +88,19 @@ jobs:
             compiler: gcc
             python_version: "3.11"
             cuda_version: "11.8.0"
-            image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu18.04
+            image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu20.04
             task: cuda
           - method: source
             compiler: gcc
             python_version: "3.9"
             cuda_version: "12.2.0"
-            image: nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu20.04
+            image: nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu22.04
             task: cuda
           - method: pip
             compiler: clang
             python_version: "3.10"
             cuda_version: "11.8.0"
-            image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu18.04
+            image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu20.04
             task: cuda
     steps:
       - name: Install latest git
@@ -113,7 +114,7 @@ jobs:
           apt-get install --no-install-recommends -y \
               git
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -70,6 +70,7 @@ jobs:
             sudo systemctl restart docker
       - name: Remove old checkout of the repository
         run: |
+          sudo rm -rf /home/guoke/actions-runner/_work/LightGBM/LightGBM/.pytest_cache
           # this needs to be run as the same user that created the files
           docker run \
             --rm \

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -97,17 +97,17 @@ jobs:
           apt-get update
           apt-get install --no-install-recommends -y \
               git
-      - name: clean up previous build directory
-        run: |
-          rm -rf $GITHUB_WORKSPACE/
-          rm -rf /github/home/miniforge/
-          mkdir -p $GITHUB_WORKSPACE/
-          echo "--- ghw ---"
-          ls -alF $GITHUB_WORKSPACE
-          echo "--- home ---"
-          ls -alF /home
-          echo "--- /github/home ---"
-          ls -alF /github/home
+      # - name: clean up previous build directory
+      #   run: |
+      #     rm -rf $GITHUB_WORKSPACE/
+      #     rm -rf /github/home/miniforge/
+      #     mkdir -p $GITHUB_WORKSPACE/
+      #     echo "--- ghw ---"
+      #     ls -alF $GITHUB_WORKSPACE
+      #     echo "--- home ---"
+      #     ls -alF /home
+      #     echo "--- /github/home ---"
+      #     ls -alF /github/home
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -69,7 +69,9 @@ jobs:
     container:
       image: ${{ matrix.image }}
       env:
+        CMAKE_BUILD_PARALLEL_LEVEL: 4
         COMPILER: ${{ matrix.compiler }}
+        CONDA: /tmp/miniforge
         CONDA_ENV: test-env
         METHOD: ${{ matrix.method }}
         OS_NAME: linux
@@ -118,7 +120,6 @@ jobs:
       - name: Setup and run tests
         run: |
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
-          export CONDA=/tmp/miniforge
           export PATH=$CONDA/bin:$PATH
 
           # check GPU usage

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -42,11 +42,6 @@ jobs:
                 gnupg-agent \
                 lsb-release \
                 software-properties-common
-            # install latest git
-            sudo add-apt-repository ppa:git-core/ppa -y
-            sudo apt-get update
-            sudo apt-get install --no-install-recommends -y \
-                git
             # set up nvidia-docker
             curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
             sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" -y
@@ -74,6 +69,7 @@ jobs:
         COMPILER: ${{ matrix.compiler }}
         CONDA: /tmp/miniforge
         CONDA_ENV: test-env
+        DEBIAN_FRONTEND: noninteractive
         METHOD: ${{ matrix.method }}
         OS_NAME: linux
         PYTHON_VERSION: ${{ matrix.python_version }}

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -53,7 +53,7 @@ jobs:
     name: ${{ matrix.task }} ${{ matrix.cuda_version }} ${{ matrix.method }} (linux, ${{ matrix.compiler }}, Python ${{ matrix.python_version }})
     runs-on: [self-hosted, linux]
     container:
-      name: ${{ matrix.image }}
+      image: ${{ matrix.image }}
       env:
         BUILD_DIRECTORY: ${GITHUB_WORKSPACE}
         COMPILER: ${{ matrix.compiler }}
@@ -63,7 +63,7 @@ jobs:
         PYTHON_VERSION: ${{ matrix.python_version }}
         TASK: ${{ matrix.task }}
       options: --gpus all
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs: [setup-docker]
     strategy:
       fail-fast: false

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Remove old checkout of the repository
         run: sudo rm -rf $GITHUB_WORKSPACE/*
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -87,6 +87,16 @@ jobs:
             image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu18.04
             task: cuda
     steps:
+      - name: Install latest git
+        run: |
+          apt-get update
+          apt-get install --no-install-recommends -y \
+              ca-certificates \
+              software-properties-common
+          add-apt-repository ppa:git-core/ppa -y
+          apt-get update
+          apt-get install --no-install-recommends -y \
+              git
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -96,17 +106,6 @@ jobs:
         run: |
           export CONDA=\$HOME/miniforge
           export PATH=\$CONDA/bin:\$PATH
-          # install latest git
-          apt-get update
-          apt-get install --no-install-recommends -y \
-              ca-certificates \
-              gnupg-agent \
-              software-properties-common
-
-          add-apt-repository ppa:git-core/ppa -y
-          apt-get update
-          apt-get install --no-install-recommends -y \
-              git
 
           # check GPU usage
           nvidia-smi

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -67,10 +67,10 @@ jobs:
                 nvidia-docker2
             sudo chmod a+rw /var/run/docker.sock
             sudo systemctl restart docker
-      - name: Remove old folder with repository
-        run: sudo rm -rf $GITHUB_WORKSPACE
+      - name: Remove old checkout of the repository
+        run: sudo rm -rf $GITHUB_WORKSPACE/*
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 5
           submodules: true

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -97,17 +97,17 @@ jobs:
           apt-get update
           apt-get install --no-install-recommends -y \
               git
-      # - name: clean up previous build directory
-      #   run: |
-      #     rm -rf $GITHUB_WORKSPACE/
-      #     rm -rf /github/home/miniforge/
-      #     mkdir -p $GITHUB_WORKSPACE/
-      #     echo "--- ghw ---"
-      #     ls -alF $GITHUB_WORKSPACE
-      #     echo "--- home ---"
-      #     ls -alF /home
-      #     echo "--- /github/home ---"
-      #     ls -alF /github/home
+      - name: clean up previous build directory
+        run: |
+          rm -rf $GITHUB_WORKSPACE/
+          rm -rf /github/home/miniforge/
+          mkdir -p $GITHUB_WORKSPACE/
+          echo "--- ghw ---"
+          ls -alF $GITHUB_WORKSPACE
+          echo "--- home ---"
+          ls -alF /home
+          echo "--- /github/home ---"
+          ls -alF /github/home
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -115,7 +115,7 @@ jobs:
           submodules: true
       - name: Setup and run tests
         run: |
-          export CONDA=$HOME/miniforge
+          export CONDA=/tmp/miniforge
           export PATH=$CONDA/bin:$PATH
 
           # check GPU usage

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -74,18 +74,18 @@ jobs:
             cuda_version: "11.8.0"
             image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu18.04
             task: cuda
-          - method: source
-            compiler: gcc
-            python_version: "3.9"
-            cuda_version: "12.2.0"
-            image: nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu20.04
-            task: cuda
-          - method: pip
-            compiler: clang
-            python_version: "3.10"
-            cuda_version: "11.8.0"
-            image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu18.04
-            task: cuda
+          # - method: source
+          #   compiler: gcc
+          #   python_version: "3.9"
+          #   cuda_version: "12.2.0"
+          #   image: nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu20.04
+          #   task: cuda
+          # - method: pip
+          #   compiler: clang
+          #   python_version: "3.10"
+          #   cuda_version: "11.8.0"
+          #   image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu18.04
+          #   task: cuda
     steps:
       - name: Install latest git
         run: |
@@ -97,6 +97,9 @@ jobs:
           apt-get update
           apt-get install --no-install-recommends -y \
               git
+      - name: clean up previous build directory
+        run: |
+          rm -rf $GITHUB_WORKSPACE/*
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -104,8 +104,8 @@ jobs:
           submodules: true
       - name: Setup and run tests
         run: |
-          export CONDA=\$HOME/miniforge
-          export PATH=\$CONDA/bin:\$PATH
+          export CONDA=$HOME/miniforge
+          export PATH=$CONDA/bin:$PATH
 
           # check GPU usage
           nvidia-smi

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -75,7 +75,7 @@ jobs:
             --rm \
             -v "$GITHUB_WORKSPACE":/opt/repo \
             -w /opt \
-            nvcr.io/nvidia/cuda:${{ matrix.cuda_version }}-devel \
+            ${{ matrix.image }} \
             rm -rf /opt/repo/*
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -103,7 +103,7 @@ jobs:
               --env PYTHON_VERSION=${{ matrix.python_version }} \
               --env TASK=${{ matrix.task }} \
               -v "$GITHUB_WORKSPACE":"${{ env.root_docker_folder }}" \
-              "$docker_img" \
+              ${{ matrix.image }} \
               /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
   all-cuda-jobs-successful:
     if: always()

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -105,6 +105,8 @@ jobs:
           ls -alF $GITHUB_WORKSPACE
           echo "--- home ---"
           ls -alF /home
+          echo "--- /github/home ---"
+          ls -alF /github/home
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -55,7 +55,6 @@ jobs:
     container:
       image: ${{ matrix.image }}
       env:
-        BUILD_DIRECTORY: ${{ github.workspace }}
         COMPILER: ${{ matrix.compiler }}
         CONDA_ENV: test-env
         METHOD: ${{ matrix.method }}
@@ -97,17 +96,17 @@ jobs:
           apt-get update
           apt-get install --no-install-recommends -y \
               git
-      - name: clean up previous build directory
-        run: |
-          rm -rf $GITHUB_WORKSPACE/
-          rm -rf /github/home/miniforge/
-          mkdir -p $GITHUB_WORKSPACE/
-          echo "--- ghw ---"
-          ls -alF $GITHUB_WORKSPACE
-          echo "--- home ---"
-          ls -alF /home
-          echo "--- /github/home ---"
-          ls -alF /github/home
+      # - name: clean up previous build directory
+      #   run: |
+      #     rm -rf $GITHUB_WORKSPACE/
+      #     rm -rf /github/home/miniforge/
+      #     mkdir -p $GITHUB_WORKSPACE/
+      #     echo "--- ghw ---"
+      #     ls -alF $GITHUB_WORKSPACE
+      #     echo "--- home ---"
+      #     ls -alF /home
+      #     echo "--- /github/home ---"
+      #     ls -alF /github/home
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -116,6 +115,7 @@ jobs:
       - name: Setup and run tests
         run: |
           export CONDA=/tmp/miniforge
+          export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           export PATH=$CONDA/bin:$PATH
 
           # check GPU usage

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -26,6 +26,7 @@ jobs:
   # This is safe as long as only 1 of these jobs runs at a time.
   restart-docker:
     name: setup-docker
+    runs-on: [self-hosted, linux]
     timeout-minutes: 30
     steps:
       - name: Setup or update software on host machine

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -47,6 +47,9 @@ jobs:
     steps:
       - name: Setup or update software on host machine
         run: |
+            # ensure latest git is pulled
+            add-apt-repository ppa:git-core/ppa -y
+            # install core packages
             sudo apt-get update
             sudo apt-get install --no-install-recommends -y \
                 apt-transport-https \
@@ -56,6 +59,7 @@ jobs:
                 gnupg-agent \
                 lsb-release \
                 software-properties-common
+            # set up nvidia-docker
             curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
             sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" -y
             curl -sL https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -97,7 +97,6 @@ jobs:
               --env BUILD_DIRECTORY=${{ env.root_docker_folder }} \
               --env COMPILER=${{ matrix.compiler }} \
               --env CONDA_ENV='test-env' \
-              --env GITHUB_ACTIONS=${{ env.github_actions }} \
               --env METHOD=${{ matrix.method }}
               --env OS_NAME=linux \
               --env PYTHON_VERSION=${{ matrix.python_version }} \

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -76,7 +76,7 @@ jobs:
             -v "$GITHUB_WORKSPACE":/opt/repo \
             -w /opt \
             ${{ matrix.image }} \
-            rm -rf /opt/repo/*
+            rm -rf /opt/repo/* || true
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -15,9 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  github_actions: 'true'
-  os_name: linux
-  conda_env: test-env
+  root_docker_folder: /LightGBM
 
 jobs:
   test:
@@ -32,16 +30,19 @@ jobs:
             compiler: gcc
             python_version: "3.11"
             cuda_version: "11.8.0"
+            image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu18.04
             task: cuda
           - method: source
             compiler: gcc
             python_version: "3.9"
             cuda_version: "12.2.0"
+            image: nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu20.04
             task: cuda
           - method: pip
             compiler: clang
             python_version: "3.10"
             cuda_version: "11.8.0"
+            image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu18.04
             task: cuda
     steps:
       - name: Setup or update software on host machine
@@ -68,7 +69,14 @@ jobs:
             sudo chmod a+rw /var/run/docker.sock
             sudo systemctl restart docker
       - name: Remove old checkout of the repository
-        run: sudo rm -rf $GITHUB_WORKSPACE/*
+        run: |
+          # this needs to be run as the same user that created the files
+          docker run \
+            --rm \
+            -v "$GITHUB_WORKSPACE":/opt/repo \
+            -w /opt \
+            nvcr.io/nvidia/cuda:${{ matrix.cuda_version }}-devel \
+            rm -rf /opt/repo/*
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -76,34 +84,27 @@ jobs:
           submodules: true
       - name: Setup and run tests
         run: |
-            export ROOT_DOCKER_FOLDER=/LightGBM
-            cat > docker.env <<EOF
-            GITHUB_ACTIONS=${{ env.github_actions }}
-            OS_NAME=${{ env.os_name }}
-            COMPILER=${{ matrix.compiler }}
-            TASK=${{ matrix.task }}
-            METHOD=${{ matrix.method }}
-            CONDA_ENV=${{ env.conda_env }}
-            PYTHON_VERSION=${{ matrix.python_version }}
-            BUILD_DIRECTORY=$ROOT_DOCKER_FOLDER
-            LGB_VER=$(head -n 1 VERSION.txt)
-            EOF
             cat > docker-script.sh <<EOF
             export CONDA=\$HOME/miniforge
             export PATH=\$CONDA/bin:\$PATH
             nvidia-smi
-            $ROOT_DOCKER_FOLDER/.ci/setup.sh || exit 1
-            $ROOT_DOCKER_FOLDER/.ci/test.sh || exit 1
+            ${{ env.root_docker_folder }}/.ci/setup.sh || exit 1
+            ${{ env.root_docker_folder }}/.ci/test.sh || exit 1
             EOF
-            cuda_version="${{ matrix.cuda_version }}"
-            cuda_major=${cuda_version%%.*}
-            docker_img="nvcr.io/nvidia/cuda:${cuda_version}-devel"
-            if [[ ${cuda_major} -eq 11 ]]; then
-                docker_img="${docker_img}-ubuntu18.04"
-            elif [[ ${cuda_major} -ge 12 ]]; then
-                docker_img="${docker_img}-ubuntu20.04"
-            fi
-            docker run --env-file docker.env -v "$GITHUB_WORKSPACE":"$ROOT_DOCKER_FOLDER" --rm --gpus all "$docker_img" /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
+            docker run \
+              --rm \
+              --gpus all \
+              --env BUILD_DIRECTORY=${{ env.root_docker_folder }} \
+              --env COMPILER=${{ matrix.compiler }} \
+              --env CONDA_ENV='test-env' \
+              --env GITHUB_ACTIONS=${{ env.github_actions }} \
+              --env METHOD=${{ matrix.method }}
+              --env OS_NAME=linux \
+              --env PYTHON_VERSION=${{ matrix.python_version }} \
+              --env TASK=${{ matrix.task }} \
+              -v "$GITHUB_WORKSPACE":"${{ env.root_docker_folder }}" \
+              "$docker_img" \
+              /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
   all-cuda-jobs-successful:
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -47,18 +47,20 @@ jobs:
     steps:
       - name: Setup or update software on host machine
         run: |
-            # ensure latest git is pulled
-            add-apt-repository ppa:git-core/ppa -y
             # install core packages
             sudo apt-get update
             sudo apt-get install --no-install-recommends -y \
                 apt-transport-https \
                 ca-certificates \
                 curl \
-                git \
                 gnupg-agent \
                 lsb-release \
                 software-properties-common
+            # install latest git
+            sudo add-apt-repository ppa:git-core/ppa -y
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends -y \
+                git
             # set up nvidia-docker
             curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
             sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" -y

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -64,7 +64,6 @@ jobs:
         TASK: ${{ matrix.task }}
       options: --gpus all
     timeout-minutes: 30
-    needs: [setup-docker]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -99,7 +99,8 @@ jobs:
               git
       - name: clean up previous build directory
         run: |
-          rm -rf $GITHUB_WORKSPACE/*
+          rm -rf $GITHUB_WORKSPACE/
+          mkdir -p $GITHUB_WORKSPACE/
           echo "--- ghw ---"
           ls -alF $GITHUB_WORKSPACE
           echo "--- home ---"

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -14,14 +14,57 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  root_docker_folder: /LightGBM
-
 jobs:
+  # # this works because all these jobs run on a single runner
+  # setup-docker:
+  #   name: setup-docker
+  #   timeout-minutes: 10
+  #   steps:
+  #     - name: Setup or update software on host machine
+  #       run: |
+  #           # install core packages
+  #           sudo apt-get update
+  #           sudo apt-get install --no-install-recommends -y \
+  #               apt-transport-https \
+  #               ca-certificates \
+  #               curl \
+  #               gnupg-agent \
+  #               lsb-release \
+  #               software-properties-common
+  #           # install latest git
+  #           sudo add-apt-repository ppa:git-core/ppa -y
+  #           sudo apt-get update
+  #           sudo apt-get install --no-install-recommends -y \
+  #               git
+  #           # set up nvidia-docker
+  #           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  #           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" -y
+  #           curl -sL https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
+  #           curl -sL https://nvidia.github.io/nvidia-docker/$(. /etc/os-release;echo $ID$VERSION_ID)/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+  #           sudo apt-get update
+  #           sudo apt-get install --no-install-recommends -y \
+  #               containerd.io \
+  #               docker-ce \
+  #               docker-ce-cli \
+  #               nvidia-docker2
+  #           sudo chmod a+rw /var/run/docker.sock
+  #           sudo systemctl restart docker
   test:
     name: ${{ matrix.task }} ${{ matrix.cuda_version }} ${{ matrix.method }} (linux, ${{ matrix.compiler }}, Python ${{ matrix.python_version }})
     runs-on: [self-hosted, linux]
+    container:
+      name: ${{ matrix.image }}
+      env:
+        BUILD_DIRECTORY: ${GITHUB_WORKSPACE}
+        COMPILER: ${{ matrix.compiler }}
+        CONDA_ENV: test-env
+        METHOD: ${{ matrix.method }}
+        OS_NAME: linux
+        PYTHON_VERSION: ${{ matrix.python_version }}
+        TASK: ${{ matrix.task }}
+      options: --gpus all
     timeout-minutes: 60
+    needs: [setup-docker]
     strategy:
       fail-fast: false
       matrix:
@@ -45,46 +88,6 @@ jobs:
             image: nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu18.04
             task: cuda
     steps:
-      - name: Setup or update software on host machine
-        run: |
-            # install core packages
-            sudo apt-get update
-            sudo apt-get install --no-install-recommends -y \
-                apt-transport-https \
-                ca-certificates \
-                curl \
-                gnupg-agent \
-                lsb-release \
-                software-properties-common
-            # install latest git
-            sudo add-apt-repository ppa:git-core/ppa -y
-            sudo apt-get update
-            sudo apt-get install --no-install-recommends -y \
-                git
-            # set up nvidia-docker
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-            sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" -y
-            curl -sL https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
-            curl -sL https://nvidia.github.io/nvidia-docker/$(. /etc/os-release;echo $ID$VERSION_ID)/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-            sudo apt-get update
-            sudo apt-get install --no-install-recommends -y \
-                containerd.io \
-                docker-ce \
-                docker-ce-cli \
-                nvidia-docker2
-            sudo chmod a+rw /var/run/docker.sock
-            sudo systemctl restart docker
-      - name: Remove old checkout of the repository
-        run: |
-          # this needs to be run as the same user that created the files
-          docker run \
-            --rm \
-            -v "$GITHUB_WORKSPACE":/opt/repo \
-            -w /opt \
-            ${{ matrix.image }} \
-            rm -rf /opt/repo/*
-          # but it won't get everything
-          sudo rm -rf "${GITHUB_WORKSPACE}/*"
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -92,26 +95,11 @@ jobs:
           submodules: true
       - name: Setup and run tests
         run: |
-            cat > docker-script.sh <<EOF
             export CONDA=\$HOME/miniforge
             export PATH=\$CONDA/bin:\$PATH
             nvidia-smi
-            ${{ env.root_docker_folder }}/.ci/setup.sh || exit 1
-            ${{ env.root_docker_folder }}/.ci/test.sh || exit 1
-            EOF
-            docker run \
-              --rm \
-              --gpus all \
-              --env BUILD_DIRECTORY=${{ env.root_docker_folder }} \
-              --env COMPILER=${{ matrix.compiler }} \
-              --env CONDA_ENV='test-env' \
-              --env METHOD=${{ matrix.method }} \
-              --env OS_NAME=linux \
-              --env PYTHON_VERSION=${{ matrix.python_version }} \
-              --env TASK=${{ matrix.task }} \
-              -v "$GITHUB_WORKSPACE":"${{ env.root_docker_folder }}" \
-              ${{ matrix.image }} \
-              /bin/bash ${{ env.root_docker_folder }}/docker-script.sh
+            $GITHUB_WORKSPACE/.ci/setup.sh
+            $GITHUB_WORKSPACE/.ci/test.sh
   all-cuda-jobs-successful:
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -83,6 +83,8 @@ jobs:
             -w /opt \
             ${{ matrix.image }} \
             rm -rf /opt/repo/*
+          # but it won't get everything
+          sudo rm -rf "${GITHUB_WORKSPACE}/*"
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -76,15 +76,13 @@ jobs:
             sudo systemctl restart docker
       - name: Remove old checkout of the repository
         run: |
-          sudo rm -rf /home/guoke/actions-runner/_work/LightGBM/LightGBM/.pytest_cache
           # this needs to be run as the same user that created the files
           docker run \
             --rm \
             -v "$GITHUB_WORKSPACE":/opt/repo \
             -w /opt \
             ${{ matrix.image }} \
-            rm -rf /opt/repo/* || true
-          sudo rm -rf "$GITHUB_WORKSPACE"/*
+            rm -rf /opt/repo/*
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -105,7 +103,7 @@ jobs:
               --env BUILD_DIRECTORY=${{ env.root_docker_folder }} \
               --env COMPILER=${{ matrix.compiler }} \
               --env CONDA_ENV='test-env' \
-              --env METHOD=${{ matrix.method }}
+              --env METHOD=${{ matrix.method }} \
               --env OS_NAME=linux \
               --env PYTHON_VERSION=${{ matrix.python_version }} \
               --env TASK=${{ matrix.task }} \

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -100,6 +100,10 @@ jobs:
       - name: clean up previous build directory
         run: |
           rm -rf $GITHUB_WORKSPACE/*
+          echo "--- ghw ---"
+          ls -alF $GITHUB_WORKSPACE
+          echo "--- home ---"
+          ls -alF /home
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -77,6 +77,7 @@ jobs:
             -w /opt \
             ${{ matrix.image }} \
             rm -rf /opt/repo/* || true
+          sudo rm -rf "$GITHUB_WORKSPACE"/*
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -55,7 +55,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
       env:
-        BUILD_DIRECTORY: ${GITHUB_WORKSPACE}
+        BUILD_DIRECTORY: ${{ github.workspace }}
         COMPILER: ${{ matrix.compiler }}
         CONDA_ENV: test-env
         METHOD: ${{ matrix.method }}

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   CONDA_ENV: test-env
-  GITHUB_ACTIONS: 'true'
   OS_NAME: 'linux'
   PYTHON_VERSION: '3.11'
   TASK: 'check-links'

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -1,114 +1,116 @@
-# name: Python-package
+name: Python-package
 
-# on:
-#   push:
-#     branches:
-#     - master
-#   pull_request:
-#     branches:
-#     - master
-#     - release/*
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+    - release/*
 
-# # automatically cancel in-progress builds if another commit is pushed
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: true
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-# env:
-#   CONDA_ENV: test-env
+env:
+  # for CMake-based builds, compile 4 objects at a time
+  # (equivalent to make -j4)
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CONDA_ENV: test-env
 
-# jobs:
-#   test:
-#     name: ${{ matrix.task }} ${{ matrix.method }} (${{ matrix.os }}, Python ${{ matrix.python_version }})
-#     runs-on: ${{ matrix.os }}
-#     timeout-minutes: 60
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         include:
-#           - os: macos-13
-#             task: regular
-#             python_version: '3.9'
-#           - os: macos-13
-#             task: sdist
-#             python_version: '3.10'
-#           - os: macos-13
-#             task: bdist
-#             python_version: '3.7'
-#           - os: macos-13
-#             task: if-else
-#             python_version: '3.9'
-#           # We're currently skipping MPI jobs on macOS, see https://github.com/microsoft/LightGBM/pull/6425
-#           # for further details.
-#           # - os: macos-13
-#           #   task: mpi
-#           #   method: source
-#           #   python_version: '3.10'
-#           # - os: macos-13
-#           #   task: mpi
-#           #   method: pip
-#           #   python_version: '3.11'
-#           # - os: macos-13
-#           #   task: mpi
-#           #   method: wheel
-#           #   python_version: '3.8'
-#     steps:
-#       - name: Checkout repository
-#         uses: actions/checkout@v3
-#         with:
-#           fetch-depth: 5
-#           submodules: true
-#       - name: Setup and run tests
-#         shell: bash
-#         run: |
-#           export TASK="${{ matrix.task }}"
-#           export METHOD="${{ matrix.method }}"
-#           export PYTHON_VERSION="${{ matrix.python_version }}"
-#           if [[ "${{ matrix.os }}" == "macos-13" ]]; then
-#               export COMPILER="gcc"
-#               export OS_NAME="macos"
-#           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-#               export COMPILER="clang"
-#               export OS_NAME="linux"
-#           fi
-#           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
-#           export LGB_VER=$(head -n 1 VERSION.txt)
-#           export CONDA=${HOME}/miniforge
-#           export PATH=${CONDA}/bin:${PATH}
-#           $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
-#           $GITHUB_WORKSPACE/.ci/test.sh || exit 1
-#   test-oldest-versions:
-#     name: Python - oldest supported versions (ubuntu-latest)
-#     runs-on: ubuntu-latest
-#     timeout-minutes: 60
-#     steps:
-#       - name: Checkout repository
-#         uses: actions/checkout@v3
-#         with:
-#           fetch-depth: 5
-#           submodules: true
-#       - name: Create wheel
-#         run: |
-#           docker run \
-#             --rm \
-#             -v $(pwd):/opt/lgb-build \
-#             -w /opt/lgb-build \
-#             lightgbm/vsts-agent:manylinux_2_28_x86_64 \
-#             /bin/bash -c 'PATH=/opt/miniforge/bin:$PATH sh ./build-python.sh bdist_wheel --nomp'
-#       - name: Test compatibility
-#         run: |
-#           docker run \
-#             --rm \
-#             -v $(pwd):/opt/lgb-build \
-#             -w /opt/lgb-build \
-#             python:3.6 \
-#             /bin/bash ./.ci/test-python-oldest.sh
-#   all-python-package-jobs-successful:
-#     if: always()
-#     runs-on: ubuntu-latest
-#     needs: [test, test-oldest-versions]
-#     steps:
-#     - name: Note that all tests succeeded
-#       uses: re-actors/alls-green@v1.2.2
-#       with:
-#         jobs: ${{ toJSON(needs) }}
+jobs:
+  test:
+    name: ${{ matrix.task }} ${{ matrix.method }} (${{ matrix.os }}, Python ${{ matrix.python_version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-13
+            task: regular
+            python_version: '3.9'
+          - os: macos-13
+            task: sdist
+            python_version: '3.10'
+          - os: macos-13
+            task: bdist
+            python_version: '3.7'
+          - os: macos-13
+            task: if-else
+            python_version: '3.9'
+          # We're currently skipping MPI jobs on macOS, see https://github.com/microsoft/LightGBM/pull/6425
+          # for further details.
+          # - os: macos-13
+          #   task: mpi
+          #   method: source
+          #   python_version: '3.10'
+          # - os: macos-13
+          #   task: mpi
+          #   method: pip
+          #   python_version: '3.11'
+          # - os: macos-13
+          #   task: mpi
+          #   method: wheel
+          #   python_version: '3.8'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
+          submodules: true
+      - name: Setup and run tests
+        shell: bash
+        run: |
+          export TASK="${{ matrix.task }}"
+          export METHOD="${{ matrix.method }}"
+          export PYTHON_VERSION="${{ matrix.python_version }}"
+          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+              export COMPILER="gcc"
+              export OS_NAME="macos"
+          elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+              export COMPILER="clang"
+              export OS_NAME="linux"
+          fi
+          export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
+          export CONDA=${HOME}/miniforge
+          export PATH=${CONDA}/bin:${PATH}
+          $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
+          $GITHUB_WORKSPACE/.ci/test.sh || exit 1
+  test-oldest-versions:
+    name: Python - oldest supported versions (ubuntu-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
+          submodules: true
+      - name: Create wheel
+        run: |
+          docker run \
+            --rm \
+            -v $(pwd):/opt/lgb-build \
+            -w /opt/lgb-build \
+            lightgbm/vsts-agent:manylinux_2_28_x86_64 \
+            /bin/bash -c 'PATH=/opt/miniforge/bin:$PATH sh ./build-python.sh bdist_wheel --nomp'
+      - name: Test compatibility
+        run: |
+          docker run \
+            --rm \
+            -v $(pwd):/opt/lgb-build \
+            -w /opt/lgb-build \
+            python:3.6 \
+            /bin/bash ./.ci/test-python-oldest.sh
+  all-python-package-jobs-successful:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [test, test-oldest-versions]
+    steps:
+    - name: Note that all tests succeeded
+      uses: re-actors/alls-green@v1.2.2
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -15,8 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # for CMake-based builds, compile 4 objects at a time
-  # (equivalent to make -j4)
   CMAKE_BUILD_PARALLEL_LEVEL: 4
   CONDA_ENV: test-env
 

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -16,7 +16,6 @@ concurrency:
 
 env:
   CONDA_ENV: test-env
-  GITHUB_ACTIONS: 'true'
 
 jobs:
   test:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -1,114 +1,114 @@
-name: Python-package
+# name: Python-package
 
-on:
-  push:
-    branches:
-    - master
-  pull_request:
-    branches:
-    - master
-    - release/*
+# on:
+#   push:
+#     branches:
+#     - master
+#   pull_request:
+#     branches:
+#     - master
+#     - release/*
 
-# automatically cancel in-progress builds if another commit is pushed
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# # automatically cancel in-progress builds if another commit is pushed
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
 
-env:
-  CONDA_ENV: test-env
+# env:
+#   CONDA_ENV: test-env
 
-jobs:
-  test:
-    name: ${{ matrix.task }} ${{ matrix.method }} (${{ matrix.os }}, Python ${{ matrix.python_version }})
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-13
-            task: regular
-            python_version: '3.9'
-          - os: macos-13
-            task: sdist
-            python_version: '3.10'
-          - os: macos-13
-            task: bdist
-            python_version: '3.7'
-          - os: macos-13
-            task: if-else
-            python_version: '3.9'
-          # We're currently skipping MPI jobs on macOS, see https://github.com/microsoft/LightGBM/pull/6425
-          # for further details.
-          # - os: macos-13
-          #   task: mpi
-          #   method: source
-          #   python_version: '3.10'
-          # - os: macos-13
-          #   task: mpi
-          #   method: pip
-          #   python_version: '3.11'
-          # - os: macos-13
-          #   task: mpi
-          #   method: wheel
-          #   python_version: '3.8'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 5
-          submodules: true
-      - name: Setup and run tests
-        shell: bash
-        run: |
-          export TASK="${{ matrix.task }}"
-          export METHOD="${{ matrix.method }}"
-          export PYTHON_VERSION="${{ matrix.python_version }}"
-          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
-              export COMPILER="gcc"
-              export OS_NAME="macos"
-          elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-              export COMPILER="clang"
-              export OS_NAME="linux"
-          fi
-          export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
-          export LGB_VER=$(head -n 1 VERSION.txt)
-          export CONDA=${HOME}/miniforge
-          export PATH=${CONDA}/bin:${PATH}
-          $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
-          $GITHUB_WORKSPACE/.ci/test.sh || exit 1
-  test-oldest-versions:
-    name: Python - oldest supported versions (ubuntu-latest)
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 5
-          submodules: true
-      - name: Create wheel
-        run: |
-          docker run \
-            --rm \
-            -v $(pwd):/opt/lgb-build \
-            -w /opt/lgb-build \
-            lightgbm/vsts-agent:manylinux_2_28_x86_64 \
-            /bin/bash -c 'PATH=/opt/miniforge/bin:$PATH sh ./build-python.sh bdist_wheel --nomp'
-      - name: Test compatibility
-        run: |
-          docker run \
-            --rm \
-            -v $(pwd):/opt/lgb-build \
-            -w /opt/lgb-build \
-            python:3.6 \
-            /bin/bash ./.ci/test-python-oldest.sh
-  all-python-package-jobs-successful:
-    if: always()
-    runs-on: ubuntu-latest
-    needs: [test, test-oldest-versions]
-    steps:
-    - name: Note that all tests succeeded
-      uses: re-actors/alls-green@v1.2.2
-      with:
-        jobs: ${{ toJSON(needs) }}
+# jobs:
+#   test:
+#     name: ${{ matrix.task }} ${{ matrix.method }} (${{ matrix.os }}, Python ${{ matrix.python_version }})
+#     runs-on: ${{ matrix.os }}
+#     timeout-minutes: 60
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include:
+#           - os: macos-13
+#             task: regular
+#             python_version: '3.9'
+#           - os: macos-13
+#             task: sdist
+#             python_version: '3.10'
+#           - os: macos-13
+#             task: bdist
+#             python_version: '3.7'
+#           - os: macos-13
+#             task: if-else
+#             python_version: '3.9'
+#           # We're currently skipping MPI jobs on macOS, see https://github.com/microsoft/LightGBM/pull/6425
+#           # for further details.
+#           # - os: macos-13
+#           #   task: mpi
+#           #   method: source
+#           #   python_version: '3.10'
+#           # - os: macos-13
+#           #   task: mpi
+#           #   method: pip
+#           #   python_version: '3.11'
+#           # - os: macos-13
+#           #   task: mpi
+#           #   method: wheel
+#           #   python_version: '3.8'
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v3
+#         with:
+#           fetch-depth: 5
+#           submodules: true
+#       - name: Setup and run tests
+#         shell: bash
+#         run: |
+#           export TASK="${{ matrix.task }}"
+#           export METHOD="${{ matrix.method }}"
+#           export PYTHON_VERSION="${{ matrix.python_version }}"
+#           if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+#               export COMPILER="gcc"
+#               export OS_NAME="macos"
+#           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+#               export COMPILER="clang"
+#               export OS_NAME="linux"
+#           fi
+#           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
+#           export LGB_VER=$(head -n 1 VERSION.txt)
+#           export CONDA=${HOME}/miniforge
+#           export PATH=${CONDA}/bin:${PATH}
+#           $GITHUB_WORKSPACE/.ci/setup.sh || exit 1
+#           $GITHUB_WORKSPACE/.ci/test.sh || exit 1
+#   test-oldest-versions:
+#     name: Python - oldest supported versions (ubuntu-latest)
+#     runs-on: ubuntu-latest
+#     timeout-minutes: 60
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v3
+#         with:
+#           fetch-depth: 5
+#           submodules: true
+#       - name: Create wheel
+#         run: |
+#           docker run \
+#             --rm \
+#             -v $(pwd):/opt/lgb-build \
+#             -w /opt/lgb-build \
+#             lightgbm/vsts-agent:manylinux_2_28_x86_64 \
+#             /bin/bash -c 'PATH=/opt/miniforge/bin:$PATH sh ./build-python.sh bdist_wheel --nomp'
+#       - name: Test compatibility
+#         run: |
+#           docker run \
+#             --rm \
+#             -v $(pwd):/opt/lgb-build \
+#             -w /opt/lgb-build \
+#             python:3.6 \
+#             /bin/bash ./.ci/test-python-oldest.sh
+#   all-python-package-jobs-successful:
+#     if: always()
+#     runs-on: ubuntu-latest
+#     needs: [test, test-oldest-versions]
+#     steps:
+#     - name: Note that all tests succeeded
+#       uses: re-actors/alls-green@v1.2.2
+#       with:
+#         jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -189,7 +189,6 @@ jobs:
         run: |
           export TASK="${{ matrix.task }}"
           export COMPILER="${{ matrix.compiler }}"
-          export GITHUB_ACTIONS="true"
           if [[ "${{ matrix.os }}" == "macos-13" ]]; then
               export OS_NAME="macos"
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
@@ -216,7 +215,6 @@ jobs:
           $env:R_VERSION = "${{ matrix.r_version }}"
           $env:R_BUILD_TYPE = "${{ matrix.build_type }}"
           $env:COMPILER = "${{ matrix.compiler }}"
-          $env:GITHUB_ACTIONS = "true"
           $env:TASK = "${{ matrix.task }}"
           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
   test-r-sanitizers:

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -1,312 +1,313 @@
-# name: R-package
+name: R-package
 
-# on:
-#   push:
-#     branches:
-#     - master
-#   pull_request:
-#     branches:
-#     - master
-#     - release/*
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+    - release/*
 
-# # automatically cancel in-progress builds if another commit is pushed
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: true
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-# env:
-#   # hack to get around this:
-#   # https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
-#   _R_CHECK_SYSTEM_CLOCK_: 0
-#   # ignore R CMD CHECK NOTE checking how long it has
-#   # been since the last submission
-#   _R_CHECK_CRAN_INCOMING_REMOTE_: 0
-#   # CRAN ignores the "installed size is too large" NOTE,
-#   # so our CI can too. Setting to a large value here just
-#   # to catch extreme problems
-#   _R_CHECK_PKG_SIZES_THRESHOLD_: 100
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  # hack to get around this:
+  # https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
+  _R_CHECK_SYSTEM_CLOCK_: 0
+  # ignore R CMD CHECK NOTE checking how long it has
+  # been since the last submission
+  _R_CHECK_CRAN_INCOMING_REMOTE_: 0
+  # CRAN ignores the "installed size is too large" NOTE,
+  # so our CI can too. Setting to a large value here just
+  # to catch extreme problems
+  _R_CHECK_PKG_SIZES_THRESHOLD_: 100
 
-# jobs:
-#   test:
-#     name: ${{ matrix.task }} (${{ matrix.os }}, ${{ matrix.compiler }}, R ${{ matrix.r_version }}, ${{ matrix.build_type }})
-#     runs-on: ${{ matrix.os }}
-#     container: ${{ matrix.container }}
-#     timeout-minutes: 60
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         include:
-#           ################
-#           # CMake builds #
-#           ################
-#           - os: ubuntu-latest
-#             task: r-package
-#             compiler: gcc
-#             r_version: 3.6
-#             build_type: cmake
-#             container: 'ubuntu:18.04'
-#           - os: ubuntu-latest
-#             task: r-package
-#             compiler: gcc
-#             r_version: 4.3
-#             build_type: cmake
-#             container: 'ubuntu:22.04'
-#           - os: ubuntu-latest
-#             task: r-package
-#             compiler: clang
-#             r_version: 3.6
-#             build_type: cmake
-#             container: 'ubuntu:18.04'
-#           - os: ubuntu-latest
-#             task: r-package
-#             compiler: clang
-#             r_version: 4.3
-#             build_type: cmake
-#             container: 'ubuntu:22.04'
-#           - os: macos-13
-#             task: r-package
-#             compiler: gcc
-#             r_version: 4.3
-#             build_type: cmake
-#             container: null
-#           - os: macos-13
-#             task: r-package
-#             compiler: clang
-#             r_version: 4.3
-#             build_type: cmake
-#             container: null
-#           - os: windows-latest
-#             task: r-package
-#             compiler: MINGW
-#             toolchain: MINGW
-#             r_version: 3.6
-#             build_type: cmake
-#             container: null
-#           - os: windows-latest
-#             task: r-package
-#             compiler: MINGW
-#             toolchain: MSYS
-#             r_version: 4.3
-#             build_type: cmake
-#             container: null
-#           # Visual Studio 2019
-#           - os: windows-2019
-#             task: r-package
-#             compiler: MSVC
-#             toolchain: MSVC
-#             r_version: 3.6
-#             build_type: cmake
-#             container: null
-#           # Visual Studio 2022
-#           - os: windows-2022
-#             task: r-package
-#             compiler: MSVC
-#             toolchain: MSVC
-#             r_version: 4.3
-#             build_type: cmake
-#             container: null
-#           ###############
-#           # CRAN builds #
-#           ###############
-#           - os: windows-latest
-#             task: r-package
-#             compiler: MINGW
-#             toolchain: MINGW
-#             r_version: 3.6
-#             build_type: cran
-#             container: null
-#           - os: windows-latest
-#             task: r-package
-#             compiler: MINGW
-#             toolchain: MSYS
-#             r_version: 4.3
-#             build_type: cran
-#             container: null
-#           - os: ubuntu-latest
-#             task: r-package
-#             compiler: gcc
-#             r_version: 4.3
-#             build_type: cran
-#             container: 'ubuntu:22.04'
-#           - os: macos-13
-#             task: r-package
-#             compiler: clang
-#             r_version: 4.3
-#             build_type: cran
-#             container: null
-#     steps:
-#       - name: Prevent conversion of line endings on Windows
-#         if: startsWith(matrix.os, 'windows')
-#         shell: pwsh
-#         run: git config --global core.autocrlf false
-#       - name: Install packages used by third-party actions
-#         if: startsWith(matrix.os, 'ubuntu')
-#         shell: bash
-#         run: |
-#           apt-get update -y
-#           apt-get install --no-install-recommends -y \
-#             ca-certificates \
-#             dirmngr \
-#             gpg \
-#             gpg-agent \
-#             software-properties-common \
-#             sudo
-#           # install newest version of git
-#           # ref:
-#           #     - https://unix.stackexchange.com/a/170831/550004
-#           #     - https://git-scm.com/download/linux
-#           add-apt-repository ppa:git-core/ppa -y
-#           apt-get update -y
-#           apt-get install --no-install-recommends -y \
-#             git
-#       - name: Trust git cloning LightGBM
-#         if: startsWith(matrix.os, 'ubuntu')
-#         run: |
-#           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-#       - name: Checkout repository
-#         uses: actions/checkout@v3
-#         with:
-#           fetch-depth: 5
-#           submodules: true
-#       - name: Install pandoc
-#         uses: r-lib/actions/setup-pandoc@v2
-#         if: matrix.container != 'ubuntu:18.04'
-#       # R 3.6 binary isn't easily available on buntu 18.04,
-#       # but setup-pandoc>=2.7.1 is uses a too-new glibc for it.
-#       # ref: https://github.com/microsoft/LightGBM/issues/6298
-#       - name: Install pandoc
-#         uses: r-lib/actions/setup-pandoc@v2.6.0
-#         if: matrix.container == 'ubuntu:18.04'
-#       - name: install tinytex
-#         if: startsWith(matrix.os, 'windows')
-#         uses: r-lib/actions/setup-tinytex@v2
-#         env:
-#           CTAN_MIRROR: https://ctan.math.illinois.edu/systems/win32/miktex
-#           TINYTEX_INSTALLER: TinyTeX
-#       - name: Setup and run tests on Linux and macOS
-#         if: matrix.os == 'macos-13' || matrix.os == 'ubuntu-latest'
-#         shell: bash
-#         run: |
-#           export TASK="${{ matrix.task }}"
-#           export COMPILER="${{ matrix.compiler }}"
-#           if [[ "${{ matrix.os }}" == "macos-13" ]]; then
-#               export OS_NAME="macos"
-#           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-#               export OS_NAME="linux"
-#               export IN_UBUNTU_BASE_CONTAINER="true"
-#               # the default version of cmake provided on Ubuntu 18.04 (v3.10.2), is not supported by LightGBM
-#               # see https://github.com/microsoft/LightGBM/issues/5642
-#               if [[ "${{ matrix.container }}" == "ubuntu:18.04" ]]; then
-#                 export INSTALL_CMAKE_FROM_RELEASES="true"
-#               fi
-#           fi
-#           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
-#           export R_VERSION="${{ matrix.r_version }}"
-#           export R_BUILD_TYPE="${{ matrix.build_type }}"
-#           $GITHUB_WORKSPACE/.ci/setup.sh
-#           $GITHUB_WORKSPACE/.ci/test.sh
-#       - name: Setup and run tests on Windows
-#         if: startsWith(matrix.os, 'windows')
-#         shell: pwsh -command ". {0}"
-#         run: |
-#           $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
-#           $env:LGB_VER = (Get-Content -TotalCount 1 $env:BUILD_SOURCESDIRECTORY\VERSION.txt).trim().replace('rc', '-')
-#           $env:TOOLCHAIN = "${{ matrix.toolchain }}"
-#           $env:R_VERSION = "${{ matrix.r_version }}"
-#           $env:R_BUILD_TYPE = "${{ matrix.build_type }}"
-#           $env:COMPILER = "${{ matrix.compiler }}"
-#           $env:TASK = "${{ matrix.task }}"
-#           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
-#   test-r-sanitizers:
-#     name: r-sanitizers (ubuntu-latest, R-devel, ${{ matrix.compiler }} ASAN/UBSAN)
-#     timeout-minutes: 60
-#     runs-on: ubuntu-latest
-#     container: wch1/r-debug
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         include:
-#           - r_customization: san
-#             compiler: gcc
-#           - r_customization: csan
-#             compiler: clang
-#     steps:
-#       - name: Trust git cloning LightGBM
-#         run: |
-#           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-#       - name: Checkout repository
-#         uses: actions/checkout@v3
-#         with:
-#           fetch-depth: 5
-#           submodules: true
-#       - name: Install packages
-#         shell: bash
-#         run: |
-#           RDscript${{ matrix.r_customization }} -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
-#           sh build-cran-package.sh --r-executable=RD${{ matrix.r_customization }}
-#           RD${{ matrix.r_customization }} CMD INSTALL lightgbm_*.tar.gz || exit 1
-#       - name: Run tests with sanitizers
-#         shell: bash
-#         run: |
-#           cd R-package/tests
-#           exit_code=0
-#           RDscript${{ matrix.r_customization }} testthat.R >> tests.log 2>&1 || exit_code=-1
-#           cat ./tests.log
-#           exit ${exit_code}
-#   test-r-debian-clang:
-#     name: r-package (debian, R-devel, clang-${{ matrix.clang-version }})
-#     timeout-minutes: 60
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         # list of versions tested in CRAN "Additional Checks":
-#         # https://cran.r-project.org/web/checks/check_issue_kinds.html
-#         clang-version:
-#           - 16
-#           - 17
-#     runs-on: ubuntu-latest
-#     container: rhub/debian-clang-devel
-#     env:
-#       DEBIAN_FRONTEND: noninteractive
-#     steps:
-#       - name: Install Git before checkout
-#         shell: bash
-#         run: |
-#           apt-get update --allow-releaseinfo-change
-#           apt-get install --no-install-recommends -y git
-#       - name: Trust git cloning LightGBM
-#         run: |
-#           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-#       - name: Checkout repository
-#         uses: actions/checkout@v3
-#         with:
-#           fetch-depth: 5
-#           submodules: true
-#       - name: install clang
-#         run: |
-#           ./.ci/install-clang-devel.sh ${{ matrix.clang-version }}
-#       - name: Install packages and run tests
-#         shell: bash
-#         run: |
-#           export PATH=/opt/R-devel/bin/:${PATH}
-#           Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
-#           sh build-cran-package.sh
-#           R CMD check --as-cran --run-donttest lightgbm_*.tar.gz || exit 1
-#           echo ""
-#           echo "install logs:"
-#           echo ""
-#           cat lightgbm.Rcheck/00install.out
-#           echo ""
-#           if grep -q -E "NOTE|WARNING|ERROR" lightgbm.Rcheck/00check.log; then
-#               echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
-#               exit 1
-#           fi
-#   all-r-package-jobs-successful:
-#     if: always()
-#     runs-on: ubuntu-latest
-#     needs: [test, test-r-sanitizers, test-r-debian-clang]
-#     steps:
-#     - name: Note that all tests succeeded
-#       uses: re-actors/alls-green@v1.2.2
-#       with:
-#         jobs: ${{ toJSON(needs) }}
+jobs:
+  test:
+    name: ${{ matrix.task }} (${{ matrix.os }}, ${{ matrix.compiler }}, R ${{ matrix.r_version }}, ${{ matrix.build_type }})
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          ################
+          # CMake builds #
+          ################
+          - os: ubuntu-latest
+            task: r-package
+            compiler: gcc
+            r_version: 3.6
+            build_type: cmake
+            container: 'ubuntu:18.04'
+          - os: ubuntu-latest
+            task: r-package
+            compiler: gcc
+            r_version: 4.3
+            build_type: cmake
+            container: 'ubuntu:22.04'
+          - os: ubuntu-latest
+            task: r-package
+            compiler: clang
+            r_version: 3.6
+            build_type: cmake
+            container: 'ubuntu:18.04'
+          - os: ubuntu-latest
+            task: r-package
+            compiler: clang
+            r_version: 4.3
+            build_type: cmake
+            container: 'ubuntu:22.04'
+          - os: macos-13
+            task: r-package
+            compiler: gcc
+            r_version: 4.3
+            build_type: cmake
+            container: null
+          - os: macos-13
+            task: r-package
+            compiler: clang
+            r_version: 4.3
+            build_type: cmake
+            container: null
+          - os: windows-latest
+            task: r-package
+            compiler: MINGW
+            toolchain: MINGW
+            r_version: 3.6
+            build_type: cmake
+            container: null
+          - os: windows-latest
+            task: r-package
+            compiler: MINGW
+            toolchain: MSYS
+            r_version: 4.3
+            build_type: cmake
+            container: null
+          # Visual Studio 2019
+          - os: windows-2019
+            task: r-package
+            compiler: MSVC
+            toolchain: MSVC
+            r_version: 3.6
+            build_type: cmake
+            container: null
+          # Visual Studio 2022
+          - os: windows-2022
+            task: r-package
+            compiler: MSVC
+            toolchain: MSVC
+            r_version: 4.3
+            build_type: cmake
+            container: null
+          ###############
+          # CRAN builds #
+          ###############
+          - os: windows-latest
+            task: r-package
+            compiler: MINGW
+            toolchain: MINGW
+            r_version: 3.6
+            build_type: cran
+            container: null
+          - os: windows-latest
+            task: r-package
+            compiler: MINGW
+            toolchain: MSYS
+            r_version: 4.3
+            build_type: cran
+            container: null
+          - os: ubuntu-latest
+            task: r-package
+            compiler: gcc
+            r_version: 4.3
+            build_type: cran
+            container: 'ubuntu:22.04'
+          - os: macos-13
+            task: r-package
+            compiler: clang
+            r_version: 4.3
+            build_type: cran
+            container: null
+    steps:
+      - name: Prevent conversion of line endings on Windows
+        if: startsWith(matrix.os, 'windows')
+        shell: pwsh
+        run: git config --global core.autocrlf false
+      - name: Install packages used by third-party actions
+        if: startsWith(matrix.os, 'ubuntu')
+        shell: bash
+        run: |
+          apt-get update -y
+          apt-get install --no-install-recommends -y \
+            ca-certificates \
+            dirmngr \
+            gpg \
+            gpg-agent \
+            software-properties-common \
+            sudo
+          # install newest version of git
+          # ref:
+          #     - https://unix.stackexchange.com/a/170831/550004
+          #     - https://git-scm.com/download/linux
+          add-apt-repository ppa:git-core/ppa -y
+          apt-get update -y
+          apt-get install --no-install-recommends -y \
+            git
+      - name: Trust git cloning LightGBM
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
+          submodules: true
+      - name: Install pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+        if: matrix.container != 'ubuntu:18.04'
+      # R 3.6 binary isn't easily available on buntu 18.04,
+      # but setup-pandoc>=2.7.1 is uses a too-new glibc for it.
+      # ref: https://github.com/microsoft/LightGBM/issues/6298
+      - name: Install pandoc
+        uses: r-lib/actions/setup-pandoc@v2.6.0
+        if: matrix.container == 'ubuntu:18.04'
+      - name: install tinytex
+        if: startsWith(matrix.os, 'windows')
+        uses: r-lib/actions/setup-tinytex@v2
+        env:
+          CTAN_MIRROR: https://ctan.math.illinois.edu/systems/win32/miktex
+          TINYTEX_INSTALLER: TinyTeX
+      - name: Setup and run tests on Linux and macOS
+        if: matrix.os == 'macos-13' || matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          export TASK="${{ matrix.task }}"
+          export COMPILER="${{ matrix.compiler }}"
+          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+              export OS_NAME="macos"
+          elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+              export OS_NAME="linux"
+              export IN_UBUNTU_BASE_CONTAINER="true"
+              # the default version of cmake provided on Ubuntu 18.04 (v3.10.2), is not supported by LightGBM
+              # see https://github.com/microsoft/LightGBM/issues/5642
+              if [[ "${{ matrix.container }}" == "ubuntu:18.04" ]]; then
+                export INSTALL_CMAKE_FROM_RELEASES="true"
+              fi
+          fi
+          export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
+          export R_VERSION="${{ matrix.r_version }}"
+          export R_BUILD_TYPE="${{ matrix.build_type }}"
+          $GITHUB_WORKSPACE/.ci/setup.sh
+          $GITHUB_WORKSPACE/.ci/test.sh
+      - name: Setup and run tests on Windows
+        if: startsWith(matrix.os, 'windows')
+        shell: pwsh -command ". {0}"
+        run: |
+          $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
+          $env:LGB_VER = (Get-Content -TotalCount 1 $env:BUILD_SOURCESDIRECTORY\VERSION.txt).trim().replace('rc', '-')
+          $env:TOOLCHAIN = "${{ matrix.toolchain }}"
+          $env:R_VERSION = "${{ matrix.r_version }}"
+          $env:R_BUILD_TYPE = "${{ matrix.build_type }}"
+          $env:COMPILER = "${{ matrix.compiler }}"
+          $env:TASK = "${{ matrix.task }}"
+          & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
+  test-r-sanitizers:
+    name: r-sanitizers (ubuntu-latest, R-devel, ${{ matrix.compiler }} ASAN/UBSAN)
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container: wch1/r-debug
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - r_customization: san
+            compiler: gcc
+          - r_customization: csan
+            compiler: clang
+    steps:
+      - name: Trust git cloning LightGBM
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
+          submodules: true
+      - name: Install packages
+        shell: bash
+        run: |
+          RDscript${{ matrix.r_customization }} -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
+          sh build-cran-package.sh --r-executable=RD${{ matrix.r_customization }}
+          RD${{ matrix.r_customization }} CMD INSTALL lightgbm_*.tar.gz || exit 1
+      - name: Run tests with sanitizers
+        shell: bash
+        run: |
+          cd R-package/tests
+          exit_code=0
+          RDscript${{ matrix.r_customization }} testthat.R >> tests.log 2>&1 || exit_code=-1
+          cat ./tests.log
+          exit ${exit_code}
+  test-r-debian-clang:
+    name: r-package (debian, R-devel, clang-${{ matrix.clang-version }})
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # list of versions tested in CRAN "Additional Checks":
+        # https://cran.r-project.org/web/checks/check_issue_kinds.html
+        clang-version:
+          - 16
+          - 17
+    runs-on: ubuntu-latest
+    container: rhub/debian-clang-devel
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Install Git before checkout
+        shell: bash
+        run: |
+          apt-get update --allow-releaseinfo-change
+          apt-get install --no-install-recommends -y git
+      - name: Trust git cloning LightGBM
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
+          submodules: true
+      - name: install clang
+        run: |
+          ./.ci/install-clang-devel.sh ${{ matrix.clang-version }}
+      - name: Install packages and run tests
+        shell: bash
+        run: |
+          export PATH=/opt/R-devel/bin/:${PATH}
+          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
+          sh build-cran-package.sh
+          R CMD check --as-cran --run-donttest lightgbm_*.tar.gz || exit 1
+          echo ""
+          echo "install logs:"
+          echo ""
+          cat lightgbm.Rcheck/00install.out
+          echo ""
+          if grep -q -E "NOTE|WARNING|ERROR" lightgbm.Rcheck/00check.log; then
+              echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
+              exit 1
+          fi
+  all-r-package-jobs-successful:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [test, test-r-sanitizers, test-r-debian-clang]
+    steps:
+    - name: Note that all tests succeeded
+      uses: re-actors/alls-green@v1.2.2
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -1,312 +1,312 @@
-name: R-package
+# name: R-package
 
-on:
-  push:
-    branches:
-    - master
-  pull_request:
-    branches:
-    - master
-    - release/*
+# on:
+#   push:
+#     branches:
+#     - master
+#   pull_request:
+#     branches:
+#     - master
+#     - release/*
 
-# automatically cancel in-progress builds if another commit is pushed
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# # automatically cancel in-progress builds if another commit is pushed
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
 
-env:
-  # hack to get around this:
-  # https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
-  _R_CHECK_SYSTEM_CLOCK_: 0
-  # ignore R CMD CHECK NOTE checking how long it has
-  # been since the last submission
-  _R_CHECK_CRAN_INCOMING_REMOTE_: 0
-  # CRAN ignores the "installed size is too large" NOTE,
-  # so our CI can too. Setting to a large value here just
-  # to catch extreme problems
-  _R_CHECK_PKG_SIZES_THRESHOLD_: 100
+# env:
+#   # hack to get around this:
+#   # https://stat.ethz.ch/pipermail/r-package-devel/2020q3/005930.html
+#   _R_CHECK_SYSTEM_CLOCK_: 0
+#   # ignore R CMD CHECK NOTE checking how long it has
+#   # been since the last submission
+#   _R_CHECK_CRAN_INCOMING_REMOTE_: 0
+#   # CRAN ignores the "installed size is too large" NOTE,
+#   # so our CI can too. Setting to a large value here just
+#   # to catch extreme problems
+#   _R_CHECK_PKG_SIZES_THRESHOLD_: 100
 
-jobs:
-  test:
-    name: ${{ matrix.task }} (${{ matrix.os }}, ${{ matrix.compiler }}, R ${{ matrix.r_version }}, ${{ matrix.build_type }})
-    runs-on: ${{ matrix.os }}
-    container: ${{ matrix.container }}
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          ################
-          # CMake builds #
-          ################
-          - os: ubuntu-latest
-            task: r-package
-            compiler: gcc
-            r_version: 3.6
-            build_type: cmake
-            container: 'ubuntu:18.04'
-          - os: ubuntu-latest
-            task: r-package
-            compiler: gcc
-            r_version: 4.3
-            build_type: cmake
-            container: 'ubuntu:22.04'
-          - os: ubuntu-latest
-            task: r-package
-            compiler: clang
-            r_version: 3.6
-            build_type: cmake
-            container: 'ubuntu:18.04'
-          - os: ubuntu-latest
-            task: r-package
-            compiler: clang
-            r_version: 4.3
-            build_type: cmake
-            container: 'ubuntu:22.04'
-          - os: macos-13
-            task: r-package
-            compiler: gcc
-            r_version: 4.3
-            build_type: cmake
-            container: null
-          - os: macos-13
-            task: r-package
-            compiler: clang
-            r_version: 4.3
-            build_type: cmake
-            container: null
-          - os: windows-latest
-            task: r-package
-            compiler: MINGW
-            toolchain: MINGW
-            r_version: 3.6
-            build_type: cmake
-            container: null
-          - os: windows-latest
-            task: r-package
-            compiler: MINGW
-            toolchain: MSYS
-            r_version: 4.3
-            build_type: cmake
-            container: null
-          # Visual Studio 2019
-          - os: windows-2019
-            task: r-package
-            compiler: MSVC
-            toolchain: MSVC
-            r_version: 3.6
-            build_type: cmake
-            container: null
-          # Visual Studio 2022
-          - os: windows-2022
-            task: r-package
-            compiler: MSVC
-            toolchain: MSVC
-            r_version: 4.3
-            build_type: cmake
-            container: null
-          ###############
-          # CRAN builds #
-          ###############
-          - os: windows-latest
-            task: r-package
-            compiler: MINGW
-            toolchain: MINGW
-            r_version: 3.6
-            build_type: cran
-            container: null
-          - os: windows-latest
-            task: r-package
-            compiler: MINGW
-            toolchain: MSYS
-            r_version: 4.3
-            build_type: cran
-            container: null
-          - os: ubuntu-latest
-            task: r-package
-            compiler: gcc
-            r_version: 4.3
-            build_type: cran
-            container: 'ubuntu:22.04'
-          - os: macos-13
-            task: r-package
-            compiler: clang
-            r_version: 4.3
-            build_type: cran
-            container: null
-    steps:
-      - name: Prevent conversion of line endings on Windows
-        if: startsWith(matrix.os, 'windows')
-        shell: pwsh
-        run: git config --global core.autocrlf false
-      - name: Install packages used by third-party actions
-        if: startsWith(matrix.os, 'ubuntu')
-        shell: bash
-        run: |
-          apt-get update -y
-          apt-get install --no-install-recommends -y \
-            ca-certificates \
-            dirmngr \
-            gpg \
-            gpg-agent \
-            software-properties-common \
-            sudo
-          # install newest version of git
-          # ref:
-          #     - https://unix.stackexchange.com/a/170831/550004
-          #     - https://git-scm.com/download/linux
-          add-apt-repository ppa:git-core/ppa -y
-          apt-get update -y
-          apt-get install --no-install-recommends -y \
-            git
-      - name: Trust git cloning LightGBM
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 5
-          submodules: true
-      - name: Install pandoc
-        uses: r-lib/actions/setup-pandoc@v2
-        if: matrix.container != 'ubuntu:18.04'
-      # R 3.6 binary isn't easily available on buntu 18.04,
-      # but setup-pandoc>=2.7.1 is uses a too-new glibc for it.
-      # ref: https://github.com/microsoft/LightGBM/issues/6298
-      - name: Install pandoc
-        uses: r-lib/actions/setup-pandoc@v2.6.0
-        if: matrix.container == 'ubuntu:18.04'
-      - name: install tinytex
-        if: startsWith(matrix.os, 'windows')
-        uses: r-lib/actions/setup-tinytex@v2
-        env:
-          CTAN_MIRROR: https://ctan.math.illinois.edu/systems/win32/miktex
-          TINYTEX_INSTALLER: TinyTeX
-      - name: Setup and run tests on Linux and macOS
-        if: matrix.os == 'macos-13' || matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: |
-          export TASK="${{ matrix.task }}"
-          export COMPILER="${{ matrix.compiler }}"
-          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
-              export OS_NAME="macos"
-          elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-              export OS_NAME="linux"
-              export IN_UBUNTU_BASE_CONTAINER="true"
-              # the default version of cmake provided on Ubuntu 18.04 (v3.10.2), is not supported by LightGBM
-              # see https://github.com/microsoft/LightGBM/issues/5642
-              if [[ "${{ matrix.container }}" == "ubuntu:18.04" ]]; then
-                export INSTALL_CMAKE_FROM_RELEASES="true"
-              fi
-          fi
-          export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
-          export R_VERSION="${{ matrix.r_version }}"
-          export R_BUILD_TYPE="${{ matrix.build_type }}"
-          $GITHUB_WORKSPACE/.ci/setup.sh
-          $GITHUB_WORKSPACE/.ci/test.sh
-      - name: Setup and run tests on Windows
-        if: startsWith(matrix.os, 'windows')
-        shell: pwsh -command ". {0}"
-        run: |
-          $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
-          $env:LGB_VER = (Get-Content -TotalCount 1 $env:BUILD_SOURCESDIRECTORY\VERSION.txt).trim().replace('rc', '-')
-          $env:TOOLCHAIN = "${{ matrix.toolchain }}"
-          $env:R_VERSION = "${{ matrix.r_version }}"
-          $env:R_BUILD_TYPE = "${{ matrix.build_type }}"
-          $env:COMPILER = "${{ matrix.compiler }}"
-          $env:TASK = "${{ matrix.task }}"
-          & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
-  test-r-sanitizers:
-    name: r-sanitizers (ubuntu-latest, R-devel, ${{ matrix.compiler }} ASAN/UBSAN)
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    container: wch1/r-debug
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - r_customization: san
-            compiler: gcc
-          - r_customization: csan
-            compiler: clang
-    steps:
-      - name: Trust git cloning LightGBM
-        run: |
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 5
-          submodules: true
-      - name: Install packages
-        shell: bash
-        run: |
-          RDscript${{ matrix.r_customization }} -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
-          sh build-cran-package.sh --r-executable=RD${{ matrix.r_customization }}
-          RD${{ matrix.r_customization }} CMD INSTALL lightgbm_*.tar.gz || exit 1
-      - name: Run tests with sanitizers
-        shell: bash
-        run: |
-          cd R-package/tests
-          exit_code=0
-          RDscript${{ matrix.r_customization }} testthat.R >> tests.log 2>&1 || exit_code=-1
-          cat ./tests.log
-          exit ${exit_code}
-  test-r-debian-clang:
-    name: r-package (debian, R-devel, clang-${{ matrix.clang-version }})
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        # list of versions tested in CRAN "Additional Checks":
-        # https://cran.r-project.org/web/checks/check_issue_kinds.html
-        clang-version:
-          - 16
-          - 17
-    runs-on: ubuntu-latest
-    container: rhub/debian-clang-devel
-    env:
-      DEBIAN_FRONTEND: noninteractive
-    steps:
-      - name: Install Git before checkout
-        shell: bash
-        run: |
-          apt-get update --allow-releaseinfo-change
-          apt-get install --no-install-recommends -y git
-      - name: Trust git cloning LightGBM
-        run: |
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 5
-          submodules: true
-      - name: install clang
-        run: |
-          ./.ci/install-clang-devel.sh ${{ matrix.clang-version }}
-      - name: Install packages and run tests
-        shell: bash
-        run: |
-          export PATH=/opt/R-devel/bin/:${PATH}
-          Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
-          sh build-cran-package.sh
-          R CMD check --as-cran --run-donttest lightgbm_*.tar.gz || exit 1
-          echo ""
-          echo "install logs:"
-          echo ""
-          cat lightgbm.Rcheck/00install.out
-          echo ""
-          if grep -q -E "NOTE|WARNING|ERROR" lightgbm.Rcheck/00check.log; then
-              echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
-              exit 1
-          fi
-  all-r-package-jobs-successful:
-    if: always()
-    runs-on: ubuntu-latest
-    needs: [test, test-r-sanitizers, test-r-debian-clang]
-    steps:
-    - name: Note that all tests succeeded
-      uses: re-actors/alls-green@v1.2.2
-      with:
-        jobs: ${{ toJSON(needs) }}
+# jobs:
+#   test:
+#     name: ${{ matrix.task }} (${{ matrix.os }}, ${{ matrix.compiler }}, R ${{ matrix.r_version }}, ${{ matrix.build_type }})
+#     runs-on: ${{ matrix.os }}
+#     container: ${{ matrix.container }}
+#     timeout-minutes: 60
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include:
+#           ################
+#           # CMake builds #
+#           ################
+#           - os: ubuntu-latest
+#             task: r-package
+#             compiler: gcc
+#             r_version: 3.6
+#             build_type: cmake
+#             container: 'ubuntu:18.04'
+#           - os: ubuntu-latest
+#             task: r-package
+#             compiler: gcc
+#             r_version: 4.3
+#             build_type: cmake
+#             container: 'ubuntu:22.04'
+#           - os: ubuntu-latest
+#             task: r-package
+#             compiler: clang
+#             r_version: 3.6
+#             build_type: cmake
+#             container: 'ubuntu:18.04'
+#           - os: ubuntu-latest
+#             task: r-package
+#             compiler: clang
+#             r_version: 4.3
+#             build_type: cmake
+#             container: 'ubuntu:22.04'
+#           - os: macos-13
+#             task: r-package
+#             compiler: gcc
+#             r_version: 4.3
+#             build_type: cmake
+#             container: null
+#           - os: macos-13
+#             task: r-package
+#             compiler: clang
+#             r_version: 4.3
+#             build_type: cmake
+#             container: null
+#           - os: windows-latest
+#             task: r-package
+#             compiler: MINGW
+#             toolchain: MINGW
+#             r_version: 3.6
+#             build_type: cmake
+#             container: null
+#           - os: windows-latest
+#             task: r-package
+#             compiler: MINGW
+#             toolchain: MSYS
+#             r_version: 4.3
+#             build_type: cmake
+#             container: null
+#           # Visual Studio 2019
+#           - os: windows-2019
+#             task: r-package
+#             compiler: MSVC
+#             toolchain: MSVC
+#             r_version: 3.6
+#             build_type: cmake
+#             container: null
+#           # Visual Studio 2022
+#           - os: windows-2022
+#             task: r-package
+#             compiler: MSVC
+#             toolchain: MSVC
+#             r_version: 4.3
+#             build_type: cmake
+#             container: null
+#           ###############
+#           # CRAN builds #
+#           ###############
+#           - os: windows-latest
+#             task: r-package
+#             compiler: MINGW
+#             toolchain: MINGW
+#             r_version: 3.6
+#             build_type: cran
+#             container: null
+#           - os: windows-latest
+#             task: r-package
+#             compiler: MINGW
+#             toolchain: MSYS
+#             r_version: 4.3
+#             build_type: cran
+#             container: null
+#           - os: ubuntu-latest
+#             task: r-package
+#             compiler: gcc
+#             r_version: 4.3
+#             build_type: cran
+#             container: 'ubuntu:22.04'
+#           - os: macos-13
+#             task: r-package
+#             compiler: clang
+#             r_version: 4.3
+#             build_type: cran
+#             container: null
+#     steps:
+#       - name: Prevent conversion of line endings on Windows
+#         if: startsWith(matrix.os, 'windows')
+#         shell: pwsh
+#         run: git config --global core.autocrlf false
+#       - name: Install packages used by third-party actions
+#         if: startsWith(matrix.os, 'ubuntu')
+#         shell: bash
+#         run: |
+#           apt-get update -y
+#           apt-get install --no-install-recommends -y \
+#             ca-certificates \
+#             dirmngr \
+#             gpg \
+#             gpg-agent \
+#             software-properties-common \
+#             sudo
+#           # install newest version of git
+#           # ref:
+#           #     - https://unix.stackexchange.com/a/170831/550004
+#           #     - https://git-scm.com/download/linux
+#           add-apt-repository ppa:git-core/ppa -y
+#           apt-get update -y
+#           apt-get install --no-install-recommends -y \
+#             git
+#       - name: Trust git cloning LightGBM
+#         if: startsWith(matrix.os, 'ubuntu')
+#         run: |
+#           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+#       - name: Checkout repository
+#         uses: actions/checkout@v3
+#         with:
+#           fetch-depth: 5
+#           submodules: true
+#       - name: Install pandoc
+#         uses: r-lib/actions/setup-pandoc@v2
+#         if: matrix.container != 'ubuntu:18.04'
+#       # R 3.6 binary isn't easily available on buntu 18.04,
+#       # but setup-pandoc>=2.7.1 is uses a too-new glibc for it.
+#       # ref: https://github.com/microsoft/LightGBM/issues/6298
+#       - name: Install pandoc
+#         uses: r-lib/actions/setup-pandoc@v2.6.0
+#         if: matrix.container == 'ubuntu:18.04'
+#       - name: install tinytex
+#         if: startsWith(matrix.os, 'windows')
+#         uses: r-lib/actions/setup-tinytex@v2
+#         env:
+#           CTAN_MIRROR: https://ctan.math.illinois.edu/systems/win32/miktex
+#           TINYTEX_INSTALLER: TinyTeX
+#       - name: Setup and run tests on Linux and macOS
+#         if: matrix.os == 'macos-13' || matrix.os == 'ubuntu-latest'
+#         shell: bash
+#         run: |
+#           export TASK="${{ matrix.task }}"
+#           export COMPILER="${{ matrix.compiler }}"
+#           if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+#               export OS_NAME="macos"
+#           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+#               export OS_NAME="linux"
+#               export IN_UBUNTU_BASE_CONTAINER="true"
+#               # the default version of cmake provided on Ubuntu 18.04 (v3.10.2), is not supported by LightGBM
+#               # see https://github.com/microsoft/LightGBM/issues/5642
+#               if [[ "${{ matrix.container }}" == "ubuntu:18.04" ]]; then
+#                 export INSTALL_CMAKE_FROM_RELEASES="true"
+#               fi
+#           fi
+#           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
+#           export R_VERSION="${{ matrix.r_version }}"
+#           export R_BUILD_TYPE="${{ matrix.build_type }}"
+#           $GITHUB_WORKSPACE/.ci/setup.sh
+#           $GITHUB_WORKSPACE/.ci/test.sh
+#       - name: Setup and run tests on Windows
+#         if: startsWith(matrix.os, 'windows')
+#         shell: pwsh -command ". {0}"
+#         run: |
+#           $env:BUILD_SOURCESDIRECTORY = $env:GITHUB_WORKSPACE
+#           $env:LGB_VER = (Get-Content -TotalCount 1 $env:BUILD_SOURCESDIRECTORY\VERSION.txt).trim().replace('rc', '-')
+#           $env:TOOLCHAIN = "${{ matrix.toolchain }}"
+#           $env:R_VERSION = "${{ matrix.r_version }}"
+#           $env:R_BUILD_TYPE = "${{ matrix.build_type }}"
+#           $env:COMPILER = "${{ matrix.compiler }}"
+#           $env:TASK = "${{ matrix.task }}"
+#           & "$env:GITHUB_WORKSPACE/.ci/test_windows.ps1"
+#   test-r-sanitizers:
+#     name: r-sanitizers (ubuntu-latest, R-devel, ${{ matrix.compiler }} ASAN/UBSAN)
+#     timeout-minutes: 60
+#     runs-on: ubuntu-latest
+#     container: wch1/r-debug
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include:
+#           - r_customization: san
+#             compiler: gcc
+#           - r_customization: csan
+#             compiler: clang
+#     steps:
+#       - name: Trust git cloning LightGBM
+#         run: |
+#           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+#       - name: Checkout repository
+#         uses: actions/checkout@v3
+#         with:
+#           fetch-depth: 5
+#           submodules: true
+#       - name: Install packages
+#         shell: bash
+#         run: |
+#           RDscript${{ matrix.r_customization }} -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
+#           sh build-cran-package.sh --r-executable=RD${{ matrix.r_customization }}
+#           RD${{ matrix.r_customization }} CMD INSTALL lightgbm_*.tar.gz || exit 1
+#       - name: Run tests with sanitizers
+#         shell: bash
+#         run: |
+#           cd R-package/tests
+#           exit_code=0
+#           RDscript${{ matrix.r_customization }} testthat.R >> tests.log 2>&1 || exit_code=-1
+#           cat ./tests.log
+#           exit ${exit_code}
+#   test-r-debian-clang:
+#     name: r-package (debian, R-devel, clang-${{ matrix.clang-version }})
+#     timeout-minutes: 60
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         # list of versions tested in CRAN "Additional Checks":
+#         # https://cran.r-project.org/web/checks/check_issue_kinds.html
+#         clang-version:
+#           - 16
+#           - 17
+#     runs-on: ubuntu-latest
+#     container: rhub/debian-clang-devel
+#     env:
+#       DEBIAN_FRONTEND: noninteractive
+#     steps:
+#       - name: Install Git before checkout
+#         shell: bash
+#         run: |
+#           apt-get update --allow-releaseinfo-change
+#           apt-get install --no-install-recommends -y git
+#       - name: Trust git cloning LightGBM
+#         run: |
+#           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+#       - name: Checkout repository
+#         uses: actions/checkout@v3
+#         with:
+#           fetch-depth: 5
+#           submodules: true
+#       - name: install clang
+#         run: |
+#           ./.ci/install-clang-devel.sh ${{ matrix.clang-version }}
+#       - name: Install packages and run tests
+#         shell: bash
+#         run: |
+#           export PATH=/opt/R-devel/bin/:${PATH}
+#           Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
+#           sh build-cran-package.sh
+#           R CMD check --as-cran --run-donttest lightgbm_*.tar.gz || exit 1
+#           echo ""
+#           echo "install logs:"
+#           echo ""
+#           cat lightgbm.Rcheck/00install.out
+#           echo ""
+#           if grep -q -E "NOTE|WARNING|ERROR" lightgbm.Rcheck/00check.log; then
+#               echo "NOTEs, WARNINGs, or ERRORs have been found by R CMD check"
+#               exit 1
+#           fi
+#   all-r-package-jobs-successful:
+#     if: always()
+#     runs-on: ubuntu-latest
+#     needs: [test, test-r-sanitizers, test-r-debian-clang]
+#     steps:
+#     - name: Note that all tests succeeded
+#       uses: re-actors/alls-green@v1.2.2
+#       with:
+#         jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -19,7 +19,6 @@ concurrency:
 env:
   COMPILER: 'gcc'
   CONDA_ENV: test-env
-  GITHUB_ACTIONS: 'true'
   OS_NAME: 'linux'
   PYTHON_VERSION: '3.11'
 

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,455 +1,456 @@
-# trigger:
-#   branches:
-#     include:
-#     - master
-#   tags:
-#     include:
-#     - v*
-# pr:
-# - master
-# - release/*
-# variables:
-#   AZURE: 'true'
-#   PYTHON_VERSION: '3.11'
-#   CONDA_ENV: test-env
-#   runCodesignValidationInjection: false
-#   skipComponentGovernanceDetection: true
-#   DOTNET_CLI_TELEMETRY_OPTOUT: true
-#   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-# resources:
-#   # The __work/ directory, where Azure DevOps writes the source files, needs to be read-write because
-#   # LightGBM's CI jobs write files in the source directory.
-#   #
-#   # For all the containers included here, all other directories that Azure mounts in are mounted as read-only
-#   # to minimize the risk of side effects from one run affecting future runs.
-#   # ref: https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/resources-containers-container
-#   containers:
-#   - container: linux-artifact-builder
-#     image: lightgbm/vsts-agent:manylinux_2_28_x86_64
-#     mountReadOnly:
-#       work: false
-#       externals: true
-#       tools: true
-#       tasks: true
-#   - container: ubuntu-latest
-#     image: 'ubuntu:22.04'
-#     options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
-#     mountReadOnly:
-#       work: false
-#       externals: true
-#       tools: true
-#       tasks: true
-#   - container: rbase
-#     image: wch1/r-debug
-#     mountReadOnly:
-#       work: false
-#       externals: true
-#       tools: true
-#       tasks: true
-# jobs:
-# ###########################################
-# - job: Linux
-# ###########################################
-#   variables:
-#     COMPILER: gcc
-#     SETUP_CONDA: 'false'
-#     OS_NAME: 'linux'
-#     PRODUCES_ARTIFACTS: 'true'
-#   pool: mariner-20240410-0
-#   container: linux-artifact-builder
-#   strategy:
-#     matrix:
-#       regular:
-#         TASK: regular
-#         PYTHON_VERSION: '3.9'
-#       sdist:
-#         TASK: sdist
-#         PYTHON_VERSION: '3.7'
-#       bdist:
-#         TASK: bdist
-#         PYTHON_VERSION: '3.8'
-#       inference:
-#         TASK: if-else
-#       mpi_source:
-#         TASK: mpi
-#         METHOD: source
-#         PYTHON_VERSION: '3.8'
-#       gpu_source:
-#         TASK: gpu
-#         METHOD: source
-#       swig:
-#         TASK: swig
-#   steps:
-#   - script: |
-#       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
-#       echo "##vso[task.prependpath]/usr/lib64/openmpi/bin"
-#       echo "##vso[task.prependpath]$CONDA/bin"
-#     displayName: 'Set variables'
-#   - script: |
-#       git clean -d -f -x
-#     displayName: 'Clean source directory'
-#   - script: |
-#       echo '$(Build.SourceVersion)' > '$(Build.ArtifactStagingDirectory)/commit.txt'
-#     displayName: 'Add commit hash to artifacts archive'
-#   - task: Bash@3
-#     displayName: Setup
-#     inputs:
-#       filePath: $(Build.SourcesDirectory)/.ci/setup.sh
-#       targetType: filePath
-#   - task: Bash@3
-#     displayName: Test
-#     inputs:
-#       filePath: $(Build.SourcesDirectory)/.ci/test.sh
-#       targetType: filePath
-#   - task: PublishBuildArtifacts@1
-#     condition: and(succeeded(), in(variables['TASK'], 'regular', 'sdist', 'bdist', 'swig'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
-#     inputs:
-#       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-#       artifactName: PackageAssets
-#       artifactType: container
-# ###########################################
-# - job: Linux_latest
-# ###########################################
-#   variables:
-#     COMPILER: clang-17
-#     DEBIAN_FRONTEND: 'noninteractive'
-#     IN_UBUNTU_BASE_CONTAINER: 'true'
-#     OS_NAME: 'linux'
-#     SETUP_CONDA: 'true'
-#   pool: mariner-20240410-0
-#   container: ubuntu-latest
-#   strategy:
-#     matrix:
-#       regular:
-#         TASK: regular
-#       sdist:
-#         TASK: sdist
-#       bdist:
-#         TASK: bdist
-#         PYTHON_VERSION: '3.9'
-#       inference:
-#         TASK: if-else
-#       mpi_source:
-#         TASK: mpi
-#         METHOD: source
-#       mpi_pip:
-#         TASK: mpi
-#         METHOD: pip
-#         PYTHON_VERSION: '3.10'
-#       mpi_wheel:
-#         TASK: mpi
-#         METHOD: wheel
-#         PYTHON_VERSION: '3.8'
-#       gpu_source:
-#         TASK: gpu
-#         METHOD: source
-#         PYTHON_VERSION: '3.10'
-#       gpu_pip:
-#         TASK: gpu
-#         METHOD: pip
-#         PYTHON_VERSION: '3.9'
-#       gpu_wheel:
-#         TASK: gpu
-#         METHOD: wheel
-#         PYTHON_VERSION: '3.8'
-#       cpp_tests:
-#         TASK: cpp-tests
-#         METHOD: with-sanitizers
-#   steps:
-#   - script: |
-#       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
-#       CONDA=$HOME/miniforge
-#       echo "##vso[task.setvariable variable=CONDA]$CONDA"
-#       echo "##vso[task.prependpath]$CONDA/bin"
-#     displayName: 'Set variables'
-#   # https://github.com/microsoft/azure-pipelines-agent/issues/2043#issuecomment-687983301
-#   - script: |
-#       /tmp/docker exec -t -u 0 ci-container \
-#       sh -c "apt-get update && apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
-#     displayName: 'Install sudo'
-#   - script: |
-#       sudo apt-get update
-#       sudo apt-get install -y --no-install-recommends git
-#       git clean -d -f -x
-#     displayName: 'Clean source directory'
-#   - task: Bash@3
-#     displayName: Setup
-#     inputs:
-#       filePath: $(Build.SourcesDirectory)/.ci/setup.sh
-#       targetType: 'filePath'
-#   - task: Bash@3
-#     displayName: Test
-#     inputs:
-#       filePath: $(Build.SourcesDirectory)/.ci/test.sh
-#       targetType: 'filePath'
-# ###########################################
-# - job: QEMU_multiarch
-# ###########################################
-#   variables:
-#     COMPILER: gcc
-#     OS_NAME: 'linux'
-#     PRODUCES_ARTIFACTS: 'true'
-#   pool:
-#     vmImage: ubuntu-22.04
-#   timeoutInMinutes: 180
-#   strategy:
-#     matrix:
-#       bdist:
-#         TASK: bdist
-#         ARCH: aarch64
-#   steps:
-#   - script: |
-#       sudo apt-get update
-#       sudo apt-get install --no-install-recommends -y \
-#         binfmt-support \
-#         qemu \
-#         qemu-user \
-#         qemu-user-static
-#     displayName: 'Install QEMU'
-#   - script: |
-#       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-#     displayName: 'Enable Docker multi-architecture support'
-#   - script: |
-#       git clean -d -f -x
-#     displayName: 'Clean source directory'
-#   - script: |
-#       export ROOT_DOCKER_FOLDER=/LightGBM
-#       cat > docker.env <<EOF
-#       AZURE=$AZURE
-#       OS_NAME=$OS_NAME
-#       COMPILER=$COMPILER
-#       TASK=$TASK
-#       METHOD=$METHOD
-#       CONDA_ENV=$CONDA_ENV
-#       PYTHON_VERSION=$PYTHON_VERSION
-#       BUILD_DIRECTORY=$ROOT_DOCKER_FOLDER
-#       PRODUCES_ARTIFACTS=$PRODUCES_ARTIFACTS
-#       BUILD_ARTIFACTSTAGINGDIRECTORY=$BUILD_ARTIFACTSTAGINGDIRECTORY
-#       EOF
-#       cat > docker-script.sh <<EOF
-#       export CONDA=\$HOME/miniforge
-#       export PATH=\$CONDA/bin:/opt/rh/llvm-toolset-7.0/root/usr/bin:\$PATH
-#       export LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:\$LD_LIBRARY_PATH
-#       $ROOT_DOCKER_FOLDER/.ci/setup.sh || exit 1
-#       $ROOT_DOCKER_FOLDER/.ci/test.sh || exit 1
-#       EOF
-#       IMAGE_URI="lightgbm/vsts-agent:manylinux2014_aarch64"
-#       docker pull "${IMAGE_URI}" || exit 1
-#       PLATFORM=$(docker inspect --format='{{.Os}}/{{.Architecture}}' "${IMAGE_URI}") || exit 1
-#       echo "detected image platform: ${PLATFORM}"
-#       docker run \
-#         --platform "${PLATFORM}" \
-#         --rm \
-#         --env-file docker.env \
-#         -v "$(Build.SourcesDirectory)":"$ROOT_DOCKER_FOLDER" \
-#         -v "$(Build.ArtifactStagingDirectory)":"$(Build.ArtifactStagingDirectory)" \
-#         "${IMAGE_URI}" \
-#         /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
-#     displayName: 'Setup and run tests'
-#   - task: PublishBuildArtifacts@1
-#     condition: and(succeeded(), in(variables['TASK'], 'bdist'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
-#     inputs:
-#       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-#       artifactName: PackageAssets
-#       artifactType: container
-# ###########################################
-# - job: macOS
-# ###########################################
-#   variables:
-#     COMPILER: clang
-#     OS_NAME: 'macos'
-#     PRODUCES_ARTIFACTS: 'true'
-#   pool:
-#     vmImage: 'macOS-11'
-#   strategy:
-#     matrix:
-#       regular:
-#         TASK: regular
-#         PYTHON_VERSION: '3.10'
-#       sdist:
-#         TASK: sdist
-#         PYTHON_VERSION: '3.9'
-#       bdist:
-#         TASK: bdist
-#       swig:
-#         TASK: swig
-#       cpp_tests:
-#         TASK: cpp-tests
-#         METHOD: with-sanitizers
-#         SANITIZERS: "address;undefined"
-#   steps:
-#   - script: |
-#       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
-#       CONDA=$AGENT_HOMEDIRECTORY/miniforge
-#       echo "##vso[task.setvariable variable=CONDA]$CONDA"
-#       echo "##vso[task.prependpath]$CONDA/bin"
-#       echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_8_X64"
-#     displayName: 'Set variables'
-#   - script: |
-#       git clean -d -f -x
-#     displayName: 'Clean source directory'
-#   - task: Bash@3
-#     displayName: Setup
-#     inputs:
-#       filePath: $(Build.SourcesDirectory)/.ci/setup.sh
-#       targetType: filePath
-#   - task: Bash@3
-#     displayName: Test
-#     inputs:
-#       filePath: $(Build.SourcesDirectory)/.ci/test.sh
-#       targetType: filePath
-#   - task: PublishBuildArtifacts@1
-#     condition: and(succeeded(), in(variables['TASK'], 'regular', 'bdist', 'swig'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
-#     inputs:
-#       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-#       artifactName: PackageAssets
-#       artifactType: container
-# ###########################################
-# - job: Windows
-# ###########################################
-#   pool:
-#     vmImage: 'windows-2019'
-#   strategy:
-#     matrix:
-#       regular:
-#         TASK: regular
-#         PYTHON_VERSION: '3.10'
-#       sdist:
-#         TASK: sdist
-#         PYTHON_VERSION: '3.9'
-#       bdist:
-#         TASK: bdist
-#       swig:
-#         TASK: swig
-#       cpp_tests:
-#         TASK: cpp-tests
-#   steps:
-#   - powershell: |
-#       Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-#     displayName: 'Set Variables'
-#   - script: |
-#       git clean -d -f -x
-#     displayName: 'Clean source directory'
-#   - script: |
-#       cmd /c "powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/install_opencl.ps1"
-#     condition: eq(variables['TASK'], 'bdist')
-#     displayName: 'Install OpenCL'
-#   - script: |
-#       cmd /c "conda config --remove channels defaults"
-#       cmd /c "conda config --add channels nodefaults"
-#       cmd /c "conda config --add channels conda-forge"
-#       cmd /c "conda config --set channel_priority strict"
-#       cmd /c "conda init powershell"
-#       cmd /c "powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/test_windows.ps1"
-#     displayName: Test
-#   - task: PublishBuildArtifacts@1
-#     condition: and(succeeded(), in(variables['TASK'], 'regular', 'bdist', 'swig'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
-#     inputs:
-#       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-#       artifactName: PackageAssets
-#       artifactType: container
-# ###########################################
-# - job: R_artifact
-# ###########################################
-#   condition: not(startsWith(variables['Build.SourceBranch'], 'refs/pull/'))
-#   pool:
-#     vmImage: 'ubuntu-22.04'
-#   container: rbase
-#   steps:
-#   - script: |
-#       git clean -d -f -x
-#     displayName: 'Clean source directory'
-#   - script: |
-#       LGB_VER=$(head -n 1 VERSION.txt | sed "s/rc/-/g")
-#       R_LIB_PATH=~/Rlib
-#       export R_LIBS=${R_LIB_PATH}
-#       mkdir -p ${R_LIB_PATH}
-#       RDscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl'),  lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())" || exit 1
-#       sh build-cran-package.sh --r-executable=RD || exit 1
-#       mv lightgbm_${LGB_VER}.tar.gz $(Build.ArtifactStagingDirectory)/lightgbm-${LGB_VER}-r-cran.tar.gz
-#     displayName: 'Build CRAN R-package'
-#   - task: PublishBuildArtifacts@1
-#     condition: succeeded()
-#     inputs:
-#       pathtoPublish: $(Build.ArtifactStagingDirectory)
-#       artifactName: R-package
-#       artifactType: container
+trigger:
+  branches:
+    include:
+    - master
+  tags:
+    include:
+    - v*
+pr:
+- master
+- release/*
+variables:
+  AZURE: 'true'
+  PYTHON_VERSION: '3.11'
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CONDA_ENV: test-env
+  runCodesignValidationInjection: false
+  skipComponentGovernanceDetection: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+resources:
+  # The __work/ directory, where Azure DevOps writes the source files, needs to be read-write because
+  # LightGBM's CI jobs write files in the source directory.
+  #
+  # For all the containers included here, all other directories that Azure mounts in are mounted as read-only
+  # to minimize the risk of side effects from one run affecting future runs.
+  # ref: https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/resources-containers-container
+  containers:
+  - container: linux-artifact-builder
+    image: lightgbm/vsts-agent:manylinux_2_28_x86_64
+    mountReadOnly:
+      work: false
+      externals: true
+      tools: true
+      tasks: true
+  - container: ubuntu-latest
+    image: 'ubuntu:22.04'
+    options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
+    mountReadOnly:
+      work: false
+      externals: true
+      tools: true
+      tasks: true
+  - container: rbase
+    image: wch1/r-debug
+    mountReadOnly:
+      work: false
+      externals: true
+      tools: true
+      tasks: true
+jobs:
+###########################################
+- job: Linux
+###########################################
+  variables:
+    COMPILER: gcc
+    SETUP_CONDA: 'false'
+    OS_NAME: 'linux'
+    PRODUCES_ARTIFACTS: 'true'
+  pool: mariner-20240410-0
+  container: linux-artifact-builder
+  strategy:
+    matrix:
+      regular:
+        TASK: regular
+        PYTHON_VERSION: '3.9'
+      sdist:
+        TASK: sdist
+        PYTHON_VERSION: '3.7'
+      bdist:
+        TASK: bdist
+        PYTHON_VERSION: '3.8'
+      inference:
+        TASK: if-else
+      mpi_source:
+        TASK: mpi
+        METHOD: source
+        PYTHON_VERSION: '3.8'
+      gpu_source:
+        TASK: gpu
+        METHOD: source
+      swig:
+        TASK: swig
+  steps:
+  - script: |
+      echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
+      echo "##vso[task.prependpath]/usr/lib64/openmpi/bin"
+      echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: 'Set variables'
+  - script: |
+      git clean -d -f -x
+    displayName: 'Clean source directory'
+  - script: |
+      echo '$(Build.SourceVersion)' > '$(Build.ArtifactStagingDirectory)/commit.txt'
+    displayName: 'Add commit hash to artifacts archive'
+  - task: Bash@3
+    displayName: Setup
+    inputs:
+      filePath: $(Build.SourcesDirectory)/.ci/setup.sh
+      targetType: filePath
+  - task: Bash@3
+    displayName: Test
+    inputs:
+      filePath: $(Build.SourcesDirectory)/.ci/test.sh
+      targetType: filePath
+  - task: PublishBuildArtifacts@1
+    condition: and(succeeded(), in(variables['TASK'], 'regular', 'sdist', 'bdist', 'swig'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: PackageAssets
+      artifactType: container
+###########################################
+- job: Linux_latest
+###########################################
+  variables:
+    COMPILER: clang-17
+    DEBIAN_FRONTEND: 'noninteractive'
+    IN_UBUNTU_BASE_CONTAINER: 'true'
+    OS_NAME: 'linux'
+    SETUP_CONDA: 'true'
+  pool: mariner-20240410-0
+  container: ubuntu-latest
+  strategy:
+    matrix:
+      regular:
+        TASK: regular
+      sdist:
+        TASK: sdist
+      bdist:
+        TASK: bdist
+        PYTHON_VERSION: '3.9'
+      inference:
+        TASK: if-else
+      mpi_source:
+        TASK: mpi
+        METHOD: source
+      mpi_pip:
+        TASK: mpi
+        METHOD: pip
+        PYTHON_VERSION: '3.10'
+      mpi_wheel:
+        TASK: mpi
+        METHOD: wheel
+        PYTHON_VERSION: '3.8'
+      gpu_source:
+        TASK: gpu
+        METHOD: source
+        PYTHON_VERSION: '3.10'
+      gpu_pip:
+        TASK: gpu
+        METHOD: pip
+        PYTHON_VERSION: '3.9'
+      gpu_wheel:
+        TASK: gpu
+        METHOD: wheel
+        PYTHON_VERSION: '3.8'
+      cpp_tests:
+        TASK: cpp-tests
+        METHOD: with-sanitizers
+  steps:
+  - script: |
+      echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
+      CONDA=$HOME/miniforge
+      echo "##vso[task.setvariable variable=CONDA]$CONDA"
+      echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: 'Set variables'
+  # https://github.com/microsoft/azure-pipelines-agent/issues/2043#issuecomment-687983301
+  - script: |
+      /tmp/docker exec -t -u 0 ci-container \
+      sh -c "apt-get update && apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
+    displayName: 'Install sudo'
+  - script: |
+      sudo apt-get update
+      sudo apt-get install -y --no-install-recommends git
+      git clean -d -f -x
+    displayName: 'Clean source directory'
+  - task: Bash@3
+    displayName: Setup
+    inputs:
+      filePath: $(Build.SourcesDirectory)/.ci/setup.sh
+      targetType: 'filePath'
+  - task: Bash@3
+    displayName: Test
+    inputs:
+      filePath: $(Build.SourcesDirectory)/.ci/test.sh
+      targetType: 'filePath'
+###########################################
+- job: QEMU_multiarch
+###########################################
+  variables:
+    COMPILER: gcc
+    OS_NAME: 'linux'
+    PRODUCES_ARTIFACTS: 'true'
+  pool:
+    vmImage: ubuntu-22.04
+  timeoutInMinutes: 180
+  strategy:
+    matrix:
+      bdist:
+        TASK: bdist
+        ARCH: aarch64
+  steps:
+  - script: |
+      sudo apt-get update
+      sudo apt-get install --no-install-recommends -y \
+        binfmt-support \
+        qemu \
+        qemu-user \
+        qemu-user-static
+    displayName: 'Install QEMU'
+  - script: |
+      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    displayName: 'Enable Docker multi-architecture support'
+  - script: |
+      git clean -d -f -x
+    displayName: 'Clean source directory'
+  - script: |
+      export ROOT_DOCKER_FOLDER=/LightGBM
+      cat > docker.env <<EOF
+      AZURE=$AZURE
+      OS_NAME=$OS_NAME
+      COMPILER=$COMPILER
+      TASK=$TASK
+      METHOD=$METHOD
+      CONDA_ENV=$CONDA_ENV
+      PYTHON_VERSION=$PYTHON_VERSION
+      BUILD_DIRECTORY=$ROOT_DOCKER_FOLDER
+      PRODUCES_ARTIFACTS=$PRODUCES_ARTIFACTS
+      BUILD_ARTIFACTSTAGINGDIRECTORY=$BUILD_ARTIFACTSTAGINGDIRECTORY
+      EOF
+      cat > docker-script.sh <<EOF
+      export CONDA=\$HOME/miniforge
+      export PATH=\$CONDA/bin:/opt/rh/llvm-toolset-7.0/root/usr/bin:\$PATH
+      export LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:\$LD_LIBRARY_PATH
+      $ROOT_DOCKER_FOLDER/.ci/setup.sh || exit 1
+      $ROOT_DOCKER_FOLDER/.ci/test.sh || exit 1
+      EOF
+      IMAGE_URI="lightgbm/vsts-agent:manylinux2014_aarch64"
+      docker pull "${IMAGE_URI}" || exit 1
+      PLATFORM=$(docker inspect --format='{{.Os}}/{{.Architecture}}' "${IMAGE_URI}") || exit 1
+      echo "detected image platform: ${PLATFORM}"
+      docker run \
+        --platform "${PLATFORM}" \
+        --rm \
+        --env-file docker.env \
+        -v "$(Build.SourcesDirectory)":"$ROOT_DOCKER_FOLDER" \
+        -v "$(Build.ArtifactStagingDirectory)":"$(Build.ArtifactStagingDirectory)" \
+        "${IMAGE_URI}" \
+        /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
+    displayName: 'Setup and run tests'
+  - task: PublishBuildArtifacts@1
+    condition: and(succeeded(), in(variables['TASK'], 'bdist'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: PackageAssets
+      artifactType: container
+###########################################
+- job: macOS
+###########################################
+  variables:
+    COMPILER: clang
+    OS_NAME: 'macos'
+    PRODUCES_ARTIFACTS: 'true'
+  pool:
+    vmImage: 'macOS-11'
+  strategy:
+    matrix:
+      regular:
+        TASK: regular
+        PYTHON_VERSION: '3.10'
+      sdist:
+        TASK: sdist
+        PYTHON_VERSION: '3.9'
+      bdist:
+        TASK: bdist
+      swig:
+        TASK: swig
+      cpp_tests:
+        TASK: cpp-tests
+        METHOD: with-sanitizers
+        SANITIZERS: "address;undefined"
+  steps:
+  - script: |
+      echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
+      CONDA=$AGENT_HOMEDIRECTORY/miniforge
+      echo "##vso[task.setvariable variable=CONDA]$CONDA"
+      echo "##vso[task.prependpath]$CONDA/bin"
+      echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_8_X64"
+    displayName: 'Set variables'
+  - script: |
+      git clean -d -f -x
+    displayName: 'Clean source directory'
+  - task: Bash@3
+    displayName: Setup
+    inputs:
+      filePath: $(Build.SourcesDirectory)/.ci/setup.sh
+      targetType: filePath
+  - task: Bash@3
+    displayName: Test
+    inputs:
+      filePath: $(Build.SourcesDirectory)/.ci/test.sh
+      targetType: filePath
+  - task: PublishBuildArtifacts@1
+    condition: and(succeeded(), in(variables['TASK'], 'regular', 'bdist', 'swig'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: PackageAssets
+      artifactType: container
+###########################################
+- job: Windows
+###########################################
+  pool:
+    vmImage: 'windows-2019'
+  strategy:
+    matrix:
+      regular:
+        TASK: regular
+        PYTHON_VERSION: '3.10'
+      sdist:
+        TASK: sdist
+        PYTHON_VERSION: '3.9'
+      bdist:
+        TASK: bdist
+      swig:
+        TASK: swig
+      cpp_tests:
+        TASK: cpp-tests
+  steps:
+  - powershell: |
+      Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+    displayName: 'Set Variables'
+  - script: |
+      git clean -d -f -x
+    displayName: 'Clean source directory'
+  - script: |
+      cmd /c "powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/install_opencl.ps1"
+    condition: eq(variables['TASK'], 'bdist')
+    displayName: 'Install OpenCL'
+  - script: |
+      cmd /c "conda config --remove channels defaults"
+      cmd /c "conda config --add channels nodefaults"
+      cmd /c "conda config --add channels conda-forge"
+      cmd /c "conda config --set channel_priority strict"
+      cmd /c "conda init powershell"
+      cmd /c "powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/test_windows.ps1"
+    displayName: Test
+  - task: PublishBuildArtifacts@1
+    condition: and(succeeded(), in(variables['TASK'], 'regular', 'bdist', 'swig'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: PackageAssets
+      artifactType: container
+###########################################
+- job: R_artifact
+###########################################
+  condition: not(startsWith(variables['Build.SourceBranch'], 'refs/pull/'))
+  pool:
+    vmImage: 'ubuntu-22.04'
+  container: rbase
+  steps:
+  - script: |
+      git clean -d -f -x
+    displayName: 'Clean source directory'
+  - script: |
+      LGB_VER=$(head -n 1 VERSION.txt | sed "s/rc/-/g")
+      R_LIB_PATH=~/Rlib
+      export R_LIBS=${R_LIB_PATH}
+      mkdir -p ${R_LIB_PATH}
+      RDscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl'),  lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())" || exit 1
+      sh build-cran-package.sh --r-executable=RD || exit 1
+      mv lightgbm_${LGB_VER}.tar.gz $(Build.ArtifactStagingDirectory)/lightgbm-${LGB_VER}-r-cran.tar.gz
+    displayName: 'Build CRAN R-package'
+  - task: PublishBuildArtifacts@1
+    condition: succeeded()
+    inputs:
+      pathtoPublish: $(Build.ArtifactStagingDirectory)
+      artifactName: R-package
+      artifactType: container
 
-# ###########################################
-# - job: Package
-# ###########################################
-#   dependsOn:
-#   - Linux
-#   - Linux_latest
-#   - QEMU_multiarch
-#   - macOS
-#   - Windows
-#   - R_artifact
-#   condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
-#   pool:
-#     vmImage: 'ubuntu-22.04'
-#   steps:
-#   # Create archives with complete source code included (with git submodules)
-#   - task: ArchiveFiles@2
-#     displayName: Create zip archive
-#     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
-#     inputs:
-#       rootFolderOrFile: $(Build.SourcesDirectory)
-#       includeRootFolder: false
-#       archiveType: zip
-#       archiveFile: '$(Build.ArtifactStagingDirectory)/archives/LightGBM-complete_source_code_zip.zip'
-#       replaceExistingArchive: true
-#   - task: ArchiveFiles@2
-#     displayName: Create tar.gz archive
-#     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
-#     inputs:
-#       rootFolderOrFile: $(Build.SourcesDirectory)
-#       includeRootFolder: false
-#       archiveType: tar
-#       tarCompression: gz
-#       archiveFile: '$(Build.ArtifactStagingDirectory)/archives/LightGBM-complete_source_code_tar_gz.tar.gz'
-#       replaceExistingArchive: true
-#   # Download all agent packages from all previous phases
-#   - task: DownloadBuildArtifacts@0
-#     displayName: Download package assets
-#     inputs:
-#       artifactName: PackageAssets
-#       downloadPath: $(Build.SourcesDirectory)/binaries
-#   - task: DownloadBuildArtifacts@0
-#     displayName: Download R-package
-#     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
-#     inputs:
-#       artifactName: R-package
-#       downloadPath: $(Build.SourcesDirectory)/R
-#   - script: |
-#       python "$(Build.SourcesDirectory)/.nuget/create_nuget.py" "$(Build.SourcesDirectory)/binaries/PackageAssets"
-#     displayName: 'Create NuGet configuration files'
-#   - task: NuGetCommand@2
-#     inputs:
-#       command: pack
-#       packagesToPack: '$(Build.SourcesDirectory)/.nuget/*.nuspec'
-#       packDestination: '$(Build.ArtifactStagingDirectory)/nuget'
-#   - task: PublishBuildArtifacts@1
-#     inputs:
-#       pathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
-#       artifactName: NuGet
-#       artifactType: container
-#   - task: GitHubRelease@0
-#     displayName: 'Create GitHub Release'
-#     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
-#     inputs:
-#       gitHubConnection: guolinke
-#       repositoryName: '$(Build.Repository.Name)'
-#       action: 'create'
-#       target: '$(Build.SourceVersion)'
-#       tagSource: 'auto'
-#       title: '$(Build.SourceBranchName)'
-#       assets: |
-#         $(Build.SourcesDirectory)/binaries/PackageAssets/*
-#         $(Build.SourcesDirectory)/R/R-package/*
-#         $(Build.ArtifactStagingDirectory)/nuget/*.nupkg
-#         $(Build.ArtifactStagingDirectory)/archives/*
-#       assetUploadMode: 'delete'
-#       isDraft: true
-#       isPreRelease: false
-#       addChangeLog: false
+###########################################
+- job: Package
+###########################################
+  dependsOn:
+  - Linux
+  - Linux_latest
+  - QEMU_multiarch
+  - macOS
+  - Windows
+  - R_artifact
+  condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
+  pool:
+    vmImage: 'ubuntu-22.04'
+  steps:
+  # Create archives with complete source code included (with git submodules)
+  - task: ArchiveFiles@2
+    displayName: Create zip archive
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+    inputs:
+      rootFolderOrFile: $(Build.SourcesDirectory)
+      includeRootFolder: false
+      archiveType: zip
+      archiveFile: '$(Build.ArtifactStagingDirectory)/archives/LightGBM-complete_source_code_zip.zip'
+      replaceExistingArchive: true
+  - task: ArchiveFiles@2
+    displayName: Create tar.gz archive
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+    inputs:
+      rootFolderOrFile: $(Build.SourcesDirectory)
+      includeRootFolder: false
+      archiveType: tar
+      tarCompression: gz
+      archiveFile: '$(Build.ArtifactStagingDirectory)/archives/LightGBM-complete_source_code_tar_gz.tar.gz'
+      replaceExistingArchive: true
+  # Download all agent packages from all previous phases
+  - task: DownloadBuildArtifacts@0
+    displayName: Download package assets
+    inputs:
+      artifactName: PackageAssets
+      downloadPath: $(Build.SourcesDirectory)/binaries
+  - task: DownloadBuildArtifacts@0
+    displayName: Download R-package
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+    inputs:
+      artifactName: R-package
+      downloadPath: $(Build.SourcesDirectory)/R
+  - script: |
+      python "$(Build.SourcesDirectory)/.nuget/create_nuget.py" "$(Build.SourcesDirectory)/binaries/PackageAssets"
+    displayName: 'Create NuGet configuration files'
+  - task: NuGetCommand@2
+    inputs:
+      command: pack
+      packagesToPack: '$(Build.SourcesDirectory)/.nuget/*.nuspec'
+      packDestination: '$(Build.ArtifactStagingDirectory)/nuget'
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
+      artifactName: NuGet
+      artifactType: container
+  - task: GitHubRelease@0
+    displayName: 'Create GitHub Release'
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+    inputs:
+      gitHubConnection: guolinke
+      repositoryName: '$(Build.Repository.Name)'
+      action: 'create'
+      target: '$(Build.SourceVersion)'
+      tagSource: 'auto'
+      title: '$(Build.SourceBranchName)'
+      assets: |
+        $(Build.SourcesDirectory)/binaries/PackageAssets/*
+        $(Build.SourcesDirectory)/R/R-package/*
+        $(Build.ArtifactStagingDirectory)/nuget/*.nupkg
+        $(Build.ArtifactStagingDirectory)/archives/*
+      assetUploadMode: 'delete'
+      isDraft: true
+      isPreRelease: false
+      addChangeLog: false

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,455 +1,455 @@
-trigger:
-  branches:
-    include:
-    - master
-  tags:
-    include:
-    - v*
-pr:
-- master
-- release/*
-variables:
-  AZURE: 'true'
-  PYTHON_VERSION: '3.11'
-  CONDA_ENV: test-env
-  runCodesignValidationInjection: false
-  skipComponentGovernanceDetection: true
-  DOTNET_CLI_TELEMETRY_OPTOUT: true
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-resources:
-  # The __work/ directory, where Azure DevOps writes the source files, needs to be read-write because
-  # LightGBM's CI jobs write files in the source directory.
-  #
-  # For all the containers included here, all other directories that Azure mounts in are mounted as read-only
-  # to minimize the risk of side effects from one run affecting future runs.
-  # ref: https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/resources-containers-container
-  containers:
-  - container: linux-artifact-builder
-    image: lightgbm/vsts-agent:manylinux_2_28_x86_64
-    mountReadOnly:
-      work: false
-      externals: true
-      tools: true
-      tasks: true
-  - container: ubuntu-latest
-    image: 'ubuntu:22.04'
-    options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
-    mountReadOnly:
-      work: false
-      externals: true
-      tools: true
-      tasks: true
-  - container: rbase
-    image: wch1/r-debug
-    mountReadOnly:
-      work: false
-      externals: true
-      tools: true
-      tasks: true
-jobs:
-###########################################
-- job: Linux
-###########################################
-  variables:
-    COMPILER: gcc
-    SETUP_CONDA: 'false'
-    OS_NAME: 'linux'
-    PRODUCES_ARTIFACTS: 'true'
-  pool: mariner-20240410-0
-  container: linux-artifact-builder
-  strategy:
-    matrix:
-      regular:
-        TASK: regular
-        PYTHON_VERSION: '3.9'
-      sdist:
-        TASK: sdist
-        PYTHON_VERSION: '3.7'
-      bdist:
-        TASK: bdist
-        PYTHON_VERSION: '3.8'
-      inference:
-        TASK: if-else
-      mpi_source:
-        TASK: mpi
-        METHOD: source
-        PYTHON_VERSION: '3.8'
-      gpu_source:
-        TASK: gpu
-        METHOD: source
-      swig:
-        TASK: swig
-  steps:
-  - script: |
-      echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
-      echo "##vso[task.prependpath]/usr/lib64/openmpi/bin"
-      echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: 'Set variables'
-  - script: |
-      git clean -d -f -x
-    displayName: 'Clean source directory'
-  - script: |
-      echo '$(Build.SourceVersion)' > '$(Build.ArtifactStagingDirectory)/commit.txt'
-    displayName: 'Add commit hash to artifacts archive'
-  - task: Bash@3
-    displayName: Setup
-    inputs:
-      filePath: $(Build.SourcesDirectory)/.ci/setup.sh
-      targetType: filePath
-  - task: Bash@3
-    displayName: Test
-    inputs:
-      filePath: $(Build.SourcesDirectory)/.ci/test.sh
-      targetType: filePath
-  - task: PublishBuildArtifacts@1
-    condition: and(succeeded(), in(variables['TASK'], 'regular', 'sdist', 'bdist', 'swig'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
-    inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: PackageAssets
-      artifactType: container
-###########################################
-- job: Linux_latest
-###########################################
-  variables:
-    COMPILER: clang-17
-    DEBIAN_FRONTEND: 'noninteractive'
-    IN_UBUNTU_BASE_CONTAINER: 'true'
-    OS_NAME: 'linux'
-    SETUP_CONDA: 'true'
-  pool: mariner-20240410-0
-  container: ubuntu-latest
-  strategy:
-    matrix:
-      regular:
-        TASK: regular
-      sdist:
-        TASK: sdist
-      bdist:
-        TASK: bdist
-        PYTHON_VERSION: '3.9'
-      inference:
-        TASK: if-else
-      mpi_source:
-        TASK: mpi
-        METHOD: source
-      mpi_pip:
-        TASK: mpi
-        METHOD: pip
-        PYTHON_VERSION: '3.10'
-      mpi_wheel:
-        TASK: mpi
-        METHOD: wheel
-        PYTHON_VERSION: '3.8'
-      gpu_source:
-        TASK: gpu
-        METHOD: source
-        PYTHON_VERSION: '3.10'
-      gpu_pip:
-        TASK: gpu
-        METHOD: pip
-        PYTHON_VERSION: '3.9'
-      gpu_wheel:
-        TASK: gpu
-        METHOD: wheel
-        PYTHON_VERSION: '3.8'
-      cpp_tests:
-        TASK: cpp-tests
-        METHOD: with-sanitizers
-  steps:
-  - script: |
-      echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
-      CONDA=$HOME/miniforge
-      echo "##vso[task.setvariable variable=CONDA]$CONDA"
-      echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: 'Set variables'
-  # https://github.com/microsoft/azure-pipelines-agent/issues/2043#issuecomment-687983301
-  - script: |
-      /tmp/docker exec -t -u 0 ci-container \
-      sh -c "apt-get update && apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
-    displayName: 'Install sudo'
-  - script: |
-      sudo apt-get update
-      sudo apt-get install -y --no-install-recommends git
-      git clean -d -f -x
-    displayName: 'Clean source directory'
-  - task: Bash@3
-    displayName: Setup
-    inputs:
-      filePath: $(Build.SourcesDirectory)/.ci/setup.sh
-      targetType: 'filePath'
-  - task: Bash@3
-    displayName: Test
-    inputs:
-      filePath: $(Build.SourcesDirectory)/.ci/test.sh
-      targetType: 'filePath'
-###########################################
-- job: QEMU_multiarch
-###########################################
-  variables:
-    COMPILER: gcc
-    OS_NAME: 'linux'
-    PRODUCES_ARTIFACTS: 'true'
-  pool:
-    vmImage: ubuntu-22.04
-  timeoutInMinutes: 180
-  strategy:
-    matrix:
-      bdist:
-        TASK: bdist
-        ARCH: aarch64
-  steps:
-  - script: |
-      sudo apt-get update
-      sudo apt-get install --no-install-recommends -y \
-        binfmt-support \
-        qemu \
-        qemu-user \
-        qemu-user-static
-    displayName: 'Install QEMU'
-  - script: |
-      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-    displayName: 'Enable Docker multi-architecture support'
-  - script: |
-      git clean -d -f -x
-    displayName: 'Clean source directory'
-  - script: |
-      export ROOT_DOCKER_FOLDER=/LightGBM
-      cat > docker.env <<EOF
-      AZURE=$AZURE
-      OS_NAME=$OS_NAME
-      COMPILER=$COMPILER
-      TASK=$TASK
-      METHOD=$METHOD
-      CONDA_ENV=$CONDA_ENV
-      PYTHON_VERSION=$PYTHON_VERSION
-      BUILD_DIRECTORY=$ROOT_DOCKER_FOLDER
-      PRODUCES_ARTIFACTS=$PRODUCES_ARTIFACTS
-      BUILD_ARTIFACTSTAGINGDIRECTORY=$BUILD_ARTIFACTSTAGINGDIRECTORY
-      EOF
-      cat > docker-script.sh <<EOF
-      export CONDA=\$HOME/miniforge
-      export PATH=\$CONDA/bin:/opt/rh/llvm-toolset-7.0/root/usr/bin:\$PATH
-      export LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:\$LD_LIBRARY_PATH
-      $ROOT_DOCKER_FOLDER/.ci/setup.sh || exit 1
-      $ROOT_DOCKER_FOLDER/.ci/test.sh || exit 1
-      EOF
-      IMAGE_URI="lightgbm/vsts-agent:manylinux2014_aarch64"
-      docker pull "${IMAGE_URI}" || exit 1
-      PLATFORM=$(docker inspect --format='{{.Os}}/{{.Architecture}}' "${IMAGE_URI}") || exit 1
-      echo "detected image platform: ${PLATFORM}"
-      docker run \
-        --platform "${PLATFORM}" \
-        --rm \
-        --env-file docker.env \
-        -v "$(Build.SourcesDirectory)":"$ROOT_DOCKER_FOLDER" \
-        -v "$(Build.ArtifactStagingDirectory)":"$(Build.ArtifactStagingDirectory)" \
-        "${IMAGE_URI}" \
-        /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
-    displayName: 'Setup and run tests'
-  - task: PublishBuildArtifacts@1
-    condition: and(succeeded(), in(variables['TASK'], 'bdist'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
-    inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: PackageAssets
-      artifactType: container
-###########################################
-- job: macOS
-###########################################
-  variables:
-    COMPILER: clang
-    OS_NAME: 'macos'
-    PRODUCES_ARTIFACTS: 'true'
-  pool:
-    vmImage: 'macOS-11'
-  strategy:
-    matrix:
-      regular:
-        TASK: regular
-        PYTHON_VERSION: '3.10'
-      sdist:
-        TASK: sdist
-        PYTHON_VERSION: '3.9'
-      bdist:
-        TASK: bdist
-      swig:
-        TASK: swig
-      cpp_tests:
-        TASK: cpp-tests
-        METHOD: with-sanitizers
-        SANITIZERS: "address;undefined"
-  steps:
-  - script: |
-      echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
-      CONDA=$AGENT_HOMEDIRECTORY/miniforge
-      echo "##vso[task.setvariable variable=CONDA]$CONDA"
-      echo "##vso[task.prependpath]$CONDA/bin"
-      echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_8_X64"
-    displayName: 'Set variables'
-  - script: |
-      git clean -d -f -x
-    displayName: 'Clean source directory'
-  - task: Bash@3
-    displayName: Setup
-    inputs:
-      filePath: $(Build.SourcesDirectory)/.ci/setup.sh
-      targetType: filePath
-  - task: Bash@3
-    displayName: Test
-    inputs:
-      filePath: $(Build.SourcesDirectory)/.ci/test.sh
-      targetType: filePath
-  - task: PublishBuildArtifacts@1
-    condition: and(succeeded(), in(variables['TASK'], 'regular', 'bdist', 'swig'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
-    inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: PackageAssets
-      artifactType: container
-###########################################
-- job: Windows
-###########################################
-  pool:
-    vmImage: 'windows-2019'
-  strategy:
-    matrix:
-      regular:
-        TASK: regular
-        PYTHON_VERSION: '3.10'
-      sdist:
-        TASK: sdist
-        PYTHON_VERSION: '3.9'
-      bdist:
-        TASK: bdist
-      swig:
-        TASK: swig
-      cpp_tests:
-        TASK: cpp-tests
-  steps:
-  - powershell: |
-      Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-    displayName: 'Set Variables'
-  - script: |
-      git clean -d -f -x
-    displayName: 'Clean source directory'
-  - script: |
-      cmd /c "powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/install_opencl.ps1"
-    condition: eq(variables['TASK'], 'bdist')
-    displayName: 'Install OpenCL'
-  - script: |
-      cmd /c "conda config --remove channels defaults"
-      cmd /c "conda config --add channels nodefaults"
-      cmd /c "conda config --add channels conda-forge"
-      cmd /c "conda config --set channel_priority strict"
-      cmd /c "conda init powershell"
-      cmd /c "powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/test_windows.ps1"
-    displayName: Test
-  - task: PublishBuildArtifacts@1
-    condition: and(succeeded(), in(variables['TASK'], 'regular', 'bdist', 'swig'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
-    inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: PackageAssets
-      artifactType: container
-###########################################
-- job: R_artifact
-###########################################
-  condition: not(startsWith(variables['Build.SourceBranch'], 'refs/pull/'))
-  pool:
-    vmImage: 'ubuntu-22.04'
-  container: rbase
-  steps:
-  - script: |
-      git clean -d -f -x
-    displayName: 'Clean source directory'
-  - script: |
-      LGB_VER=$(head -n 1 VERSION.txt | sed "s/rc/-/g")
-      R_LIB_PATH=~/Rlib
-      export R_LIBS=${R_LIB_PATH}
-      mkdir -p ${R_LIB_PATH}
-      RDscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl'),  lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())" || exit 1
-      sh build-cran-package.sh --r-executable=RD || exit 1
-      mv lightgbm_${LGB_VER}.tar.gz $(Build.ArtifactStagingDirectory)/lightgbm-${LGB_VER}-r-cran.tar.gz
-    displayName: 'Build CRAN R-package'
-  - task: PublishBuildArtifacts@1
-    condition: succeeded()
-    inputs:
-      pathtoPublish: $(Build.ArtifactStagingDirectory)
-      artifactName: R-package
-      artifactType: container
+# trigger:
+#   branches:
+#     include:
+#     - master
+#   tags:
+#     include:
+#     - v*
+# pr:
+# - master
+# - release/*
+# variables:
+#   AZURE: 'true'
+#   PYTHON_VERSION: '3.11'
+#   CONDA_ENV: test-env
+#   runCodesignValidationInjection: false
+#   skipComponentGovernanceDetection: true
+#   DOTNET_CLI_TELEMETRY_OPTOUT: true
+#   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+# resources:
+#   # The __work/ directory, where Azure DevOps writes the source files, needs to be read-write because
+#   # LightGBM's CI jobs write files in the source directory.
+#   #
+#   # For all the containers included here, all other directories that Azure mounts in are mounted as read-only
+#   # to minimize the risk of side effects from one run affecting future runs.
+#   # ref: https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/resources-containers-container
+#   containers:
+#   - container: linux-artifact-builder
+#     image: lightgbm/vsts-agent:manylinux_2_28_x86_64
+#     mountReadOnly:
+#       work: false
+#       externals: true
+#       tools: true
+#       tasks: true
+#   - container: ubuntu-latest
+#     image: 'ubuntu:22.04'
+#     options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
+#     mountReadOnly:
+#       work: false
+#       externals: true
+#       tools: true
+#       tasks: true
+#   - container: rbase
+#     image: wch1/r-debug
+#     mountReadOnly:
+#       work: false
+#       externals: true
+#       tools: true
+#       tasks: true
+# jobs:
+# ###########################################
+# - job: Linux
+# ###########################################
+#   variables:
+#     COMPILER: gcc
+#     SETUP_CONDA: 'false'
+#     OS_NAME: 'linux'
+#     PRODUCES_ARTIFACTS: 'true'
+#   pool: mariner-20240410-0
+#   container: linux-artifact-builder
+#   strategy:
+#     matrix:
+#       regular:
+#         TASK: regular
+#         PYTHON_VERSION: '3.9'
+#       sdist:
+#         TASK: sdist
+#         PYTHON_VERSION: '3.7'
+#       bdist:
+#         TASK: bdist
+#         PYTHON_VERSION: '3.8'
+#       inference:
+#         TASK: if-else
+#       mpi_source:
+#         TASK: mpi
+#         METHOD: source
+#         PYTHON_VERSION: '3.8'
+#       gpu_source:
+#         TASK: gpu
+#         METHOD: source
+#       swig:
+#         TASK: swig
+#   steps:
+#   - script: |
+#       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
+#       echo "##vso[task.prependpath]/usr/lib64/openmpi/bin"
+#       echo "##vso[task.prependpath]$CONDA/bin"
+#     displayName: 'Set variables'
+#   - script: |
+#       git clean -d -f -x
+#     displayName: 'Clean source directory'
+#   - script: |
+#       echo '$(Build.SourceVersion)' > '$(Build.ArtifactStagingDirectory)/commit.txt'
+#     displayName: 'Add commit hash to artifacts archive'
+#   - task: Bash@3
+#     displayName: Setup
+#     inputs:
+#       filePath: $(Build.SourcesDirectory)/.ci/setup.sh
+#       targetType: filePath
+#   - task: Bash@3
+#     displayName: Test
+#     inputs:
+#       filePath: $(Build.SourcesDirectory)/.ci/test.sh
+#       targetType: filePath
+#   - task: PublishBuildArtifacts@1
+#     condition: and(succeeded(), in(variables['TASK'], 'regular', 'sdist', 'bdist', 'swig'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
+#     inputs:
+#       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+#       artifactName: PackageAssets
+#       artifactType: container
+# ###########################################
+# - job: Linux_latest
+# ###########################################
+#   variables:
+#     COMPILER: clang-17
+#     DEBIAN_FRONTEND: 'noninteractive'
+#     IN_UBUNTU_BASE_CONTAINER: 'true'
+#     OS_NAME: 'linux'
+#     SETUP_CONDA: 'true'
+#   pool: mariner-20240410-0
+#   container: ubuntu-latest
+#   strategy:
+#     matrix:
+#       regular:
+#         TASK: regular
+#       sdist:
+#         TASK: sdist
+#       bdist:
+#         TASK: bdist
+#         PYTHON_VERSION: '3.9'
+#       inference:
+#         TASK: if-else
+#       mpi_source:
+#         TASK: mpi
+#         METHOD: source
+#       mpi_pip:
+#         TASK: mpi
+#         METHOD: pip
+#         PYTHON_VERSION: '3.10'
+#       mpi_wheel:
+#         TASK: mpi
+#         METHOD: wheel
+#         PYTHON_VERSION: '3.8'
+#       gpu_source:
+#         TASK: gpu
+#         METHOD: source
+#         PYTHON_VERSION: '3.10'
+#       gpu_pip:
+#         TASK: gpu
+#         METHOD: pip
+#         PYTHON_VERSION: '3.9'
+#       gpu_wheel:
+#         TASK: gpu
+#         METHOD: wheel
+#         PYTHON_VERSION: '3.8'
+#       cpp_tests:
+#         TASK: cpp-tests
+#         METHOD: with-sanitizers
+#   steps:
+#   - script: |
+#       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
+#       CONDA=$HOME/miniforge
+#       echo "##vso[task.setvariable variable=CONDA]$CONDA"
+#       echo "##vso[task.prependpath]$CONDA/bin"
+#     displayName: 'Set variables'
+#   # https://github.com/microsoft/azure-pipelines-agent/issues/2043#issuecomment-687983301
+#   - script: |
+#       /tmp/docker exec -t -u 0 ci-container \
+#       sh -c "apt-get update && apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
+#     displayName: 'Install sudo'
+#   - script: |
+#       sudo apt-get update
+#       sudo apt-get install -y --no-install-recommends git
+#       git clean -d -f -x
+#     displayName: 'Clean source directory'
+#   - task: Bash@3
+#     displayName: Setup
+#     inputs:
+#       filePath: $(Build.SourcesDirectory)/.ci/setup.sh
+#       targetType: 'filePath'
+#   - task: Bash@3
+#     displayName: Test
+#     inputs:
+#       filePath: $(Build.SourcesDirectory)/.ci/test.sh
+#       targetType: 'filePath'
+# ###########################################
+# - job: QEMU_multiarch
+# ###########################################
+#   variables:
+#     COMPILER: gcc
+#     OS_NAME: 'linux'
+#     PRODUCES_ARTIFACTS: 'true'
+#   pool:
+#     vmImage: ubuntu-22.04
+#   timeoutInMinutes: 180
+#   strategy:
+#     matrix:
+#       bdist:
+#         TASK: bdist
+#         ARCH: aarch64
+#   steps:
+#   - script: |
+#       sudo apt-get update
+#       sudo apt-get install --no-install-recommends -y \
+#         binfmt-support \
+#         qemu \
+#         qemu-user \
+#         qemu-user-static
+#     displayName: 'Install QEMU'
+#   - script: |
+#       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+#     displayName: 'Enable Docker multi-architecture support'
+#   - script: |
+#       git clean -d -f -x
+#     displayName: 'Clean source directory'
+#   - script: |
+#       export ROOT_DOCKER_FOLDER=/LightGBM
+#       cat > docker.env <<EOF
+#       AZURE=$AZURE
+#       OS_NAME=$OS_NAME
+#       COMPILER=$COMPILER
+#       TASK=$TASK
+#       METHOD=$METHOD
+#       CONDA_ENV=$CONDA_ENV
+#       PYTHON_VERSION=$PYTHON_VERSION
+#       BUILD_DIRECTORY=$ROOT_DOCKER_FOLDER
+#       PRODUCES_ARTIFACTS=$PRODUCES_ARTIFACTS
+#       BUILD_ARTIFACTSTAGINGDIRECTORY=$BUILD_ARTIFACTSTAGINGDIRECTORY
+#       EOF
+#       cat > docker-script.sh <<EOF
+#       export CONDA=\$HOME/miniforge
+#       export PATH=\$CONDA/bin:/opt/rh/llvm-toolset-7.0/root/usr/bin:\$PATH
+#       export LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:\$LD_LIBRARY_PATH
+#       $ROOT_DOCKER_FOLDER/.ci/setup.sh || exit 1
+#       $ROOT_DOCKER_FOLDER/.ci/test.sh || exit 1
+#       EOF
+#       IMAGE_URI="lightgbm/vsts-agent:manylinux2014_aarch64"
+#       docker pull "${IMAGE_URI}" || exit 1
+#       PLATFORM=$(docker inspect --format='{{.Os}}/{{.Architecture}}' "${IMAGE_URI}") || exit 1
+#       echo "detected image platform: ${PLATFORM}"
+#       docker run \
+#         --platform "${PLATFORM}" \
+#         --rm \
+#         --env-file docker.env \
+#         -v "$(Build.SourcesDirectory)":"$ROOT_DOCKER_FOLDER" \
+#         -v "$(Build.ArtifactStagingDirectory)":"$(Build.ArtifactStagingDirectory)" \
+#         "${IMAGE_URI}" \
+#         /bin/bash $ROOT_DOCKER_FOLDER/docker-script.sh
+#     displayName: 'Setup and run tests'
+#   - task: PublishBuildArtifacts@1
+#     condition: and(succeeded(), in(variables['TASK'], 'bdist'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
+#     inputs:
+#       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+#       artifactName: PackageAssets
+#       artifactType: container
+# ###########################################
+# - job: macOS
+# ###########################################
+#   variables:
+#     COMPILER: clang
+#     OS_NAME: 'macos'
+#     PRODUCES_ARTIFACTS: 'true'
+#   pool:
+#     vmImage: 'macOS-11'
+#   strategy:
+#     matrix:
+#       regular:
+#         TASK: regular
+#         PYTHON_VERSION: '3.10'
+#       sdist:
+#         TASK: sdist
+#         PYTHON_VERSION: '3.9'
+#       bdist:
+#         TASK: bdist
+#       swig:
+#         TASK: swig
+#       cpp_tests:
+#         TASK: cpp-tests
+#         METHOD: with-sanitizers
+#         SANITIZERS: "address;undefined"
+#   steps:
+#   - script: |
+#       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
+#       CONDA=$AGENT_HOMEDIRECTORY/miniforge
+#       echo "##vso[task.setvariable variable=CONDA]$CONDA"
+#       echo "##vso[task.prependpath]$CONDA/bin"
+#       echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_8_X64"
+#     displayName: 'Set variables'
+#   - script: |
+#       git clean -d -f -x
+#     displayName: 'Clean source directory'
+#   - task: Bash@3
+#     displayName: Setup
+#     inputs:
+#       filePath: $(Build.SourcesDirectory)/.ci/setup.sh
+#       targetType: filePath
+#   - task: Bash@3
+#     displayName: Test
+#     inputs:
+#       filePath: $(Build.SourcesDirectory)/.ci/test.sh
+#       targetType: filePath
+#   - task: PublishBuildArtifacts@1
+#     condition: and(succeeded(), in(variables['TASK'], 'regular', 'bdist', 'swig'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
+#     inputs:
+#       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+#       artifactName: PackageAssets
+#       artifactType: container
+# ###########################################
+# - job: Windows
+# ###########################################
+#   pool:
+#     vmImage: 'windows-2019'
+#   strategy:
+#     matrix:
+#       regular:
+#         TASK: regular
+#         PYTHON_VERSION: '3.10'
+#       sdist:
+#         TASK: sdist
+#         PYTHON_VERSION: '3.9'
+#       bdist:
+#         TASK: bdist
+#       swig:
+#         TASK: swig
+#       cpp_tests:
+#         TASK: cpp-tests
+#   steps:
+#   - powershell: |
+#       Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+#     displayName: 'Set Variables'
+#   - script: |
+#       git clean -d -f -x
+#     displayName: 'Clean source directory'
+#   - script: |
+#       cmd /c "powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/install_opencl.ps1"
+#     condition: eq(variables['TASK'], 'bdist')
+#     displayName: 'Install OpenCL'
+#   - script: |
+#       cmd /c "conda config --remove channels defaults"
+#       cmd /c "conda config --add channels nodefaults"
+#       cmd /c "conda config --add channels conda-forge"
+#       cmd /c "conda config --set channel_priority strict"
+#       cmd /c "conda init powershell"
+#       cmd /c "powershell -ExecutionPolicy Bypass -File %BUILD_SOURCESDIRECTORY%/.ci/test_windows.ps1"
+#     displayName: Test
+#   - task: PublishBuildArtifacts@1
+#     condition: and(succeeded(), in(variables['TASK'], 'regular', 'bdist', 'swig'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
+#     inputs:
+#       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+#       artifactName: PackageAssets
+#       artifactType: container
+# ###########################################
+# - job: R_artifact
+# ###########################################
+#   condition: not(startsWith(variables['Build.SourceBranch'], 'refs/pull/'))
+#   pool:
+#     vmImage: 'ubuntu-22.04'
+#   container: rbase
+#   steps:
+#   - script: |
+#       git clean -d -f -x
+#     displayName: 'Clean source directory'
+#   - script: |
+#       LGB_VER=$(head -n 1 VERSION.txt | sed "s/rc/-/g")
+#       R_LIB_PATH=~/Rlib
+#       export R_LIBS=${R_LIB_PATH}
+#       mkdir -p ${R_LIB_PATH}
+#       RDscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl'),  lib = '${R_LIB_PATH}', dependencies = c('Depends', 'Imports', 'LinkingTo'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())" || exit 1
+#       sh build-cran-package.sh --r-executable=RD || exit 1
+#       mv lightgbm_${LGB_VER}.tar.gz $(Build.ArtifactStagingDirectory)/lightgbm-${LGB_VER}-r-cran.tar.gz
+#     displayName: 'Build CRAN R-package'
+#   - task: PublishBuildArtifacts@1
+#     condition: succeeded()
+#     inputs:
+#       pathtoPublish: $(Build.ArtifactStagingDirectory)
+#       artifactName: R-package
+#       artifactType: container
 
-###########################################
-- job: Package
-###########################################
-  dependsOn:
-  - Linux
-  - Linux_latest
-  - QEMU_multiarch
-  - macOS
-  - Windows
-  - R_artifact
-  condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
-  pool:
-    vmImage: 'ubuntu-22.04'
-  steps:
-  # Create archives with complete source code included (with git submodules)
-  - task: ArchiveFiles@2
-    displayName: Create zip archive
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
-    inputs:
-      rootFolderOrFile: $(Build.SourcesDirectory)
-      includeRootFolder: false
-      archiveType: zip
-      archiveFile: '$(Build.ArtifactStagingDirectory)/archives/LightGBM-complete_source_code_zip.zip'
-      replaceExistingArchive: true
-  - task: ArchiveFiles@2
-    displayName: Create tar.gz archive
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
-    inputs:
-      rootFolderOrFile: $(Build.SourcesDirectory)
-      includeRootFolder: false
-      archiveType: tar
-      tarCompression: gz
-      archiveFile: '$(Build.ArtifactStagingDirectory)/archives/LightGBM-complete_source_code_tar_gz.tar.gz'
-      replaceExistingArchive: true
-  # Download all agent packages from all previous phases
-  - task: DownloadBuildArtifacts@0
-    displayName: Download package assets
-    inputs:
-      artifactName: PackageAssets
-      downloadPath: $(Build.SourcesDirectory)/binaries
-  - task: DownloadBuildArtifacts@0
-    displayName: Download R-package
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
-    inputs:
-      artifactName: R-package
-      downloadPath: $(Build.SourcesDirectory)/R
-  - script: |
-      python "$(Build.SourcesDirectory)/.nuget/create_nuget.py" "$(Build.SourcesDirectory)/binaries/PackageAssets"
-    displayName: 'Create NuGet configuration files'
-  - task: NuGetCommand@2
-    inputs:
-      command: pack
-      packagesToPack: '$(Build.SourcesDirectory)/.nuget/*.nuspec'
-      packDestination: '$(Build.ArtifactStagingDirectory)/nuget'
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
-      artifactName: NuGet
-      artifactType: container
-  - task: GitHubRelease@0
-    displayName: 'Create GitHub Release'
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
-    inputs:
-      gitHubConnection: guolinke
-      repositoryName: '$(Build.Repository.Name)'
-      action: 'create'
-      target: '$(Build.SourceVersion)'
-      tagSource: 'auto'
-      title: '$(Build.SourceBranchName)'
-      assets: |
-        $(Build.SourcesDirectory)/binaries/PackageAssets/*
-        $(Build.SourcesDirectory)/R/R-package/*
-        $(Build.ArtifactStagingDirectory)/nuget/*.nupkg
-        $(Build.ArtifactStagingDirectory)/archives/*
-      assetUploadMode: 'delete'
-      isDraft: true
-      isPreRelease: false
-      addChangeLog: false
+# ###########################################
+# - job: Package
+# ###########################################
+#   dependsOn:
+#   - Linux
+#   - Linux_latest
+#   - QEMU_multiarch
+#   - macOS
+#   - Windows
+#   - R_artifact
+#   condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/pull/')))
+#   pool:
+#     vmImage: 'ubuntu-22.04'
+#   steps:
+#   # Create archives with complete source code included (with git submodules)
+#   - task: ArchiveFiles@2
+#     displayName: Create zip archive
+#     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+#     inputs:
+#       rootFolderOrFile: $(Build.SourcesDirectory)
+#       includeRootFolder: false
+#       archiveType: zip
+#       archiveFile: '$(Build.ArtifactStagingDirectory)/archives/LightGBM-complete_source_code_zip.zip'
+#       replaceExistingArchive: true
+#   - task: ArchiveFiles@2
+#     displayName: Create tar.gz archive
+#     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+#     inputs:
+#       rootFolderOrFile: $(Build.SourcesDirectory)
+#       includeRootFolder: false
+#       archiveType: tar
+#       tarCompression: gz
+#       archiveFile: '$(Build.ArtifactStagingDirectory)/archives/LightGBM-complete_source_code_tar_gz.tar.gz'
+#       replaceExistingArchive: true
+#   # Download all agent packages from all previous phases
+#   - task: DownloadBuildArtifacts@0
+#     displayName: Download package assets
+#     inputs:
+#       artifactName: PackageAssets
+#       downloadPath: $(Build.SourcesDirectory)/binaries
+#   - task: DownloadBuildArtifacts@0
+#     displayName: Download R-package
+#     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+#     inputs:
+#       artifactName: R-package
+#       downloadPath: $(Build.SourcesDirectory)/R
+#   - script: |
+#       python "$(Build.SourcesDirectory)/.nuget/create_nuget.py" "$(Build.SourcesDirectory)/binaries/PackageAssets"
+#     displayName: 'Create NuGet configuration files'
+#   - task: NuGetCommand@2
+#     inputs:
+#       command: pack
+#       packagesToPack: '$(Build.SourcesDirectory)/.nuget/*.nuspec'
+#       packDestination: '$(Build.ArtifactStagingDirectory)/nuget'
+#   - task: PublishBuildArtifacts@1
+#     inputs:
+#       pathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
+#       artifactName: NuGet
+#       artifactType: container
+#   - task: GitHubRelease@0
+#     displayName: 'Create GitHub Release'
+#     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+#     inputs:
+#       gitHubConnection: guolinke
+#       repositoryName: '$(Build.Repository.Name)'
+#       action: 'create'
+#       target: '$(Build.SourceVersion)'
+#       tagSource: 'auto'
+#       title: '$(Build.SourceBranchName)'
+#       assets: |
+#         $(Build.SourcesDirectory)/binaries/PackageAssets/*
+#         $(Build.SourcesDirectory)/R/R-package/*
+#         $(Build.ArtifactStagingDirectory)/nuget/*.nupkg
+#         $(Build.ArtifactStagingDirectory)/archives/*
+#       assetUploadMode: 'delete'
+#       isDraft: true
+#       isPreRelease: false
+#       addChangeLog: false

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -82,7 +82,6 @@ jobs:
   steps:
   - script: |
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
-      echo "##vso[task.setvariable variable=LGB_VER]$(head -n 1 VERSION.txt)"
       echo "##vso[task.prependpath]/usr/lib64/openmpi/bin"
       echo "##vso[task.prependpath]$CONDA/bin"
     displayName: 'Set variables'
@@ -159,7 +158,6 @@ jobs:
   steps:
   - script: |
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
-      echo "##vso[task.setvariable variable=LGB_VER]$(head -n 1 VERSION.txt)"
       CONDA=$HOME/miniforge
       echo "##vso[task.setvariable variable=CONDA]$CONDA"
       echo "##vso[task.prependpath]$CONDA/bin"
@@ -225,7 +223,6 @@ jobs:
       CONDA_ENV=$CONDA_ENV
       PYTHON_VERSION=$PYTHON_VERSION
       BUILD_DIRECTORY=$ROOT_DOCKER_FOLDER
-      LGB_VER=$(head -n 1 VERSION.txt)
       PRODUCES_ARTIFACTS=$PRODUCES_ARTIFACTS
       BUILD_ARTIFACTSTAGINGDIRECTORY=$BUILD_ARTIFACTSTAGINGDIRECTORY
       EOF
@@ -283,7 +280,6 @@ jobs:
   steps:
   - script: |
       echo "##vso[task.setvariable variable=BUILD_DIRECTORY]$BUILD_SOURCESDIRECTORY"
-      echo "##vso[task.setvariable variable=LGB_VER]$(head -n 1 VERSION.txt)"
       CONDA=$AGENT_HOMEDIRECTORY/miniforge
       echo "##vso[task.setvariable variable=CONDA]$CONDA"
       echo "##vso[task.prependpath]$CONDA/bin"


### PR DESCRIPTION
Proposes the following changes to the CI setup:

In the CUDA jobs:

* add support for triggering a build by clicking a button in the UI ([workflow dispatch](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs))
* removes code running *"set up `nvidia-docker` and restart the docker daemon"* on every CUDA build
    - *to save a bit of CI time on each CUDA build*
    - *added an option to do this on the manual runs, so that can be done by every maintainer but*
* upgrades Ubuntu versions
    - *to Ubuntu 20.04 for CUDA 11.x, Ubuntu 22.04 for CUDA 12.x (see Notes)*
* uses GitHub Actions container support directly instead of calling `docker run` in a `script:` block
* writes miniforge to `/tmp` instead of a directory that's mounted in from the self-hosted runner
    - *to avoid files being left behind on the hosted runner, which I found sometimes happened in failed builds, causing conflicts like "`/home/github/miniforge` already exists" on the next build*
* updates `actions/checkout` from `v1` to `v3`
    - *can't go all the way to `v4` yet because GLIBC in the container images used in this job aren't new enough*

On most of the CI jobs:

* stops setting unused variable `GITHUB_ACTIONS=true`
   - *this is set automatically by `GITHUB_ACTIONS` anyway ([docs](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables))
* moves *"read LightGBM's version out of `VERSION.txt`"* into the 2 CI scripts that need it, instead of having it defined as inline shell code across most of the CI configs
* sets `CMAKE_BUILD_PARALLEL_LEVEL=4` environment variable (see Notes)

If any of these generate a lot of discussion, I'll split this up into smaller PRs. But thought the sum total was small enough to do as a single PR.

## Notes for Reviewers

### Why set `CMAKE_BUILD_PARALLEL_LEVEL`?

This environment variable is the equivalent of passing e.g. `-j4` to `cmake --build` or `make`.
It tells that build tool (Ninja, in most of our builds here), to compile multiple objects at a time.

We set that in builds that separately invoke `cmake`, like here:

https://github.com/microsoft/LightGBM/blob/3e9ab53c7d0c03258c947b34d99669c5bb887525/.ci/test.sh#L56

But currently any builds that are just running `sh build-python.sh` or `Rscript build_r.R` are performing serial compilation.

Setting this to a value greater than `1` should speed up builds.
I chose `4` because we're already using `-j4` in lots of places, and it seems to be working well.

References:

* `scikit-build-core` docs recommending this ([link](https://github.com/scikit-build/scikit-build-core/blob/86f40d949741d8e6ce4d9f55264a6d05224408dd/docs/faqs.md?plain=1#L28))
* CMake docs on `CMAKE_BUILD_PARALLEL_LEVEL` ([link](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html))

### Why update Ubuntu versions?

It helps with the GitHub Actions Node 16/20 situation: https://github.com/microsoft/LightGBM/pull/6453#issuecomment-2118649947.

But more importantly, I think it's more likely to match the set of operating systems and library versions that `lightgbm` users are using in their environments.

Ubuntu 22.04 has been available for 2 years ([Ubuntu release history](https://ubuntu.com/about/release-cycle)) and all of RAPIDS CI uses Ubuntu 20.04 and 22.04:

https://github.com/rapidsai/shared-workflows/blob/19d17957e59cf81574f214e043adf8cff7db9447/.github/workflows/wheels-test.yaml#L81-L85

### Other References

Some related PRs explaining the history of the CUDA jobs:

* #3549
* #4763