### PR TITLE
[python-package] remove MSVS solution files from sdist

### DIFF
--- a/build-python.sh
+++ b/build-python.sh
@@ -205,7 +205,6 @@ create_isolated_source_dir() {
     cp -R ./include ./lightgbm-python
     cp -R ./src ./lightgbm-python
     cp -R ./swig ./lightgbm-python
-    cp -R ./windows ./lightgbm-python
 
     # include only specific files from external_libs, to keep the package
     # small and avoid redistributing code with licenses incompatible with

--- a/build-python.sh
+++ b/build-python.sh
@@ -302,8 +302,7 @@ if test "${INSTALL}" = true; then
             ./external_libs \
             ./include \
             ./src \
-            ./swig \
-            ./windows
+            ./swig
         # use regular-old setuptools for these builds, to avoid
         # trying to recompile the shared library
         sed -i.bak -e '/start:build-system/,/end:build-system/d' pyproject.toml


### PR DESCRIPTION
Based on my understanding from https://github.com/microsoft/LightGBM/pull/6689#issuecomment-2437371601, the `.sln` and `.vcxproj` files in the `windows/` directory are intended for use in the Visual Studio GUI, and don't need to be included in the source distribution of the Python package ("sdist").

This proposes removing them, to make the sdist on PyPI slightly smaller.