### PR TITLE
[docs] add supertree in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ LightGBMLSS (An extension of LightGBM to probabilistic modelling from which pred
 
 FLAML (AutoML library for hyperparameter optimization): https://github.com/microsoft/FLAML
 
+supertree (interactive visualization of decision trees): https://github.com/mljar/supertree
+
 Optuna (hyperparameter optimization framework): https://github.com/optuna/optuna
 
 Julia-package: https://github.com/IQVIA-ML/LightGBM.jl


### PR DESCRIPTION
Hi LightGBM Team!

I've added in readme a new package for decision tree visualization - `supertree`. It works with `LGBMClassifier` and `LGBMRegressor`. The package can be used in notebook environment (Jupyter, Colab) or in Python script. I hope it will be useful for LightGBM users. Thank you!