### PR TITLE
[ci] update some linting versions

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -97,12 +97,12 @@ fi
 if [[ $TASK == "lint" ]]; then
     mamba create -q -y -n $CONDA_ENV \
         ${CONDA_PYTHON_REQUIREMENT} \
-        'cmakelint>=1.4.2' \
-        'cpplint>=1.6.0' \
-        'matplotlib-base>=3.8.3' \
-        'mypy>=1.8.0' \
-        'pre-commit>=3.6.0' \
-        'pyarrow>=6.0' \
+        'cmakelint>=1.4.3' \
+        'cpplint>=1.6.1' \
+        'matplotlib-base>=3.9.1' \
+        'mypy>=1.11.1' \
+        'pre-commit>=3.8.0' \
+        'pyarrow-core>=17.0' \
         'r-lintr>=3.1.2'
     source activate $CONDA_ENV
     echo "Linting Python code"
@@ -124,7 +124,7 @@ if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
         -y \
         -n $CONDA_ENV \
             'doxygen>=1.10.0' \
-            'rstcheck>=6.2.0' || exit 1
+            'rstcheck>=6.2.4' || exit 1
     source activate $CONDA_ENV
     # check reStructuredText formatting
     cd "${BUILD_DIRECTORY}/python-package"

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -98,7 +98,7 @@ if [[ $TASK == "lint" ]]; then
     mamba create -q -y -n $CONDA_ENV \
         ${CONDA_PYTHON_REQUIREMENT} \
         'cmakelint>=1.4.3' \
-        'cpplint>=1.6.1' \
+        'cpplint>=1.6.0' \
         'matplotlib-base>=3.9.1' \
         'mypy>=1.11.1' \
         'pre-commit>=3.8.0' \

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -17,13 +17,14 @@ concurrency:
 
 env:
   COMPILER: 'gcc'
+  MAKEFLAGS: '-j4'
   OS_NAME: 'linux'
   PYTHON_VERSION: '3.12'
 
 jobs:
   test:
     name: ${{ matrix.task }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         args: ["--settings-path", "python-package/pyproject.toml"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.7
+    rev: v0.5.7
     hooks:
       # Run the linter.
       - id: ruff

--- a/tests/python_package_test/test_sklearn.py
+++ b/tests/python_package_test/test_sklearn.py
@@ -53,7 +53,7 @@ def _create_data(task, n_samples=100, n_features=4):
         elif task == "multiclass-classification":
             centers = 3
         else:
-            ValueError(f"Unknown classification task '{task}'")
+            raise ValueError(f"Unknown classification task '{task}'")
         X, y = make_blobs(n_samples=n_samples, n_features=n_features, centers=centers, random_state=42)
         g = None
     elif task == "regression":


### PR DESCRIPTION
Contributes to #3763.

Updates some linting versions.

* newest versions of all `conda install`'d stuff for the `lint` and `check-docs` tests
* newest `pre-commit` hook versions from `pre-commit autoupdate`

Happy to say the newest version of `ruff` caught a bug... a Python test that could accidentally not raise an exception because of a missing `raise` statement! This fixes that as well.