### PR TITLE
[ci] resolve shellcheck errors in .ci/check_python_dists.sh

### DIFF
--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -20,7 +20,7 @@ twine check --strict ${DIST_DIR}/* || exit 1
 
 if { test "${TASK}" = "bdist" || test "${METHOD}" = "wheel"; }; then
     echo "check-wheel-contents..."
-    check-wheel-contents "${DIST_DIR}/*.whl" || exit 1
+    check-wheel-contents ${DIST_DIR}/*.whl || exit 1
 fi
 
 PY_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -49,7 +49,7 @@ if [ "$PY_MINOR_VER" -gt 7 ]; then
             --max-allowed-size-compressed '5M' \
             --max-allowed-size-uncompressed '15M' \
             --max-allowed-files 800 \
-            "${DIST_DIR}/*" || exit 1
+            "$(echo ${DIST_DIR}/*)" || exit 1
     fi
 else
     echo "skipping pydistcheck (does not support Python 3.${PY_MINOR_VER})"

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -42,7 +42,7 @@ if [ "$PY_MINOR_VER" -gt 7 ]; then
             --max-allowed-size-compressed '5M' \
             --max-allowed-size-uncompressed '15M' \
             --max-allowed-files 800 \
-            "${DIST_DIR}/*" || exit 1
+            "$(echo ${DIST_DIR}/*)" || exit 1
     else
         pydistcheck \
             --inspect \

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e -E -u
 

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e -E -u
+set -e -u
 
 DIST_DIR=${1}
 

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -35,7 +35,7 @@ if [ "$PY_MINOR_VER" -gt 7 ]; then
             --max-allowed-size-uncompressed '100M' \
             --max-allowed-files 800 \
             "${DIST_DIR}/*" || exit 1
-    elif { test $(uname -m) = "aarch64"; }; then
+    elif { test "$(uname -m)" = "aarch64"; }; then
         pydistcheck \
             --inspect \
             --ignore 'compiled-objects-have-debug-symbols' \

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e -E -u
 
@@ -16,15 +16,15 @@ pip install \
     twine || exit 1
 
 echo "twine check..."
-twine check --strict ${DIST_DIR}/* || exit 1
+twine check --strict "${DIST_DIR}/*" || exit 1
 
 if { test "${TASK}" = "bdist" || test "${METHOD}" = "wheel"; }; then
     echo "check-wheel-contents..."
-    check-wheel-contents ${DIST_DIR}/*.whl || exit 1
+    check-wheel-contents "${DIST_DIR}/*.whl" || exit 1
 fi
 
 PY_MINOR_VER=$(python -c "import sys; print(sys.version_info.minor)")
-if [ $PY_MINOR_VER -gt 7 ]; then
+if [ "$PY_MINOR_VER" -gt 7 ]; then
     echo "pydistcheck..."
     pip install 'pydistcheck>=0.7.0'
     if { test "${TASK}" = "cuda" || test "${METHOD}" = "wheel"; }; then
@@ -34,7 +34,7 @@ if [ $PY_MINOR_VER -gt 7 ]; then
             --ignore 'distro-too-large-compressed' \
             --max-allowed-size-uncompressed '100M' \
             --max-allowed-files 800 \
-            ${DIST_DIR}/* || exit 1
+            "${DIST_DIR}/*" || exit 1
     elif { test $(uname -m) = "aarch64"; }; then
         pydistcheck \
             --inspect \
@@ -42,14 +42,14 @@ if [ $PY_MINOR_VER -gt 7 ]; then
             --max-allowed-size-compressed '5M' \
             --max-allowed-size-uncompressed '15M' \
             --max-allowed-files 800 \
-            ${DIST_DIR}/* || exit 1
+            "${DIST_DIR}/*" || exit 1
     else
         pydistcheck \
             --inspect \
             --max-allowed-size-compressed '5M' \
             --max-allowed-size-uncompressed '15M' \
             --max-allowed-files 800 \
-            ${DIST_DIR}/* || exit 1
+            "${DIST_DIR}/*" || exit 1
     fi
 else
     echo "skipping pydistcheck (does not support Python 3.${PY_MINOR_VER})"

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -34,7 +34,7 @@ if [ "$PY_MINOR_VER" -gt 7 ]; then
             --ignore 'distro-too-large-compressed' \
             --max-allowed-size-uncompressed '100M' \
             --max-allowed-files 800 \
-            "${DIST_DIR}/*" || exit 1
+            "$(echo ${DIST_DIR}/*)" || exit 1
     elif { test "$(uname -m)" = "aarch64"; }; then
         pydistcheck \
             --inspect \

--- a/.ci/check_python_dists.sh
+++ b/.ci/check_python_dists.sh
@@ -16,7 +16,7 @@ pip install \
     twine || exit 1
 
 echo "twine check..."
-twine check --strict "${DIST_DIR}/*" || exit 1
+twine check --strict ${DIST_DIR}/* || exit 1
 
 if { test "${TASK}" = "bdist" || test "${METHOD}" = "wheel"; }; then
     echo "check-wheel-contents..."


### PR DESCRIPTION
Contributing to #6498 , So in the file ```.ci/check_python_dists.sh``` the errors raise by shellcheck were

```
In .ci/check_python_dists.sh line 3:
set -e -E -u
       ^-- SC3041 (warning): In POSIX sh, set flag -E is undefined.
```
So I changes the shebang line from ```#!/bin/sh``` to ```#!/bin/bash``` 

Then shellcheck was giving errors based on [SC2086](https://www.shellcheck.net/wiki/SC2086) i.e. 

```
In .ci/check_python_dists.sh line 23:
    check-wheel-contents ${DIST_DIR}/*.whl || exit 1
                         ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.
```
The same errors were also on line 19,37,45,52 which can be resolved by changing ```${DIST_DIR}/*``` to ```"${DIST_DIR}/*"```