### PR TITLE
[python-package] Fix inconsistency in `predict()` output shape for 1-tree models

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1248,7 +1248,7 @@ class _InnerPredictor:
         if pred_leaf:
             preds = preds.astype(np.int32)
         is_sparse = isinstance(preds, (list, scipy.sparse.spmatrix))
-        if not is_sparse and preds.size != nrow or pred_leaf:
+        if not is_sparse and preds.size != nrow or (pred_leaf or pred_contrib):
             if preds.size % nrow == 0:
                 preds = preds.reshape(nrow, -1)
             else:

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1248,7 +1248,7 @@ class _InnerPredictor:
         if pred_leaf:
             preds = preds.astype(np.int32)
         is_sparse = isinstance(preds, (list, scipy.sparse.spmatrix))
-        if not is_sparse and preds.size != nrow or (pred_leaf or pred_contrib):
+        if not is_sparse and (preds.size != nrow or pred_leaf or pred_contrib):
             if preds.size % nrow == 0:
                 preds = preds.reshape(nrow, -1)
             else:

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1248,7 +1248,7 @@ class _InnerPredictor:
         if pred_leaf:
             preds = preds.astype(np.int32)
         is_sparse = isinstance(preds, (list, scipy.sparse.spmatrix))
-        if not is_sparse and preds.size != nrow:
+        if not is_sparse and preds.size != nrow or pred_leaf:
             if preds.size % nrow == 0:
                 preds = preds.reshape(nrow, -1)
             else:

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2307,7 +2307,16 @@ def test_refit():
     assert err_pred > new_err_pred
 
 
-def test_refit_with_one_tree():
+def test_refit_with_one_tree_regression():
+    X, y = make_regression(n_samples=10_000, n_features=10)
+    lgb_train = lgb.Dataset(X, label=y)
+    params = {"objective": "regression", "verbosity": -1}
+    model = lgb.train(params, lgb_train, num_boost_round=1)
+    model_refit = model.refit(X, y)
+    assert isinstance(model_refit, lgb.Booster)
+
+
+def test_refit_with_one_tree_binary_classification():
     X, y = load_breast_cancer(return_X_y=True)
     lgb_train = lgb.Dataset(X, label=y)
     params = {"objective": "binary", "verbosity": -1}
@@ -2315,9 +2324,11 @@ def test_refit_with_one_tree():
     model_refit = model.refit(X, y)
     assert isinstance(model_refit, lgb.Booster)
 
-    X, y = make_regression(n_samples=10_000, n_features=10)
-    lgb_train = lgb.Dataset(X, label=y)
-    params = {"objective": "regression", "verbosity": -1}
+
+def test_refit_with_one_tree_multiclass_classification():
+    X, y = load_iris(return_X_y=True)
+    lgb_train = lgb.Dataset(X, y)
+    params = {"objective": "multiclass", "num_class": 3, "verbose": -1}
     model = lgb.train(params, lgb_train, num_boost_round=1)
     model_refit = model.refit(X, y)
     assert isinstance(model_refit, lgb.Booster)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -3890,7 +3890,7 @@ def test_predict_regression_output_shape():
     assert bst.predict(X).shape == (n_samples,)
     assert bst.predict(X, pred_contrib=True).shape == (n_samples, n_features + 1)
     assert bst.predict(X, pred_leaf=True).shape == (n_samples, 1)
-    
+
     # 2-round model
     bst = lgb.train(params, dtrain, num_boost_round=2)
     assert bst.predict(X).shape == (n_samples,)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -15,7 +15,7 @@ import numpy as np
 import psutil
 import pytest
 from scipy.sparse import csr_matrix, isspmatrix_csc, isspmatrix_csr
-from sklearn.datasets import load_svmlight_file, make_blobs, make_multilabel_classification
+from sklearn.datasets import load_svmlight_file, make_blobs, make_multilabel_classification, make_regression
 from sklearn.metrics import average_precision_score, log_loss, mean_absolute_error, mean_squared_error, roc_auc_score
 from sklearn.model_selection import GroupKFold, TimeSeriesSplit, train_test_split
 
@@ -2314,6 +2314,14 @@ def test_refit_with_one_tree():
     model = lgb.train(params, lgb_train, num_boost_round=1)
     model_refit = model.refit(X, y)
     assert isinstance(model_refit, lgb.Booster)
+
+
+def test_pred_leaf_output_shape():
+    X, y = make_regression(n_samples=10_000, n_features=10)
+    dtrain = lgb.Dataset(X, label=y)
+    params = {"objective": "regression", "verbosity": -1}
+    assert lgb.train(params, dtrain, num_boost_round=1).predict(X, pred_leaf=True).shape == (10_000, 1)
+    assert lgb.train(params, dtrain, num_boost_round=2).predict(X, pred_leaf=True).shape == (10_000, 2)
 
 
 def test_refit_dataset_params(rng):

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2314,7 +2314,7 @@ def test_refit():
 
 
 def test_refit_with_one_tree_regression():
-    X, y = make_regression(n_samples=10_000, n_features=10)
+    X, y = make_regression(n_samples=1_000, n_features=2)
     lgb_train = lgb.Dataset(X, label=y)
     params = {"objective": "regression", "verbosity": -1}
     model = lgb.train(params, lgb_train, num_boost_round=1)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2310,7 +2310,7 @@ def test_refit():
 def test_refit_with_one_tree():
     X, y = load_breast_cancer(return_X_y=True)
     lgb_train = lgb.Dataset(X, label=y)
-    params={"objective": "binary", "num_trees": 1, "verbosity": -1}
+    params = {"objective": "binary", "num_trees": 1, "verbosity": -1}
     model = lgb.train(params, lgb_train, num_boost_round=1)
     model_refit = model.refit(X, y)
     assert isinstance(model_refit, lgb.Booster)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -3939,20 +3939,6 @@ def test_predict_multiclass_classification_output_shape():
     assert bst.predict(X, pred_leaf=True).shape == (n_samples, n_classes * 2)
 
 
-def test_predict_leaf_multiclass_classification_output_shape():
-    X, y = make_classification(n_samples=10_000, n_features=10, n_classes=3, n_informative=6)
-    dtrain = lgb.Dataset(X, label=y)
-    params = {"objective": "multiclass", "verbosity": -1, "num_class": 3}
-    assert lgb.train(params, dtrain, num_boost_round=1).predict(X, pred_leaf=True).shape == (10_000, 3)
-
-
-def test_predict_contrib_multiclass_classification_output_shape():
-    X, y = make_classification(n_samples=10_000, n_features=10, n_classes=3, n_informative=6)
-    dtrain = lgb.Dataset(X, label=y)
-    params = {"objective": "multiclass", "verbosity": -1, "num_class": 3}
-    assert lgb.train(params, dtrain, num_boost_round=1).predict(X, pred_contrib=True).shape == (10_000, 33)
-
-
 def test_average_precision_metric():
     # test against sklearn average precision metric
     X, y = load_breast_cancer(return_X_y=True)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -16,10 +16,10 @@ import psutil
 import pytest
 from scipy.sparse import csr_matrix, isspmatrix_csc, isspmatrix_csr
 from sklearn.datasets import (
-    load_svmlight_file, 
-    make_blobs, 
-    make_classification, 
-    make_multilabel_classification, 
+    load_svmlight_file,
+    make_blobs,
+    make_classification,
+    make_multilabel_classification,
     make_regression,
 )
 from sklearn.metrics import average_precision_score, log_loss, mean_absolute_error, mean_squared_error, roc_auc_score

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2315,6 +2315,13 @@ def test_refit_with_one_tree():
     model_refit = model.refit(X, y)
     assert isinstance(model_refit, lgb.Booster)
 
+    X, y = make_regression(n_samples=10_000, n_features=10)
+    lgb_train = lgb.Dataset(X, label=y)
+    params = {"objective": "regression", "verbosity": -1}
+    model = lgb.train(params, lgb_train, num_boost_round=1)
+    model_refit = model.refit(X, y)
+    assert isinstance(model_refit, lgb.Booster)
+
 
 def test_pred_leaf_output_shape():
     X, y = make_regression(n_samples=10_000, n_features=10)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2307,6 +2307,15 @@ def test_refit():
     assert err_pred > new_err_pred
 
 
+def test_refit_with_one_tree():
+    X, y = load_breast_cancer(return_X_y=True)
+    lgb_train = lgb.Dataset(X, label=y)
+    params={"objective": "binary", "num_trees": 1, "verbosity": -1}
+    model = lgb.train(params, lgb_train, num_boost_round=1)
+    model_refit = model.refit(X, y)
+    assert isinstance(model_refit, lgb.Booster)
+
+
 def test_refit_dataset_params(rng):
     # check refit accepts dataset_params
     X, y = load_breast_cancer(return_X_y=True)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -2310,7 +2310,7 @@ def test_refit():
 def test_refit_with_one_tree():
     X, y = load_breast_cancer(return_X_y=True)
     lgb_train = lgb.Dataset(X, label=y)
-    params = {"objective": "binary", "num_trees": 1, "verbosity": -1}
+    params = {"objective": "binary", "verbosity": -1}
     model = lgb.train(params, lgb_train, num_boost_round=1)
     model_refit = model.refit(X, y)
     assert isinstance(model_refit, lgb.Booster)

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -15,7 +15,13 @@ import numpy as np
 import psutil
 import pytest
 from scipy.sparse import csr_matrix, isspmatrix_csc, isspmatrix_csr
-from sklearn.datasets import load_svmlight_file, make_blobs, make_classification, make_multilabel_classification, make_regression
+from sklearn.datasets import (
+    load_svmlight_file, 
+    make_blobs, 
+    make_classification, 
+    make_multilabel_classification, 
+    make_regression,
+)
 from sklearn.metrics import average_precision_score, log_loss, mean_absolute_error, mean_squared_error, roc_auc_score
 from sklearn.model_selection import GroupKFold, TimeSeriesSplit, train_test_split
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/LightGBM/issues/6737