### PR TITLE
[R-package] [docs] update cran-comments for v4.5.0 release

### DIFF
--- a/R-package/cran-comments.md
+++ b/R-package/cran-comments.md
@@ -4,7 +4,7 @@
 
 ### CRAN response
 
-TBD
+Accepted to CRAN
 
 ### Maintainer Notes
 


### PR DESCRIPTION
v4.5.0 has been accepted to CRAN and is passing almost all checks (one has not been run yet). 

<img width="626" alt="image" src="https://github.com/user-attachments/assets/fd99f99a-d19a-4e30-ab9a-9eff5325c3e6">

ref: https://cran.r-project.org/web/checks/check_results_lightgbm.html

This proposes updating `cran-comments.md` to indicate that this release was accepted to CRAN.