### PR TITLE
[ci] prevent C API tests from leaving files behind (fixes #6361)

### DIFF
--- a/tests/c_api_test/test_.py
+++ b/tests/c_api_test/test_.py
@@ -25,7 +25,7 @@ dtype_int64 = 3
 
 
 def c_str(string):
-    return ctypes.c_char_p(string.encode("utf-8"))
+    return ctypes.c_char_p(str(string).encode("utf-8"))
 
 
 def load_from_file(filename, reference):
@@ -203,8 +203,8 @@ def test_booster(tmp_path):
     LIB.LGBM_BoosterCreateFromModelfile(c_str(str(model_path)), ctypes.byref(num_total_model), ctypes.byref(booster2))
     data = np.loadtxt(str(binary_example_dir / "binary.test"), dtype=np.float64)
     mat = data[:, 1:]
-    preb = np.empty(mat.shape[0], dtype=np.float64)
-    num_preb = ctypes.c_int64(0)
+    preds = np.empty(mat.shape[0], dtype=np.float64)
+    num_preds = ctypes.c_int64(0)
     data = np.asarray(mat.reshape(mat.size), dtype=np.float64)
     LIB.LGBM_BoosterPredictForMat(
         booster2,
@@ -217,8 +217,8 @@ def test_booster(tmp_path):
         ctypes.c_int(0),
         ctypes.c_int(25),
         c_str(""),
-        ctypes.byref(num_preb),
-        preb.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+        ctypes.byref(num_preds),
+        preds.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
     )
     LIB.LGBM_BoosterPredictForFile(
         booster2,
@@ -228,7 +228,7 @@ def test_booster(tmp_path):
         ctypes.c_int(0),
         ctypes.c_int(25),
         c_str(""),
-        c_str("preb.txt"),
+        c_str(tmp_path / "preds.txt"),
     )
     LIB.LGBM_BoosterPredictForFile(
         booster2,
@@ -238,7 +238,7 @@ def test_booster(tmp_path):
         ctypes.c_int(10),
         ctypes.c_int(25),
         c_str(""),
-        c_str("preb.txt"),
+        c_str(tmp_path / "preds.txt"),
     )
     LIB.LGBM_BoosterFree(booster2)
 


### PR DESCRIPTION
fixes #6361

I was testing whether #6361 could be closed by recent PRs, and realized that I'd missed one local file when listing the test files there... `"preb.txt"`, created by the C API tests.

This does the following:

* ensures that file isn't left behind
* changes all uses of "preb" to "preds" (it always refers to predictions, so I think "preb" was just a typo)

## Notes for Reviews

### How I tested this

Ran all the tests locally (on my Mac, with all optional dependencies installed)

```shell
# Python and C API tests
sh build-python.sh install
pytest tests/

# R tests
sh build-cran-package.sh --no-build-vignettes
MAKEFLAGS="-j4" R CMD INSTALL --with-keep.source ./lightgbm*.tar.gz
cd R-package/tests
Rscript testthat.R

# C++ tests
rm -rf ./build
cmake -B build -S . -DBUILD_CPP_TEST=ON -DUSE_OPENMP=OFF
cmake --build build --target testlightgbm -j4
./testlightgbm
```

Checked that no files were left behind.

```shell
# look for local files (including those ignored by git)
git check-ignore -v -- *
git status --ignored
```