### PR TITLE
[ci] prevent Dask tests from leaving files behind

### DIFF
--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1527,11 +1527,11 @@ def test_predict_with_raw_score(task, output, cluster):
             assert_eq(raw_predictions, pred_proba_raw)
 
 
-def test_distributed_quantized_training(cluster):
+def test_distributed_quantized_training(tmp_path, cluster):
     with Client(cluster) as client:
         X, y, w, _, dX, dy, dw, _ = _create_data(objective="regression", output="array")
 
-        np.savetxt("data_dask.csv", np.hstack([np.array([y]).T, X]), fmt="%f,%f,%f,%f,%f")
+        np.savetxt(tmp_path / "data_dask.csv", np.hstack([y[:, None], X]), fmt="%f,%f,%f,%f,%f")
 
         params = {
             "boosting_type": "gbdt",

--- a/tests/python_package_test/test_dask.py
+++ b/tests/python_package_test/test_dask.py
@@ -1531,7 +1531,7 @@ def test_distributed_quantized_training(tmp_path, cluster):
     with Client(cluster) as client:
         X, y, w, _, dX, dy, dw, _ = _create_data(objective="regression", output="array")
 
-        np.savetxt(tmp_path / "data_dask.csv", np.hstack([y[:, None], X]), fmt="%f,%f,%f,%f,%f")
+        np.savetxt(tmp_path / "data_dask.csv", np.hstack([np.array([y]).T, X]), fmt="%f,%f,%f,%f,%f")
 
         params = {
             "boosting_type": "gbdt",


### PR DESCRIPTION
Contributes to #6361 

Prevents the following files from being left behind when the Python tests are run:

* `data_dask.csv`

`data_dask.csv` goes to pytest temporary folder, gets teared down after test runs