### PR TITLE
[python-package] No warning if single alias of num_boost_round is passed

### DIFF
--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -199,9 +199,10 @@ def train(
         fobj = params["objective"]
         params["objective"] = "none"
     num_boost_round_aliases = [alias for alias in _ConfigAliases.get("num_iterations") if alias in params]
-    num_boost_round = params.pop(num_boost_round_aliases[-1])
-    if num_boost_round_aliases[:-1]:
-        _log_warning(f"Found `{num_boost_round_aliases[-1]}` in params. Will use it instead of `{num_boost_round_aliases[:-1]}`")
+    if num_boost_round_aliases:
+        num_boost_round = params.pop(num_boost_round_aliases[-1])
+        if num_boost_round_aliases[:-1]:
+            _log_warning(f"Found `{num_boost_round_aliases[-1]}` in params. Will use it instead of `{num_boost_round_aliases[:-1]}`")
     params["num_iterations"] = num_boost_round
     # setting early stopping via global params should be possible
     params = _choose_param_value(

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -198,10 +198,10 @@ def train(
     if callable(params["objective"]):
         fobj = params["objective"]
         params["objective"] = "none"
-    for alias in _ConfigAliases.get("num_iterations"):
-        if alias in params:
-            num_boost_round = params.pop(alias)
-            _log_warning(f"Found `{alias}` in params. Will use it instead of argument")
+    num_boost_round_aliases = [alias for alias in _ConfigAliases.get("num_iterations") if alias in params]
+    num_boost_round = params.pop(num_boost_round_aliases[-1])
+    if num_boost_round_aliases[:-1]:
+        _log_warning(f"Found `{num_boost_round_aliases[-1]}` in params. Will use it instead of `{num_boost_round_aliases[:-1]}`")
     params["num_iterations"] = num_boost_round
     # setting early stopping via global params should be possible
     params = _choose_param_value(


### PR DESCRIPTION
I see a misleading warning log line when I pass a 'num_iterations' argument my training params. There should be no alias warning in that case, only when more than one alias for the number of boosted trees is passed.

By picking the last of the alias in the possibles (available in params), the "tie breaking behaviour" should be conserved.