### PR TITLE
[ci] [R-package] run 'R CMD check' as a foreground task

### DIFF
--- a/.ci/test_r_package.sh
+++ b/.ci/test_r_package.sh
@@ -200,22 +200,10 @@ fi
 # fails tests if either ERRORs or WARNINGs are thrown by
 # R CMD CHECK
 check_succeeded="yes"
-(
-    R CMD check ${PKG_TARBALL} \
-        --as-cran \
-        --run-donttest \
-    || check_succeeded="no"
-) &
-
-# R CMD check suppresses output, some CIs kill builds after
-# a few minutes with no output. This trick gives R CMD check more time
-#     * https://github.com/travis-ci/travis-ci/issues/4190#issuecomment-169987525
-#     * https://stackoverflow.com/a/29890106/3986677
-CHECK_PID=$!
-while kill -0 ${CHECK_PID} >/dev/null 2>&1; do
-    echo -n -e " \b"
-    sleep 5
-done
+R CMD check ${PKG_TARBALL} \
+    --as-cran \
+    --run-donttest \
+|| check_succeeded="no"
 
 echo "R CMD check build logs:"
 BUILD_LOG_FILE=lightgbm.Rcheck/00install.out


### PR DESCRIPTION
Contributes to #6498

4 years ago, this project was running a lot of its R-package testing on Travis CI. We experienced an issue where `R CMD check` would run for too long without emitting a new log line, and as a result Travis killed jobs.

A workaround was introduced in #3092 ... running `R CMD check` as a background task and polling for the status of it's process ID.

I strongly suspect this is no longer necessary:

* we are not on Travis any more (and I suspect that GitHub Actions does not have a similar timeout based on log output)
* the R package compiles faster in CI than it did 4 years ago

This proposes removing that workaround, to hopefully make it a bit easier to understand the CI setup. It also fixes some `shellcheck` errors, mentioned in https://github.com/microsoft/LightGBM/pull/6501#discussion_r1649241854

## How I tested this

Checked a few of the logs to be sure `R CMD check` is really being run and is succeeding. Looks good to me!

https://github.com/microsoft/LightGBM/actions/runs/9788164564/job/27025779285?pr=6508#step:9:2015

If it wasn't safe to remove this, we'd see jobs outright fail. I'm pretty confident this is safe to do.