### PR TITLE
[python-package] ignore scikit-learn 'check_sample_weight_equivalence' estimator check (fixes #6678)

### DIFF
--- a/.ci/conda-envs/ci-core-py38.txt
+++ b/.ci/conda-envs/ci-core-py38.txt
@@ -41,6 +41,7 @@ bokeh=3.1.*
 fsspec=2024.5.*
 msgpack-python=1.0.*
 pluggy=1.5.*
+pyparsing=3.1.4
 pytz=2024.1
 setuptools=69.5.*
 snappy=1.2.*

--- a/python-package/lightgbm/sklearn.py
+++ b/python-package/lightgbm/sklearn.py
@@ -678,6 +678,12 @@ class LGBMModel(_LGBMModelBase):
                 "check_no_attributes_set_in_init": "scikit-learn incorrectly asserts that private attributes "
                 "cannot be set in __init__: "
                 "(see https://github.com/microsoft/LightGBM/issues/2628)",
+                "check_sample_weight_equivalence": (
+                    "In LightGBM, setting a sample's weight to 0 can produce a different result than omitting the sample. "
+                    "Such samples intentionally still affect count-based measures like 'min_data_in_leaf' "
+                    "(https://github.com/microsoft/LightGBM/issues/5626#issuecomment-1712706678) and the estimated distribution "
+                    "of features for Dataset construction (see https://github.com/microsoft/LightGBM/issues/5553)."
+                ),
             },
         }
 


### PR DESCRIPTION
Fixes #6678

Fixes #6680

As of https://github.com/scikit-learn/scikit-learn/pull/29818 (which will be in `scikit-learn` 1.6), `scikit-learn` contains an estimator check that enforces the following behavior:

> *check that setting sample_weight to zero / integer is equivalent to removing / repeating corresponding samples*

This new check is breaking CI here... LightGBM does not work that way.

* `weight=0.0` samples' feature values still contribute to feature distributions and therefore bin boundaries in `Dataset` histograms (https://github.com/microsoft/LightGBM/issues/5553)
* every sample counts as exactly `1` sample for the perspective of count-based hyper-parameters like `min_data_in_leaf` (https://github.com/microsoft/LightGBM/issues/5626#issuecomment-1712706678)

This PR proposes skipping that estimator check, just as `scikit-learn` is currently doing for `HistGradientBoosting*` estimators ([code link](https://github.com/scikit-learn/scikit-learn/blob/30f7d8a5fc6a8a020d2bd291fe8e79776eb06fce/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py#L1392-L1397)).

## Notes for Reviewers

We *could* modify LightGBM's `scikit-learn` estimators to match this expected behavior by excluding rows with `weight=0` and creating copies of rows with `int(weight)>=2` before passing it through to `Dataset` here:

https://github.com/microsoft/LightGBM/blob/bbeecc09af946c5ff9b84d1ada4749a9f26bca31/python-package/lightgbm/sklearn.py#L938-L947

I don't support doing that... I think it'd add significant complexity (do count-based hyperparameters need to be modified? how does this affect Dask estimators?) for questionable benefit.

I think just skipping this compliance check is the right thing for `lightgbm` right now.