### PR TITLE
[ci] [R-package] add arm64 macOS R-package CI job (fixes #6481)

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -290,7 +290,7 @@ fi
 #
 # _mm_prefetch will not work on arm64 architecture
 # ref: https://github.com/microsoft/LightGBM/issues/4124
-if [[ $R_BUILD_TYPE == "cran" ]] && [[ $ARCH != "arm64 "]]; then
+if [[ $R_BUILD_TYPE == "cran" ]] && [[ $ARCH != "arm64" ]]; then
     mm_prefetch_working=$(
         cat $BUILD_LOG_FILE \
         | grep --count -E "checking whether MM_PREFETCH work.*yes"

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -278,20 +278,22 @@ fi
 #
 # _mm_prefetch will not work on arm64 architecture
 # ref: https://github.com/microsoft/LightGBM/issues/4124
-if [[ $R_BUILD_TYPE == "cran" ]] && [[ $ARCH != "arm64" ]]; then
-    mm_prefetch_working=$(
-        cat $BUILD_LOG_FILE \
-        | grep --count -E "checking whether MM_PREFETCH work.*yes"
-    )
-else
-    mm_prefetch_working=$(
-        cat $BUILD_LOG_FILE \
-        | grep --count -E ".*Performing Test MM_PREFETCH - Success"
-    )
-fi
-if [[ $mm_prefetch_working -ne 1 ]]; then
-    echo "MM_PREFETCH test was not passed"
-    exit 1
+if [[ $ARCH != "arm64" ]]; then
+    if [[ $R_BUILD_TYPE == "cran" ]]; then
+        mm_prefetch_working=$(
+            cat $BUILD_LOG_FILE \
+            | grep --count -E "checking whether MM_PREFETCH work.*yes"
+        )
+    else
+        mm_prefetch_working=$(
+            cat $BUILD_LOG_FILE \
+            | grep --count -E ".*Performing Test MM_PREFETCH - Success"
+        )
+    fi
+    if [[ $mm_prefetch_working -ne 1 ]]; then
+        echo "MM_PREFETCH test was not passed"
+        exit 1
+    fi
 fi
 
 # this check makes sure that CI builds of the package

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -287,7 +287,10 @@ fi
 
 # this check makes sure that CI builds of the package
 # actually use MM_PREFETCH preprocessor definition
-if [[ $R_BUILD_TYPE == "cran" ]]; then
+#
+# _mm_prefetch will not work on arm64 architecture
+# ref: https://github.com/microsoft/LightGBM/issues/4124
+if [[ $R_BUILD_TYPE == "cran" ]] && [[ $ARCH != "arm64 "]]; then
     mm_prefetch_working=$(
         cat $BUILD_LOG_FILE \
         | grep --count -E "checking whether MM_PREFETCH work.*yes"

--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -104,6 +104,18 @@ if [[ $OS_NAME == "macos" ]]; then
     sudo installer \
         -pkg $(pwd)/R.pkg \
         -target / || exit 1
+
+    # install tidy v5.8.0
+    # ref: https://groups.google.com/g/r-sig-mac/c/7u_ivEj4zhM
+    TIDY_URL=https://github.com/htacg/tidy-html5/releases/download/5.8.0/tidy-5.8.0-macos-x86_64+arm64.pkg
+    curl -sL ${TIDY_URL} -o tidy.pkg
+    sudo installer \
+        -pkg $(pwd)/tidy.pkg \
+        -target /
+
+    # ensure that this newer version of 'tidy' is used by 'R CMD check'
+    # ref: https://cran.r-project.org/doc/manuals/R-exts.html#Checking-packages
+    export R_TIDYCMD=/usr/local/bin/tidy
 fi
 
 # fix for issue where CRAN was not returning {lattice} and {evaluate} when using R 3.6

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -185,12 +185,12 @@ jobs:
           CTAN_MIRROR: https://ctan.math.illinois.edu/systems/win32/miktex
           TINYTEX_INSTALLER: TinyTeX
       - name: Setup and run tests on Linux and macOS
-        if: matrix.os == 'macos-13' || matrix.os == 'ubuntu-latest'
+        if: matrix.os.startsWith('macos') || matrix.os.startsWith('ubuntu')
         shell: bash
         run: |
           export TASK="${{ matrix.task }}"
           export COMPILER="${{ matrix.compiler }}"
-          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+          if [[ "${{ matrix.os }}" =~ ^macos ]]; then
               export OS_NAME="macos"
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
               export OS_NAME="linux"

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -185,7 +185,7 @@ jobs:
           CTAN_MIRROR: https://ctan.math.illinois.edu/systems/win32/miktex
           TINYTEX_INSTALLER: TinyTeX
       - name: Setup and run tests on Linux and macOS
-        if: matrix.os.startsWith('macos') || matrix.os.startsWith('ubuntu')
+        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
         shell: bash
         run: |
           export TASK="${{ matrix.task }}"

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -54,12 +54,6 @@ jobs:
           - os: ubuntu-latest
             task: r-package
             compiler: clang
-            r_version: 3.6
-            build_type: cmake
-            container: 'ubuntu:18.04'
-          - os: ubuntu-latest
-            task: r-package
-            compiler: clang
             r_version: 4.3
             build_type: cmake
             container: 'ubuntu:22.04'
@@ -129,6 +123,13 @@ jobs:
             build_type: cran
             container: 'ubuntu:22.04'
           - os: macos-13
+            task: r-package
+            compiler: clang
+            r_version: 4.3
+            build_type: cran
+            container: null
+          # macos-14 = arm64
+          - os: macos-14
             task: r-package
             compiler: clang
             r_version: 4.3


### PR DESCRIPTION
Fixes #6481

Proposes adding an arm64 macOS CI job testing the R package. CRAN checks every submission on an arm64 Mac (https://cran.r-project.org/web/checks/check_flavors.html), so hopefully this will help catch issues before attempting submissions to CRAN.

To avoid further growing the CI matrix, this proposes dropping the job that tests the R package compiled with `clang` on Linux with R 3.6.  I think that's ok, because there are others covering compiling the R package with `gcc` on Linux

https://github.com/microsoft/LightGBM/blob/fc788a51b61368f78246e5c450f0ea77d263eb2b/.github/workflows/r_package.yml#L58-L63

And because we're planning to move away from supporting R 3.6: https://github.com/microsoft/LightGBM/pull/6442#issuecomment-2159162313

This should also reduce the manual testing effort for releases: https://github.com/microsoft/LightGBM/pull/6439#issuecomment-2167206451