### PR TITLE
[ci] [R-package] use --no-xattrs when re-tarring CRAN-style package

### DIFF
--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -202,8 +202,12 @@ if ${BUILD_VIGNETTES} ; then
         rm -f ./lightgbm/src/utils/*.o
 
         echo "re-tarring ${TARBALL_NAME}"
+        # --no-xattrs is the default in GNU tar but not some distributions of BSD tar.
+        # Enable it here to avoid errors on macOS.
+        # ref: https://stackoverflow.com/a/74373784/3986677
         tar \
             -cz \
+            --no-xattrs \
             -f "${TARBALL_NAME}" \
             lightgbm \
         > /dev/null 2>&1


### PR DESCRIPTION
On my M2 Mac, with R 4.3.3 installed from CRAN, I found that the following:

```shell
sh build-cran-package.sh
R CMD INSTALL --with-keep.source ./lightgbm_4.4.0.99.tar.gz
```

Fails like this:

```text
Error in rawToChar(info) : 
  embedded nul in string: '30 mtime=1720906116.345798869\n57 LIBARCHIVE.xattr.com.apple.provenance=AQAAf4WY23sneC8\n49 SCHILY.xattr.com.apple.provenance=\001\0\0\177\x85\x98\xdb{'x/\n'
```

Based on https://stackoverflow.com/a/74373784/3986677 and similar, it seems that the root cause is that BSD `tar` (the one available on my mac) copies "extra file attributes" into archives it creates. This is the opposite of what GNU tar does. From https://www.gnu.org/software/tar/manual/tar.html#Extended-File-Attributes

```text
‘--no-xattrs’
Disable extended attributes support. This is the default.
```

This proposes specifying `--no-xattrs` so we get the same behavior building the R package and macOS and Linux.

<details><summary>output of 'tar --version' (click me)</summary>

```text
bsdtar 3.5.3 - libarchive 3.5.3 zlib/1.2.12 liblzma/5.4.3 bz2lib/1.0.8
```

</details>

<details><summary>output of 'R --version' (click me)</summary>

```text
R version 4.3.3 (2024-02-29) -- "Angel Food Cake"
Copyright (C) 2024 The R Foundation for Statistical Computing
Platform: aarch64-apple-darwin20 (64-bit)
```

</details>