### PR TITLE
[R-package] only warn about early stopping and DART boosting being incompatible if early stopping was requested

### DIFF
--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -295,7 +295,7 @@ lgb.cv <- function(params = list()
 
   # Cannot use early stopping with 'dart' boosting
   if (using_dart) {
-    if (using_early_stopping){
+    if (using_early_stopping) {
       warning("Early stopping is not available in 'dart' mode.")
     }
     using_early_stopping <- FALSE

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -295,7 +295,9 @@ lgb.cv <- function(params = list()
 
   # Cannot use early stopping with 'dart' boosting
   if (using_dart) {
-    warning("Early stopping is not available in 'dart' mode.")
+    if (using_early_stopping)
+      warning("Early stopping is not available in 'dart' mode.")
+
     using_early_stopping <- FALSE
 
     # Remove the cb_early_stop() function if it was passed in to callbacks

--- a/R-package/R/lgb.cv.R
+++ b/R-package/R/lgb.cv.R
@@ -295,9 +295,9 @@ lgb.cv <- function(params = list()
 
   # Cannot use early stopping with 'dart' boosting
   if (using_dart) {
-    if (using_early_stopping)
+    if (using_early_stopping){
       warning("Early stopping is not available in 'dart' mode.")
-
+    }
     using_early_stopping <- FALSE
 
     # Remove the cb_early_stop() function if it was passed in to callbacks

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -258,9 +258,9 @@ lgb.train <- function(params = list(),
 
   # Cannot use early stopping with 'dart' boosting
   if (using_dart) {
-    if (using_early_stopping)
+    if (using_early_stopping) {
       warning("Early stopping is not available in 'dart' mode.")
-
+    }
     using_early_stopping <- FALSE
 
     # Remove the cb_early_stop() function if it was passed in to callbacks

--- a/R-package/R/lgb.train.R
+++ b/R-package/R/lgb.train.R
@@ -258,7 +258,9 @@ lgb.train <- function(params = list(),
 
   # Cannot use early stopping with 'dart' boosting
   if (using_dart) {
-    warning("Early stopping is not available in 'dart' mode.")
+    if (using_early_stopping)
+      warning("Early stopping is not available in 'dart' mode.")
+
     using_early_stopping <- FALSE
 
     # Remove the cb_early_stop() function if it was passed in to callbacks

--- a/R-package/tests/testthat/test_parameters.R
+++ b/R-package/tests/testthat/test_parameters.R
@@ -91,7 +91,7 @@ test_that(".PARAMETER_ALIASES() uses the internal session cache", {
   expect_false(exists(cache_key, where = .lgb_session_cache_env))
 })
 
-test_that("lightgbm should warn if you use 'dart' boosting with early stopping, specified with 'boosting' or aliases", {
+test_that("training should warn if you use 'dart' boosting with early stopping", {
   for (boosting_param in .PARAMETER_ALIASES()[["boosting"]]) {
     params <- list(
         num_leaves = 5L
@@ -108,8 +108,8 @@ test_that("lightgbm should warn if you use 'dart' boosting with early stopping, 
         data = train$data
         , label = train$label
         , params = params
-        , nrounds = 5L
-        , verbose = -1L
+        , nrounds = 2L
+        , verbose = .LGB_VERBOSITY
         , early_stopping_rounds = 1L
       )
     }, regexp = "Early stopping is not available in 'dart' mode")
@@ -120,50 +120,50 @@ test_that("lightgbm should warn if you use 'dart' boosting with early stopping, 
         data = train$data
         , label = train$label
         , params = params
-        , nrounds = 5L
-        , verbose = -1L
+        , nrounds = 2L
+        , verbose = .LGB_VERBOSITY
         , early_stopping_rounds = NULL
       )
     })
   }
 })
 
-test_that(
-  "lgb.cv should warn if you use 'dart' boosting with early stopping, specified with 'boosting' or aliases", {
-    for (boosting_param in .PARAMETER_ALIASES()[["boosting"]]) {
-      params <- list(
-        num_leaves = 5L
-        , objective = "binary"
-        , metric = "binary_error"
-        , num_threads = .LGB_MAX_THREADS
-      )
-      params[[boosting_param]] <- "dart"
+test_that("lgb.cv() should warn if you use 'dart' boosting with early stopping", {
+  for (boosting_param in .PARAMETER_ALIASES()[["boosting"]]) {
+    params <- list(
+      num_leaves = 5L
+      , objective = "binary"
+      , metric = "binary_error"
+      , num_threads = .LGB_MAX_THREADS
+    )
+    params[[boosting_param]] <- "dart"
 
-      # warning: early stopping requested
-      expect_warning({
-        result <- lgb.cv(
-          data = lgb.Dataset(
-            data  = train$data
-            , label = train$label
-          )
-          , params = params
-          , nrounds = 5L
-          , verbose = -1L
-          , early_stopping_rounds = 1L)
-        }, regexp = "Early stopping is not available in 'dart' mode")
-
-      # no warning: early stopping not requested
-      expect_silent({
-        result <- lgb.cv(
-          data = lgb.Dataset(
-            data  = train$data
-            , label = train$label
-          )
-          , params = params
-          , nrounds = 5L
-          , verbose = -1L
-          , early_stopping_rounds = NULL
+    # warning: early stopping requested
+    expect_warning({
+      result <- lgb.cv(
+        data = lgb.Dataset(
+          data  = train$data
+          , label = train$label
         )
-      })
-    }
-  })
+        , params = params
+        , nrounds = 2L
+        , verbose = .LGB_VERBOSITY
+        , early_stopping_rounds = 1L
+      )
+    }, regexp = "Early stopping is not available in 'dart' mode")
+
+    # no warning: early stopping not requested
+    expect_silent({
+      result <- lgb.cv(
+        data = lgb.Dataset(
+          data  = train$data
+          , label = train$label
+        )
+        , params = params
+        , nrounds = 2L
+        , verbose = .LGB_VERBOSITY
+        , early_stopping_rounds = NULL
+      )
+    })
+  }
+})

--- a/R-package/tests/testthat/test_parameters.R
+++ b/R-package/tests/testthat/test_parameters.R
@@ -115,7 +115,7 @@ test_that("training should warn if you use 'dart' boosting and requesting early 
     }, regexp = "Early stopping is not available in 'dart' mode")
 
     # no warning: early stopping not requested
-    expect_no_warning({
+    expect_silent({
       result <- lightgbm(
         data = train$data
         , label = train$label
@@ -124,14 +124,12 @@ test_that("training should warn if you use 'dart' boosting and requesting early 
         , verbose = -1L
         , early_stopping_rounds = NULL
       )
-    }
-    )
+    })
   }
 })
 
 test_that(
-  desc = "lgb.cv() should only warn if you use 'dart' boosting, specified with 'boosting' or aliases",
-  code = {
+  "lgb.cv() should only warn if you use 'dart' boosting, specified with 'boosting' or aliases",{
     for (boosting_param in .PARAMETER_ALIASES()[["boosting"]]) {
       params <- list(
         num_leaves = 5L
@@ -151,23 +149,21 @@ test_that(
           , params = params
           , nrounds = 5L
           , verbose = -1L
-          , early_stopping_rounds = 1L
-        )
-      }, regexp = "Early stopping is not available in 'dart' mode")
+          , early_stopping_rounds = 1L)
+        }, regexp = "Early stopping is not available in 'dart' mode")
 
       # no warning: early stopping not requested
-      expect_no_warning({
+      expect_silent({
         result <- lgb.cv(
           data = lgb.Dataset(
             data  = train$data
             , label = train$label
           )
           , params = params
-          , nrounds = 5L,
+          , nrounds = 5L
           , verbose = -1L
           , early_stopping_rounds = NULL
         )
       })
     }
-  }
-)
+  })

--- a/R-package/tests/testthat/test_parameters.R
+++ b/R-package/tests/testthat/test_parameters.R
@@ -91,7 +91,7 @@ test_that(".PARAMETER_ALIASES() uses the internal session cache", {
   expect_false(exists(cache_key, where = .lgb_session_cache_env))
 })
 
-test_that("training should only warn if you use 'dart' boosting, specified with 'boosting' or aliases", {
+test_that("training should warn if you use 'dart' boosting and requesting early stopping, specified with 'boosting' or aliases", {
   for (boosting_param in .PARAMETER_ALIASES()[["boosting"]]) {
     params <- list(
         num_leaves = 5L
@@ -102,8 +102,7 @@ test_that("training should only warn if you use 'dart' boosting, specified with 
     )
     params[[boosting_param]] <- "dart"
 
-    # expect warning
-    # if early_stopping_rounds is specified
+    # warning: early stopping requested
     expect_warning({
       result <- lightgbm(
         data = train$data
@@ -115,10 +114,7 @@ test_that("training should only warn if you use 'dart' boosting, specified with 
       )
     }, regexp = "Early stopping is not available in 'dart' mode")
 
-    # expect no warning
-    # if early_stopping_rounds is not
-    # specified see:
-    # https://github.com/microsoft/LightGBM/issues/6612
+    # no warning: early stopping not requested
     expect_no_warning({
       result <- lightgbm(
         data = train$data
@@ -139,20 +135,18 @@ test_that(
     for (boosting_param in .PARAMETER_ALIASES()[["boosting"]]) {
       params <- list(
         num_leaves = 5L
-        , learning_rate = 0.05
         , objective = "binary"
         , metric = "binary_error"
         , num_threads = .LGB_MAX_THREADS
       )
       params[[boosting_param]] <- "dart"
 
-      # expect warning
-      # if early_stopping_rounds is specified
+      # warning: early stopping requested
       expect_warning({
         result <- lgb.cv(
           data = lgb.Dataset(
-            data  = train$data,
-            label = train$label
+            data  = train$data
+            , label = train$label
           )
           , params = params
           , nrounds = 5L
@@ -161,23 +155,19 @@ test_that(
         )
       }, regexp = "Early stopping is not available in 'dart' mode")
 
-      # expect no warning
-      # if early_stopping_rounds is not
-      # specified see:
-      # https://github.com/microsoft/LightGBM/issues/6612
+      # no warning: early stopping not requested
       expect_no_warning({
         result <- lgb.cv(
           data = lgb.Dataset(
-            data  = train$data,
-            label = train$label
+            data  = train$data
+            , label = train$label
           )
           , params = params
           , nrounds = 5L,
           , verbose = -1L
           , early_stopping_rounds = NULL
         )
-      }
-      )
+      })
     }
   }
 )

--- a/R-package/tests/testthat/test_parameters.R
+++ b/R-package/tests/testthat/test_parameters.R
@@ -91,7 +91,7 @@ test_that(".PARAMETER_ALIASES() uses the internal session cache", {
   expect_false(exists(cache_key, where = .lgb_session_cache_env))
 })
 
-test_that("training should warn if you use 'dart' boosting and requesting early stopping, specified with 'boosting' or aliases", {
+test_that("lightgbm should warn if you use 'dart' boosting with early stopping, specified with 'boosting' or aliases", {
   for (boosting_param in .PARAMETER_ALIASES()[["boosting"]]) {
     params <- list(
         num_leaves = 5L
@@ -129,7 +129,7 @@ test_that("training should warn if you use 'dart' boosting and requesting early 
 })
 
 test_that(
-  "lgb.cv() should only warn if you use 'dart' boosting, specified with 'boosting' or aliases",{
+  "lgb.cv should warn if you use 'dart' boosting with early stopping, specified with 'boosting' or aliases", {
     for (boosting_param in .PARAMETER_ALIASES()[["boosting"]]) {
       params <- list(
         num_leaves = 5L


### PR DESCRIPTION
Fixes #6612

* Fix: The associated functions have been fixed by adding a nested if-statement that only triggers if the dart-booster is specified with early_stopping_rounds != NULL.

* Unittests: The unit-test in test_parameters.R have been rewritten in the following way

	* The lightgbm()-test have had a expect_no_warning()-clause added if the model is correctly specified.

	* A new unittest have been created that checks wether lgb.cv() throws a warning errorneously.

This commit closes https://github.com/microsoft/LightGBM/issues/6612. :wrench: