### PR TITLE
[python-package] remove setup.cfg

### DIFF
--- a/python-package/setup.cfg
+++ b/python-package/setup.cfg
@@ -1,5 +1,0 @@
-[options]
-include_package_data = True
-
-[options.packages.find]
-where = lightgbm


### PR DESCRIPTION
I don't think `python-package/setup.cfg` serves any purpose in this project any more. This proposes removing it it.

## Notes for Reviewers

### How I tested this

The configuration in `setup.cfg` doesn't affect `scikit-build-core` based builds ([see docs here](https://github.com/scikit-build/scikit-build-core/blob/a6f954a0f477269ea43f6804fe57d76316a89e24/docs/migration_guide.md?plain=1#L22-L30)), so I just tested the `--precompile` option where a `setuptools` build backend is substituted in:

https://github.com/microsoft/LightGBM/blob/a9df7f113f7e603ed06dcc04baf2bc55f28ba090/build-python.sh#L308-L316

```shell
cmake -B build -S .
cmake --build build --target _lightgbm -j4
sh build-python.sh install --precompile
```

Saw the unit tests pass

```shell
pytest tests/python_package_test
```

And the package contained the expected files:

```shell
tar -tf ./dist/*.tar.gz
```

<details><summary>list of files (click me)</summary>

```text
lightgbm-4.5.0.99/
lightgbm-4.5.0.99/LICENSE
lightgbm-4.5.0.99/MANIFEST.in
lightgbm-4.5.0.99/PKG-INFO
lightgbm-4.5.0.99/README.rst
lightgbm-4.5.0.99/lightgbm/
lightgbm-4.5.0.99/lightgbm/__init__.py
lightgbm-4.5.0.99/lightgbm/basic.py
lightgbm-4.5.0.99/lightgbm/callback.py
lightgbm-4.5.0.99/lightgbm/compat.py
lightgbm-4.5.0.99/lightgbm/dask.py
lightgbm-4.5.0.99/lightgbm/engine.py
lightgbm-4.5.0.99/lightgbm/lib/
lightgbm-4.5.0.99/lightgbm/lib/lib_lightgbm.dylib
lightgbm-4.5.0.99/lightgbm/libpath.py
lightgbm-4.5.0.99/lightgbm/plotting.py
lightgbm-4.5.0.99/lightgbm/py.typed
lightgbm-4.5.0.99/lightgbm/sklearn.py
lightgbm-4.5.0.99/lightgbm.egg-info/
lightgbm-4.5.0.99/lightgbm.egg-info/PKG-INFO
lightgbm-4.5.0.99/lightgbm.egg-info/SOURCES.txt
lightgbm-4.5.0.99/lightgbm.egg-info/dependency_links.txt
lightgbm-4.5.0.99/lightgbm.egg-info/requires.txt
lightgbm-4.5.0.99/lightgbm.egg-info/top_level.txt
lightgbm-4.5.0.99/pyproject.toml
lightgbm-4.5.0.99/setup.cfg
```

</details>