### PR TITLE
[python-package] drop Python 3.6 support, add Python 3.12

### DIFF
--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -12,6 +12,7 @@ echo "checking Python package distributions in '${DIST_DIR}'"
 
 pip install \
     -qq \
+    auditwheel \
     check-wheel-contents \
     twine || exit 1
 
@@ -21,6 +22,8 @@ twine check --strict ${DIST_DIR}/* || exit 1
 if { test "${TASK}" = "bdist" || test "${METHOD}" = "wheel"; }; then
     echo "check-wheel-contents..."
     check-wheel-contents ${DIST_DIR}/*.whl || exit 1
+    echo "auditwheel show ..."
+    auditwheel show ${DIST_DIR}/*.whl || exit 1
 fi
 
 PY_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")

--- a/.ci/conda-envs/ci-core-py38.txt
+++ b/.ci/conda-envs/ci-core-py38.txt
@@ -1,0 +1,51 @@
+# [description]
+#
+#   Similar to ci-core.txt, but specific to Python 3.8.
+#
+#   Unlike ci-core.txt, this includes a Python version and uses
+#   `=` and `<=` pins to make solves faster and prevent against
+#   issues like https://github.com/microsoft/LightGBM/pull/6370.
+#
+# [usage]
+#
+#   conda create \
+#     --name test-env \
+#     --file ./.ci/conda-envs/ci-core-py38.txt
+#
+
+# python
+python=3.8.*
+
+# direct imports
+cffi=1.15.*
+dask=2023.5.*
+distributed=2023.5.*
+joblib=1.4.*
+matplotlib-base=3.7.*
+numpy=1.24.*
+pandas=1.5.*
+pyarrow-core=16.1.*
+python-graphviz=0.20.*
+scikit-learn=1.3.*
+scipy=1.10.*
+
+# testing-only dependencies
+cloudpickle=3.0.*
+pluggy=1.5.*
+psutil=5.9.8
+pytest=8.2.*
+
+# other recursive dependencies, just
+# pinned here to help speed up solves
+bokeh=3.1.*
+fsspec=2024.5.*
+msgpack-python=1.0.*
+pluggy=1.5.*
+pytz=2024.1
+setuptools=69.5.*
+snappy=1.2.*
+tomli=2.0.*
+tornado=6.4.*
+wheel=0.43.*
+zict=3.0.*
+zipp=3.17.*

--- a/.ci/test-python-oldest.sh
+++ b/.ci/test-python-oldest.sh
@@ -3,18 +3,20 @@
 set -e -E -u -o pipefail
 
 # oldest versions of dependencies published after
-# minimum supported Python version's first release
+# minimum supported Python version's first release,
+# for which there are wheels compatible with the
+# python:{version} image
 #
 # see https://devguide.python.org/versions/
 #
 echo "installing lightgbm's dependencies"
 pip install \
   'cffi==1.15.1' \
-  'numpy==1.16.6' \
-  'pandas==0.24.0' \
+  'numpy==1.19.0' \
+  'pandas==1.1.3' \
   'pyarrow==6.0.1' \
-  'scikit-learn==0.18.2' \
-  'scipy==0.19.0' \
+  'scikit-learn==0.24.0' \
+  'scipy==1.6.0' \
 || exit 1
 echo "done installing lightgbm's dependencies"
 

--- a/.ci/test-python-oldest.sh
+++ b/.ci/test-python-oldest.sh
@@ -10,7 +10,6 @@ set -e -E -u -o pipefail
 echo "installing lightgbm's dependencies"
 pip install \
   'cffi==1.15.1' \
-  'dataclasses' \
   'numpy==1.16.6' \
   'pandas==0.24.0' \
   'pyarrow==6.0.1' \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -2,6 +2,8 @@
 
 set -e -E -o -u pipefail
 
+export LD_DEBUG=libs
+
 # defaults
 IN_UBUNTU_BASE_CONTAINER=${IN_UBUNTU_BASE_CONTAINER:-"false"}
 METHOD=${METHOD:-""}

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -130,6 +130,8 @@ fi
 
 if [[ $PYTHON_VERSION == "3.7" ]]; then
     CONDA_REQUIREMENT_FILES="--file ${BUILD_DIRECTORY}/.ci/conda-envs/ci-core-py37.txt"
+elif [[ $PYTHON_VERSION == "3.8" ]]; then
+    CONDA_REQUIREMENT_FILES="--file ${BUILD_DIRECTORY}/.ci/conda-envs/ci-core-py38.txt"
 else
     CONDA_REQUIREMENT_FILES="--file ${BUILD_DIRECTORY}/.ci/conda-envs/ci-core.txt"
 fi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -2,8 +2,6 @@
 
 set -e -E -o -u pipefail
 
-export LD_DEBUG=libs
-
 # defaults
 IN_UBUNTU_BASE_CONTAINER=${IN_UBUNTU_BASE_CONTAINER:-"false"}
 METHOD=${METHOD:-""}
@@ -156,6 +154,8 @@ if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "clang" ]]; then
     for LIBOMP_ALIAS in libgomp.dylib libiomp5.dylib libomp.dylib; do sudo ln -sf "$(brew --cellar libomp)"/*/lib/libomp.dylib $CONDA_PREFIX/lib/$LIBOMP_ALIAS || exit 1; done
 fi
 
+export LD_DEBUG=libs
+
 if [[ $TASK == "sdist" ]]; then
     cd $BUILD_DIRECTORY && sh ./build-python.sh sdist || exit 1
     sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit 1
@@ -247,13 +247,13 @@ elif [[ $TASK == "cuda" ]]; then
             --config-settings=cmake.define.USE_CUDA=ON \
             $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER.tar.gz \
         || exit 1
-        pytest $BUILD_DIRECTORY/tests/python_package_test || exit 1
+        pytest $BUILD_DIRECTORY/tests/python_package_test/test_basic.py || exit 1
         exit 0
     elif [[ $METHOD == "wheel" ]]; then
         cd $BUILD_DIRECTORY && sh ./build-python.sh bdist_wheel --cuda || exit 1
         sh $BUILD_DIRECTORY/.ci/check_python_dists.sh $BUILD_DIRECTORY/dist || exit 1
         pip install --user $BUILD_DIRECTORY/dist/lightgbm-$LGB_VER*.whl -v || exit 1
-        pytest $BUILD_DIRECTORY/tests || exit 1
+        pytest $BUILD_DIRECTORY/tests/python_package_test/test_basic.py || exit 1
         exit 0
     elif [[ $METHOD == "source" ]]; then
         cmake -B build -S . -DUSE_CUDA=ON

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -53,6 +53,8 @@ conda update -q -y conda
 
 if ($env:PYTHON_VERSION -eq "3.7") {
   $env:CONDA_REQUIREMENT_FILE = "$env:BUILD_SOURCESDIRECTORY/.ci/conda-envs/ci-core-py37.txt"
+} elseif ($env:PYTHON_VERSION -eq "3.8") {
+  $env:CONDA_REQUIREMENT_FILE = "$env:BUILD_SOURCESDIRECTORY/.ci/conda-envs/ci-core-py38.txt"
 } else {
   $env:CONDA_REQUIREMENT_FILE = "$env:BUILD_SOURCESDIRECTORY/.ci/conda-envs/ci-core.txt"
 }

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -30,17 +30,17 @@ jobs:
         include:
           - method: wheel
             compiler: gcc
-            python_version: "3.11"
+            python_version: "3.10"
             cuda_version: "11.8.0"
             task: cuda
           - method: source
             compiler: gcc
-            python_version: "3.9"
+            python_version: "3.12"
             cuda_version: "12.2.0"
             task: cuda
           - method: pip
             compiler: clang
-            python_version: "3.10"
+            python_version: "3.11"
             cuda_version: "11.8.0"
             task: cuda
     steps:

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -11,7 +11,7 @@ env:
   CONDA_ENV: test-env
   GITHUB_ACTIONS: 'true'
   OS_NAME: 'linux'
-  PYTHON_VERSION: '3.11'
+  PYTHON_VERSION: '3.12'
   TASK: 'check-links'
 
 jobs:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -29,30 +29,30 @@ jobs:
         include:
           - os: macos-13
             task: regular
-            python_version: '3.9'
-          - os: macos-13
-            task: sdist
             python_version: '3.10'
           - os: macos-13
+            task: sdist
+            python_version: '3.11'
+          - os: macos-13
             task: bdist
-            python_version: '3.7'
+            python_version: '3.8'
           - os: macos-13
             task: if-else
-            python_version: '3.9'
+            python_version: '3.10'
           # We're currently skipping MPI jobs on macOS, see https://github.com/microsoft/LightGBM/pull/6425
           # for further details.
           # - os: macos-13
           #   task: mpi
           #   method: source
-          #   python_version: '3.10'
-          # - os: macos-13
-          #   task: mpi
-          #   method: pip
           #   python_version: '3.11'
           # - os: macos-13
           #   task: mpi
+          #   method: pip
+          #   python_version: '3.12'
+          # - os: macos-13
+          #   task: mpi
           #   method: wheel
-          #   python_version: '3.8'
+          #   python_version: '3.9'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -102,7 +102,7 @@ jobs:
             --rm \
             -v $(pwd):/opt/lgb-build \
             -w /opt/lgb-build \
-            python:3.6 \
+            python:3.7 \
             /bin/bash ./.ci/test-python-oldest.sh
   all-python-package-jobs-successful:
     if: always()

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -21,7 +21,7 @@ env:
   CONDA_ENV: test-env
   GITHUB_ACTIONS: 'true'
   OS_NAME: 'linux'
-  PYTHON_VERSION: '3.11'
+  PYTHON_VERSION: '3.12'
 
 jobs:
   test:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -10,7 +10,7 @@ pr:
 - release/*
 variables:
   AZURE: 'true'
-  PYTHON_VERSION: '3.11'
+  PYTHON_VERSION: '3.12'
   CONDA_ENV: test-env
   runCodesignValidationInjection: false
   skipComponentGovernanceDetection: true
@@ -61,19 +61,19 @@ jobs:
     matrix:
       regular:
         TASK: regular
-        PYTHON_VERSION: '3.9'
+        PYTHON_VERSION: '3.10'
       sdist:
         TASK: sdist
-        PYTHON_VERSION: '3.7'
+        PYTHON_VERSION: '3.8'
       bdist:
         TASK: bdist
-        PYTHON_VERSION: '3.8'
+        PYTHON_VERSION: '3.9'
       inference:
         TASK: if-else
       mpi_source:
         TASK: mpi
         METHOD: source
-        PYTHON_VERSION: '3.8'
+        PYTHON_VERSION: '3.9'
       gpu_source:
         TASK: gpu
         METHOD: source
@@ -127,7 +127,7 @@ jobs:
         TASK: sdist
       bdist:
         TASK: bdist
-        PYTHON_VERSION: '3.9'
+        PYTHON_VERSION: '3.10'
       inference:
         TASK: if-else
       mpi_source:
@@ -136,23 +136,23 @@ jobs:
       mpi_pip:
         TASK: mpi
         METHOD: pip
-        PYTHON_VERSION: '3.10'
+        PYTHON_VERSION: '3.11'
       mpi_wheel:
         TASK: mpi
         METHOD: wheel
-        PYTHON_VERSION: '3.8'
+        PYTHON_VERSION: '3.9'
       gpu_source:
         TASK: gpu
         METHOD: source
-        PYTHON_VERSION: '3.10'
+        PYTHON_VERSION: '3.11'
       gpu_pip:
         TASK: gpu
         METHOD: pip
-        PYTHON_VERSION: '3.9'
+        PYTHON_VERSION: '3.10'
       gpu_wheel:
         TASK: gpu
         METHOD: wheel
-        PYTHON_VERSION: '3.8'
+        PYTHON_VERSION: '3.9'
       cpp_tests:
         TASK: cpp-tests
         METHOD: with-sanitizers

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -15,10 +15,10 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence"
 ]
 dependencies = [
-    "dataclasses ; python_version < '3.7'",
     "numpy",
     "scipy"
 ]
@@ -29,7 +29,7 @@ maintainers = [
 ]
 name = "lightgbm"
 readme = "README.rst"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 version = "4.3.0.99"
 
 [project.optional-dependencies]

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -69,7 +69,7 @@ ninja.make-fallback = true
 cmake.args = [
     "-D__BUILD_FOR_PYTHON:BOOL=ON"
 ]
-cmake.verbose = false
+cmake.verbose = true
 cmake.build-type = "Release"
 cmake.targets = ["_lightgbm"]
 # stripping binaries should be turned back on once this is fixed:


### PR DESCRIPTION
Inspired by this discussion: https://github.com/microsoft/LightGBM/pull/6375#issuecomment-2018388889

Proposes the following:

* bump `python-requires` to  `>= 3.7`
* run the one "oldest versions of everything" job on Python 3.7 instead of Python 3.6
* run most CI jobs on 1 minor version of Python newer than what it's currently on
   - *which includes adding the first Python 3.12 jobs here!*
* narrowly pin dependencies in Python 3.8 jobs to a specific, known-working environment

## Notes for Reviewers

### Why these versions?

I picked the oldest versions where `pip install` run in the `python:3.7` docker image found a wheel. Found that building those old versions `scipy` and `pandas` from their sdists failed with a variety of errors.

Summary:

* `cffi` = unchanged at `1.15.1` ([Jun 2022](https://pypi.org/project/cffi/1.15.1/))
* `numpy` = from `1.16.6` ([Dec 2019](https://pypi.org/project/numpy/1.16.6/)) to `1.19.1` ([Jul 2020](https://pypi.org/project/numpy/1.19.1/))
* `pandas` = from `0.24.0` ([Jan 2019](https://pypi.org/project/pandas/0.24.0/)) to `1.1.3` ([Oct 2020](https://pypi.org/project/pandas/1.1.3/))
* `pyarrow` = unchanged at `6.0.1` ([Nov 2021](https://pypi.org/project/pyarrow/6.0.1/))
* `scikit-learn` = `0.18.2` ([Jun 2017](https://pypi.org/project/scikit-learn/0.18.2/)) to `0.24.0` ([Dec 2020](https://pypi.org/project/scikit-learn/0.24.0/))
* `scipy` = `0.19.0` ([Mar 2017](https://pypi.org/project/scipy/0.19.0/)) to `1.6.0` ([Dec 2020](https://pypi.org/project/scipy/1.6.0/))
