### PR TITLE
[cmake] fixes static build for macos with OpenMP enabled (fixes #6601)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -752,7 +752,7 @@ endif()
 #
 # This reduces the risk of runtime issues resulting from multiple {libgomp,libiomp,libomp}.dylib being loaded.
 #
-if(APPLE AND USE_OPENMP)
+if(APPLE AND USE_OPENMP AND NOT BUILD_STATIC_LIB)
   # store path to {libgomp,libiomp,libomp}.dylib found at build time in a variable
   get_target_property(
     OpenMP_LIBRARY_LOCATION
@@ -794,23 +794,21 @@ if(APPLE AND USE_OPENMP)
     )
   endif()
 
-  if(NOT BUILD_STATIC_LIB)
-    # Override the absolute path to OpenMP with a relative one using @rpath.
-    #
-    # This also ensures that if a {libgomp,libiomp,libomp}.dylib has already been loaded, it'll just use that.
-    add_custom_command(
-      TARGET _lightgbm
-      POST_BUILD
-        COMMAND
-          install_name_tool
-          -change
-          ${OpenMP_LIBRARY_LOCATION}
-          "@rpath/${OpenMP_LIBRARY_NAME}"
-          "${__LIB_LIGHTGBM_FILENAME}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMENT "Replacing hard-coded OpenMP install_name with '@rpath/${OpenMP_LIBRARY_NAME}'..."
-    )
-  endif()
+  # Override the absolute path to OpenMP with a relative one using @rpath.
+  #
+  # This also ensures that if a {libgomp,libiomp,libomp}.dylib has already been loaded, it'll just use that.
+  add_custom_command(
+    TARGET _lightgbm
+    POST_BUILD
+      COMMAND
+        install_name_tool
+        -change
+        ${OpenMP_LIBRARY_LOCATION}
+        "@rpath/${OpenMP_LIBRARY_NAME}"
+        "${__LIB_LIGHTGBM_FILENAME}"
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      COMMENT "Replacing hard-coded OpenMP install_name with '@rpath/${OpenMP_LIBRARY_NAME}'..."
+  )
   # add RPATH entries to ensure the loader looks in the following, in the following order:
   #
   #   - ${OpenMP_LIBRARY_DIR}        (wherever find_package(OpenMP) found OpenMP at build time)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -794,21 +794,23 @@ if(APPLE AND USE_OPENMP)
     )
   endif()
 
-  # Override the absolute path to OpenMP with a relative one using @rpath.
-  #
-  # This also ensures that if a {libgomp,libiomp,libomp}.dylib has already been loaded, it'll just use that.
-  add_custom_command(
-    TARGET _lightgbm
-    POST_BUILD
-      COMMAND
-        install_name_tool
-        -change
-        ${OpenMP_LIBRARY_LOCATION}
-        "@rpath/${OpenMP_LIBRARY_NAME}"
-        "${__LIB_LIGHTGBM_FILENAME}"
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      COMMENT "Replacing hard-coded OpenMP install_name with '@rpath/${OpenMP_LIBRARY_NAME}'..."
-  )
+  if(NOT BUILD_STATIC_LIB)
+    # Override the absolute path to OpenMP with a relative one using @rpath.
+    #
+    # This also ensures that if a {libgomp,libiomp,libomp}.dylib has already been loaded, it'll just use that.
+    add_custom_command(
+      TARGET _lightgbm
+      POST_BUILD
+        COMMAND
+          install_name_tool
+          -change
+          ${OpenMP_LIBRARY_LOCATION}
+          "@rpath/${OpenMP_LIBRARY_NAME}"
+          "${__LIB_LIGHTGBM_FILENAME}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Replacing hard-coded OpenMP install_name with '@rpath/${OpenMP_LIBRARY_NAME}'..."
+    )
+  endif()
   # add RPATH entries to ensure the loader looks in the following, in the following order:
   #
   #   - ${OpenMP_LIBRARY_DIR}        (wherever find_package(OpenMP) found OpenMP at build time)


### PR DESCRIPTION
Fixes #6601 with `-DBUILD_STATIC_LIB=ON` on macos with `USE_OPENMP` enabled
