### PR TITLE
[ci] [R-package] re-enable R-devel clang16 job (fixes #6607)

### DIFF
--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -268,9 +268,7 @@ jobs:
         #   * CRAN "additional checks": https://cran.r-project.org/web/checks/check_issue_kinds.html
         #   * images: https://r-hub.github.io/containers/containers.html
         image:
-          # clang16 should be re-enabled once it's fixed upstream
-          # ref: https://github.com/microsoft/LightGBM/issues/6607
-          #- clang16
+          - clang16
           - clang17
           - clang18
           - clang19


### PR DESCRIPTION
Checking if #6607 has been resolved by changes to R-devel or the container images used for that test.

(edited): fixes #6607 😁 