### PR TITLE
[ci] skip R-devel clang16 job

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -268,7 +268,9 @@ jobs:
         #   * CRAN "additional checks": https://cran.r-project.org/web/checks/check_issue_kinds.html
         #   * images: https://r-hub.github.io/containers/containers.html
         image:
-          - clang16
+          # clang16 should be re-enabled once it's fixed upstream
+          # ref: https://github.com/microsoft/LightGBM/issues/6607
+          #- clang16
           - clang17
           - clang18
           - clang19


### PR DESCRIPTION
See #6607.

I'm proposing skipping this job for now, to unblock CI here. It's failing for non-LightGBM reasons.

If we check again in a week or 2 and it's still broken, we should open an issue in https://github.com/r-hub/containers