### PR TITLE
[ci] revert clang-18 LD_LIBRARY_PATH workaround

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -316,11 +316,6 @@ jobs:
       - name: Install packages and run tests
         shell: bash
         run: |
-          # patch around library-loading issues in clang18 image
-          # ref: https://github.com/microsoft/LightGBM/issues/6553
-          if [[ "${{ matrix.image }}" == "clang18" ]]; then
-            export LD_LIBRARY_PATH="/usr/lib/llvm-18/lib:${LD_LIBRARY_PATH}"
-          fi
           Rscript -e "install.packages(c('R6', 'data.table', 'jsonlite', 'knitr', 'markdown', 'Matrix', 'RhpcBLASctl', 'testthat'), repos = 'https://cran.rstudio.com', Ncpus = parallel::detectCores())"
           sh build-cran-package.sh
           if [[ "${{ matrix.image }}" =~ "clang" ]]; then


### PR DESCRIPTION
Reverts the change from #6554. It seems that the issue reported in #6553 was already fixed upstream 😁 

ref: https://github.com/r-hub/containers/issues/70#issuecomment-2238089905