### PR TITLE
[ci] set upper bound on dask

### DIFF
--- a/.ci/conda-envs/ci-core.txt
+++ b/.ci/conda-envs/ci-core.txt
@@ -18,7 +18,7 @@
 
 # direct imports
 cffi>=1.16
-dask>=2023.5.0
+dask>=2023.5.0,<2024.12
 joblib>=1.3.2
 matplotlib-base>=3.7.3
 numpy>=1.24.4


### PR DESCRIPTION
Sets an upper bound on dask to unblock the CI jobs until #6739 is resolved.