### PR TITLE
[tests][python]  fix nan in pandas bool column

### DIFF
--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -4156,9 +4156,9 @@ def test_pandas_nullable_dtypes(rng_fixed_seed):
     # introduce some missing values
     df.loc[1, "x1"] = np.nan
     df.loc[2, "x2"] = np.nan
-    df.loc[3, "x4"] = np.nan
-    # the previous line turns x3 into object dtype in recent versions of pandas
+    # in recent versions of pandas, type 'bool' is incompatible with nan values in x4
     df["x4"] = df["x4"].astype(np.float64)
+    df.loc[3, "x4"] = np.nan
     y = df["x1"] * df["x2"] + df["x3"] * (1 + df["x4"])
     y = y.fillna(0)
 


### PR DESCRIPTION
Unblock CI.

Fix for recent pandas error
```
E           TypeError: Invalid value 'nan' for dtype 'bool'
```
For example, https://github.com/microsoft/LightGBM/actions/runs/9863990666/job/27237966034?pr=6526#step:4:546

Everything is OK with `boolean` dtype later in this test:
https://github.com/microsoft/LightGBM/blob/fc788a51b61368f78246e5c450f0ea77d263eb2b/tests/python_package_test/test_engine.py#L4175