### PR TITLE
[ci] Fix version matching between RTD pages and R-package pages

### DIFF
--- a/docs/_static/js/script.js
+++ b/docs/_static/js/script.js
@@ -4,7 +4,7 @@ $(function() {
 
     /* List each class property item on a new line
        https://github.com/microsoft/LightGBM/issues/5073 */
-    if(window.location.pathname.toLocaleLowerCase().indexOf('pythonapi') != -1) {
+    if(window.location.pathname.toLocaleLowerCase().indexOf('pythonapi') !== -1) {
         $('.py.property').each(function() { this.style.setProperty('display', 'inline', 'important'); });
     }
 
@@ -12,7 +12,7 @@ $(function() {
     var current_version_elems = $('nav.wy-nav-side > * div.version');
     if(current_version_elems.length !== 0) {
         var current_version = $(current_version_elems[0]).text().trim();
-        if(current_version !== 'latest') {
+        if((current_version !== 'latest') && (window.location.pathname.toLocaleLowerCase().indexOf('/latest/') === -1)) {
             $('a.reference.external[href$="/latest/R/reference/"]').each(function() {
                 $(this).attr('href', function (_, val) { return val.replace('/latest/', '/' + current_version + '/'); });
             });

--- a/docs/_static/js/script.js
+++ b/docs/_static/js/script.js
@@ -8,12 +8,10 @@ $(function() {
         $('.py.property').each(function() { this.style.setProperty('display', 'inline', 'important'); });
     }
 
-    /* Fix needed */
-    var current_version_elems = $('.rst-current-version');
+    /* Point to the same version of R API as the current docs version */
+    var current_version_elems = $('nav.wy-nav-side > * div.version');
     if(current_version_elems.length !== 0) {
-        var current_version = $(current_version_elems[0]).contents().filter(function() {
-            return this.nodeType == 3;
-        }).text().trim().split(' ').pop();
+        var current_version = $(current_version_elems[0]).text().trim();
         if(current_version !== 'latest') {
             $('a.reference.external[href$="/latest/R/reference/"]').each(function() {
                 $(this).attr('href', function (_, val) { return val.replace('/latest/', '/' + current_version + '/'); });

--- a/docs/_static/js/script.js
+++ b/docs/_static/js/script.js
@@ -8,15 +8,12 @@ $(function() {
         $('.py.property').each(function() { this.style.setProperty('display', 'inline', 'important'); });
     }
 
-    /* Point to the same version of R API as the current docs version */
-    var current_version_elems = $('nav.wy-nav-side > * div.version');
-    if(current_version_elems.length !== 0) {
-        var current_version = $(current_version_elems[0]).text().trim();
-        if((current_version !== 'latest') && (window.location.pathname.toLocaleLowerCase().indexOf('/latest/') === -1)) {
-            $('a.reference.external[href$="/latest/R/reference/"]').each(function() {
-                $(this).attr('href', function (_, val) { return val.replace('/latest/', '/' + current_version + '/'); });
-            });
-        }
+    /* Point to the same version of R API as the current docs branch */
+    var current_branch = window.location.pathname.toLocaleLowerCase().split('/')[2];
+    if(current_branch !== 'latest') {
+        $('a.reference.external[href$="/latest/R/reference/"]').each(function() {
+            $(this).attr('href', function (_, val) { return val.replace('/latest/', '/' + current_branch + '/'); });
+        });
     }
 
     /* Collapse specified sections in the installation guide */

--- a/docs/_static/js/script.js
+++ b/docs/_static/js/script.js
@@ -8,7 +8,7 @@ $(function() {
         $('.py.property').each(function() { this.style.setProperty('display', 'inline', 'important'); });
     }
 
-    /* Point to the same version of R API as the current docs version */
+    /* Fix needed */
     var current_version_elems = $('.rst-current-version');
     if(current_version_elems.length !== 0) {
         var current_version = $(current_version_elems[0]).contents().filter(function() {

--- a/docs/_static/js/script.js
+++ b/docs/_static/js/script.js
@@ -8,16 +8,8 @@ $(function() {
         $('.py.property').each(function() { this.style.setProperty('display', 'inline', 'important'); });
     }
 
-    /* Point to the same version of R API as the current docs branch */
-    var current_branch = window.location.pathname.toLocaleLowerCase().split('/')[2];
-    if(current_branch !== 'latest') {
-        $('a.reference.external[href$="/latest/R/reference/"]').each(function() {
-            $(this).attr('href', function (_, val) { return val.replace('/latest/', '/' + current_branch + '/'); });
-        });
-    }
-
     /* Collapse specified sections in the installation guide */
-    if(window.location.pathname.toLocaleLowerCase().indexOf('installation-guide') != -1) {
+    if(window.location.pathname.toLocaleLowerCase().indexOf('installation-guide') !== -1) {
         $('<style>.closed, .opened {cursor: pointer;} .closed:before, .opened:before {font-family: FontAwesome; display: inline-block; padding-right: 6px;} .closed:before {content: "\\f078";} .opened:before {content: "\\f077";}</style>').appendTo('body');
         var collapsable = [
             '#build-threadless-version-not-recommended',


### PR DESCRIPTION
~I believe this element selectors are quite unreliable and subject to frequent changes.~
OK, it's shadow DOM, so we simply cannot access it.

![image](https://github.com/user-attachments/assets/52873306-3842-44af-9e3c-48bd75ed1f80)

Unfortunately, this fix will be active only with next release and is not backported to previous versions.