### PR TITLE
[ci] update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 # offer a reasonable automatic best-guess
 
 # catch-all rule (this only gets matched if no rules below match)
-*    @guolinke @jameslamb @shiyu1994 @jmoralez @borchero
+*    @guolinke @jameslamb @shiyu1994 @jmoralez @borchero @StrikerRUS


### PR DESCRIPTION
Proposes adding @StrikerRUS back to `CODEOWNERS`, to be automatically added as a reviewer on PRs.

@StrikerRUS since #5998, we've stopped having specialization in the `CODEOWNERS` file (no more "these people are R reviewers", "these people are Python reviewers", etc.) and switched to just having everyone added to every PR by default. That more closely matched the current state of the project and abilities/interests of the reviewers.

If you don't want to be added as a reviewer on every PR by default let me know, and we can close this.