### PR TITLE
[ci] remove Docker volumes during Azure cleanup

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -69,15 +69,17 @@ jobs:
       # check disk usage
       print-diagnostics
       # remove old containers, container images, volumes
-      # ref: https://stackoverflow.com/a/32723127/3986677)
+      # ref: https://stackoverflow.com/a/32723127/3986677
+      # ref: https://depot.dev/blog/docker-clear-cache#removing-everything-with-docker-system-prune
       echo "---- running 'docker system prune' ----"
       /tmp/docker system prune \
         --all \
         --force \
+        --volumes \
         --filter until=720h
       # check disk usage again
       print-diagnostics
-    displayName: clean
+    displayName: Clean
 ###########################################
 - job: Linux
 ###########################################


### PR DESCRIPTION
I believe we don't need preserving anonymous volumes during cleanup.

Refer to https://depot.dev/blog/docker-clear-cache#removing-everything-with-docker-system-prune and https://docs.docker.com/reference/cli/docker/system/prune/.

> By default, volumes aren't removed to prevent important data from being deleted if there is currently no container using the volume. Use the `--volumes` flag when running the command to prune anonymous volumes as well: