### PR TITLE
[docs] Add conda downloads badge

### DIFF
--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -1,7 +1,7 @@
 LightGBM Python-package
 =======================
 
-|License| |Python Versions| |PyPI Version| |Downloads| |API Docs|
+|License| |Python Versions| |PyPI Version| |PyPI Downloads| |conda Downloads| |API Docs|
 
 Installation
 ------------
@@ -294,7 +294,9 @@ To check that a contribution to the package matches its style expectations, run 
    :target: https://pypi.org/project/lightgbm
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/lightgbm.svg?logo=pypi&logoColor=white
    :target: https://pypi.org/project/lightgbm
-.. |Downloads| image:: https://pepy.tech/badge/lightgbm
+.. |PyPI Downloads| image:: https://img.shields.io/pepy/dt/lightgbm?logo=pypi&logoColor=white&label=pypi%20downloads
    :target: https://pepy.tech/project/lightgbm
+.. |conda Downloads| image:: https://img.shields.io/conda/d/conda-forge/lightgbm?logo=conda-forge&logoColor=white&label=conda%20downloads
+   :target: https://anaconda.org/conda-forge/lightgbm
 .. |API Docs| image:: https://readthedocs.org/projects/lightgbm/badge/?version=latest
    :target: https://lightgbm.readthedocs.io/en/latest/Python-API.html

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -297,6 +297,6 @@ To check that a contribution to the package matches its style expectations, run 
 .. |PyPI Downloads| image:: https://img.shields.io/pepy/dt/lightgbm?logo=pypi&logoColor=white&label=pypi%20downloads
    :target: https://pepy.tech/project/lightgbm
 .. |conda Downloads| image:: https://img.shields.io/conda/d/conda-forge/lightgbm?logo=conda-forge&logoColor=white&label=conda%20downloads
-   :target: https://anaconda.org/conda-forge/lightgbm
+   :target: https://anaconda.org/conda-forge/lightgbm/files
 .. |API Docs| image:: https://readthedocs.org/projects/lightgbm/badge/?version=latest
    :target: https://lightgbm.readthedocs.io/en/latest/Python-API.html


### PR DESCRIPTION
I'd like to add conda version badge as well, but it's currently broken: https://github.com/conda-forge/lightgbm-feedstock/issues/59.