### PR TITLE
[ci] Add dependabot configuration for updating git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,11 @@ updates:
       prefix: "[ci]"
     labels:
       - maintenance
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "[c++]"
+    labels:
+      - maintenance


### PR DESCRIPTION
Implementation of [this comment](https://github.com/microsoft/LightGBM/issues/3763#issuecomment-2241755186).

In contrast to CI updates, I refrained from grouping together updates of git submodules to isolate potential issues to individual dependencies. If this creates too many PRs, we can, of course, change this behavior at a later point.