### PR TITLE
WIP: [python-package] remove unnecessary layer of try-catching in conditional imports

### DIFF
--- a/python-package/lightgbm/__init__.py
+++ b/python-package/lightgbm/__init__.py
@@ -10,21 +10,10 @@ from pathlib import Path
 # and its dependencies as early as possible
 from .basic import Booster, Dataset, Sequence, register_logger
 from .callback import EarlyStopException, early_stopping, log_evaluation, record_evaluation, reset_parameter
+from .dask import DaskLGBMClassifier, DaskLGBMRanker, DaskLGBMRegressor
 from .engine import CVBooster, cv, train
-
-try:
-    from .sklearn import LGBMClassifier, LGBMModel, LGBMRanker, LGBMRegressor
-except ImportError:
-    pass
-try:
-    from .plotting import create_tree_digraph, plot_importance, plot_metric, plot_split_value_histogram, plot_tree
-except ImportError:
-    pass
-try:
-    from .dask import DaskLGBMClassifier, DaskLGBMRanker, DaskLGBMRegressor
-except ImportError:
-    pass
-
+from .plotting import create_tree_digraph, plot_importance, plot_metric, plot_split_value_histogram, plot_tree
+from .sklearn import LGBMClassifier, LGBMModel, LGBMRanker, LGBMRegressor
 
 _version_path = Path(__file__).absolute().parent / "VERSION.txt"
 if _version_path.is_file():


### PR DESCRIPTION
Optional dependencies in this project are handled via a pattern like this in `compat.py`:

```python
try:
    from sklearn.preprocessing import LabelEncoder
    # ... many more ...
    SKLEARN_INSTALLED = True
except ImportError:
    LabelEncoder = None
    SKLEARN_INSTALLED = False
```

That ensures that importing from `lightgbm` and `lightgbm.sklearn` still works even in environments where `scikit-learn` is not installed.

Given this protection, this additional layer of try-catching in the top-level `__init__.py` is unnecessary:

https://github.com/microsoft/LightGBM/blob/53e0ddf7cd6eb281e3bec6273b19ff541c69bfa6/python-package/lightgbm/__init__.py#L15-L19

This proposes removing it, for the following reasons:

* simplifies the code
* makes debugging other import issues easier (see "Notes for Reviewers")
* maybe speeds up imports a tiny bit? (I'm not sure)

## Notes for Reviewers

The try-catches removed in this PR have been in `lightgbm` for 8+ years, since #97

### How I tested this

Installed the library.

```shell
cmake -B build -S .
cmake --build build --target _lightgbm -j4
sh build-python.sh install --precompile
```

Tried importing uninstalling `scikit-learn` and them importing `LGBMClassifier`.

```shell
pip uninstall --yes scikit-learn scipy
python -c "from lightgbm import LGBMClassifier"
```



