### PR TITLE
[docs] fix inaccurate comment for `force_col_wise` param with CUDA version

### DIFF
--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -397,7 +397,7 @@ void Config::CheckParamConflict(const std::unordered_map<std::string, std::strin
     }
   }
   if (device_type == std::string("gpu")) {
-    // force col-wise for gpu, and cuda version
+    // force col-wise for gpu version
     force_col_wise = true;
     force_row_wise = false;
     if (deterministic) {


### PR DESCRIPTION
With CUDA, `force_row_wise` is used.

https://github.com/microsoft/LightGBM/blob/d2b4e7374957e0d05a3a7d5ec695940287d4dc36/src/io/config.cpp#L410-L413