### PR TITLE
cmake: add missing lib_lightgbm_swig.so to lightgbmlib.jar on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,6 +576,12 @@ if(USE_SWIG)
           copy_if_different
           "${PROJECT_SOURCE_DIR}/lib_lightgbm.so"
           com/microsoft/ml/lightgbm/linux/x86_64
+          COMMAND
+          "${CMAKE_COMMAND}"
+          -E
+          copy_if_different
+          "${PROJECT_SOURCE_DIR}/lib_lightgbm_swig.so"
+          com/microsoft/ml/lightgbm/linux/x86_64
         COMMAND "${Java_JAR_EXECUTABLE}" -cf lightgbmlib.jar com
     )
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,7 +576,7 @@ if(USE_SWIG)
           copy_if_different
           "${PROJECT_SOURCE_DIR}/lib_lightgbm.so"
           com/microsoft/ml/lightgbm/linux/x86_64
-          COMMAND
+        COMMAND
           "${CMAKE_COMMAND}"
           -E
           copy_if_different


### PR DESCRIPTION
A PR [ [cmake] [swig] use CMake's built-in file-copying mechanisms instead of 'cp' #6259 ](https://github.com/microsoft/LightGBM/pull/6259) introduced a small build regression:

* before: for Linux, both `lib_lightgbm.so` and `lib_lightgbm_swig.so` were included into the JAR
* after: only `lib_lightgbm.so` is part of the JAR.

Lack of the SWIG wrapper makes it impossible to link to the library from the JVM. Mac and Windows builds do include the SWIG wrapper properly and are not affected by this regression.

This PR adds back the `lib_lightgbm_swig.so` library to the JAR build process on Linux. I'm maintaining the [lightgbm4j](https://github.com/metarank/lightgbm4j) library and find it very convenient to re-use your build artifacts :)