### PR TITLE
[ci] restore nuget artifact creation

### DIFF
--- a/.ci/create-nuget.py
+++ b/.ci/create-nuget.py
@@ -8,20 +8,20 @@ from shutil import copyfile
 
 if __name__ == "__main__":
     source = Path(sys.argv[1])
-    current_dir = Path(__file__).absolute().parent
-    linux_folder_path = current_dir / "runtimes" / "linux-x64" / "native"
+    nuget_dir = Path(__file__).absolute().parent / "nuget"
+    linux_folder_path = nuget_dir / "runtimes" / "linux-x64" / "native"
     linux_folder_path.mkdir(parents=True, exist_ok=True)
-    osx_folder_path = current_dir / "runtimes" / "osx-x64" / "native"
+    osx_folder_path = nuget_dir / "runtimes" / "osx-x64" / "native"
     osx_folder_path.mkdir(parents=True, exist_ok=True)
-    windows_folder_path = current_dir / "runtimes" / "win-x64" / "native"
+    windows_folder_path = nuget_dir / "runtimes" / "win-x64" / "native"
     windows_folder_path.mkdir(parents=True, exist_ok=True)
-    build_folder_path = current_dir / "build"
+    build_folder_path = nuget_dir / "build"
     build_folder_path.mkdir(parents=True, exist_ok=True)
     copyfile(source / "lib_lightgbm.so", linux_folder_path / "lib_lightgbm.so")
     copyfile(source / "lib_lightgbm.dylib", osx_folder_path / "lib_lightgbm.dylib")
     copyfile(source / "lib_lightgbm.dll", windows_folder_path / "lib_lightgbm.dll")
     copyfile(source / "lightgbm.exe", windows_folder_path / "lightgbm.exe")
-    version = (current_dir.parent / "VERSION.txt").read_text(encoding="utf-8").strip().replace("rc", "-rc")
+    version = (nuget_dir.parents[1] / "VERSION.txt").read_text(encoding="utf-8").strip().replace("rc", "-rc")
     nuget_str = rf"""<?xml version="1.0"?>
     <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
     <metadata>
@@ -76,6 +76,6 @@ if __name__ == "__main__":
     </Target>
     </Project>
     """
-    (current_dir / "LightGBM.nuspec").write_text(nuget_str, encoding="utf-8")
-    (current_dir / "build" / "LightGBM.props").write_text(prop_str, encoding="utf-8")
-    (current_dir / "build" / "LightGBM.targets").write_text(target_str, encoding="utf-8")
+    (nuget_dir / "LightGBM.nuspec").write_text(nuget_str, encoding="utf-8")
+    (nuget_dir / "build" / "LightGBM.props").write_text(prop_str, encoding="utf-8")
+    (nuget_dir / "build" / "LightGBM.targets").write_text(target_str, encoding="utf-8")

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -424,7 +424,7 @@ jobs:
   - task: NuGetCommand@2
     inputs:
       command: pack
-      packagesToPack: '$(Build.SourcesDirectory)/.nuget/*.nuspec'
+      packagesToPack: '$(Build.SourcesDirectory)/.ci/nuget/*.nuspec'
       packDestination: '$(Build.ArtifactStagingDirectory)/nuget'
   - task: PublishBuildArtifacts@1
     inputs:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - master
+    - ci/nuget
   tags:
     include:
     - v*

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - master
-    - ci/nuget
   tags:
     include:
     - v*


### PR DESCRIPTION
I'm sorry, I somehow overlooked one `nuget` occurrence in #6581. It resulted in empty NuGet artifact.

`NuGetCommand` job before #6581:

```
Starting: NuGetCommand
==============================================================================
Task         : NuGet
Description  : Restore, pack, or push NuGet packages, or run a NuGet command. Supports NuGet.org and authenticated feeds like Azure Artifacts and MyGet. Uses NuGet.exe and works with .NET Framework apps. For .NET Core and .NET Standard apps, use the .NET Core task.
Version      : 2.238.1
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget
==============================================================================
Caching tool: NuGet 4.9.6 x64
Found tool in cache: NuGet 4.9.6 x64
Resolved from tool cache: 4.9.6
Using version: 4.9.6
Found tool in cache: NuGet 4.9.6 x64
Attempting to pack file: /home/vsts/work/1/s/.nuget/LightGBM.nuspec
/usr/bin/mono /opt/hostedtoolcache/NuGet/4.9.6/x64/nuget.exe pack /home/vsts/work/1/s/.nuget/LightGBM.nuspec -NonInteractive -OutputDirectory /home/vsts/work/1/a/nuget -Verbosity Detailed
NuGet Version: 4.9.6.8
Attempting to build package from 'LightGBM.nuspec'.

Id: LightGBM
Version: 4.5.0.99
Authors: Guolin Ke
Description: A fast, distributed, high performance gradient boosting framework
Project Url: https://github.com/microsoft/LightGBM
Tags: machine-learning, data-mining, distributed, native, boosting, gbdt
Dependencies: None

Added file '[Content_Types].xml'.
Added file '_rels/.rels'.
Added file 'build/LightGBM.props'.
Added file 'build/LightGBM.targets'.
Added file 'LightGBM.nuspec'.
Added file 'package/services/metadata/core-properties/6705225962884ae1870f68bca0710dbc.psmdcp'.
Added file 'runtimes/linux-x64/native/lib_lightgbm.so'.
Added file 'runtimes/osx-x64/native/lib_lightgbm.dylib'.
Added file 'runtimes/win-x64/native/lib_lightgbm.dll'.
Added file 'runtimes/win-x64/native/lightgbm.exe'.

Successfully created package '/home/vsts/work/1/a/nuget/LightGBM.4.5.0.99.nupkg'.
Finishing: NuGetCommand
```
https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=16754&view=logs&j=1d2f55de-c984-5e06-0d18-75388f298a89&t=307511b8-9d21-5cb4-f937-677cd350b1b1&l=1

---

`NuGetCommand` job after #6581:

```
Starting: NuGetCommand
==============================================================================
Task         : NuGet
Description  : Restore, pack, or push NuGet packages, or run a NuGet command. Supports NuGet.org and authenticated feeds like Azure Artifacts and MyGet. Uses NuGet.exe and works with .NET Framework apps. For .NET Core and .NET Standard apps, use the .NET Core task.
Version      : 2.238.1
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget
==============================================================================
Caching tool: NuGet 4.9.6 x64
Found tool in cache: NuGet 4.9.6 x64
Resolved from tool cache: 4.9.6
Using version: 4.9.6
Found tool in cache: NuGet 4.9.6 x64
Finishing: NuGetCommand
```
https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=16797&view=logs&j=1d2f55de-c984-5e06-0d18-75388f298a89&t=307511b8-9d21-5cb4-f937-677cd350b1b1&l=1

---

`NuGetCommand` job with this PR:
```
Starting: NuGetCommand
==============================================================================
Task         : NuGet
Description  : Restore, pack, or push NuGet packages, or run a NuGet command. Supports NuGet.org and authenticated feeds like Azure Artifacts and MyGet. Uses NuGet.exe and works with .NET Framework apps. For .NET Core and .NET Standard apps, use the .NET Core task.
Version      : 2.238.1
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget
==============================================================================
Caching tool: NuGet 4.9.6 x64
Found tool in cache: NuGet 4.9.6 x64
Resolved from tool cache: 4.9.6
Using version: 4.9.6
Found tool in cache: NuGet 4.9.6 x64
Attempting to pack file: /home/vsts/work/1/s/.ci/nuget/LightGBM.nuspec
/usr/bin/mono /opt/hostedtoolcache/NuGet/4.9.6/x64/nuget.exe pack /home/vsts/work/1/s/.ci/nuget/LightGBM.nuspec -NonInteractive -OutputDirectory /home/vsts/work/1/a/nuget -Verbosity Detailed
NuGet Version: 4.9.6.8
Attempting to build package from 'LightGBM.nuspec'.

Id: LightGBM
Version: 4.5.0.99
Authors: Guolin Ke
Description: A fast, distributed, high performance gradient boosting framework
Project Url: https://github.com/microsoft/LightGBM
Tags: machine-learning, data-mining, distributed, native, boosting, gbdt
Dependencies: None

Added file '[Content_Types].xml'.
Added file '_rels/.rels'.
Added file 'build/LightGBM.props'.
Added file 'build/LightGBM.targets'.
Added file 'LightGBM.nuspec'.
Added file 'package/services/metadata/core-properties/12afcaf97a564b56a37d0104795543c9.psmdcp'.
Added file 'runtimes/linux-x64/native/lib_lightgbm.so'.
Added file 'runtimes/osx-x64/native/lib_lightgbm.dylib'.
Added file 'runtimes/win-x64/native/lib_lightgbm.dll'.
Added file 'runtimes/win-x64/native/lightgbm.exe'.

Successfully created package '/home/vsts/work/1/a/nuget/LightGBM.4.5.0.99.nupkg'.
Finishing: NuGetCommand
```
https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=16825&view=logs&j=1d2f55de-c984-5e06-0d18-75388f298a89&t=307511b8-9d21-5cb4-f937-677cd350b1b1&l=1