### PR TITLE
[ci] replace uses of 'mamba' with 'conda', use Python 12 for test-python-latest-job

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -66,7 +66,7 @@ fi
 CONDA_PYTHON_REQUIREMENT="python=$PYTHON_VERSION[build=*cpython]"
 
 if [[ $TASK == "if-else" ]]; then
-    mamba create -q -y -n $CONDA_ENV ${CONDA_PYTHON_REQUIREMENT} numpy
+    conda create -q -y -n $CONDA_ENV ${CONDA_PYTHON_REQUIREMENT} numpy
     source activate $CONDA_ENV
     cmake -B build -S . || exit 1
     cmake --build build --target lightgbm -j4 || exit 1
@@ -95,7 +95,7 @@ if [[ $TASK == "swig" ]]; then
 fi
 
 if [[ $TASK == "lint" ]]; then
-    mamba create -q -y -n $CONDA_ENV \
+    conda create -q -y -n $CONDA_ENV \
         ${CONDA_PYTHON_REQUIREMENT} \
         'cmakelint>=1.4.3' \
         'cpplint>=1.6.0' \
@@ -116,10 +116,10 @@ fi
 
 if [[ $TASK == "check-docs" ]] || [[ $TASK == "check-links" ]]; then
     cd "${BUILD_DIRECTORY}/docs"
-    mamba env create \
+    conda env create \
         -n $CONDA_ENV \
         --file ./env.yml || exit 1
-    mamba install \
+    conda install \
         -q \
         -y \
         -n $CONDA_ENV \
@@ -157,7 +157,7 @@ else
     CONDA_REQUIREMENT_FILES="--file ${BUILD_DIRECTORY}/.ci/conda-envs/ci-core.txt"
 fi
 
-mamba create \
+conda create \
     -y \
     -n $CONDA_ENV \
     ${CONDA_REQUIREMENT_FILES} \
@@ -306,7 +306,7 @@ matplotlib.use\(\"Agg\"\)\
 ' plot_example.py  # prevent interactive window mode
     sed -i'.bak' 's/graph.render(view=True)/graph.render(view=False)/' plot_example.py
     # requirements for examples
-    mamba install -y -n $CONDA_ENV \
+    conda install -y -n $CONDA_ENV \
         'h5py>=3.10' \
         'ipywidgets>=8.1.2' \
         'notebook>=7.1.2'

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -115,7 +115,7 @@ jobs:
             --rm \
             -v $(pwd):/opt/lgb-build \
             -w /opt/lgb-build \
-            python:3.12 \
+            python:3.13 \
             /bin/bash ./.ci/test-python-latest.sh
   test-oldest-versions:
     name: Python - oldest supported versions (ubuntu-latest)

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -115,7 +115,7 @@ jobs:
             --rm \
             -v $(pwd):/opt/lgb-build \
             -w /opt/lgb-build \
-            python:3.13 \
+            python:3.12 \
             /bin/bash ./.ci/test-python-latest.sh
   test-oldest-versions:
     name: Python - oldest supported versions (ubuntu-latest)

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -115,7 +115,7 @@ jobs:
             --rm \
             -v $(pwd):/opt/lgb-build \
             -w /opt/lgb-build \
-            python:3.11 \
+            python:3.12 \
             /bin/bash ./.ci/test-python-latest.sh
   test-oldest-versions:
     name: Python - oldest supported versions (ubuntu-latest)


### PR DESCRIPTION
Trying to fix https://github.com/microsoft/LightGBM/pull/6539#issuecomment-2392516473

Starting with the `23.10` release of `conda` (about a year ago), the `conda` executable now uses the mamba solver by default... so there's no need to invoke the `mamba` executable any more:

* https://docs.conda.io/projects/conda/en/latest/release-notes.html#id55
* https://conda.org/blog/2023-11-06-conda-23-10-0-release/

We should be able to use `conda {command}` instead of `mamba {command}` without any loss of performance now, and I'm hoping it will fix the issue with `mamba` reported in the linked comment above.

## Notes for Reviewers

Searched for all uses of `mamba` like this:

```shell
git grep 'mamba'
```