### PR TITLE
[python-package] update to scikit-build-core 0.10

### DIFF
--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -57,21 +57,21 @@ changelog = "https://github.com/microsoft/LightGBM/releases"
 # start:build-system
 [build-system]
 
-requires = ["scikit-build-core>=0.9.3"]
+requires = ["scikit-build-core>=0.10.1"]
 build-backend = "scikit_build_core.build"
 
 # based on https://github.com/scikit-build/scikit-build-core#configuration
 [tool.scikit-build]
 
-cmake.version = ">=3.28"
+cmake.version = "CMakeLists.txt"
 ninja.version = ">=1.11"
 ninja.make-fallback = true
 cmake.args = [
     "-D__BUILD_FOR_PYTHON:BOOL=ON"
 ]
-cmake.verbose = false
+build.verbose = false
 cmake.build-type = "Release"
-cmake.targets = ["_lightgbm"]
+build.targets = ["_lightgbm"]
 # stripping binaries should be turned back on once this is fixed:
 # https://github.com/jameslamb/pydistcheck/issues/235
 install.strip = false
@@ -80,7 +80,7 @@ sdist.reproducible = true
 wheel.py-api = "py3"
 experimental = false
 strict-config = false
-minimum-version = "0.9.3"
+minimum-version = "build-system.requires"
 
 # end:build-system
 


### PR DESCRIPTION
There is a new `sckit-build-core` minor version with lots of nice improvements. This proposes updating to it here in LightGBM.

See https://iscinumpy.dev/post/scikit-build-core-0-10/ for details.