### PR TITLE
[ci] fix MSVC warning about builds in temp directory

### DIFF
--- a/.ci/test_r_package_windows.ps1
+++ b/.ci/test_r_package_windows.ps1
@@ -195,7 +195,6 @@ if ($env:COMPILER -ne "MSVC") {
   }
 
 } else {
-  $env:TMPDIR = $env:USERPROFILE  # to avoid warnings about incremental builds inside a temp directory
   $INSTALL_LOG_FILE_NAME = "$env:BUILD_SOURCESDIRECTORY\00install_out.txt"
   Run-R-Code-Redirect-Stderr "source('build_r.R')" 1> $INSTALL_LOG_FILE_NAME ; $install_succeeded = $?
   Write-Output "----- build and install logs -----"

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -8,6 +8,11 @@ function Check-Output {
 
 $env:CONDA_ENV = "test-env"
 $env:LGB_VER = (Get-Content $env:BUILD_SOURCESDIRECTORY\VERSION.txt).trim()
+# Use home directory as temp directory
+# to avoid
+# > warning MSB8029: The Intermediate directory or Output directory cannot reside under the Temporary directory
+# > as it could lead to issues with incremental build.
+$env:TMPDIR = $env:USERPROFILE
 
 if ($env:TASK -eq "r-package") {
   & .\.ci\test_r_package_windows.ps1 ; Check-Output $?

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -12,7 +12,7 @@ $env:LGB_VER = (Get-Content $env:BUILD_SOURCESDIRECTORY\VERSION.txt).trim()
 # > warning MSB8029: The Intermediate directory or Output directory cannot reside under the Temporary directory
 # > as it could lead to issues with incremental build.
 # And make sure this directory is always clean
-$env:TMPDIR = $env:USERPROFILE\tmp
+$env:TMPDIR = "$env:USERPROFILE\tmp"
 Remove-Item $env:TMPDIR -Force -Recurse -ErrorAction Ignore
 [Void][System.IO.Directory]::CreateDirectory($env:TMPDIR)
 

--- a/.ci/test_windows.ps1
+++ b/.ci/test_windows.ps1
@@ -8,11 +8,13 @@ function Check-Output {
 
 $env:CONDA_ENV = "test-env"
 $env:LGB_VER = (Get-Content $env:BUILD_SOURCESDIRECTORY\VERSION.txt).trim()
-# Use home directory as temp directory
-# to avoid
+# Use custom temp directory to avoid
 # > warning MSB8029: The Intermediate directory or Output directory cannot reside under the Temporary directory
 # > as it could lead to issues with incremental build.
-$env:TMPDIR = $env:USERPROFILE
+# And make sure this directory is always clean
+$env:TMPDIR = $env:USERPROFILE\tmp
+Remove-Item $env:TMPDIR -Force -Recurse -ErrorAction Ignore
+[Void][System.IO.Directory]::CreateDirectory($env:TMPDIR)
 
 if ($env:TASK -eq "r-package") {
   & .\.ci\test_r_package_windows.ps1 ; Check-Output $?


### PR DESCRIPTION
Currently this fix is applied only to R-package builds.
This PR proposes adding this fix to all Windows builds.

```
C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\Microsoft.CppBuild.targets(400,5): warning MSB8029: The Intermediate directory or Output directory cannot reside under the Temporary directory as it could lead to issues with incremental build.
```
https://ci.appveyor.com/project/guolinke/lightgbm/builds/50283647/job/bo2wb8ejurn0b0k6#L798