### PR TITLE
[ci] [python-package] temporarily stop testing against scikit-learn nightlies, load lib_lightgbm earlier

### DIFF
--- a/.ci/conda-envs/ci-core.txt
+++ b/.ci/conda-envs/ci-core.txt
@@ -23,7 +23,7 @@ joblib>=1.3.2
 matplotlib-base>=3.7.3
 numpy>=1.24.4
 pandas>2.0
-pyarrow>=6.0
+pyarrow-core>=6.0
 python-graphviz>=0.20.3
 scikit-learn>=1.3.2
 scipy>=1.1

--- a/.ci/test-python-latest.sh
+++ b/.ci/test-python-latest.sh
@@ -22,7 +22,7 @@ python -m pip install \
         'numpy>=2.0.0.dev0' \
         'matplotlib>=3.10.0.dev0' \
         'pandas>=3.0.0.dev0' \
-        'scikit-learn<1.16.0a0' \
+        'scikit-learn<1.6.0a0' \
         'scipy>=1.15.0.dev0'
 
 python -m pip install \

--- a/.ci/test-python-latest.sh
+++ b/.ci/test-python-latest.sh
@@ -22,7 +22,7 @@ python -m pip install \
         'numpy>=2.0.0.dev0' \
         'matplotlib>=3.10.0.dev0' \
         'pandas>=3.0.0.dev0' \
-        'scikit-learn<1.6.0a0' \
+        'scikit-learn==1.5.*' \
         'scipy>=1.15.0.dev0'
 
 python -m pip install \

--- a/.ci/test-python-latest.sh
+++ b/.ci/test-python-latest.sh
@@ -22,6 +22,7 @@ python -m pip install \
         'numpy>=2.0.0.dev0' \
         'matplotlib>=3.10.0.dev0' \
         'pandas>=3.0.0.dev0' \
+        'scikit-learn<1.16.0a0' \
         'scipy>=1.15.0.dev0'
 
 python -m pip install \

--- a/.ci/test-python-latest.sh
+++ b/.ci/test-python-latest.sh
@@ -22,7 +22,6 @@ python -m pip install \
         'numpy>=2.0.0.dev0' \
         'matplotlib>=3.10.0.dev0' \
         'pandas>=3.0.0.dev0' \
-        'scikit-learn>=1.6.dev0' \
         'scipy>=1.15.0.dev0'
 
 python -m pip install \

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -4,53 +4,10 @@
 Contributors: https://github.com/microsoft/LightGBM/graphs/contributors.
 """
 
-import platform
-
-# gcc's libgomp tries to allocate a small amount of aligned static thread-local storage ("TLS")
-# when it's dynamically loaded.
-#
-# If it's not able to find a block of aligned memory large enough, loading fails like this:
-#
-#   > ../lib/libgomp.so.1: cannot allocate memory in static TLS block
-#
-# On aarch64 Linux, processes and loaded libraries share the same pool of static TLS,
-# which makes such failures more likely on that architecture.
-# (ref: https://bugzilla.redhat.com/show_bug.cgi?id=1722181#c6)
-#
-# Therefore, the later in a process libgomp.so is loaded, the greater the risk that loading
-# it will fail in this way... so lightgbm tries to dlopen() it immediately, before any
-# other imports or computation.
-#
-# This should generally be safe to do ... many other dynamically-loaded libraries have fallbacks
-# that allow successful loading if there isn't sufficient static TLS available.
-#
-# libgomp.so absolutely needing it, by design, makes it a special case
-# (ref: https://gcc.gcc.gnu.narkive.com/vOXMQqLA/failure-to-dlopen-libgomp-due-to-static-tls-data).
-#
-# other references:
-#
-#   * https://github.com/microsoft/LightGBM/pull/6654#issuecomment-2352014275
-#   * https://github.com/microsoft/LightGBM/issues/6509
-#   * https://maskray.me/blog/2021-02-14-all-about-thread-local-storage
-#   * https://bugzilla.redhat.com/show_bug.cgi?id=1722181#c6
-#
-if platform.system().lower() == "linux" and platform.processor().lower() == "aarch64":
-    import ctypes
-
-    try:
-        # this issue seems specific to libgomp, so no need to attempt e.g. libomp or libiomp
-        _ = ctypes.CDLL("libgomp.so.1", ctypes.RTLD_GLOBAL)
-    except:  # noqa: E722
-        # this needs to be try-catched, to handle these situations:
-        #
-        #   * LightGBM built without OpenMP (-DUSE_OPENMP=OFF)
-        #   * non-gcc OpenMP used (e.g. clang/libomp, icc/libiomp)
-        #   * no file "libgomp.so" available to the linker (e.g. maybe only "libgomp.so.1")
-        #
-        pass
-
 from pathlib import Path
 
+# .basic is intentionally loaded as early as possible, to dlopen() lib_lightgbm.{dll,dylib,so}
+# and its dependencies as early as possible
 from .basic import Booster, Dataset, Sequence, register_logger
 from .callback import EarlyStopException, early_stopping, log_evaluation, record_evaluation, reset_parameter
 from .engine import CVBooster, cv, train

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -38,7 +38,7 @@ if platform.system().lower() == "linux" and platform.processor().lower() == "aar
     import ctypes
 
     try:
-        # this seems specific to libgomp, so no need to attempt e.g. libomp or libiomp
+        # this issue seems specific to libgomp, so no need to attempt e.g. libomp or libiomp
         _ = ctypes.CDLL("libgomp.so.1", ctypes.RTLD_GLOBAL)
     except:  # noqa: E722
         # this needs to be try-catched, to handle these situations:

--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -4,6 +4,51 @@
 Contributors: https://github.com/microsoft/LightGBM/graphs/contributors.
 """
 
+import platform
+
+# gcc's libgomp tries to allocate a small amount of aligned static thread-local storage ("TLS")
+# when it's dynamically loaded.
+#
+# If it's not able to find a block of aligned memory large enough, loading fails like this:
+#
+#   > ../lib/libgomp.so.1: cannot allocate memory in static TLS block
+#
+# On aarch64 Linux, processes and loaded libraries share the same pool of static TLS,
+# which makes such failures more likely on that architecture.
+# (ref: https://bugzilla.redhat.com/show_bug.cgi?id=1722181#c6)
+#
+# Therefore, the later in a process libgomp.so is loaded, the greater the risk that loading
+# it will fail in this way... so lightgbm tries to dlopen() it immediately, before any
+# other imports or computation.
+#
+# This should generally be safe to do ... many other dynamically-loaded libraries have fallbacks
+# that allow successful loading if there isn't sufficient static TLS available.
+#
+# libgomp.so absolutely needing it, by design, makes it a special case
+# (ref: https://gcc.gcc.gnu.narkive.com/vOXMQqLA/failure-to-dlopen-libgomp-due-to-static-tls-data).
+#
+# other references:
+#
+#   * https://github.com/microsoft/LightGBM/pull/6654#issuecomment-2352014275
+#   * https://github.com/microsoft/LightGBM/issues/6509
+#   * https://maskray.me/blog/2021-02-14-all-about-thread-local-storage
+#   * https://bugzilla.redhat.com/show_bug.cgi?id=1722181#c6
+#
+if platform.system().lower() == "linux" and platform.processor().lower() == "aarch64":
+    import ctypes
+
+    try:
+        # this seems specific to libgomp, so no need to attempt e.g. libomp or libiomp
+        _ = ctypes.CDLL("libgomp.so.1", ctypes.RTLD_GLOBAL)
+    except:  # noqa: E722
+        # this needs to be try-catched, to handle these situations:
+        #
+        #   * LightGBM built without OpenMP (-DUSE_OPENMP=OFF)
+        #   * non-gcc OpenMP used (e.g. clang/libomp, icc/libiomp)
+        #   * no file "libgomp.so" available to the linker (e.g. maybe only "libgomp.so.1")
+        #
+        pass
+
 from pathlib import Path
 
 from .basic import Booster, Dataset, Sequence, register_logger

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1,6 +1,13 @@
 # coding: utf-8
 """Wrapper for C API of LightGBM."""
 
+# This import causes lib_lightgbm.{dll,dylib,so} to be loaded.
+# It's intentionally done here, as early as possible, to avoid issues like
+# "libgomp.so.1: cannot allocate memory in static TLS block" on aarch64 Linux.
+#
+# For details, see the "cannot allocate memory in static TLS block" entry in docs/FAQ.rst.
+from .libpath import _LIB  # isort: skip
+
 import abc
 import ctypes
 import inspect
@@ -37,7 +44,6 @@ from .compat import (
     pd_DataFrame,
     pd_Series,
 )
-from .libpath import find_lib_path
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -160,6 +166,12 @@ ZERO_THRESHOLD = 1e-35
 _MULTICLASS_OBJECTIVES = {"multiclass", "multiclassova", "multiclass_ova", "ova", "ovr", "softmax"}
 
 
+class LightGBMError(Exception):
+    """Error thrown by LightGBM."""
+
+    pass
+
+
 def _is_zero(x: float) -> bool:
     return -ZERO_THRESHOLD <= x <= ZERO_THRESHOLD
 
@@ -259,26 +271,13 @@ def _log_callback(msg: bytes) -> None:
     _log_native(str(msg.decode("utf-8")))
 
 
-def _load_lib() -> ctypes.CDLL:
-    """Load LightGBM library."""
-    lib_path = find_lib_path()
-    lib = ctypes.cdll.LoadLibrary(lib_path[0])
-    lib.LGBM_GetLastError.restype = ctypes.c_char_p
-    callback = ctypes.CFUNCTYPE(None, ctypes.c_char_p)
-    lib.callback = callback(_log_callback)  # type: ignore[attr-defined]
-    if lib.LGBM_RegisterLogCallback(lib.callback) != 0:
-        raise LightGBMError(lib.LGBM_GetLastError().decode("utf-8"))
-    return lib
-
-
-# we don't need lib_lightgbm while building docs
-_LIB: ctypes.CDLL
+# connect the Python logger to logging in lib_lightgbm
 if environ.get("LIGHTGBM_BUILD_DOC", False):
-    from unittest.mock import Mock  # isort: skip
-
-    _LIB = Mock(ctypes.CDLL)  # type: ignore
-else:
-    _LIB = _load_lib()
+    _LIB.LGBM_GetLastError.restype = ctypes.c_char_p
+    callback = ctypes.CFUNCTYPE(None, ctypes.c_char_p)
+    _LIB.callback = callback(_log_callback)  # type: ignore[attr-defined]
+    if _LIB.LGBM_RegisterLogCallback(_LIB.callback) != 0:
+        raise LightGBMError(_LIB.LGBM_GetLastError().decode("utf-8"))
 
 
 _NUMERIC_TYPES = (int, float, bool)
@@ -550,12 +549,6 @@ class _TempFile:
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         if self.path.is_file():
             self.path.unlink()
-
-
-class LightGBMError(Exception):
-    """Error thrown by LightGBM."""
-
-    pass
 
 
 # DeprecationWarning is not shown by default, so let's create our own with higher level

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -272,7 +272,7 @@ def _log_callback(msg: bytes) -> None:
 
 
 # connect the Python logger to logging in lib_lightgbm
-if environ.get("LIGHTGBM_BUILD_DOC", False):
+if not environ.get("LIGHTGBM_BUILD_DOC", False):
     _LIB.LGBM_GetLastError.restype = ctypes.c_char_p
     callback = ctypes.CFUNCTYPE(None, ctypes.c_char_p)
     _LIB.callback = callback(_log_callback)  # type: ignore[attr-defined]

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 """Find the path to LightGBM dynamic library files."""
 
+import ctypes
+from os import environ
 from pathlib import Path
 from platform import system
 from typing import List
@@ -8,7 +10,7 @@ from typing import List
 __all__: List[str] = []
 
 
-def find_lib_path() -> List[str]:
+def _find_lib_path() -> List[str]:
     """Find the path to LightGBM library files.
 
     Returns
@@ -35,3 +37,13 @@ def find_lib_path() -> List[str]:
         dll_path_joined = "\n".join(map(str, dll_path))
         raise Exception(f"Cannot find lightgbm library file in following paths:\n{dll_path_joined}")
     return lib_path
+
+
+# we don't need lib_lightgbm while building docs
+_LIB: ctypes.CDLL
+if environ.get("LIGHTGBM_BUILD_DOC", False):
+    from unittest.mock import Mock  # isort: skip
+
+    _LIB = Mock(ctypes.CDLL)  # type: ignore
+else:
+    _LIB = ctypes.cdll.LoadLibrary(_find_lib_path()[0])


### PR DESCRIPTION
As described in https://github.com/microsoft/LightGBM/issues/6653, `lightgbm` is currently failing scikit-learn compatibility tests against the latest `scikit-learn` nightlies (1.6.0dev0).

That's being worked on in https://github.com/microsoft/LightGBM/pull/6651.

This PR proposes temporarily dropping `scikit-learn` from the list of projects whose nightlies `lightgbm` is tested against, to unblock CI here.

**Update (Sep 22)**

While working on this, CI for the Python package started failing in another way:

```text
libgomp.so.1: cannot allocate memory in static TLS block
```

This proposes a permanent fix for that as well... trying to `dlopen()` load_lightgbm as early as possible when running `import lightgbm`.