### PR TITLE
[ci] upgrade linters to latest version

### DIFF
--- a/.ci/get_workflow_status.py
+++ b/.ci/get_workflow_status.py
@@ -6,6 +6,7 @@
 
 TRIGGER_PHRASE: Code phrase that triggers workflow.
 """
+
 import json
 from os import environ
 from sys import argv, exit

--- a/.nuget/create_nuget.py
+++ b/.nuget/create_nuget.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 """Script for generating files with NuGet package metadata."""
+
 import datetime
 import sys
 from pathlib import Path

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ exclude: |
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -25,7 +25,7 @@ repos:
         args: ["--settings-path", "python-package/pyproject.toml"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.2.1
+    rev: v0.4.7
     hooks:
       # Run the linter.
       - id: ruff

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute.
 """Sphinx configuration file."""
+
 import datetime
 import os
 import sys

--- a/helpers/check_dynamic_dependencies.py
+++ b/helpers/check_dynamic_dependencies.py
@@ -12,6 +12,7 @@ Version history for these symbols can be found at the following:
 * GLIBCXX: https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
 * OMP/GOMP: https://github.com/gcc-mirror/gcc/blob/master/libgomp/libgomp.map
 """
+
 import re
 import sys
 from pathlib import Path

--- a/helpers/parameter_generator.py
+++ b/helpers/parameter_generator.py
@@ -6,6 +6,7 @@ with list of all parameters, aliases table and other routines
 along with parameters description in LightGBM/docs/Parameters.rst file
 from the information in LightGBM/include/LightGBM/config.h file.
 """
+
 import re
 from collections import defaultdict
 from pathlib import Path

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -3,6 +3,7 @@
 
 Contributors: https://github.com/microsoft/LightGBM/graphs/contributors.
 """
+
 from pathlib import Path
 
 from .basic import Booster, Dataset, Sequence, register_logger

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 """Wrapper for C API of LightGBM."""
+
 import abc
 import ctypes
 import inspect

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 """Callbacks library."""
+
 from collections import OrderedDict
 from dataclasses import dataclass
 from functools import partial

--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -6,6 +6,7 @@ dask.Array and dask.DataFrame collections.
 
 It is based on dask-lightgbm, which was based on dask-xgboost.
 """
+
 import operator
 import socket
 from collections import defaultdict

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 """Library with training routines of LightGBM."""
+
 import copy
 import json
 import warnings

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 """Find the path to LightGBM dynamic library files."""
+
 from pathlib import Path
 from platform import system
 from typing import List

--- a/python-package/lightgbm/plotting.py
+++ b/python-package/lightgbm/plotting.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 """Plotting library."""
+
 import math
 from copy import deepcopy
 from io import BytesIO

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 """Scikit-learn wrapper interface for LightGBM."""
+
 import copy
 from inspect import signature
 from pathlib import Path


### PR DESCRIPTION
Proposes upgrading `pre-commit` hooks to their latest versions. I did that by running this from the root of the repo:

```shell
pre-commit autoupdate
```

The other formatting changes in this PR were made by `ruff`.

```shell
pre-commit run --all-files
```