### PR TITLE
[docs] remove pmml redirect, simplify some other docs

### DIFF
--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -40,13 +40,7 @@ if ($env:TASK -eq "swig") {
 conda init powershell
 conda activate
 conda config --set always_yes yes --set changeps1 no
-
-# ref:
-# * https://stackoverflow.com/a/62897729/3986677
-# * https://github.com/microsoft/LightGBM/issues/5899
-conda install "brotlipy>=0.7"
-
-conda update -q -y conda
+conda update -q -y conda "python=$env:PYTHON_VERSION[build=*cpython]"
 
 if ($env:PYTHON_VERSION -eq "3.7") {
   $env:CONDA_REQUIREMENT_FILE = "$env:BUILD_SOURCESDIRECTORY/.ci/conda-envs/ci-core-py37.txt"

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Support
 -------
 
 - Ask a question [on Stack Overflow with the `lightgbm` tag](https://stackoverflow.com/questions/ask?tags=lightgbm), we monitor this for new questions.
-- Open **bug reports** and **feature requests** (not questions) on [GitHub issues](https://github.com/microsoft/LightGBM/issues).
+- Open **bug reports** and **feature requests** on [GitHub issues](https://github.com/microsoft/LightGBM/issues).
 
 How to Contribute
 -----------------
@@ -155,8 +155,6 @@ Guolin Ke, Qi Meng, Thomas Finley, Taifeng Wang, Wei Chen, Weidong Ma, Qiwei Ye,
 Qi Meng, Guolin Ke, Taifeng Wang, Wei Chen, Qiwei Ye, Zhi-Ming Ma, Tie-Yan Liu. "[A Communication-Efficient Parallel Algorithm for Decision Tree](http://papers.nips.cc/paper/6380-a-communication-efficient-parallel-algorithm-for-decision-tree)". Advances in Neural Information Processing Systems 29 (NIPS 2016), pp. 1279-1287.
 
 Huan Zhang, Si Si and Cho-Jui Hsieh. "[GPU Acceleration for Large-scale Tree Boosting](https://arxiv.org/abs/1706.08359)". SysML Conference, 2018.
-
-**Note**: If you use LightGBM in your GitHub projects, please add `lightgbm` in the `requirements.txt`.
 
 License
 -------

--- a/pmml/README.md
+++ b/pmml/README.md
@@ -1,6 +1,0 @@
-PMML Generator
-==============
-
-The old Python convert script is removed due to it cannot support the new format of categorical features.
-
-Please refer to https://github.com/jpmml/jpmml-lightgbm.

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -11,8 +11,6 @@ Preparation
 
 32-bit Python is not supported. Please install 64-bit version. If you have a strong need to install with 32-bit Python, refer to `Build 32-bit Version with 32-bit Python section <#build-32-bit-version-with-32-bit-python>`__.
 
-`setuptools <https://pypi.org/project/setuptools>`_ is needed.
-
 Install from `PyPI <https://pypi.org/project/lightgbm>`_
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
@@ -298,10 +296,6 @@ Refer to the walk through examples in `Python guide folder <https://github.com/m
 
 Development Guide
 -----------------
-
-The code style of Python-package follows `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_.
-
-The package's documentation strings (docstrings) are written in the `numpydoc style <https://numpydoc.readthedocs.io/en/latest/format.html>`_.
 
 To check that a contribution to the package matches its style expectations, run the following from the root of the repo.
 


### PR DESCRIPTION
I'm planning to invest heavily in the project's documentation for the next release. I think there are some opportunities to make things simpler and to make it more likely that people are able to find the information they need without turning to Stack Overflow or the issues pages.

This proposes the following:

* removing the `pmml/` folder
  - *it's just there to preserve a link to https://github.com/jpmml/jpmml-lightgbm, but that project is already linked to from the main README*
* removes language about preferred style in the Python README
  - *this is enforced via linters and doesn't need to also be documented in the README (which, remember, is also the homepage at https://pypi.org/project/lightgbm/)*
* other small removals