### PR TITLE
[python-package] Change build settings to set strict-config to false

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -72,6 +72,7 @@ jobs:
         OS_NAME: linux
         PYTHON_VERSION: ${{ matrix.python_version }}
         TASK: ${{ matrix.task }}
+        SKBUILD_STRICT_CONFIG: true
       options: --gpus all
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   CMAKE_BUILD_PARALLEL_LEVEL: 4
+  SKBUILD_STRICT_CONFIG: true
 
 jobs:
   test:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -15,6 +15,7 @@ variables:
   skipComponentGovernanceDetection: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  SKBUILD_STRICT_CONFIG: true
 resources:
   # The __work/ directory, where Azure DevOps writes the source files, needs to be read-write because
   # LightGBM's CI jobs write files in the source directory.

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -79,7 +79,7 @@ logging.level = "INFO"
 sdist.reproducible = true
 wheel.py-api = "py3"
 experimental = false
-strict-config = true
+strict-config = false
 minimum-version = "0.9.3"
 
 # end:build-system


### PR DESCRIPTION
# Context
[Setuptools](https://setuptools.pypa.io) recently introduced a new way for editable installations. Unfortunately, that does not work well with many tools at this moment in time, nor does it work well with a mono-repo. For that reason we choose to stick with the old way of doing editable installations which is shown [here on setuptools docs](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#strict-editable-installs).
```
pip install -e . --config-settings editable_mode=strict
```
(You will most likely see this appear on more places as people upgrade `pip` versions and the new way of editable installations becomes the default.)

Our code-base, of which we have 20+ different teams with different ML tooling, works as expected with this approach. Unfortunately, `lightgbm` is the exception. 

# In this MR
`lightgbm` throws an error on receiving the `editable_mode=strict` due to the [strict-config = true](https://github.com/scikit-build/scikit-build-core?tab=readme-ov-file#configuration).

```
ERROR: Unrecognized options in config-settings:
editable_mode -> Did you mean: editable?
```

There is no reason to throw errors on flags it does not understand, as it does not impact the compilation. Therefore I propose to set this value to `False`.