### PR TITLE
[python-package] Correctly recognize LGBMClassifier(num_class=2, objective="multiclass") as multiclass classification

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -157,6 +157,8 @@ _LGBM_SetFieldType = Union[
 
 ZERO_THRESHOLD = 1e-35
 
+_MULTICLASS_OBJECTIVES = {"multiclass", "multiclassova", "multiclass_ova", "ova", "ovr", "softmax"}
+
 
 def _is_zero(x: float) -> bool:
     return -ZERO_THRESHOLD <= x <= ZERO_THRESHOLD

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -467,7 +467,7 @@ def _extract_evaluation_meta_data(
         # It's possible, for example, to pass 3 eval sets through `eval_set`,
         # but only 1 init_score through `eval_init_score`.
         #
-        # This if-else accounts for that possiblity.
+        # This if-else accounts for that possibility.
         if len(collection) > i:
             return collection[i]
         else:
@@ -1011,7 +1011,7 @@ class LGBMModel(_LGBMModelBase):
                 f"match the input. Model n_features_ is {self._n_features} and "
                 f"input n_features is {n_features}"
             )
-        # retrive original params that possibly can be used in both training and prediction
+        # retrieve original params that possibly can be used in both training and prediction
         # and then overwrite them (considering aliases) with params that were passed directly in prediction
         predict_params = self._process_params(stage="predict")
         for alias in _ConfigAliases.get_by_alias(

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1361,7 +1361,7 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
                 "Returning raw scores instead."
             )
             return result
-        elif self._n_classes > 2 or raw_score or pred_leaf or pred_contrib:  # type: ignore [operator]
+        elif self._n_classes > 2 or len(result.shape) > 1 or raw_score or pred_leaf or pred_contrib:  # type: ignore [operator]
             return result
         else:
             return np.vstack((1.0 - result, result)).transpose()

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -10,6 +10,7 @@ import numpy as np
 import scipy.sparse
 
 from .basic import (
+    _MULTICLASS_OBJECTIVES,
     Booster,
     Dataset,
     LightGBMError,
@@ -1392,8 +1393,7 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
     @property
     def __is_multiclass(self) -> bool:
         """:obj:`bool`:  Indicator of whether the classifier is used for multiclass."""
-        multiclass_objectives = ("multiclass", "softmax", "multiclassova", "multiclass_ova", "ova", "ovr")
-        return self._n_classes > 2 or (isinstance(self._objective, str) and self._objective in multiclass_objectives)
+        return self._n_classes > 2 or (isinstance(self._objective, str) and self._objective in _MULTICLASS_OBJECTIVES)
 
 
 class LGBMRanker(LGBMModel):

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -1251,7 +1251,7 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
                 eval_metric_list = [eval_metric]
             else:
                 eval_metric_list = []
-            if self._n_classes > 2:
+            if self.__is_multiclass:
                 for index, metric in enumerate(eval_metric_list):
                     if metric in {"logloss", "binary_logloss"}:
                         eval_metric_list[index] = "multi_logloss"
@@ -1361,7 +1361,7 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
                 "Returning raw scores instead."
             )
             return result
-        elif self._n_classes > 2 or len(result.shape) > 1 or raw_score or pred_leaf or pred_contrib:  # type: ignore [operator]
+        elif self.__is_multiclass or raw_score or pred_leaf or pred_contrib:  # type: ignore [operator]
             return result
         else:
             return np.vstack((1.0 - result, result)).transpose()
@@ -1388,6 +1388,12 @@ class LGBMClassifier(_LGBMClassifierBase, LGBMModel):
         if not self.__sklearn_is_fitted__():
             raise LGBMNotFittedError("No classes found. Need to call fit beforehand.")
         return self._n_classes
+
+    @property
+    def __is_multiclass(self) -> bool:
+        """:obj:`bool`:  Indicator of whether the classifier is used for multiclass."""
+        multiclass_objectives = ("multiclass", "softmax", "multiclassova", "multiclass_ova", "ova", "ovr")
+        return self._n_classes > 2 or (isinstance(self._objective, str) and self._objective in multiclass_objectives)
 
 
 class LGBMRanker(LGBMModel):

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -719,6 +719,18 @@ def test_predict():
     with pytest.raises(AssertionError):
         np.testing.assert_allclose(res_engine, res_sklearn_params)
 
+    # Test multiclass binary classification
+    rng = np.random.Generator(np.random.PCG64())
+    X_train = rng.uniform(low=0, high=1, size=[20, 3])
+    y_train = rng.choice([0, 1], size=20)
+
+    gbm = lgb.train({"objective": "multiclass", "num_class": 2, "verbose": -1}, lgb.Dataset(X_train, y_train))
+    clf = lgb.LGBMClassifier(objective="multiclass", num_classes=2).fit(X_train, y_train)
+
+    res_engine = gbm.predict(X_train)
+    res_sklearn = clf.predict_proba(X_train)
+    np.testing.assert_allclose(res_engine, res_sklearn)
+
 
 def test_predict_with_params_from_init():
     X, y = load_iris(return_X_y=True)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -736,7 +736,7 @@ def test_predict():
     np.testing.assert_allclose(res_engine, res_sklearn)
 
     res_class_sklearn = clf.predict(X_train)
-    np.testing.assert_allclose(res_class_sklearn, np.concat([np.zeros(49), np.ones(51)], axis=0))
+    np.testing.assert_allclose(res_class_sklearn, np.concatenate([np.zeros(49), np.ones(51)]))
 
 
 def test_predict_with_params_from_init():

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -723,7 +723,7 @@ def test_predict():
     num_samples = 100
     num_classes = 2
     X_train = np.linspace(start=0, stop=10, num=num_samples * 3).reshape(num_samples, 3)
-    y_train = np.repeat([0, 1], repeats=num_samples / 2)
+    y_train = np.concatenate([np.zeros(int(num_samples / 2 - 10)), np.ones(int(num_samples / 2 + 10))])
 
     gbm = lgb.train({"objective": "multiclass", "num_class": num_classes, "verbose": -1}, lgb.Dataset(X_train, y_train))
     clf = lgb.LGBMClassifier(objective="multiclass", num_classes=num_classes).fit(X_train, y_train)
@@ -736,7 +736,7 @@ def test_predict():
     np.testing.assert_allclose(res_engine, res_sklearn)
 
     res_class_sklearn = clf.predict(X_train)
-    np.testing.assert_allclose(res_class_sklearn, np.concatenate([np.zeros(49), np.ones(51)]))
+    np.testing.assert_allclose(res_class_sklearn, y_train)
 
 
 def test_predict_with_params_from_init():

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -720,19 +720,22 @@ def test_predict():
         np.testing.assert_allclose(res_engine, res_sklearn_params)
 
     # Test multiclass binary classification
-    num_samples, num_classes = 20, 2
-    rng = np.random.Generator(np.random.PCG64())
-    X_train = rng.uniform(low=0, high=1, size=[num_samples, 3])
-    y_train = rng.choice([0, 1], size=num_samples)
+    num_samples, num_classes = 5, 2
+    X_train = np.ones((num_samples, 3))
+    y_train = np.zeros((num_samples,))
 
     gbm = lgb.train({"objective": "multiclass", "num_class": num_classes, "verbose": -1}, lgb.Dataset(X_train, y_train))
     clf = lgb.LGBMClassifier(objective="multiclass", num_classes=num_classes).fit(X_train, y_train)
 
     res_engine = gbm.predict(X_train)
     res_sklearn = clf.predict_proba(X_train)
+
     assert res_engine.shape == (num_samples, num_classes)
     assert res_sklearn.shape == (num_samples, num_classes)
     np.testing.assert_allclose(res_engine, res_sklearn)
+
+    res_class_sklearn = clf.predict(X_train)
+    np.testing.assert_allclose(res_class_sklearn, np.zeros((num_samples,)))
 
 
 def test_predict_with_params_from_init():

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -1053,6 +1053,20 @@ def test_metrics():
     assert len(gbm.evals_result_["training"]) == 1
     assert "binary_logloss" in gbm.evals_result_["training"]
 
+    # the evaluation metric changes to multiclass metric even num classes is 2 for multiclass objective
+    gbm = lgb.LGBMClassifier(objective="multiclass", num_classes=2, **params).fit(
+        eval_metric="binary_logloss", **params_fit
+    )
+    assert len(gbm._evals_result["training"]) == 1
+    assert "multi_logloss" in gbm.evals_result_["training"]
+
+    # the evaluation metric changes to multiclass metric even num classes is 2 for ovr objective
+    gbm = lgb.LGBMClassifier(objective="ovr", num_classes=2, **params).fit(eval_metric="binary_error", **params_fit)
+    assert gbm.objective_ == "ovr"
+    assert len(gbm.evals_result_["training"]) == 2
+    assert "multi_logloss" in gbm.evals_result_["training"]
+    assert "multi_error" in gbm.evals_result_["training"]
+
 
 def test_multiple_eval_metrics():
     X, y = load_breast_cancer(return_X_y=True)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -736,7 +736,7 @@ def test_predict():
     np.testing.assert_allclose(res_engine, res_sklearn)
 
     res_class_sklearn = clf.predict(X_train)
-    np.testing.assert_allclose(res_class_sklearn, np.concat([np.zeros(49), np.ones(51)]), axis=0)
+    np.testing.assert_allclose(res_class_sklearn, np.concat([np.zeros(49), np.ones(51)], axis=0))
 
 
 def test_predict_with_params_from_init():

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -720,9 +720,10 @@ def test_predict():
         np.testing.assert_allclose(res_engine, res_sklearn_params)
 
     # Test multiclass binary classification
-    num_samples, num_classes = 5, 2
-    X_train = np.ones((num_samples, 3))
-    y_train = np.zeros((num_samples,))
+    num_samples = 100
+    num_classes = 2
+    X_train = np.linspace(start=0, stop=10, num=num_samples * 3).reshape(num_samples, 3)
+    y_train = np.repeat([0, 1], repeats=num_samples / 2)
 
     gbm = lgb.train({"objective": "multiclass", "num_class": num_classes, "verbose": -1}, lgb.Dataset(X_train, y_train))
     clf = lgb.LGBMClassifier(objective="multiclass", num_classes=num_classes).fit(X_train, y_train)
@@ -735,7 +736,7 @@ def test_predict():
     np.testing.assert_allclose(res_engine, res_sklearn)
 
     res_class_sklearn = clf.predict(X_train)
-    np.testing.assert_allclose(res_class_sklearn, np.zeros((num_samples,)))
+    np.testing.assert_allclose(res_class_sklearn, np.concat([np.zeros(49), np.ones(51)]), axis=0)
 
 
 def test_predict_with_params_from_init():

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -720,15 +720,18 @@ def test_predict():
         np.testing.assert_allclose(res_engine, res_sklearn_params)
 
     # Test multiclass binary classification
+    num_samples, num_classes = 20, 2
     rng = np.random.Generator(np.random.PCG64())
-    X_train = rng.uniform(low=0, high=1, size=[20, 3])
-    y_train = rng.choice([0, 1], size=20)
+    X_train = rng.uniform(low=0, high=1, size=[num_samples, 3])
+    y_train = rng.choice([0, 1], size=num_samples)
 
-    gbm = lgb.train({"objective": "multiclass", "num_class": 2, "verbose": -1}, lgb.Dataset(X_train, y_train))
-    clf = lgb.LGBMClassifier(objective="multiclass", num_classes=2).fit(X_train, y_train)
+    gbm = lgb.train({"objective": "multiclass", "num_class": num_classes, "verbose": -1}, lgb.Dataset(X_train, y_train))
+    clf = lgb.LGBMClassifier(objective="multiclass", num_classes=num_classes).fit(X_train, y_train)
 
     res_engine = gbm.predict(X_train)
     res_sklearn = clf.predict_proba(X_train)
+    assert res_engine.shape == (num_samples, num_classes)
+    assert res_sklearn.shape == (num_samples, num_classes)
     np.testing.assert_allclose(res_engine, res_sklearn)
 
 


### PR DESCRIPTION
fixes #6519
fixes #3636

I created a pull request addressing issue [#6519](https://github.com/microsoft/LightGBM/issues/6519), which I've also encountered. 
I modified the code to use `np.vstack` only when `result.shape` look like `(num_data,)`, and some typos.
