### PR TITLE
[python-package] remove uses of deprecated NumPy random number generation APIs, require 'numpy>=1.17.0'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,7 +405,7 @@ python-package/lightgbm/VERSION.txt
 
 # R build artefacts
 **/autom4te.cache/
-conftest*
+R-package/conftest*
 R-package/config.status
 !R-package/data/agaricus.test.rda
 !R-package/data/agaricus.train.rda

--- a/docs/Python-Intro.rst
+++ b/docs/Python-Intro.rst
@@ -59,8 +59,9 @@ Many of the examples in this page use functionality from ``numpy``. To run the e
 
 .. code:: python
 
-    data = np.random.rand(500, 10)  # 500 entities, each contains 10 features
-    label = np.random.randint(2, size=500)  # binary target
+    rng = np.random.default_rng()
+    data = rng.uniform(size=(500, 10))  # 500 entities, each contains 10 features
+    label = rng.integers(low=0, high=2, size=(500, ))  # binary target
     train_data = lgb.Dataset(data, label=label)
 
 **To load a scipy.sparse.csr\_matrix array into Dataset:**
@@ -139,7 +140,8 @@ It doesn't need to convert to one-hot encoding, and is much faster than one-hot 
 
 .. code:: python
 
-    w = np.random.rand(500, )
+    rng = np.random.default_rng()
+    w = rng.uniform(size=(500, ))
     train_data = lgb.Dataset(data, label=label, weight=w)
 
 or
@@ -147,7 +149,8 @@ or
 .. code:: python
 
     train_data = lgb.Dataset(data, label=label)
-    w = np.random.rand(500, )
+    rng = np.random.default_rng()
+    w = rng.uniform(size=(500, ))
     train_data.set_weight(w)
 
 And you can use ``Dataset.set_init_score()`` to set initial score, and ``Dataset.set_group()`` to set group/query data for ranking tasks.
@@ -249,7 +252,8 @@ A model that has been trained or loaded can perform predictions on datasets:
 .. code:: python
 
     # 7 entities, each contains 10 features
-    data = np.random.rand(7, 10)
+    rng = np.random.default_rng()
+    data = rng.uniform(size=(7, 10))
     ypred = bst.predict(data)
 
 If early stopping is enabled during training, you can get predictions from the best iteration with ``bst.best_iteration``:

--- a/examples/python-guide/logistic_regression.py
+++ b/examples/python-guide/logistic_regression.py
@@ -22,15 +22,15 @@ import lightgbm as lgb
 #################
 # Simulate some binary data with a single categorical and
 #   single continuous predictor
-np.random.seed(0)
+rng = np.random.default_rng(seed=0)
 N = 1000
 X = pd.DataFrame({"continuous": range(N), "categorical": np.repeat([0, 1, 2, 3, 4], N / 5)})
 CATEGORICAL_EFFECTS = [-1, -1, -2, -2, 2]
 LINEAR_TERM = np.array(
     [-0.5 + 0.01 * X["continuous"][k] + CATEGORICAL_EFFECTS[X["categorical"][k]] for k in range(X.shape[0])]
-) + np.random.normal(0, 1, X.shape[0])
+) + rng.normal(loc=0, scale=1, size=X.shape[0])
 TRUE_PROB = expit(LINEAR_TERM)
-Y = np.random.binomial(1, TRUE_PROB, size=N)
+Y = rng.binomial(n=1, p=TRUE_PROB, size=N)
 DATA = {
     "X": X,
     "probability_labels": TRUE_PROB,
@@ -65,10 +65,9 @@ def experiment(objective, label_type, data):
     result : dict
         Experiment summary stats.
     """
-    np.random.seed(0)
     nrounds = 5
     lgb_data = data[f"lgb_with_{label_type}_labels"]
-    params = {"objective": objective, "feature_fraction": 1, "bagging_fraction": 1, "verbose": -1}
+    params = {"objective": objective, "feature_fraction": 1, "bagging_fraction": 1, "verbose": -1, "seed": 123}
     time_zero = time.time()
     gbm = lgb.train(params, lgb_data, num_boost_round=nrounds)
     y_fitted = gbm.predict(data["X"])

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -37,18 +37,6 @@ except ImportError:
 
     concat = None
 
-"""numpy"""
-try:
-    from numpy.random import Generator as np_random_Generator
-except ImportError:
-
-    class np_random_Generator:  # type: ignore
-        """Dummy class for np.random.Generator."""
-
-        def __init__(self, *args: Any, **kwargs: Any):
-            pass
-
-
 """matplotlib"""
 try:
     import matplotlib  # noqa: F401

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -40,7 +40,6 @@ from .compat import (
     _LGBMModelBase,
     _LGBMRegressorBase,
     dt_DataTable,
-    np_random_Generator,
     pd_DataFrame,
 )
 from .engine import train
@@ -475,7 +474,7 @@ class LGBMModel(_LGBMModelBase):
         colsample_bytree: float = 1.0,
         reg_alpha: float = 0.0,
         reg_lambda: float = 0.0,
-        random_state: Optional[Union[int, np.random.RandomState, "np.random.Generator"]] = None,
+        random_state: Optional[Union[int, np.random.RandomState, np.random.Generator]] = None,
         n_jobs: Optional[int] = None,
         importance_type: str = "split",
         **kwargs: Any,
@@ -738,7 +737,7 @@ class LGBMModel(_LGBMModelBase):
 
         if isinstance(params["random_state"], np.random.RandomState):
             params["random_state"] = params["random_state"].randint(np.iinfo(np.int32).max)
-        elif isinstance(params["random_state"], np_random_Generator):
+        elif isinstance(params["random_state"], np.random.Generator):
             params["random_state"] = int(params["random_state"].integers(np.iinfo(np.int32).max))
         if self._n_classes > 2:
             for alias in _ConfigAliases.get("num_class"):

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence"
 ]
 dependencies = [
-    "numpy",
+    "numpy>=1.17.0",
     "scipy"
 ]
 description = "LightGBM Python Package"
@@ -156,6 +156,8 @@ select = [
     "E",
     # pyflakes
     "F",
+    # NumPy-specific rules
+    "NPY",
     # pylint
     "PL",
     # flake8-return: unnecessary assignment before return

--- a/tests/python_package_test/conftest.py
+++ b/tests/python_package_test/conftest.py
@@ -1,0 +1,12 @@
+import numpy as np
+import pytest
+
+
+@pytest.fixture(scope="function")
+def rng():
+    return np.random.default_rng()
+
+
+@pytest.fixture(scope="function")
+def rng_fixed_seed():
+    return np.random.default_rng(seed=42)

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -136,7 +136,7 @@ def _create_sequence_from_ndarray(data, num_seq, batch_size):
 @pytest.mark.parametrize("batch_size", [3, None])
 @pytest.mark.parametrize("include_0_and_nan", [False, True])
 @pytest.mark.parametrize("num_seq", [1, 3])
-def test_sequence(tmpdir, sample_count, batch_size, include_0_and_nan, num_seq):
+def test_sequence(tmpdir, sample_count, batch_size, include_0_and_nan, num_seq, rng):
     params = {"bin_construct_sample_cnt": sample_count}
 
     nrow = 50
@@ -175,7 +175,6 @@ def test_sequence(tmpdir, sample_count, batch_size, include_0_and_nan, num_seq):
 
     # Test for validation set.
     # Select some random rows as valid data.
-    rng = np.random.default_rng()  # Pass integer to set seed when needed.
     valid_idx = (rng.random(10) * nrow).astype(np.int32)
     valid_data = data[valid_idx, :]
     valid_X = valid_data[:, :-1]
@@ -201,7 +200,7 @@ def test_sequence(tmpdir, sample_count, batch_size, include_0_and_nan, num_seq):
 
 
 @pytest.mark.parametrize("num_seq", [1, 2])
-def test_sequence_get_data(num_seq):
+def test_sequence_get_data(num_seq, rng):
     nrow = 20
     ncol = 11
     data = np.arange(nrow * ncol, dtype=np.float64).reshape((nrow, ncol))
@@ -212,7 +211,7 @@ def test_sequence_get_data(num_seq):
     seq_ds = lgb.Dataset(seqs, label=Y, params=None, free_raw_data=False).construct()
     assert seq_ds.get_data() == seqs
 
-    used_indices = np.random.choice(np.arange(nrow), nrow // 3, replace=False)
+    used_indices = rng.choice(a=np.arange(nrow), size=nrow // 3, replace=False)
     subset_data = seq_ds.subset(used_indices).construct()
     np.testing.assert_array_equal(subset_data.get_data(), X[sorted(used_indices)])
 
@@ -246,8 +245,8 @@ def test_chunked_dataset_linear():
     valid_data.construct()
 
 
-def test_save_dataset_subset_and_load_from_file(tmp_path):
-    data = np.random.rand(100, 2)
+def test_save_dataset_subset_and_load_from_file(tmp_path, rng):
+    data = rng.standard_normal(size=(100, 2))
     params = {"max_bin": 50, "min_data_in_bin": 10}
     ds = lgb.Dataset(data, params=params)
     ds.subset([1, 2, 3, 5, 8]).save_binary(tmp_path / "subset.bin")
@@ -267,18 +266,18 @@ def test_subset_group():
     assert subset_group[1] == 9
 
 
-def test_add_features_throws_if_num_data_unequal():
-    X1 = np.random.random((100, 1))
-    X2 = np.random.random((10, 1))
+def test_add_features_throws_if_num_data_unequal(rng):
+    X1 = rng.uniform(size=(100, 1))
+    X2 = rng.uniform(size=(10, 1))
     d1 = lgb.Dataset(X1).construct()
     d2 = lgb.Dataset(X2).construct()
     with pytest.raises(lgb.basic.LightGBMError):
         d1.add_features_from(d2)
 
 
-def test_add_features_throws_if_datasets_unconstructed():
-    X1 = np.random.random((100, 1))
-    X2 = np.random.random((100, 1))
+def test_add_features_throws_if_datasets_unconstructed(rng):
+    X1 = rng.uniform(size=(100, 1))
+    X2 = rng.uniform(size=(100, 1))
     with pytest.raises(ValueError):
         d1 = lgb.Dataset(X1)
         d2 = lgb.Dataset(X2)
@@ -293,8 +292,8 @@ def test_add_features_throws_if_datasets_unconstructed():
         d1.add_features_from(d2)
 
 
-def test_add_features_equal_data_on_alternating_used_unused(tmp_path):
-    X = np.random.random((100, 5))
+def test_add_features_equal_data_on_alternating_used_unused(tmp_path, rng):
+    X = rng.uniform(size=(100, 5))
     X[:, [1, 3]] = 0
     names = [f"col_{i}" for i in range(5)]
     for j in range(1, 5):
@@ -313,8 +312,8 @@ def test_add_features_equal_data_on_alternating_used_unused(tmp_path):
         assert dtxt == d1txt
 
 
-def test_add_features_same_booster_behaviour(tmp_path):
-    X = np.random.random((100, 5))
+def test_add_features_same_booster_behaviour(tmp_path, rng):
+    X = rng.uniform(size=(100, 5))
     X[:, [1, 3]] = 0
     names = [f"col_{i}" for i in range(5)]
     for j in range(1, 5):
@@ -322,7 +321,7 @@ def test_add_features_same_booster_behaviour(tmp_path):
         d2 = lgb.Dataset(X[:, j:], feature_name=names[j:]).construct()
         d1.add_features_from(d2)
         d = lgb.Dataset(X, feature_name=names).construct()
-        y = np.random.random(100)
+        y = rng.uniform(size=(100,))
         d1.set_label(y)
         d.set_label(y)
         b1 = lgb.Booster(train_set=d1)
@@ -341,11 +340,11 @@ def test_add_features_same_booster_behaviour(tmp_path):
         assert dtxt == d1txt
 
 
-def test_add_features_from_different_sources():
+def test_add_features_from_different_sources(rng):
     pd = pytest.importorskip("pandas")
     n_row = 100
     n_col = 5
-    X = np.random.random((n_row, n_col))
+    X = rng.uniform(size=(n_row, n_col))
     xxs = [X, sparse.csr_matrix(X), pd.DataFrame(X)]
     names = [f"col_{i}" for i in range(n_col)]
     seq = _create_sequence_from_ndarray(X, 1, 30)
@@ -380,9 +379,9 @@ def test_add_features_from_different_sources():
             assert d1.feature_name == res_feature_names
 
 
-def test_add_features_does_not_fail_if_initial_dataset_has_zero_informative_features(capsys):
+def test_add_features_does_not_fail_if_initial_dataset_has_zero_informative_features(capsys, rng):
     arr_a = np.zeros((100, 1), dtype=np.float32)
-    arr_b = np.random.normal(size=(100, 5))
+    arr_b = rng.uniform(size=(100, 5))
 
     dataset_a = lgb.Dataset(arr_a).construct()
     expected_msg = (
@@ -402,10 +401,10 @@ def test_add_features_does_not_fail_if_initial_dataset_has_zero_informative_feat
     assert dataset_a._handle.value == original_handle
 
 
-def test_cegb_affects_behavior(tmp_path):
-    X = np.random.random((100, 5))
+def test_cegb_affects_behavior(tmp_path, rng):
+    X = rng.uniform(size=(100, 5))
     X[:, [1, 3]] = 0
-    y = np.random.random(100)
+    y = rng.uniform(size=(100,))
     names = [f"col_{i}" for i in range(5)]
     ds = lgb.Dataset(X, feature_name=names).construct()
     ds.set_label(y)
@@ -433,10 +432,10 @@ def test_cegb_affects_behavior(tmp_path):
         assert basetxt != casetxt
 
 
-def test_cegb_scaling_equalities(tmp_path):
-    X = np.random.random((100, 5))
+def test_cegb_scaling_equalities(tmp_path, rng):
+    X = rng.uniform(size=(100, 5))
     X[:, [1, 3]] = 0
-    y = np.random.random(100)
+    y = rng.uniform(size=(100,))
     names = [f"col_{i}" for i in range(5)]
     ds = lgb.Dataset(X, feature_name=names).construct()
     ds.set_label(y)
@@ -573,10 +572,10 @@ def test_dataset_construction_overwrites_user_provided_metadata_fields():
     np_assert_array_equal(dtrain.get_field("weight"), expected_weight, strict=True)
 
 
-def test_dataset_construction_with_high_cardinality_categorical_succeeds():
+def test_dataset_construction_with_high_cardinality_categorical_succeeds(rng):
     pd = pytest.importorskip("pandas")
-    X = pd.DataFrame({"x1": np.random.randint(0, 5_000, 10_000)})
-    y = np.random.rand(10_000)
+    X = pd.DataFrame({"x1": rng.integers(low=0, high=5_000, size=(10_000,))})
+    y = rng.uniform(size=(10_000,))
     ds = lgb.Dataset(X, y, categorical_feature=["x1"])
     ds.construct()
     assert ds.num_data() == 10_000
@@ -663,11 +662,11 @@ def test_choose_param_value_objective(objective_alias):
 
 @pytest.mark.parametrize("collection", ["1d_np", "2d_np", "pd_float", "pd_str", "1d_list", "2d_list"])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_list_to_1d_numpy(collection, dtype):
+def test_list_to_1d_numpy(collection, dtype, rng):
     collection2y = {
-        "1d_np": np.random.rand(10),
-        "2d_np": np.random.rand(10, 1),
-        "pd_float": np.random.rand(10),
+        "1d_np": rng.uniform(size=(10,)),
+        "2d_np": rng.uniform(size=(10, 1)),
+        "pd_float": rng.uniform(size=(10,)),
         "pd_str": ["a", "b"],
         "1d_list": [1] * 10,
         "2d_list": [[1], [2]],
@@ -696,7 +695,7 @@ def test_list_to_1d_numpy(collection, dtype):
 
 
 @pytest.mark.parametrize("init_score_type", ["array", "dataframe", "list"])
-def test_init_score_for_multiclass_classification(init_score_type):
+def test_init_score_for_multiclass_classification(init_score_type, rng):
     init_score = [[i * 10 + j for j in range(3)] for i in range(10)]
     if init_score_type == "array":
         init_score = np.array(init_score)
@@ -704,7 +703,7 @@ def test_init_score_for_multiclass_classification(init_score_type):
         if not PANDAS_INSTALLED:
             pytest.skip("Pandas is not installed.")
         init_score = pd_DataFrame(init_score)
-    data = np.random.rand(10, 2)
+    data = rng.uniform(size=(10, 2))
     ds = lgb.Dataset(data, init_score=init_score).construct()
     np.testing.assert_equal(ds.get_field("init_score"), init_score)
     np.testing.assert_equal(ds.init_score, init_score)
@@ -741,16 +740,20 @@ def test_param_aliases():
 
 
 def _bad_gradients(preds, _):
-    return np.random.randn(len(preds) + 1), np.random.rand(len(preds) + 1)
+    rng = np.random.default_rng()
+    # "bad" = 1 element too many
+    size = (len(preds) + 1,)
+    return rng.standard_normal(size=size), rng.uniform(size=size)
 
 
 def _good_gradients(preds, _):
-    return np.random.randn(*preds.shape), np.random.rand(*preds.shape)
+    rng = np.random.default_rng()
+    return rng.standard_normal(size=preds.shape), rng.uniform(size=preds.shape)
 
 
-def test_custom_objective_safety():
+def test_custom_objective_safety(rng):
     nrows = 100
-    X = np.random.randn(nrows, 5)
+    X = rng.standard_normal(size=(nrows, 5))
     y_binary = np.arange(nrows) % 2
     classes = [0, 1, 2]
     nclass = len(classes)
@@ -771,9 +774,9 @@ def test_custom_objective_safety():
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("feature_name", [["x1", "x2"], "auto"])
-def test_no_copy_when_single_float_dtype_dataframe(dtype, feature_name):
+def test_no_copy_when_single_float_dtype_dataframe(dtype, feature_name, rng):
     pd = pytest.importorskip("pandas")
-    X = np.random.rand(10, 2).astype(dtype)
+    X = rng.uniform(size=(10, 2)).astype(dtype)
     df = pd.DataFrame(X)
     built_data = lgb.basic._data_from_pandas(
         data=df, feature_name=feature_name, categorical_feature="auto", pandas_categorical=None
@@ -784,9 +787,9 @@ def test_no_copy_when_single_float_dtype_dataframe(dtype, feature_name):
 
 @pytest.mark.parametrize("feature_name", [["x1"], [42], "auto"])
 @pytest.mark.parametrize("categories", ["seen", "unseen"])
-def test_categorical_code_conversion_doesnt_modify_original_data(feature_name, categories):
+def test_categorical_code_conversion_doesnt_modify_original_data(feature_name, categories, rng):
     pd = pytest.importorskip("pandas")
-    X = np.random.choice(["a", "b"], 100).reshape(-1, 1)
+    X = rng.choice(a=["a", "b"], size=(100, 1))
     column_name = "a" if feature_name == "auto" else feature_name[0]
     df = pd.DataFrame(X.copy(), columns=[column_name], dtype="category")
     if categories == "seen":
@@ -814,15 +817,15 @@ def test_categorical_code_conversion_doesnt_modify_original_data(feature_name, c
 
 
 @pytest.mark.parametrize("min_data_in_bin", [2, 10])
-def test_feature_num_bin(min_data_in_bin):
+def test_feature_num_bin(min_data_in_bin, rng):
     X = np.vstack(
         [
-            np.random.rand(100),
+            rng.uniform(size=(100,)),
             np.array([1, 2] * 50),
             np.array([0, 1, 2] * 33 + [0]),
             np.array([1, 2] * 49 + 2 * [np.nan]),
             np.zeros(100),
-            np.random.choice([0, 1], 100),
+            rng.choice(a=[0, 1], size=(100,)),
         ]
     ).T
     n_continuous = X.shape[1] - 1
@@ -862,9 +865,9 @@ def test_feature_num_bin(min_data_in_bin):
         ds.feature_num_bin(num_features)
 
 
-def test_feature_num_bin_with_max_bin_by_feature():
-    X = np.random.rand(100, 3)
-    max_bin_by_feature = np.random.randint(3, 30, size=X.shape[1])
+def test_feature_num_bin_with_max_bin_by_feature(rng):
+    X = rng.uniform(size=(100, 3))
+    max_bin_by_feature = rng.integers(low=3, high=30, size=X.shape[1])
     ds = lgb.Dataset(X, params={"max_bin_by_feature": max_bin_by_feature}).construct()
     actual_num_bins = [ds.feature_num_bin(i) for i in range(X.shape[1])]
     np.testing.assert_equal(actual_num_bins, max_bin_by_feature)
@@ -882,8 +885,8 @@ def test_set_leaf_output():
     np.testing.assert_allclose(bst.predict(X), y_pred + 1)
 
 
-def test_feature_names_are_set_correctly_when_no_feature_names_passed_into_Dataset():
+def test_feature_names_are_set_correctly_when_no_feature_names_passed_into_Dataset(rng):
     ds = lgb.Dataset(
-        data=np.random.randn(100, 3),
+        data=rng.standard_normal(size=(100, 3)),
     )
     assert ds.construct().feature_name == ["Column_0", "Column_1", "Column_2"]

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -340,7 +340,7 @@ def test_grid_search():
     assert evals_result == grid.best_estimator_.evals_result_
 
 
-def test_random_search():
+def test_random_search(rng):
     X, y = load_iris(return_X_y=True)
     y = y.astype(str)  # utilize label encoder at it's max power
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
@@ -349,8 +349,8 @@ def test_random_search():
     params = {"subsample": 0.8, "subsample_freq": 1}
     param_dist = {
         "boosting_type": ["rf", "gbdt"],
-        "n_estimators": [np.random.randint(low=3, high=10) for i in range(n_iter)],
-        "reg_alpha": [np.random.uniform(low=0.01, high=0.06) for i in range(n_iter)],
+        "n_estimators": rng.integers(low=3, high=10, size=(n_iter,)).tolist(),
+        "reg_alpha": rng.uniform(low=0.01, high=0.06, size=(n_iter,)).tolist(),
     }
     fit_params = {"eval_set": [(X_val, y_val)], "eval_metric": constant_metric, "callbacks": [lgb.early_stopping(2)]}
     rand = RandomizedSearchCV(
@@ -556,29 +556,29 @@ def test_feature_importances_type():
     assert importance_split_top1 != importance_gain_top1
 
 
-def test_pandas_categorical():
+# why fixed seed?
+# sometimes there is no difference how cols are treated (cat or not cat)
+def test_pandas_categorical(rng_fixed_seed):
     pd = pytest.importorskip("pandas")
-    np.random.seed(42)  # sometimes there is no difference how cols are treated (cat or not cat)
     X = pd.DataFrame(
         {
-            "A": np.random.permutation(["a", "b", "c", "d"] * 75),  # str
-            "B": np.random.permutation([1, 2, 3] * 100),  # int
-            "C": np.random.permutation([0.1, 0.2, -0.1, -0.1, 0.2] * 60),  # float
-            "D": np.random.permutation([True, False] * 150),  # bool
-            "E": pd.Categorical(np.random.permutation(["z", "y", "x", "w", "v"] * 60), ordered=True),
+            "A": rng_fixed_seed.permutation(["a", "b", "c", "d"] * 75),  # str
+            "B": rng_fixed_seed.permutation([1, 2, 3] * 100),  # int
+            "C": rng_fixed_seed.permutation([0.1, 0.2, -0.1, -0.1, 0.2] * 60),  # float
+            "D": rng_fixed_seed.permutation([True, False] * 150),  # bool
+            "E": pd.Categorical(rng_fixed_seed.permutation(["z", "y", "x", "w", "v"] * 60), ordered=True),
         }
     )  # str and ordered categorical
-    y = np.random.permutation([0, 1] * 150)
+    y = rng_fixed_seed.permutation([0, 1] * 150)
     X_test = pd.DataFrame(
         {
-            "A": np.random.permutation(["a", "b", "e"] * 20),  # unseen category
-            "B": np.random.permutation([1, 3] * 30),
-            "C": np.random.permutation([0.1, -0.1, 0.2, 0.2] * 15),
-            "D": np.random.permutation([True, False] * 30),
-            "E": pd.Categorical(np.random.permutation(["z", "y"] * 30), ordered=True),
+            "A": rng_fixed_seed.permutation(["a", "b", "e"] * 20),  # unseen category
+            "B": rng_fixed_seed.permutation([1, 3] * 30),
+            "C": rng_fixed_seed.permutation([0.1, -0.1, 0.2, 0.2] * 15),
+            "D": rng_fixed_seed.permutation([True, False] * 30),
+            "E": pd.Categorical(rng_fixed_seed.permutation(["z", "y"] * 30), ordered=True),
         }
     )
-    np.random.seed()  # reset seed
     cat_cols_actual = ["A", "B", "C", "D"]
     cat_cols_to_store = cat_cols_actual + ["E"]
     X[cat_cols_actual] = X[cat_cols_actual].astype("category")
@@ -620,21 +620,21 @@ def test_pandas_categorical():
     assert gbm6.booster_.pandas_categorical == cat_values
 
 
-def test_pandas_sparse():
+def test_pandas_sparse(rng):
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame(
         {
-            "A": pd.arrays.SparseArray(np.random.permutation([0, 1, 2] * 100)),
-            "B": pd.arrays.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
-            "C": pd.arrays.SparseArray(np.random.permutation([True, False] * 150)),
+            "A": pd.arrays.SparseArray(rng.permutation([0, 1, 2] * 100)),
+            "B": pd.arrays.SparseArray(rng.permutation([0.0, 0.1, 0.2, -0.1, 0.2] * 60)),
+            "C": pd.arrays.SparseArray(rng.permutation([True, False] * 150)),
         }
     )
-    y = pd.Series(pd.arrays.SparseArray(np.random.permutation([0, 1] * 150)))
+    y = pd.Series(pd.arrays.SparseArray(rng.permutation([0, 1] * 150)))
     X_test = pd.DataFrame(
         {
-            "A": pd.arrays.SparseArray(np.random.permutation([0, 2] * 30)),
-            "B": pd.arrays.SparseArray(np.random.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
-            "C": pd.arrays.SparseArray(np.random.permutation([True, False] * 30)),
+            "A": pd.arrays.SparseArray(rng.permutation([0, 2] * 30)),
+            "B": pd.arrays.SparseArray(rng.permutation([0.0, 0.1, 0.2, -0.1] * 15)),
+            "C": pd.arrays.SparseArray(rng.permutation([True, False] * 30)),
         }
     )
     for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
@@ -1073,11 +1073,11 @@ def test_multiple_eval_metrics():
     assert "binary_logloss" in gbm.evals_result_["training"]
 
 
-def test_nan_handle():
+def test_nan_handle(rng):
     nrows = 100
     ncols = 10
-    X = np.random.randn(nrows, ncols)
-    y = np.random.randn(nrows) + np.full(nrows, 1e30)
+    X = rng.standard_normal(size=(nrows, ncols))
+    y = rng.standard_normal(size=(nrows,)) + np.full(nrows, 1e30)
     weight = np.zeros(nrows)
     params = {"n_estimators": 20, "verbose": -1}
     params_fit = {"X": X, "y": y, "sample_weight": weight, "eval_set": (X, y), "callbacks": [lgb.early_stopping(5)]}
@@ -1410,13 +1410,13 @@ def test_validate_features(task):
 @pytest.mark.parametrize("X_type", ["dt_DataTable", "list2d", "numpy", "scipy_csc", "scipy_csr", "pd_DataFrame"])
 @pytest.mark.parametrize("y_type", ["list1d", "numpy", "pd_Series", "pd_DataFrame"])
 @pytest.mark.parametrize("task", ["binary-classification", "multiclass-classification", "regression"])
-def test_classification_and_regression_minimally_work_with_all_all_accepted_data_types(X_type, y_type, task):
+def test_classification_and_regression_minimally_work_with_all_all_accepted_data_types(X_type, y_type, task, rng):
     if any(t.startswith("pd_") for t in [X_type, y_type]) and not PANDAS_INSTALLED:
         pytest.skip("pandas is not installed")
     if any(t.startswith("dt_") for t in [X_type, y_type]) and not DATATABLE_INSTALLED:
         pytest.skip("datatable is not installed")
     X, y, g = _create_data(task, n_samples=2_000)
-    weights = np.abs(np.random.randn(y.shape[0]))
+    weights = np.abs(rng.standard_normal(size=(y.shape[0],)))
 
     if task == "binary-classification" or task == "regression":
         init_score = np.full_like(y, np.mean(y))
@@ -1487,13 +1487,13 @@ def test_classification_and_regression_minimally_work_with_all_all_accepted_data
 @pytest.mark.parametrize("X_type", ["dt_DataTable", "list2d", "numpy", "scipy_csc", "scipy_csr", "pd_DataFrame"])
 @pytest.mark.parametrize("y_type", ["list1d", "numpy", "pd_DataFrame", "pd_Series"])
 @pytest.mark.parametrize("g_type", ["list1d_float", "list1d_int", "numpy", "pd_Series"])
-def test_ranking_minimally_works_with_all_all_accepted_data_types(X_type, y_type, g_type):
+def test_ranking_minimally_works_with_all_all_accepted_data_types(X_type, y_type, g_type, rng):
     if any(t.startswith("pd_") for t in [X_type, y_type, g_type]) and not PANDAS_INSTALLED:
         pytest.skip("pandas is not installed")
     if any(t.startswith("dt_") for t in [X_type, y_type, g_type]) and not DATATABLE_INSTALLED:
         pytest.skip("datatable is not installed")
     X, y, g = _create_data(task="ranking", n_samples=1_000)
-    weights = np.abs(np.random.randn(y.shape[0]))
+    weights = np.abs(rng.standard_normal(size=(y.shape[0],)))
     init_score = np.full_like(y, np.mean(y))
     X_valid = X * 2
 


### PR DESCRIPTION
Contributes to #6454

This PR moves `lightgbm` closer to compatibility with `numpy` 2.x

* adds the NumPy 2.0 deprecation `ruff` rules to linting config ([ruff docs](https://docs.astral.sh/ruff/rules/#numpy-specific-rules-npy))
* removes all uses of `np.random.{method}` convenience functions (which are deprecated) in favor of the corresponding `np.random.Generator.{method}` calls

And to accompany that:

* adds a floor of `numpy>1.17.0`

## Notes for Reviewers

### How I identified these

That `ruff` rule identified 95 instances of the following.

```text
NPY002 Replace legacy `np.random.choice` call with `np.random.Generator`
NPY002 Replace legacy `np.random.normal` call with `np.random.Generator`
NPY002 Replace legacy `np.random.rand` call with `np.random.Generator`
NPY002 Replace legacy `np.random.randint` call with `np.random.Generator`
NPY002 Replace legacy `np.random.permutation` call with `np.random.Generator`
NPY002 Replace legacy `np.random.randn` call with `np.random.Generator`
NPY002 Replace legacy `np.random.seed` call with `np.random.Generator`
NPY002 Replace legacy `np.random.uniform` call with `np.random.Generator`
```

### Why these particular replacements?

Based mainly on the docstrings of those `numpy` functions (which recommend replacements). I tried to follow these rules:

<details><summary>details (click me)</summary>

**`np.random.choice(a, size)`**

Chooses a random sample (with replacement by default) of size `size` from array `a`

replacement: `np.random.Generator.choice()`

**`np.random.normal(loc, scale)`**

Chooses from a normal distribution centered at `loc` with standard deviation `scale`.

replacement: `np.random.Generator.normal()`

**`np.random.permutation()`**

Takes in a sequence and randomly permutes it.

replacement: `np.random.Generator.permutation()`

**`np.random.rand()`**

Chooses random floats from a uniform distribution `[0, 1)`

replacement: `np.random.Generator.uniform()`

**`np.random.randint(low, high)`**

Chooses random integers from uniform distribution `[low, high)`.

replacement: `np.random.Generator.integers()`

**`np.random.randn()`**

Chooses random floats from the standard normal distribution

replacement: `np.random.Generator.standard_normal()`

**`np.random.uniform(low, high)`**

Chooses random floats from uniform distribution `[low, high)`.

replacement: `np.random.Generator.uniform()`

**`np.random.seed(seed)`**

Resets the random number generator seed for the `np.random.RandomState` object. That affects all future
`np.random.{method}()` calls.

replacement: explicitly creating a `np.random.Generator` with that seed, e.g. `np.random.default_rng(seed)`

</details>

### Why mark this `breaking` and add a floor on `numpy`?

The `np.random.Generator` class was introduced in `numpy==1.17.0`.

That release was in July 2019... almost 5 years ago. The highest Python version it had wheels for was Python 3.7 (https://pypi.org/project/numpy/1.17.0/#files).

`scikit-learn` also has had a higher floor than this (`numpy>=1.17.3`) for 2 years (https://github.com/scikit-learn/scikit-learn/pull/22674), so anyone using `lightgbm` with any version of `scikit-learn` release in the last 2 years won't be affected at all by this change.

Given that, I don't think adding that a `>= 1.17.0` floor should be too disruptive, and in exchange we can use the non-deprecated `np.random.Generator` API unconditionally.

### What else remains for NumPy 2.0 support?

I'm not sure. In #6467, I'm working on adding a CI job that tests `lightgbm` against NumPy, `pandas`, `pyarrow`, `scipy`, and `scikit-learn` nightlies.

Pulling these randomness changes off of that because I think they're well-defined and ready to review.