### PR TITLE
[docs] fix link to multiple OpenMP issue description

### DIFF
--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -202,7 +202,7 @@ If you are using any Python package that depends on ``threadpoolctl``, you also 
 
 Detailed description of conflicts between multiple OpenMP instances is provided in the `following document <https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md>`__.
 
-**Solution**: Assuming you are using LightGBM Python-package and conda as a package manager, we strongly recommend using ``conda-forge`` channel as the only source of all your Python package installations because it contains built-in patches to workaround OpenMP conflicts. Some other workarounds are listed `here <https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md#workarounds-for-intel-openmp-and-llvm-openmp-case>`__.
+**Solution**: Assuming you are using LightGBM Python-package and conda as a package manager, we strongly recommend using ``conda-forge`` channel as the only source of all your Python package installations because it contains built-in patches to workaround OpenMP conflicts. Some other workarounds are listed `here <https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md>`__ under the "Workarounds for Intel OpenMP and LLVM OpenMP case" section.
 
 If this is not your case, then you should find conflicting OpenMP library installations on your own and leave only one of them.
 

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -202,7 +202,7 @@ If you are using any Python package that depends on ``threadpoolctl``, you also 
 
 Detailed description of conflicts between multiple OpenMP instances is provided in the `following document <https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md>`__.
 
-**Solution**: Assuming you are using LightGBM Python-package and conda as a package manager, we strongly recommend using ``conda-forge`` channel as the only source of all your Python package installations because it contains built-in patches to workaround OpenMP conflicts. Some other workarounds are listed `here <https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md#user-content-workarounds-for-intel-openmp-and-llvm-openmp-case>`__.
+**Solution**: Assuming you are using LightGBM Python-package and conda as a package manager, we strongly recommend using ``conda-forge`` channel as the only source of all your Python package installations because it contains built-in patches to workaround OpenMP conflicts. Some other workarounds are listed `here <https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md#workarounds-for-intel-openmp-and-llvm-openmp-case>`__.
 
 If this is not your case, then you should find conflicting OpenMP library installations on your own and leave only one of them.
 


### PR DESCRIPTION
Fix flaky error 
```
URL        `https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md#user-content-workarounds-for-intel-openmp-and-llvm-openmp-case'
Name       `here'
Parent URL file:///home/runner/work/LightGBM/LightGBM/docs/_build/html/FAQ.html, line 307, col 396
Real URL   https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md#user-content-workarounds-for-intel-openmp-and-llvm-openmp-case
Check time 2.337 seconds
D/L time   0.003 seconds
Size       178.06KB
Warning    [None] Anchor
           `user-content-workarounds-for-intel-openmp-and-llvm-openmp-case'
           (decoded:
           `user-content-workarounds-for-intel-openmp-and-llvm-openmp-case')
           not found. Available anchors:
           `action-menu-7bcd7c74-3a41-4bfd-8d70-cfb51e70[764](https://github.com/microsoft/LightGBM/actions/runs/9987785649/job/27602867047#step:3:765)4-button',
           `action-menu-7bcd7c74-3a41-4bfd-8d70-cfb51e707644-list',
           `action-menu-7bcd7c74-3a41-4bfd-8d70-cfb51e707644-overlay',
           `actions-repo-tab-count', `actions-tab',
           `ajax-error-message', `book-icon', `bookmark-icon',
           `circle-icon', `client-env', `code-icon',
           `code-repo-tab-count', `code-review-icon',
           `code-square-icon', `code-tab', `codespaces-icon',
           `comment-discussion-icon', `comment-icon',
           `copilot-error-icon', `copilot-icon',
           `credit-card-icon', `custom-scopes-dialog',
           `custom-scopes-dialog-description',
           `custom-scopes-dialog-title', `custom_scope_id',
           `custom_scope_name', `custom_scope_query',
           `device-desktop-icon', `device-mobile-icon',
           `enterprise-available-add-ons-heading', `feedback',
           `feedback-dialog', `feedback-dialog-title',
           `file-code-icon', `fork-button', `ghcc', `gift-icon',
           `globe-icon', `heart-icon', `history-icon',
           `icon-button-80a447f2-c749-47e1-9d10-2e66c2c47030',
           `include_email', `insights-repo-tab-count',
           `insights-tab', `issue-opened-icon',
           `issues-repo-tab-count', `issues-tab',
           `item-16f1da91-e958-4b66-9a28-28ee7351018e',
           `item-54a1b0dd-b2cb-4efa-ad86-50fcf36f1499',
           `item-5a2b88b6-4cc9-4a43-a1d9-1be81125ce63',
           `item-b7b62e64-[796](https://github.com/microsoft/LightGBM/actions/runs/9987785649/job/27602867047#step:3:797)1-4dfa-9b8f-d25966cfabce',
           `item-d8683a95-3a72-4747-86d2-a2b0740f6e85',
           `item-e2b3af2e-22f5-424e-aae3-1fd6c46f2bf6',
           `item-f6665de6-cc16-4264-b5dd-23704975b9c0',
           `js-flash-container',
           `js-global-screen-reader-notice',
           `js-global-screen-reader-notice-assertive',
           `js-repo-pjax-container',
           `open-source-repositories-heading',
           `organization-icon', `package-icon', `pencil-icon',
           `play-icon', `plus-circle-icon',
           `product-explore-heading', `project-icon',
           `projects-repo-tab-count', `projects-tab',
           `pull-requests-repo-tab-count', `pull-requests-tab',
           `query-builder-query-builder-test',
           `query-builder-test', `query-builder-test-clear',
           `query-builder-test-clear-button',
           `query-builder-test-label',
           `query-builder-test-leadingvisual-wrap',
           `query-builder-test-results',
           `repo-content-pjax-container',
           `repo-content-turbo-frame', `repo-icon',
           `repo-network-counter', `repo-stars-counter-star',
           `repository-container-header',
           `repository-details-container',
           `repository-details-watch-button',
           `resources-explore-heading',
           `resources-topics-heading',
           `responsive-meta-container', `rocket-icon',
           `search-icon', `search-suggestions-dialog',
           `search-suggestions-dialog-header', `security-tab',
           `server-icon', `shield-check-icon',
           `site-details-dialog',
           `snippet-clipboard-copy-button',
           `snippet-clipboard-copy-button-unpositioned',
           `solutions-by-industry-heading',
           `solutions-by-size-heading',
           `solutions-by-use-case-heading', `sr-footer-heading',
           `start-of-content', `team-icon',
           `tooltip-13d30f02-54ff-44f7-b0d1-44858fc5344b',
           `tooltip-2b2ffe95-b3e2-45ad-9122-24eece381d73',
           `tooltip-914aa1d4-f862-4210-a555-6704bed8eafa',
           `trash-icon',
           `validation-7e386ae7-8c20-452a-908c-539cefdab6fa',
           `workflow-icon'.
Result     Valid: 200 OK
```
https://github.com/microsoft/LightGBM/actions/workflows/linkchecker.yml
and make Link checks badge green.

I guess GitHub creates anchors in md-docs via some js script and sometimes it cannot generate anchor in time that `linkchecker` waits for.