### PR TITLE
[ci] [docs] fix link-checks job

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -8,6 +8,7 @@ on:
     - cron: '0 8 * * *'
 
 env:
+  COMPILER: gcc
   OS_NAME: 'linux'
   PYTHON_VERSION: '3.12'
   TASK: 'check-links'

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -149,7 +149,7 @@ and copy memory as required by creating new processes instead of forking (or, us
 
 Cloud platform container services may cause LightGBM to hang, if they use Linux fork to run multiple containers on a
 single instance. For example, LightGBM hangs in AWS Batch array jobs, which `use the ECS agent
-<https://aws.amazon.com/batch/faqs/#Features>`__ to manage multiple running jobs. Setting ``nthreads=1`` mitigates the issue.
+<https://aws.amazon.com/batch/faqs>`__ to manage multiple running jobs. Setting ``nthreads=1`` mitigates the issue.
 
 12. Why is early stopping not enabled by default in LightGBM?
 -------------------------------------------------------------
@@ -321,7 +321,7 @@ We are doing our best to provide universal wheels which have high running speed 
 However, sometimes it's just impossible to guarantee the possibility of usage of LightGBM in any specific environment (see `Microsoft/LightGBM#1743 <https://github.com/microsoft/LightGBM/issues/1743>`__).
 
 Therefore, the first thing you should try in case of segfaults is **compiling from the source** using ``pip install --no-binary lightgbm lightgbm``.
-For the OS-specific prerequisites see `this guide <https://github.com/microsoft/LightGBM/blob/master/python-package/README.rst#user-content-build-from-sources>`__.
+For the OS-specific prerequisites see https://github.com/microsoft/LightGBM/blob/master/python-package/README.rst.
 
 Also, feel free to post a new issue in our GitHub repository. We always look at each case individually and try to find a root cause.
 

--- a/docs/GPU-Windows.rst
+++ b/docs/GPU-Windows.rst
@@ -602,9 +602,9 @@ And open an issue in GitHub `here`_ with that log.
 
 .. _Boost: https://www.boost.org/users/history/
 
-.. _Prebuilt Boost x86_64: https://www.rpmfind.net/linux/fedora/linux/releases/38/Everything/x86_64/os/Packages/m/mingw64-boost-static-1.78.0-4.fc38.noarch.rpm
+.. _Prebuilt Boost x86_64: https://www.rpmfind.net/linux/fedora/linux/releases/40/Everything/x86_64/os/Packages/m/mingw64-boost-static-1.78.0-9.fc40.noarch.rpm
 
-.. _Prebuilt Boost i686: https://www.rpmfind.net/linux/fedora/linux/releases/38/Everything/x86_64/os/Packages/m/mingw32-boost-static-1.78.0-4.fc38.noarch.rpm
+.. _Prebuilt Boost i686: https://www.rpmfind.net/linux/fedora/linux/releases/40/Everything/x86_64/os/Packages/m/mingw32-boost-static-1.78.0-9.fc40.noarch.rpm
 
 .. _7zip: https://www.7-zip.org/download.html
 


### PR DESCRIPTION
The link-checks CI job is failing, like this:

```text
/home/runner/work/LightGBM/LightGBM/.ci/test.sh: line 19: COMPILER: unbound variable
```

([build link](https://github.com/microsoft/LightGBM/actions/runs/9593794916/job/26454997974))

I suspect that's a result of the changes in #6266. This fixes that.

Also fixes some broken links (404s) and "anchor-not-found" issues.

## Notes for Reviewers

### How I tested this

Manually triggered a run on this branch, saw it pass: https://github.com/microsoft/LightGBM/actions/runs/9608163802/job/26500497894