### PR TITLE
[ci] Remove gcc tests on MacOS

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -11,16 +11,9 @@ ARCH=$(uname -m)
 
 
 if [[ $OS_NAME == "macos" ]]; then
-    if  [[ $COMPILER == "clang" ]]; then
-        brew install libomp
-        if [[ $AZURE == "true" ]]; then
-            sudo xcode-select -s /Applications/Xcode_13.1.0.app/Contents/Developer || exit 1
-        fi
-    else  # gcc
-        # Check https://github.com/actions/runner-images/tree/main/images/macos for available
-        # versions of Xcode
-        sudo xcode-select -s /Applications/Xcode_14.3.1.app/Contents/Developer || exit 1
-        brew install gcc
+    brew install libomp
+    if [[ $AZURE == "true" ]]; then
+        sudo xcode-select -s /Applications/Xcode_13.1.0.app/Contents/Developer || exit 1
     fi
     if [[ $TASK == "mpi" ]]; then
         brew install open-mpi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -13,10 +13,7 @@ ARCH=$(uname -m)
 
 LGB_VER=$(head -n 1 "${BUILD_DIRECTORY}/VERSION.txt")
 
-if [[ $OS_NAME == "macos" ]] && [[ $COMPILER == "gcc" ]]; then
-    export CXX=g++-11
-    export CC=gcc-11
-elif [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "clang" ]]; then
+if [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "clang" ]]; then
     export CXX=clang++
     export CC=clang
 elif [[ $OS_NAME == "linux" ]] && [[ $COMPILER == "clang-17" ]]; then

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -42,20 +42,18 @@ jobs:
             task: bdist
             method: wheel
             python_version: '3.10'
-          # We're currently skipping MPI jobs on macOS, see https://github.com/microsoft/LightGBM/pull/6425
-          # for further details.
-          # - os: macos-13
-          #   task: mpi
-          #   method: source
-          #   python_version: '3.11'
-          # - os: macos-13
-          #   task: mpi
-          #   method: pip
-          #   python_version: '3.12'
-          # - os: macos-13
-          #   task: mpi
-          #   method: wheel
-          #   python_version: '3.9'
+          - os: macos-13
+            task: mpi
+            method: source
+            python_version: '3.11'
+          - os: macos-13
+            task: mpi
+            method: pip
+            python_version: '3.12'
+          - os: macos-13
+            task: mpi
+            method: wheel
+            python_version: '3.9'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -68,17 +66,8 @@ jobs:
           export TASK="${{ matrix.task }}"
           export METHOD="${{ matrix.method }}"
           export PYTHON_VERSION="${{ matrix.python_version }}"
-          if [[ "${{ matrix.os }}" == "macos-14" ]]; then
-              # use clang when creating macOS release artifacts
-              export COMPILER="clang"
-              export OS_NAME="macos"
-          elif [[ "${{ matrix.os }}" == "macos-13" ]]; then
-              export COMPILER="gcc"
-              export OS_NAME="macos"
-          elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-              export COMPILER="clang"
-              export OS_NAME="linux"
-          fi
+          export COMPILER="clang"
+          export OS_NAME="macos"
           export BUILD_DIRECTORY="$GITHUB_WORKSPACE"
           export CONDA=${HOME}/miniforge
           export PATH=${CONDA}/bin:${PATH}

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -68,12 +68,6 @@ jobs:
             container: 'ubuntu:22.04'
           - os: macos-13
             task: r-package
-            compiler: gcc
-            r_version: 4.3
-            build_type: cmake
-            container: null
-          - os: macos-13
-            task: r-package
             compiler: clang
             r_version: 4.3
             build_type: cmake


### PR DESCRIPTION
For some time, I've been thinking about simplifying the toolchain setup in this repository by leveraging more of the `conda` ecosystem. While working on this, I realized that `gcc` is not available on `conda-forge` for MacOS. I briefly talked to @xhochy about this earlier and he mentioned that it is very uncommon for `gcc` to be used for compilation on MacOS.

As a result, I'd propose to get rid of `gcc` compilation on MacOS in the CI. This opens the avenue for using the `conda` ecosystem to manage all dependencies required for compilation. While it is obviously _possible_ to compile LightGBM using `gcc` on MacOS, I don't think it is necessary to officially support it.

---

As a side-effect, this PR also re-enables the MPI jobs on MacOS.