### PR TITLE
[fix] resolve potential attack in linker connection building

### DIFF
--- a/src/network/linkers_socket.cpp
+++ b/src/network/linkers_socket.cpp
@@ -157,6 +157,9 @@ void Linkers::ListenThread(int incoming_cnt) {
     }
     int* ptr_in_rank = reinterpret_cast<int*>(buffer);
     int in_rank = *ptr_in_rank;
+    if (in_rank < 0 && in_rank >= num_machines_) {
+      Log::Fatal("Invalid rank %d found during initialization of linkers. The world size is %d", in_rank, num_machines_);
+    }
     // add new socket
     SetLinker(in_rank, handler);
     ++connected_cnt;

--- a/src/network/linkers_socket.cpp
+++ b/src/network/linkers_socket.cpp
@@ -158,7 +158,7 @@ void Linkers::ListenThread(int incoming_cnt) {
     int* ptr_in_rank = reinterpret_cast<int*>(buffer);
     int in_rank = *ptr_in_rank;
     if (in_rank < 0 || in_rank >= num_machines_) {
-      Log::Fatal("Invalid rank %d found during initialization of linkers. The world size is %d", in_rank, num_machines_);
+      Log::Fatal("Invalid rank %d found during initialization of linkers. The world size is %d.", in_rank, num_machines_);
     }
     // add new socket
     SetLinker(in_rank, handler);

--- a/src/network/linkers_socket.cpp
+++ b/src/network/linkers_socket.cpp
@@ -157,7 +157,7 @@ void Linkers::ListenThread(int incoming_cnt) {
     }
     int* ptr_in_rank = reinterpret_cast<int*>(buffer);
     int in_rank = *ptr_in_rank;
-    if (in_rank < 0 && in_rank >= num_machines_) {
+    if (in_rank < 0 || in_rank >= num_machines_) {
       Log::Fatal("Invalid rank %d found during initialization of linkers. The world size is %d", in_rank, num_machines_);
     }
     // add new socket


### PR DESCRIPTION
This is to resolve potential attack when building a connection in the initialization of distributed training. An attacker could send a malicious rank through the listener, causing an out of bound write. This was found by our secure research team.