### PR TITLE
[c++] include <cstdint> wherever uint8_t is used

### DIFF
--- a/include/LightGBM/bin.h
+++ b/include/LightGBM/bin.h
@@ -9,6 +9,7 @@
 #include <LightGBM/utils/common.h>
 #include <LightGBM/utils/file_io.h>
 
+#include <cstdint>
 #include <limits>
 #include <string>
 #include <functional>

--- a/include/LightGBM/cuda/cuda_column_data.hpp
+++ b/include/LightGBM/cuda/cuda_column_data.hpp
@@ -13,6 +13,7 @@
 #include <LightGBM/bin.h>
 #include <LightGBM/utils/openmp_wrapper.h>
 
+#include <cstdint>
 #include <vector>
 
 namespace LightGBM {

--- a/include/LightGBM/cuda/cuda_row_data.hpp
+++ b/include/LightGBM/cuda/cuda_row_data.hpp
@@ -15,6 +15,7 @@
 #include <LightGBM/train_share_states.h>
 #include <LightGBM/utils/openmp_wrapper.h>
 
+#include <cstdint>
 #include <vector>
 
 #define COPY_SUBROW_BLOCK_SIZE_ROW_DATA (1024)

--- a/include/LightGBM/dataset.h
+++ b/include/LightGBM/dataset.h
@@ -15,6 +15,7 @@
 #include <LightGBM/utils/random.h>
 #include <LightGBM/utils/text_reader.h>
 
+#include <cstdint>
 #include <string>
 #include <functional>
 #include <map>

--- a/include/LightGBM/feature_group.h
+++ b/include/LightGBM/feature_group.h
@@ -10,6 +10,7 @@
 #include <LightGBM/meta.h>
 #include <LightGBM/utils/random.h>
 
+#include <cstdint>
 #include <cstdio>
 #include <memory>
 #include <vector>

--- a/include/LightGBM/train_share_states.h
+++ b/include/LightGBM/train_share_states.h
@@ -11,6 +11,7 @@
 #include <LightGBM/utils/threading.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/include/LightGBM/tree.h
+++ b/include/LightGBM/tree.h
@@ -8,6 +8,7 @@
 #include <LightGBM/dataset.h>
 #include <LightGBM/meta.h>
 
+#include <cstdint>
 #include <string>
 #include <map>
 #include <memory>

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <cstdio>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>

--- a/src/io/cuda/cuda_column_data.cpp
+++ b/src/io/cuda/cuda_column_data.cpp
@@ -7,6 +7,8 @@
 
 #include <LightGBM/cuda/cuda_column_data.hpp>
 
+#include <cstdint>
+
 namespace LightGBM {
 
 CUDAColumnData::CUDAColumnData(const data_size_t num_data, const int gpu_device_id) {

--- a/src/io/json11.cpp
+++ b/src/io/json11.cpp
@@ -23,6 +23,7 @@
 #include <LightGBM/utils/log.h>
 
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <limits>


### PR DESCRIPTION
Earlier today, I got an email from Prof. Brian Ripley (from CRAN):

> _**subject:** CRAN packages missing `<cstint>` header_
>
> _**body:** Current snapshots of g++ 15 are complaining that you have omitted the header <cstdint>.  Please follow the advice in the log at your next update.  (We would contact you again if this persists when a release date for GCC 15 is known, but they tend to give only a week's notice.)_

Linking to these logs for a build of `lightgbm` with gcc-15: https://www.stats.ox.ac.uk/pub/bdr/gcc15/lightgbm.out

It contains compilation errors like this:

```text
io/json11.cpp: In function 'void json11_internal_lightgbm::dump(const std::string&, std::string*)':
io/json11.cpp:93:28: error: 'uint8_t' does not name a type
   93 |     } else if (static_cast<uint8_t>(ch) <= 0x1f) {
      |                            ^~~~~~~
io/json11.cpp:26:1: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
```

From the `gcc` docs (https://gcc.gnu.org/gcc-15/porting_to.html):

> _Some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library. As such, C++ programs that used standard library components without including the right headers will no longer compile._

> _In particular, the following header is used less widely within libstdc++ and may need to be included explicitly when compiling with GCC 15:_
>   * _`<cstdint>` (for `std::int8_t`, `std::int32_t `, etc.)_


There are more notes on this at https://gcc.gnu.org/gcc-15/porting_to.html

## Notes for Reviewers

### CI job?

I'm not sure how to get a development version of GCC 15 here in CI, to confirm that this is working. https://r-hub.github.io/containers/, for example, does not have a gcc-15 image yet.

If this PR passes all CI (which tests a wide range of compilers and operating systems), I think we should merge it and include it in the next release. Hopefully that will be sufficient.

We can test against gcc-15 as a separate effort.