### PR TITLE
Cast errors

### DIFF
--- a/include/LightGBM/arrow.h
+++ b/include/LightGBM/arrow.h
@@ -122,7 +122,7 @@ class ArrowChunkedArray {
                            const struct ArrowSchema* schema)
       : releases_arrow_(true) {
     chunks_.reserve(n_chunks);
-    for (auto k = 0; k < n_chunks; ++k) {
+    for (int64_t k = 0; k < n_chunks; ++k) {
       if (chunks[k].length == 0) continue;
       chunks_.push_back(&chunks[k]);
     }

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1604,7 +1604,7 @@ int LGBM_DatasetCreateFromCSC(const void* col_ptr,
   }
   OMP_INIT_EX();
   #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
-  for (int i = 0; i < ncol_ptr - 1; ++i) {
+  for (int i = 0; i < static_cast<int>(ncol_ptr - 1); ++i) {
     OMP_LOOP_EX_BEGIN();
     const int tid = omp_get_thread_num();
     int feature_idx = ret->InnerFeatureIndex(i);

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1464,7 +1464,7 @@ int LGBM_DatasetCreateFromCSR(const void* indptr,
   }
   OMP_INIT_EX();
   #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
-  for (int i = 0; i < nindptr - 1; ++i) {
+  for (int i = 0; i < static_cast<int>(nindptr - 1); ++i) {
     OMP_LOOP_EX_BEGIN();
     const int tid = omp_get_thread_num();
     auto one_row = get_row_fun(i);

--- a/src/io/metadata.cpp
+++ b/src/io/metadata.cpp
@@ -531,7 +531,7 @@ void Metadata::SetQueriesFromIterator(It first, It last) {
 
   data_size_t sum = 0;
   #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static) reduction(+:sum)
-  for (data_size_t i = 0; i < last - first; ++i) {
+  for (data_size_t i = 0; i < static_cast<data_size_t>(last - first); ++i) {
     sum += first[i];
   }
   if (num_data_ != sum) {


### PR DESCRIPTION
Fix 4 of 5 security code scanning errors from https://github.com/microsoft/LightGBM/security/code-scanning.

The 5th one is error about `fmt` submodule code.