### PR TITLE
Remove template parameters from copy constructor

### DIFF
--- a/src/io/dense_bin.hpp
+++ b/src/io/dense_bin.hpp
@@ -614,7 +614,7 @@ class DenseBin : public Bin {
 #endif
   std::vector<uint8_t> buf_;
 
-  DenseBin<VAL_T, IS_4BIT>(const DenseBin<VAL_T, IS_4BIT>& other)
+  DenseBin(const DenseBin<VAL_T, IS_4BIT>& other)
       : num_data_(other.num_data_), data_(other.data_) {}
 };
 

--- a/src/io/multi_val_dense_bin.hpp
+++ b/src/io/multi_val_dense_bin.hpp
@@ -343,7 +343,7 @@ class MultiValDenseBin : public MultiValBin {
   std::vector<uint32_t> offsets_;
   std::vector<VAL_T, Common::AlignmentAllocator<VAL_T, 32>> data_;
 
-  MultiValDenseBin<VAL_T>(const MultiValDenseBin<VAL_T>& other)
+  MultiValDenseBin(const MultiValDenseBin<VAL_T>& other)
     : num_data_(other.num_data_), num_bin_(other.num_bin_), num_feature_(other.num_feature_),
       offsets_(other.offsets_), data_(other.data_) {
   }

--- a/src/io/multi_val_sparse_bin.hpp
+++ b/src/io/multi_val_sparse_bin.hpp
@@ -430,8 +430,7 @@ class MultiValSparseBin : public MultiValBin {
   std::vector<INDEX_T> t_size_;
   std::vector<uint32_t> offsets_;
 
-  MultiValSparseBin<INDEX_T, VAL_T>(
-      const MultiValSparseBin<INDEX_T, VAL_T>& other)
+  MultiValSparseBin(const MultiValSparseBin<INDEX_T, VAL_T>& other)
       : num_data_(other.num_data_),
         num_bin_(other.num_bin_),
         estimate_element_per_row_(other.estimate_element_per_row_),

--- a/src/io/sparse_bin.hpp
+++ b/src/io/sparse_bin.hpp
@@ -782,7 +782,7 @@ class SparseBin : public Bin {
 
   SparseBin<VAL_T>* Clone() override;
 
-  SparseBin<VAL_T>(const SparseBin<VAL_T>& other)
+  SparseBin(const SparseBin<VAL_T>& other)
       : num_data_(other.num_data_),
         deltas_(other.deltas_),
         vals_(other.vals_),


### PR DESCRIPTION
Contributes to #6033

C++23 no longer allow template parameters in constructor