### PR TITLE
[python-package] avoid overwriting dependencies via 'build-python.sh install'

### DIFF
--- a/build-python.sh
+++ b/build-python.sh
@@ -364,13 +364,12 @@ fi
 if test "${INSTALL}" = true; then
     echo "--- installing lightgbm ---"
     cd ../dist
-    # remove existing installation
-    # (useful when building the dev version multiple times, where the version number doesn't change)
-    pip uninstall --yes lightgbm
     # ref for use of '--find-links': https://stackoverflow.com/a/52481267/3986677
     pip install \
         ${PIP_INSTALL_ARGS} \
+        --ignore-installed \
         --no-cache-dir \
+        --no-deps \
         --find-links=. \
         lightgbm
     cd ../


### PR DESCRIPTION
Building a Python wheel + installing it like this:

```shell
sh build-python.sh bdist_wheel install
```

Will also overwrite `numpy` and `scipy` in the installation environment. When working in a conda environment, that'll also replace conda's `numpy` / `scipy` with a wheel from PyPI... which can sometimes lead to undesirable consequences like failed imports.

This could be avoided by just building a wheel yourself and then installing it + telling `pip` not to overwrite any dependencies, like this:

```shell
sh build-python.sh bdist_wheel
pip install --no-deps dist/*.whl
```

This PR proposes just making that the default behavior, to make local development a bit easier.

It also proposes remove the `pip uninstall lightgbm` in that script with passing `--ignore-installed` to `pip install`... that way the locally-built version overwrites the already-installed one every time, without generating a log message like *"WARNING: Skipping lightgbm as it is not installed."*