### PR TITLE
[docs] add note about pyodide support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ lightgbm-transform (feature transformation binding): https://github.com/microsof
 
 `postgresml` (LightGBM training and prediction in SQL, via a Postgres extension): https://github.com/postgresml/postgresml
 
-`pyodide` (run `lightgbm` Python package in a web browser): https://github.com/pyodide/pyodide
+`pyodide` (run `lightgbm` Python-package in a web browser): https://github.com/pyodide/pyodide
 
 `vaex-ml` (Python DataFrame library with its own interface to LightGBM): https://github.com/vaexio/vaex
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ lightgbm-transform (feature transformation binding): https://github.com/microsof
 
 `postgresml` (LightGBM training and prediction in SQL, via a Postgres extension): https://github.com/postgresml/postgresml
 
+`pyodide` (run `lightgbm` Python package in a web browser): https://github.com/pyodide/pyodide
+
 `vaex-ml` (Python DataFrame library with its own interface to LightGBM): https://github.com/vaexio/vaex
 
 Support


### PR DESCRIPTION
This is SO COOL .... I learned tonight that Pyodide is building a version of the `lightgbm` Python package that runs in a web browser.

https://github.com/pyodide/pyodide/tree/main/packages/lightgbm

Try it yourself.... go to https://pyodide.org/en/stable/console.html (recommended from https://pyodide.org/en/stable/usage/index.html), and run the following:

```python
import lightgbm as lgb
from sklearn.datasets import make_regression
from sklearn.metrics import r2_score

X, y = make_regression(n_samples=10_000, n_features=5, n_informative=5)
bst = lgb.train(
    train_set=lgb.Dataset(X, label=y),
    params={"objective": "regression", "verbose": -1}
)

print(r2_score(y, bst.predict(X)))
# 0.995701411473822
```

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/15d6c6ba-94a9-46b6-a92a-460e8342c1f1">

🤯 🤯 🤯 🤯 

This proposes adding a note about that to the README.