### PR TITLE
[R-package] Use `Rf_`-prefixed versions of protect/unprotect

### DIFF
--- a/R-package/src/lightgbm_R.cpp
+++ b/R-package/src/lightgbm_R.cpp
@@ -53,24 +53,24 @@ void delete_cpp_char_vec(SEXP R_ptr) {
 #ifndef LGB_NO_ALTREP
 SEXP make_altrepped_raw_vec(void *void_ptr) {
   std::unique_ptr<std::vector<char>> *ptr_to_cpp_vec = static_cast<std::unique_ptr<std::vector<char>>*>(void_ptr);
-  SEXP R_ptr = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
-  SEXP R_raw = PROTECT(R_new_altrep(lgb_altrepped_char_vec, R_NilValue, R_NilValue));
+  SEXP R_ptr = Rf_protect(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+  SEXP R_raw = Rf_protect(R_new_altrep(lgb_altrepped_char_vec, R_NilValue, R_NilValue));
 
   R_SetExternalPtrAddr(R_ptr, ptr_to_cpp_vec->get());
   R_RegisterCFinalizerEx(R_ptr, delete_cpp_char_vec, TRUE);
   ptr_to_cpp_vec->release();
 
   R_set_altrep_data1(R_raw, R_ptr);
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return R_raw;
 }
 #else
 SEXP make_r_raw_vec(void *void_ptr) {
   std::unique_ptr<std::vector<char>> *ptr_to_cpp_vec = static_cast<std::unique_ptr<std::vector<char>>*>(void_ptr);
   R_xlen_t len = ptr_to_cpp_vec->get()->size();
-  SEXP out = PROTECT(Rf_allocVector(RAWSXP, len));
+  SEXP out = Rf_protect(Rf_allocVector(RAWSXP, len));
   std::copy(ptr_to_cpp_vec->get()->begin(), ptr_to_cpp_vec->get()->end(), reinterpret_cast<char*>(RAW(out)));
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return out;
 }
 #define make_altrepped_raw_vec make_r_raw_vec
@@ -132,9 +132,9 @@ template <class T>
 SEXP make_altrepped_vec_from_arr(void *void_ptr) {
   T *arr = static_cast<arr_and_len<T>*>(void_ptr)->arr;
   uint64_t len = static_cast<arr_and_len<T>*>(void_ptr)->len;
-  SEXP R_ptr = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
-  SEXP R_len = PROTECT(Rf_allocVector(REALSXP, 1));
-  SEXP R_vec = PROTECT(R_new_altrep(get_altrep_class_for_type<T>(), R_NilValue, R_NilValue));
+  SEXP R_ptr = Rf_protect(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+  SEXP R_len = Rf_protect(Rf_allocVector(REALSXP, 1));
+  SEXP R_vec = Rf_protect(R_new_altrep(get_altrep_class_for_type<T>(), R_NilValue, R_NilValue));
 
   REAL(R_len)[0] = static_cast<double>(len);
   R_SetExternalPtrAddr(R_ptr, arr);
@@ -142,7 +142,7 @@ SEXP make_altrepped_vec_from_arr(void *void_ptr) {
 
   R_set_altrep_data1(R_vec, R_ptr);
   R_set_altrep_data2(R_vec, R_len);
-  UNPROTECT(3);
+  Rf_unprotect(3);
   return R_vec;
 }
 #else
@@ -150,9 +150,9 @@ template <class T>
 SEXP make_R_vec_from_arr(void *void_ptr) {
   T *arr = static_cast<arr_and_len<T>*>(void_ptr)->arr;
   uint64_t len = static_cast<arr_and_len<T>*>(void_ptr)->len;
-  SEXP out = PROTECT(Rf_allocVector(get_sexptype_class_for_type<T>(), len));
+  SEXP out = Rf_protect(Rf_allocVector(get_sexptype_class_for_type<T>(), len));
   std::copy(arr, arr + len, get_r_vec_ptr<T>(out));
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return out;
 }
 #define make_altrepped_vec_from_arr make_R_vec_from_arr
@@ -288,18 +288,18 @@ SEXP LGBM_DatasetCreateFromFile_R(SEXP filename,
   SEXP parameters,
   SEXP reference) {
   R_API_BEGIN();
-  SEXP ret = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+  SEXP ret = Rf_protect(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
   DatasetHandle handle = nullptr;
   DatasetHandle ref = nullptr;
   if (!Rf_isNull(reference)) {
     ref = R_ExternalPtrAddr(reference);
   }
-  const char* filename_ptr = CHAR(PROTECT(Rf_asChar(filename)));
-  const char* parameters_ptr = CHAR(PROTECT(Rf_asChar(parameters)));
+  const char* filename_ptr = CHAR(Rf_protect(Rf_asChar(filename)));
+  const char* parameters_ptr = CHAR(Rf_protect(Rf_asChar(parameters)));
   CHECK_CALL(LGBM_DatasetCreateFromFile(filename_ptr, parameters_ptr, ref, &handle));
   R_SetExternalPtrAddr(ret, handle);
   R_RegisterCFinalizerEx(ret, _DatasetFinalizer, TRUE);
-  UNPROTECT(3);
+  Rf_unprotect(3);
   return ret;
   R_API_END();
 }
@@ -313,14 +313,14 @@ SEXP LGBM_DatasetCreateFromCSC_R(SEXP indptr,
   SEXP parameters,
   SEXP reference) {
   R_API_BEGIN();
-  SEXP ret = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+  SEXP ret = Rf_protect(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
   const int* p_indptr = INTEGER(indptr);
   const int* p_indices = INTEGER(indices);
   const double* p_data = REAL(data);
   int64_t nindptr = static_cast<int64_t>(Rf_asInteger(num_indptr));
   int64_t ndata = static_cast<int64_t>(Rf_asInteger(nelem));
   int64_t nrow = static_cast<int64_t>(Rf_asInteger(num_row));
-  const char* parameters_ptr = CHAR(PROTECT(Rf_asChar(parameters)));
+  const char* parameters_ptr = CHAR(Rf_protect(Rf_asChar(parameters)));
   DatasetHandle handle = nullptr;
   DatasetHandle ref = nullptr;
   if (!Rf_isNull(reference)) {
@@ -331,7 +331,7 @@ SEXP LGBM_DatasetCreateFromCSC_R(SEXP indptr,
     nrow, parameters_ptr, ref, &handle));
   R_SetExternalPtrAddr(ret, handle);
   R_RegisterCFinalizerEx(ret, _DatasetFinalizer, TRUE);
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return ret;
   R_API_END();
 }
@@ -342,11 +342,11 @@ SEXP LGBM_DatasetCreateFromMat_R(SEXP data,
   SEXP parameters,
   SEXP reference) {
   R_API_BEGIN();
-  SEXP ret = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+  SEXP ret = Rf_protect(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
   int32_t nrow = static_cast<int32_t>(Rf_asInteger(num_row));
   int32_t ncol = static_cast<int32_t>(Rf_asInteger(num_col));
   double* p_mat = REAL(data);
-  const char* parameters_ptr = CHAR(PROTECT(Rf_asChar(parameters)));
+  const char* parameters_ptr = CHAR(Rf_protect(Rf_asChar(parameters)));
   DatasetHandle handle = nullptr;
   DatasetHandle ref = nullptr;
   if (!Rf_isNull(reference)) {
@@ -356,7 +356,7 @@ SEXP LGBM_DatasetCreateFromMat_R(SEXP data,
     parameters_ptr, ref, &handle));
   R_SetExternalPtrAddr(ret, handle);
   R_RegisterCFinalizerEx(ret, _DatasetFinalizer, TRUE);
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return ret;
   R_API_END();
 }
@@ -367,7 +367,7 @@ SEXP LGBM_DatasetGetSubset_R(SEXP handle,
   SEXP parameters) {
   R_API_BEGIN();
   _AssertDatasetHandleNotNull(handle);
-  SEXP ret = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+  SEXP ret = Rf_protect(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
   int32_t len = static_cast<int32_t>(Rf_asInteger(len_used_row_indices));
   std::unique_ptr<int32_t[]> idxvec(new int32_t[len]);
   // convert from one-based to zero-based index
@@ -378,14 +378,14 @@ SEXP LGBM_DatasetGetSubset_R(SEXP handle,
   for (int32_t i = 0; i < len; ++i) {
     idxvec[i] = static_cast<int32_t>(used_row_indices_[i] - 1);
   }
-  const char* parameters_ptr = CHAR(PROTECT(Rf_asChar(parameters)));
+  const char* parameters_ptr = CHAR(Rf_protect(Rf_asChar(parameters)));
   DatasetHandle res = nullptr;
   CHECK_CALL(LGBM_DatasetGetSubset(R_ExternalPtrAddr(handle),
     idxvec.get(), len, parameters_ptr,
     &res));
   R_SetExternalPtrAddr(ret, res);
   R_RegisterCFinalizerEx(ret, _DatasetFinalizer, TRUE);
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return ret;
   R_API_END();
 }
@@ -394,7 +394,7 @@ SEXP LGBM_DatasetSetFeatureNames_R(SEXP handle,
   SEXP feature_names) {
   R_API_BEGIN();
   _AssertDatasetHandleNotNull(handle);
-  auto vec_names = Split(CHAR(PROTECT(Rf_asChar(feature_names))), '\t');
+  auto vec_names = Split(CHAR(Rf_protect(Rf_asChar(feature_names))), '\t');
   int len = static_cast<int>(vec_names.size());
   std::unique_ptr<const char*[]> vec_sptr(new const char*[len]);
   for (int i = 0; i < len; ++i) {
@@ -402,13 +402,13 @@ SEXP LGBM_DatasetSetFeatureNames_R(SEXP handle,
   }
   CHECK_CALL(LGBM_DatasetSetFeatureNames(R_ExternalPtrAddr(handle),
     vec_sptr.get(), len));
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return R_NilValue;
   R_API_END();
 }
 
 SEXP LGBM_DatasetGetFeatureNames_R(SEXP handle) {
-  SEXP cont_token = PROTECT(R_MakeUnwindCont());
+  SEXP cont_token = Rf_protect(R_MakeUnwindCont());
   R_API_BEGIN();
   _AssertDatasetHandleNotNull(handle);
   SEXP feature_names;
@@ -446,11 +446,11 @@ SEXP LGBM_DatasetGetFeatureNames_R(SEXP handle) {
         ptr_names.data()));
   }
   CHECK_EQ(len, out_len);
-  feature_names = PROTECT(safe_R_string(static_cast<R_xlen_t>(len), &cont_token));
+  feature_names = Rf_protect(safe_R_string(static_cast<R_xlen_t>(len), &cont_token));
   for (int i = 0; i < len; ++i) {
     SET_STRING_ELT(feature_names, i, safe_R_mkChar(ptr_names[i], &cont_token));
   }
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return feature_names;
   R_API_END();
 }
@@ -459,10 +459,10 @@ SEXP LGBM_DatasetSaveBinary_R(SEXP handle,
   SEXP filename) {
   R_API_BEGIN();
   _AssertDatasetHandleNotNull(handle);
-  const char* filename_ptr = CHAR(PROTECT(Rf_asChar(filename)));
+  const char* filename_ptr = CHAR(Rf_protect(Rf_asChar(filename)));
   CHECK_CALL(LGBM_DatasetSaveBinary(R_ExternalPtrAddr(handle),
     filename_ptr));
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return R_NilValue;
   R_API_END();
 }
@@ -484,7 +484,7 @@ SEXP LGBM_DatasetSetField_R(SEXP handle,
   R_API_BEGIN();
   _AssertDatasetHandleNotNull(handle);
   int len = Rf_asInteger(num_element);
-  const char* name = CHAR(PROTECT(Rf_asChar(field_name)));
+  const char* name = CHAR(Rf_protect(Rf_asChar(field_name)));
   if (!strcmp("group", name) || !strcmp("query", name)) {
     CHECK_CALL(LGBM_DatasetSetField(R_ExternalPtrAddr(handle), name, INTEGER(field_data), len, C_API_DTYPE_INT32));
   } else if (!strcmp("init_score", name)) {
@@ -494,7 +494,7 @@ SEXP LGBM_DatasetSetField_R(SEXP handle,
     std::copy(REAL(field_data), REAL(field_data) + len, vec.get());
     CHECK_CALL(LGBM_DatasetSetField(R_ExternalPtrAddr(handle), name, vec.get(), len, C_API_DTYPE_FLOAT32));
   }
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return R_NilValue;
   R_API_END();
 }
@@ -504,7 +504,7 @@ SEXP LGBM_DatasetGetField_R(SEXP handle,
   SEXP field_data) {
   R_API_BEGIN();
   _AssertDatasetHandleNotNull(handle);
-  const char* name = CHAR(PROTECT(Rf_asChar(field_name)));
+  const char* name = CHAR(Rf_protect(Rf_asChar(field_name)));
   int out_len = 0;
   int out_type = 0;
   const void* res;
@@ -526,7 +526,7 @@ SEXP LGBM_DatasetGetField_R(SEXP handle,
     auto p_data = reinterpret_cast<const float*>(res);
     std::copy(p_data, p_data + out_len, REAL(field_data));
   }
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return R_NilValue;
   R_API_END();
 }
@@ -536,7 +536,7 @@ SEXP LGBM_DatasetGetFieldSize_R(SEXP handle,
   SEXP out) {
   R_API_BEGIN();
   _AssertDatasetHandleNotNull(handle);
-  const char* name = CHAR(PROTECT(Rf_asChar(field_name)));
+  const char* name = CHAR(Rf_protect(Rf_asChar(field_name)));
   int out_len = 0;
   int out_type = 0;
   const void* res;
@@ -545,7 +545,7 @@ SEXP LGBM_DatasetGetFieldSize_R(SEXP handle,
     out_len -= 1;
   }
   INTEGER(out)[0] = out_len;
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return R_NilValue;
   R_API_END();
 }
@@ -553,10 +553,10 @@ SEXP LGBM_DatasetGetFieldSize_R(SEXP handle,
 SEXP LGBM_DatasetUpdateParamChecking_R(SEXP old_params,
   SEXP new_params) {
   R_API_BEGIN();
-  const char* old_params_ptr = CHAR(PROTECT(Rf_asChar(old_params)));
-  const char* new_params_ptr = CHAR(PROTECT(Rf_asChar(new_params)));
+  const char* old_params_ptr = CHAR(Rf_protect(Rf_asChar(old_params)));
+  const char* new_params_ptr = CHAR(Rf_protect(Rf_asChar(new_params)));
   CHECK_CALL(LGBM_DatasetUpdateParamChecking(old_params_ptr, new_params_ptr));
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return R_NilValue;
   R_API_END();
 }
@@ -613,34 +613,34 @@ SEXP LGBM_BoosterCreate_R(SEXP train_data,
   SEXP parameters) {
   R_API_BEGIN();
   _AssertDatasetHandleNotNull(train_data);
-  SEXP ret = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
-  const char* parameters_ptr = CHAR(PROTECT(Rf_asChar(parameters)));
+  SEXP ret = Rf_protect(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+  const char* parameters_ptr = CHAR(Rf_protect(Rf_asChar(parameters)));
   BoosterHandle handle = nullptr;
   CHECK_CALL(LGBM_BoosterCreate(R_ExternalPtrAddr(train_data), parameters_ptr, &handle));
   R_SetExternalPtrAddr(ret, handle);
   R_RegisterCFinalizerEx(ret, _BoosterFinalizer, TRUE);
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return ret;
   R_API_END();
 }
 
 SEXP LGBM_BoosterCreateFromModelfile_R(SEXP filename) {
   R_API_BEGIN();
-  SEXP ret = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+  SEXP ret = Rf_protect(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
   int out_num_iterations = 0;
-  const char* filename_ptr = CHAR(PROTECT(Rf_asChar(filename)));
+  const char* filename_ptr = CHAR(Rf_protect(Rf_asChar(filename)));
   BoosterHandle handle = nullptr;
   CHECK_CALL(LGBM_BoosterCreateFromModelfile(filename_ptr, &out_num_iterations, &handle));
   R_SetExternalPtrAddr(ret, handle);
   R_RegisterCFinalizerEx(ret, _BoosterFinalizer, TRUE);
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return ret;
   R_API_END();
 }
 
 SEXP LGBM_BoosterLoadModelFromString_R(SEXP model_str) {
   R_API_BEGIN();
-  SEXP ret = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+  SEXP ret = Rf_protect(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
   SEXP temp = NULL;
   int n_protected = 1;
   int out_num_iterations = 0;
@@ -655,7 +655,7 @@ SEXP LGBM_BoosterLoadModelFromString_R(SEXP model_str) {
       break;
     }
     case STRSXP: {
-      temp = PROTECT(STRING_ELT(model_str, 0));
+      temp = Rf_protect(STRING_ELT(model_str, 0));
       n_protected++;
       model_str_ptr = reinterpret_cast<const char*>(CHAR(temp));
     }
@@ -664,7 +664,7 @@ SEXP LGBM_BoosterLoadModelFromString_R(SEXP model_str) {
   CHECK_CALL(LGBM_BoosterLoadModelFromString(model_str_ptr, &out_num_iterations, &handle));
   R_SetExternalPtrAddr(ret, handle);
   R_RegisterCFinalizerEx(ret, _BoosterFinalizer, TRUE);
-  UNPROTECT(n_protected);
+  Rf_unprotect(n_protected);
   return ret;
   R_API_END();
 }
@@ -703,9 +703,9 @@ SEXP LGBM_BoosterResetParameter_R(SEXP handle,
   SEXP parameters) {
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
-  const char* parameters_ptr = CHAR(PROTECT(Rf_asChar(parameters)));
+  const char* parameters_ptr = CHAR(Rf_protect(Rf_asChar(parameters)));
   CHECK_CALL(LGBM_BoosterResetParameter(R_ExternalPtrAddr(handle), parameters_ptr));
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return R_NilValue;
   R_API_END();
 }
@@ -795,7 +795,7 @@ SEXP LGBM_BoosterGetLowerBoundValue_R(SEXP handle,
 }
 
 SEXP LGBM_BoosterGetEvalNames_R(SEXP handle) {
-  SEXP cont_token = PROTECT(R_MakeUnwindCont());
+  SEXP cont_token = Rf_protect(R_MakeUnwindCont());
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
   SEXP eval_names;
@@ -834,11 +834,11 @@ SEXP LGBM_BoosterGetEvalNames_R(SEXP handle) {
         ptr_names.data()));
   }
   CHECK_EQ(out_len, len);
-  eval_names = PROTECT(safe_R_string(static_cast<R_xlen_t>(len), &cont_token));
+  eval_names = Rf_protect(safe_R_string(static_cast<R_xlen_t>(len), &cont_token));
   for (int i = 0; i < len; ++i) {
     SET_STRING_ELT(eval_names, i, safe_R_mkChar(ptr_names[i], &cont_token));
   }
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return eval_names;
   R_API_END();
 }
@@ -908,14 +908,14 @@ SEXP LGBM_BoosterPredictForFile_R(SEXP handle,
   SEXP result_filename) {
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
-  const char* data_filename_ptr = CHAR(PROTECT(Rf_asChar(data_filename)));
-  const char* parameter_ptr = CHAR(PROTECT(Rf_asChar(parameter)));
-  const char* result_filename_ptr = CHAR(PROTECT(Rf_asChar(result_filename)));
+  const char* data_filename_ptr = CHAR(Rf_protect(Rf_asChar(data_filename)));
+  const char* parameter_ptr = CHAR(Rf_protect(Rf_asChar(parameter)));
+  const char* result_filename_ptr = CHAR(Rf_protect(Rf_asChar(result_filename)));
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
   CHECK_CALL(LGBM_BoosterPredictForFile(R_ExternalPtrAddr(handle), data_filename_ptr,
     Rf_asInteger(data_has_header), pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), parameter_ptr,
     result_filename_ptr));
-  UNPROTECT(3);
+  Rf_unprotect(3);
   return R_NilValue;
   R_API_END();
 }
@@ -964,12 +964,12 @@ SEXP LGBM_BoosterPredictForCSC_R(SEXP handle,
   int64_t nrow = static_cast<int64_t>(Rf_asInteger(num_row));
   double* ptr_ret = REAL(out_result);
   int64_t out_len;
-  const char* parameter_ptr = CHAR(PROTECT(Rf_asChar(parameter)));
+  const char* parameter_ptr = CHAR(Rf_protect(Rf_asChar(parameter)));
   CHECK_CALL(LGBM_BoosterPredictForCSC(R_ExternalPtrAddr(handle),
     p_indptr, C_API_DTYPE_INT32, p_indices,
     p_data, C_API_DTYPE_FLOAT64, nindptr, ndata,
     nrow, pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), parameter_ptr, &out_len, ptr_ret));
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return R_NilValue;
   R_API_END();
 }
@@ -989,7 +989,7 @@ SEXP LGBM_BoosterPredictForCSR_R(SEXP handle,
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
-  const char* parameter_ptr = CHAR(PROTECT(Rf_asChar(parameter)));
+  const char* parameter_ptr = CHAR(Rf_protect(Rf_asChar(parameter)));
   int64_t out_len;
   CHECK_CALL(LGBM_BoosterPredictForCSR(R_ExternalPtrAddr(handle),
     INTEGER(indptr), C_API_DTYPE_INT32, INTEGER(indices),
@@ -997,7 +997,7 @@ SEXP LGBM_BoosterPredictForCSR_R(SEXP handle,
     Rf_xlength(indptr), Rf_xlength(data), Rf_asInteger(ncols),
     pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration),
     parameter_ptr, &out_len, REAL(out_result)));
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return R_NilValue;
   R_API_END();
 }
@@ -1016,7 +1016,7 @@ SEXP LGBM_BoosterPredictForCSRSingleRow_R(SEXP handle,
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
-  const char* parameter_ptr = CHAR(PROTECT(Rf_asChar(parameter)));
+  const char* parameter_ptr = CHAR(Rf_protect(Rf_asChar(parameter)));
   int nnz = static_cast<int>(Rf_xlength(data));
   const int indptr[] = {0, nnz};
   int64_t out_len;
@@ -1026,7 +1026,7 @@ SEXP LGBM_BoosterPredictForCSRSingleRow_R(SEXP handle,
     2, nnz, Rf_asInteger(ncols),
     pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration),
     parameter_ptr, &out_len, REAL(out_result)));
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return R_NilValue;
   R_API_END();
 }
@@ -1046,8 +1046,8 @@ SEXP LGBM_BoosterPredictForCSRSingleRowFastInit_R(SEXP handle,
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
-  SEXP ret = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
-  const char* parameter_ptr = CHAR(PROTECT(Rf_asChar(parameter)));
+  SEXP ret = Rf_protect(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+  const char* parameter_ptr = CHAR(Rf_protect(Rf_asChar(parameter)));
   FastConfigHandle out_fastConfig;
   CHECK_CALL(LGBM_BoosterPredictForCSRSingleRowFastInit(R_ExternalPtrAddr(handle),
     pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration),
@@ -1055,7 +1055,7 @@ SEXP LGBM_BoosterPredictForCSRSingleRowFastInit_R(SEXP handle,
     parameter_ptr, &out_fastConfig));
   R_SetExternalPtrAddr(ret, out_fastConfig);
   R_RegisterCFinalizerEx(ret, LGBM_FastConfigFree_wrapped, TRUE);
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return ret;
   R_API_END();
 }
@@ -1095,12 +1095,12 @@ SEXP LGBM_BoosterPredictForMat_R(SEXP handle,
   int32_t ncol = static_cast<int32_t>(Rf_asInteger(num_col));
   const double* p_mat = REAL(data);
   double* ptr_ret = REAL(out_result);
-  const char* parameter_ptr = CHAR(PROTECT(Rf_asChar(parameter)));
+  const char* parameter_ptr = CHAR(Rf_protect(Rf_asChar(parameter)));
   int64_t out_len;
   CHECK_CALL(LGBM_BoosterPredictForMat(R_ExternalPtrAddr(handle),
     p_mat, C_API_DTYPE_FLOAT64, nrow, ncol, COL_MAJOR,
     pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), parameter_ptr, &out_len, ptr_ret));
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return R_NilValue;
   R_API_END();
 }
@@ -1128,12 +1128,12 @@ SEXP LGBM_BoosterPredictSparseOutput_R(SEXP handle,
   SEXP start_iteration,
   SEXP num_iteration,
   SEXP parameter) {
-  SEXP cont_token = PROTECT(R_MakeUnwindCont());
+  SEXP cont_token = Rf_protect(R_MakeUnwindCont());
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
   const char* out_names[] = {"indptr", "indices", "data", ""};
-  SEXP out = PROTECT(Rf_mkNamed(VECSXP, out_names));
-  const char* parameter_ptr = CHAR(PROTECT(Rf_asChar(parameter)));
+  SEXP out = Rf_protect(Rf_mkNamed(VECSXP, out_names));
+  const char* parameter_ptr = CHAR(Rf_protect(Rf_asChar(parameter)));
 
   int64_t out_len[2];
   void *out_indptr;
@@ -1179,7 +1179,7 @@ SEXP LGBM_BoosterPredictSparseOutput_R(SEXP handle,
       static_cast<void*>(&data_str), throw_R_memerr, &cont_token, cont_token));
   pointers_struct->data = nullptr;
 
-  UNPROTECT(3);
+  Rf_unprotect(3);
   return out;
   R_API_END();
 }
@@ -1196,14 +1196,14 @@ SEXP LGBM_BoosterPredictForMatSingleRow_R(SEXP handle,
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
-  const char* parameter_ptr = CHAR(PROTECT(Rf_asChar(parameter)));
+  const char* parameter_ptr = CHAR(Rf_protect(Rf_asChar(parameter)));
   double* ptr_ret = REAL(out_result);
   int64_t out_len;
   CHECK_CALL(LGBM_BoosterPredictForMatSingleRow(R_ExternalPtrAddr(handle),
     REAL(data), C_API_DTYPE_FLOAT64, Rf_xlength(data), 1,
     pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration),
     parameter_ptr, &out_len, ptr_ret));
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return R_NilValue;
   R_API_END();
 }
@@ -1219,8 +1219,8 @@ SEXP LGBM_BoosterPredictForMatSingleRowFastInit_R(SEXP handle,
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
   int pred_type = GetPredictType(is_rawscore, is_leafidx, is_predcontrib);
-  SEXP ret = PROTECT(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
-  const char* parameter_ptr = CHAR(PROTECT(Rf_asChar(parameter)));
+  SEXP ret = Rf_protect(R_MakeExternalPtr(nullptr, R_NilValue, R_NilValue));
+  const char* parameter_ptr = CHAR(Rf_protect(Rf_asChar(parameter)));
   FastConfigHandle out_fastConfig;
   CHECK_CALL(LGBM_BoosterPredictForMatSingleRowFastInit(R_ExternalPtrAddr(handle),
     pred_type, Rf_asInteger(start_iteration), Rf_asInteger(num_iteration),
@@ -1228,7 +1228,7 @@ SEXP LGBM_BoosterPredictForMatSingleRowFastInit_R(SEXP handle,
     parameter_ptr, &out_fastConfig));
   R_SetExternalPtrAddr(ret, out_fastConfig);
   R_RegisterCFinalizerEx(ret, LGBM_FastConfigFree_wrapped, TRUE);
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return ret;
   R_API_END();
 }
@@ -1251,9 +1251,9 @@ SEXP LGBM_BoosterSaveModel_R(SEXP handle,
   SEXP start_iteration) {
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
-  const char* filename_ptr = CHAR(PROTECT(Rf_asChar(filename)));
+  const char* filename_ptr = CHAR(Rf_protect(Rf_asChar(filename)));
   CHECK_CALL(LGBM_BoosterSaveModel(R_ExternalPtrAddr(handle), Rf_asInteger(start_iteration), Rf_asInteger(num_iteration), Rf_asInteger(feature_importance_type), filename_ptr));
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return R_NilValue;
   R_API_END();
 }
@@ -1266,7 +1266,7 @@ SEXP LGBM_BoosterSaveModelToString_R(SEXP handle,
   SEXP num_iteration,
   SEXP feature_importance_type,
   SEXP start_iteration) {
-  SEXP cont_token = PROTECT(R_MakeUnwindCont());
+  SEXP cont_token = Rf_protect(R_MakeUnwindCont());
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
   int64_t out_len = 0;
@@ -1281,7 +1281,7 @@ SEXP LGBM_BoosterSaveModelToString_R(SEXP handle,
     CHECK_CALL(LGBM_BoosterSaveModelToString(R_ExternalPtrAddr(handle), start_iter, num_iter, importance_type, out_len, &out_len, inner_char_buf->data()));
   }
   SEXP out = R_UnwindProtect(make_altrepped_raw_vec, &inner_char_buf, throw_R_memerr, &cont_token, cont_token);
-  UNPROTECT(1);
+  Rf_unprotect(1);
   return out;
   R_API_END();
 }
@@ -1290,7 +1290,7 @@ SEXP LGBM_BoosterSaveModelToString_R(SEXP handle,
   SEXP num_iteration,
   SEXP feature_importance_type,
   SEXP start_iteration) {
-  SEXP cont_token = PROTECT(R_MakeUnwindCont());
+  SEXP cont_token = Rf_protect(R_MakeUnwindCont());
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
   int64_t out_len = 0;
@@ -1300,14 +1300,14 @@ SEXP LGBM_BoosterSaveModelToString_R(SEXP handle,
   int importance_type = Rf_asInteger(feature_importance_type);
   std::vector<char> inner_char_buf(buf_len);
   CHECK_CALL(LGBM_BoosterSaveModelToString(R_ExternalPtrAddr(handle), start_iter, num_iter, importance_type, buf_len, &out_len, inner_char_buf.data()));
-  SEXP model_str = PROTECT(safe_R_raw(out_len, &cont_token));
+  SEXP model_str = Rf_protect(safe_R_raw(out_len, &cont_token));
   // if the model string was larger than the initial buffer, call the function again, writing directly to the R object
   if (out_len > buf_len) {
     CHECK_CALL(LGBM_BoosterSaveModelToString(R_ExternalPtrAddr(handle), start_iter, num_iter, importance_type, out_len, &out_len, reinterpret_cast<char*>(RAW(model_str))));
   } else {
     std::copy(inner_char_buf.begin(), inner_char_buf.begin() + out_len, reinterpret_cast<char*>(RAW(model_str)));
   }
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return model_str;
   R_API_END();
 }
@@ -1317,7 +1317,7 @@ SEXP LGBM_BoosterDumpModel_R(SEXP handle,
   SEXP num_iteration,
   SEXP feature_importance_type,
   SEXP start_iteration) {
-  SEXP cont_token = PROTECT(R_MakeUnwindCont());
+  SEXP cont_token = Rf_protect(R_MakeUnwindCont());
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
   SEXP model_str;
@@ -1333,15 +1333,15 @@ SEXP LGBM_BoosterDumpModel_R(SEXP handle,
     inner_char_buf.resize(out_len);
     CHECK_CALL(LGBM_BoosterDumpModel(R_ExternalPtrAddr(handle), start_iter, num_iter, importance_type, out_len, &out_len, inner_char_buf.data()));
   }
-  model_str = PROTECT(safe_R_string(static_cast<R_xlen_t>(1), &cont_token));
+  model_str = Rf_protect(safe_R_string(static_cast<R_xlen_t>(1), &cont_token));
   SET_STRING_ELT(model_str, 0, safe_R_mkChar(inner_char_buf.data(), &cont_token));
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return model_str;
   R_API_END();
 }
 
 SEXP LGBM_DumpParamAliases_R() {
-  SEXP cont_token = PROTECT(R_MakeUnwindCont());
+  SEXP cont_token = Rf_protect(R_MakeUnwindCont());
   R_API_BEGIN();
   SEXP aliases_str;
   int64_t out_len = 0;
@@ -1353,15 +1353,15 @@ SEXP LGBM_DumpParamAliases_R() {
     inner_char_buf.resize(out_len);
     CHECK_CALL(LGBM_DumpParamAliases(out_len, &out_len, inner_char_buf.data()));
   }
-  aliases_str = PROTECT(safe_R_string(static_cast<R_xlen_t>(1), &cont_token));
+  aliases_str = Rf_protect(safe_R_string(static_cast<R_xlen_t>(1), &cont_token));
   SET_STRING_ELT(aliases_str, 0, safe_R_mkChar(inner_char_buf.data(), &cont_token));
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return aliases_str;
   R_API_END();
 }
 
 SEXP LGBM_BoosterGetLoadedParam_R(SEXP handle) {
-  SEXP cont_token = PROTECT(R_MakeUnwindCont());
+  SEXP cont_token = Rf_protect(R_MakeUnwindCont());
   R_API_BEGIN();
   _AssertBoosterHandleNotNull(handle);
   SEXP params_str;
@@ -1374,9 +1374,9 @@ SEXP LGBM_BoosterGetLoadedParam_R(SEXP handle) {
     inner_char_buf.resize(out_len);
     CHECK_CALL(LGBM_BoosterGetLoadedParam(R_ExternalPtrAddr(handle), out_len, &out_len, inner_char_buf.data()));
   }
-  params_str = PROTECT(safe_R_string(static_cast<R_xlen_t>(1), &cont_token));
+  params_str = Rf_protect(safe_R_string(static_cast<R_xlen_t>(1), &cont_token));
   SET_STRING_ELT(params_str, 0, safe_R_mkChar(inner_char_buf.data(), &cont_token));
-  UNPROTECT(2);
+  Rf_unprotect(2);
   return params_str;
   R_API_END();
 }


### PR DESCRIPTION
From similar PR in XGBoost: https://github.com/dmlc/xgboost/pull/10465

This PR modifies the R C-level function code to call the versions of protect/unprotect that have `Rf_` prefixes. This is currently not required by CRAN as their non-Rf equivalents `PROTECT`/`UNPROTECT` are simple defines aliasing to `Rf_protect`/`Rf_unprotect`, but the situation might change in the future.