### PR TITLE
[ci] enable OpenMP support in cpp tests

### DIFF
--- a/.ci/test-windows.ps1
+++ b/.ci/test-windows.ps1
@@ -22,7 +22,7 @@ if ($env:TASK -eq "r-package") {
 }
 
 if ($env:TASK -eq "cpp-tests") {
-  cmake -B build -S . -DBUILD_CPP_TEST=ON -DUSE_OPENMP=OFF -DUSE_DEBUG=ON -A x64
+  cmake -B build -S . -DBUILD_CPP_TEST=ON -DUSE_DEBUG=ON -A x64
   cmake --build build --target testlightgbm --config Debug ; Check-Output $?
   .\Debug\testlightgbm.exe ; Check-Output $?
   Exit 0

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -56,7 +56,7 @@ if [[ "$TASK" == "cpp-tests" ]]; then
     else
         extra_cmake_opts=""
     fi
-    cmake -B build -S . -DBUILD_CPP_TEST=ON -DUSE_OPENMP=OFF -DUSE_DEBUG=ON $extra_cmake_opts
+    cmake -B build -S . -DBUILD_CPP_TEST=ON -DUSE_DEBUG=ON $extra_cmake_opts
     cmake --build build --target testlightgbm -j4 || exit 1
     ./testlightgbm || exit 1
     exit 0


### PR DESCRIPTION
As #4125 was fixed we don't need to disable OpenMP support in cpp tests anymore. 🎉 