### PR TITLE
[test][python] fix pandas DeprecationWarning about `is_sparse` function

### DIFF
--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -1812,7 +1812,7 @@ def test_pandas_sparse(rng):
         }
     )
     for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
-        assert pd.api.types.is_sparse(dtype)
+        assert isinstance(dtype, pd.SparseDtype)
     params = {"objective": "binary", "verbose": -1}
     lgb_train = lgb.Dataset(X, y)
     gbm = lgb.train(params, lgb_train, num_boost_round=10)

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -638,7 +638,7 @@ def test_pandas_sparse(rng):
         }
     )
     for dtype in pd.concat([X.dtypes, X_test.dtypes, pd.Series(y.dtypes)]):
-        assert pd.api.types.is_sparse(dtype)
+        assert isinstance(dtype, pd.SparseDtype)
     gbm = lgb.sklearn.LGBMClassifier(n_estimators=10).fit(X, y)
     pred_sparse = gbm.predict(X_test, raw_score=True)
     if hasattr(X_test, "sparse"):


### PR DESCRIPTION
Fix the following error:
```
DeprecationWarning: is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.
```

LightGBM requires pandas>=0.24.0
https://github.com/microsoft/LightGBM/blob/6c76b6b72ad77ba85285053b8aae209f3a5060ad/python-package/pyproject.toml#L44-L46
So I checked that `pd.SparseDtype` is available in that version:
https://pandas.pydata.org/pandas-docs/version/0.24/reference/api/pandas.SparseDtype.html

Also, they've been performing `isinstance` check under the hood since the begging:
https://github.com/pandas-dev/pandas/blob/83eb2428ceb6257042173582f3f436c2c887aa69/pandas/core/dtypes/common.py#L216-L219