### PR TITLE
[ci] modify CodeQL settings

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -13,6 +13,8 @@ variables:
   PYTHON_VERSION: '3.12'
   runCodesignValidationInjection: false
   skipComponentGovernanceDetection: true
+  Codeql.Enabled: false
+  Codeql.SkipTaskAutoInjection: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   SKBUILD_STRICT_CONFIG: true


### PR DESCRIPTION
For the last few days, we've observed 2 CI issues which happen on every build triggered by a merge to `master`... but which do not happen on PRs.

* #6543
* #6544

Comparing logs between those types of builds, I found only 1 seemingly-significant difference between them... on builds triggered by merges to `master`, tasks called `Initialize CodeQL` and `Finalize CodeQL` are automatically injected.

This proposes trying to prevent those tasks from being injected. If we do that and see a few builds on `master` succeed, we'll be able to say with confidence that the CodeQL jobs were the issue.

More context on how these jobs might cause the CI failures we've observed https://github.com/microsoft/LightGBM/issues/6544#issuecomment-2241487432

## Notes for Reviewers

### Docs on where this comes from or how to turn it off?

I couldn't really find any. "Configure GitHub Advanced Security for Azure DevOps" ([Azure DevOps docs](https://learn.microsoft.com/en-us/azure/devops/repos/security/configure-github-advanced-security-features?view=azure-devops&tabs=yaml)) describes how to **enable** this scanning, but does not talk about auto-injection.

The variables I'm proposing adding to `.vsts-ci.yml` were found in other large projects' configs:

* `dotnet/roslyn` ([link](https://github.com/dotnet/roslyn/blob/49963240f932ccff51b5696b4c33c5a0d94819e6/azure-pipelines-compliance.yml#L26C11-L26C25))
* `dotnet/sourcelink` ([link](https://github.com/dotnet/sourcelink/blob/669979bf371a587c908f732499df0ed883cd5d6c/azure-pipelines-codeql.yml#L14-L15))
* `interpretml/interpret` ([link](https://github.com/interpretml/interpret/commit/adbeaa9eb3adb76553fa06f2c6a664fd0be62b50))
* `Microsoft/STL` ([link](https://github.com/microsoft/STL/blob/6c320794241d2ddfb79a729c57fa347c47a9d77c/azure-devops/config.yml#L25-L26))
* `posit-dev/positron` ([link](https://github.com/posit-dev/positron/blob/9dfa34e1eb5a42ebbd1c1d17b55bef7e7bf0bf1f/build/azure-pipelines/product-build.yml#L151-L152))

I'm not sure how those projects learned about them... I haven't yet found any documentation referencing them.

This is not the first time we've had to do something like this ... @StrikerRUS I remembered you something very similar back in November 2022: #5175.

### How to test this

The only way to test this is to merge to `master`, as this behavior is only observable there.