### PR TITLE
[ci] add shellcheck, use latest pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ exclude: |
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -25,7 +25,7 @@ repos:
         args: ["--settings-path", "python-package/pyproject.toml"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.7
+    rev: v0.7.0
     hooks:
       # Run the linter.
       - id: ruff
@@ -35,3 +35,7 @@ repos:
       - id: ruff-format
         args: ["--config", "python-package/pyproject.toml"]
         types_or: [python, jupyter]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+    - id: shellcheck

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -876,8 +876,7 @@ def _load_pandas_categorical(
         max_offset = -getsize(file_name)
         with open(file_name, "rb") as f:
             while True:
-                if offset < max_offset:
-                    offset = max_offset
+                offset = max(offset, max_offset)
                 f.seek(offset, SEEK_END)
                 lines = f.readlines()
                 if len(lines) >= 2:


### PR DESCRIPTION
Contributes to #6498

* enforces `shellcheck` checks in CI
* updates all pre-commit hooks to their latest versions (via `pre-commit autoupdate`)

Fixes 1 new warning found by `ruff`

```text
python-package/lightgbm/basic.py:879:17: PLR1730 [*] Replace `if` statement with `offset = max(offset, max_offset)
```

## Notes for reviewers

Double-checked, and `shellcheck-py` ships wheels for Linux, Windows, and macOS ... so everyone working on the project should be able to keep running `pre-commit` without issue.

ref: https://pypi.org/project/shellcheck-py/#files