### PR TITLE
[python-package] stop relying on string concatenation / splitting for cv() eval results

### DIFF
--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -325,11 +325,14 @@ class _EarlyStoppingCallback:
             _log_warning("Early stopping is not available in dart mode")
             return
 
+        # get details of the first dataset
+        first_dataset_name, first_metric_name, *_ = env.evaluation_result_list[0]
+
         # validation sets are guaranteed to not be identical to the training data in cv()
         if isinstance(env.model, Booster):
             only_train_set = len(env.evaluation_result_list) == 1 and self._is_train_set(
-                ds_name=env.evaluation_result_list[0][0],
-                eval_name=env.evaluation_result_list[0][1].split(" ")[0],
+                ds_name=first_dataset_name,
+                eval_name=first_dataset_name,
                 env=env,
             )
             if only_train_set:
@@ -368,8 +371,7 @@ class _EarlyStoppingCallback:
                 _log_info(f"Using {self.min_delta} as min_delta for all metrics.")
             deltas = [self.min_delta] * n_datasets * n_metrics
 
-        # split is needed for "<dataset type> <metric>" case (e.g. "train l1")
-        self.first_metric = env.evaluation_result_list[0][1].split(" ")[-1]
+        self.first_metric = first_metric_name
         for eval_ret, delta in zip(env.evaluation_result_list, deltas):
             self.best_iter.append(0)
             if eval_ret[3]:  # greater is better

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -72,7 +72,11 @@ class CallbackEnv:
 
 
 def _using_cv(env: CallbackEnv) -> bool:
-    return env.__class__.__name__ == "CVBooster"
+    """Check if model in callback env is a CVBooster"""
+    # this string-matching is used instead of isinstance() to avoid a circular import
+    return env.model.__class__.__name__ == "CVBooster" or any(
+        c.__name__ == "CVBooster" for c in env.model.__class__.__bases__
+    )
 
 
 def _format_eval_result(value: _EvalResultTuple, show_stdv: bool) -> str:

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -73,15 +73,13 @@ class CallbackEnv:
 
 def _format_eval_result(value: _EvalResultTuple, show_stdv: bool) -> str:
     """Format metric string."""
-    if len(value) == 4:
-        return f"{value[0]}'s {value[1]}: {value[2]:g}"
-    elif len(value) == 5:
-        if show_stdv:
-            return f"{value[0]}'s {value[1]}: {value[2]:g} + {value[4]:g}"  # type: ignore[misc]
-        else:
-            return f"{value[0]}'s {value[1]}: {value[2]:g}"
-    else:
-        raise ValueError("Wrong metric value")
+    dataset_name, metric_name, metric_value, *_ = value
+    out = f"{dataset_name}'s {metric_name}: {metric_value:g}"
+    # tuples from cv() sometimes have a 5th item, with standard deviation of
+    # the evaluation metric (taken over all cross-validation folds)
+    if show_stdv and len(value) == 5:
+        out += f" + {value[4]:g}"
+    return out
 
 
 class _LogEvaluationCallback:

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -72,7 +72,7 @@ class CallbackEnv:
 
 
 def _using_cv(env: CallbackEnv) -> bool:
-    """Check if model in callback env is a CVBooster"""
+    """Check if model in callback env is a CVBooster."""
     # this string-matching is used instead of isinstance() to avoid a circular import
     return env.model.__class__.__name__ == "CVBooster" or any(
         c.__name__ == "CVBooster" for c in env.model.__class__.__bases__

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -71,12 +71,12 @@ class CallbackEnv:
     evaluation_result_list: Optional[_ListOfEvalResultTuples]
 
 
-def _using_cv(env: CallbackEnv) -> bool:
+def _is_using_cv(env: CallbackEnv) -> bool:
     """Check if model in callback env is a CVBooster."""
-    # this string-matching is used instead of isinstance() to avoid a circular import
-    return env.model.__class__.__name__ == "CVBooster" or any(
-        c.__name__ == "CVBooster" for c in env.model.__class__.__bases__
-    )
+    # this import is here to avoid a circular import
+    from .engine import CVBooster
+
+    return isinstance(env.model, CVBooster)
 
 
 def _format_eval_result(value: _EvalResultTuple, show_stdv: bool) -> str:
@@ -314,7 +314,7 @@ class _EarlyStoppingCallback:
         """Check, by name, if a given Dataset is the training data."""
         # for lgb.cv() with eval_train_metric=True, evaluation is also done on the training set
         # and those metrics are considered for early stopping
-        if _using_cv(env) and dataset_name == "train":
+        if _is_using_cv(env) and dataset_name == "train":
             return True
 
         # for lgb.train(), it's possible to pass the training data via valid_sets with any eval_name

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -71,6 +71,10 @@ class CallbackEnv:
     evaluation_result_list: Optional[_ListOfEvalResultTuples]
 
 
+def _using_cv(env: CallbackEnv) -> bool:
+    return env.__class__.__name__ == "CVBooster"
+
+
 def _format_eval_result(value: _EvalResultTuple, show_stdv: bool) -> str:
     """Format metric string."""
     dataset_name, metric_name, metric_value, *_ = value
@@ -306,7 +310,7 @@ class _EarlyStoppingCallback:
         """Check, by name, if a given Dataset is the training data."""
         # for lgb.cv() with eval_train_metric=True, evaluation is also done on the training set
         # and those metrics are considered for early stopping
-        if env.model.__class__.__name__ == "CVBooster" and dataset_name == "train":
+        if _using_cv(env) and dataset_name == "train":
             return True
 
         # for lgb.train(), it's possible to pass the training data via valid_sets with any eval_name

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -302,15 +302,15 @@ class _EarlyStoppingCallback:
     def _lt_delta(self, curr_score: float, best_score: float, delta: float) -> bool:
         return curr_score < best_score - delta
 
-    def _is_train_set(self, ds_name: str, eval_name: str, env: CallbackEnv) -> bool:
+    def _is_train_set(self, dataset_name: str, env: CallbackEnv) -> bool:
         """Check, by name, if a given Dataset is the training data."""
         # for lgb.cv() with eval_train_metric=True, evaluation is also done on the training set
         # and those metrics are considered for early stopping
-        if env.model.__class__.__name__ == "CVBooster" and eval_name == "train":
+        if env.model.__class__.__name__ == "CVBooster" and dataset_name == "train":
             return True
 
         # for lgb.train(), it's possible to pass the training data via valid_sets with any eval_name
-        if isinstance(env.model, Booster) and ds_name == env.model._train_data_name:
+        if isinstance(env.model, Booster) and dataset_name == env.model._train_data_name:
             return True
 
         return False
@@ -331,8 +331,7 @@ class _EarlyStoppingCallback:
         # validation sets are guaranteed to not be identical to the training data in cv()
         if isinstance(env.model, Booster):
             only_train_set = len(env.evaluation_result_list) == 1 and self._is_train_set(
-                ds_name=first_dataset_name,
-                eval_name=first_dataset_name,
+                dataset_name=first_dataset_name,
                 env=env,
             )
             if only_train_set:
@@ -416,8 +415,7 @@ class _EarlyStoppingCallback:
             if self.first_metric_only and self.first_metric != metric_name:
                 continue  # use only the first metric for early stopping
             if self._is_train_set(
-                ds_name=dataset_name,
-                eval_name=dataset_name,
+                dataset_name=dataset_name,
                 env=env,
             ):
                 continue  # train data for lgb.cv or sklearn wrapper (underlying lgb.train)

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -594,8 +594,7 @@ def _agg_cv_result(
     metric_types: Dict[Tuple[str, str], bool] = OrderedDict()
     metric_values: Dict[Tuple[str, str], List[float]] = OrderedDict()
     for one_result in raw_results:
-        for one_line in one_result:
-            dataset_name, metric_name, metric_value, is_higher_better = one_line
+        for dataset_name, metric_name, metric_value, is_higher_better in one_result:
             key = (dataset_name, metric_name)
             metric_types[key] = is_higher_better
             metric_values.setdefault(key, [])

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -585,10 +585,11 @@ def _agg_cv_result(
     metric_type: Dict[str, bool] = {}
     for one_result in raw_results:
         for one_line in one_result:
-            key = f"{one_line[0]} {one_line[1]}"
-            metric_type[key] = one_line[3]
+            dataset_name, metric_name, metric_value, is_higher_better = one_line
+            key = f"{dataset_name} {metric_name}"
+            metric_type[key] = is_higher_better
             cvmap.setdefault(key, [])
-            cvmap[key].append(one_line[2])
+            cvmap[key].append(metric_value)
     return [("cv_agg", k, float(np.mean(v)), metric_type[k], float(np.std(v))) for k, v in cvmap.items()]
 
 

--- a/python-package/lightgbm/engine.py
+++ b/python-package/lightgbm/engine.py
@@ -605,10 +605,7 @@ def _agg_cv_result(
     # [
     #     (<dataset_name>, <metric_name>, mean(<values>), <is_higher_better>, std_dev(<values>))
     # ]
-    return [
-        (k[0], k[1], float(np.mean(v)), metric_types[k], float(np.std(v)))
-        for k, v in metric_values.items()
-    ]
+    return [(k[0], k[1], float(np.mean(v)), metric_types[k], float(np.std(v))) for k, v in metric_values.items()]
 
 
 def cv(

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -64,6 +64,13 @@ def constant_metric(preds, train_data):
     return ("error", 0.0, False)
 
 
+def constant_metric_multi(preds, train_data):
+    return [
+        ("important_metric", 1.5, False),
+        ("irrelevant_metric", 7.8, False),
+    ]
+
+
 def decreasing_metric(preds, train_data):
     return ("decreasing_metric", next(decreasing_generator), False)
 
@@ -2570,6 +2577,13 @@ def test_metrics():
     assert "valid binary_logloss-mean" in res
     assert "valid error-mean" in res
 
+    # default metric in args with 1 custom function returning a list of 2 metrics
+    res = get_cv_result(metrics="binary_logloss", feval=constant_metric_multi)
+    assert len(res) == 6
+    assert "valid binary_logloss-mean" in res
+    assert res["valid important_metric-mean"] == [1.5, 1.5]
+    assert res["valid irrelevant_metric-mean"] == [7.8, 7.8]
+
     # non-default metric in args with custom one
     res = get_cv_result(metrics="binary_error", feval=constant_metric)
     assert len(res) == 4
@@ -2702,6 +2716,13 @@ def test_metrics():
     assert len(evals_result["valid_0"]) == 2
     assert "binary_logloss" in evals_result["valid_0"]
     assert "error" in evals_result["valid_0"]
+
+    # default metric in params with custom function returning a list of 2 metrics
+    train_booster(params=params_obj_metric_log_verbose, feval=constant_metric_multi)
+    assert len(evals_result["valid_0"]) == 3
+    assert "binary_logloss" in evals_result["valid_0"]
+    assert evals_result["valid_0"]["important_metric"] == [1.5, 1.5]
+    assert evals_result["valid_0"]["irrelevant_metric"] == [7.8, 7.8]
 
     # non-default metric in params with custom one
     train_booster(params=params_obj_metric_err_verbose, feval=constant_metric)


### PR DESCRIPTION
Contributes to #6748

There are a few activities where `lightgbm` (the Python package) needs to inspect the output of one or more evaluation metrics on one or more datasets.

For example:

* early stopping
* printing evaluation results
* recording evaluation results in memory (e.g. in a dictionary) for use after training

For `train()` and other APIs that end up using it, it tracks those using a list of tuples like this (pseudocode):

```python:
[
  ({dataset_name}, {metric_name}, {is_higher_better}, {metric_value}).
  ...
]
```

`cv()` does something similar. However, its "metric value" is actually a mean of such values taken over all cross-validation folds. Because multiple values are being aggregated, it appends a 5th item with the standard deviation.

```text
[
  ({dataset_name}, {metric_name}, {is_higher_better}, mean({metric_value}), stddev({metric_value}),
  ...
]
```

Some code in `callbacks.py` needs to know, given a list of such tuples, whether they were produced by cross-validation or regular `train()`.

To facilitate that while still somewhat preserving the schema for the tuples, the `cv()` code:

* concatenates the first and second elements into 1
* appends the string literal `"cv_agg"` to the beginning of the tuple

So e.g. `("valid1", "auc", ...)` becomes `("cv_agg", "valid1 auc", ...)`. That happens here:

https://github.com/microsoft/LightGBM/blob/480600b3afaf2a0a6f32cf417edf9567f625b2c3/python-package/lightgbm/engine.py#L580-L592

Every place dealing with such tuples then needs to deal with that, including splitting and re-combining that second element. Like this:

https://github.com/microsoft/LightGBM/blob/480600b3afaf2a0a6f32cf417edf9567f625b2c3/python-package/lightgbm/callback.py#L416-L418

This proposes changes to remove that, so that the `cv()` and `train()` tuples follow a similar schema and all the complexity of splitting and re-combining names can be removed.

It also standardizes on the names from https://github.com/microsoft/LightGBM/pull/6749#discussion_r1882415461

## Notes for Reviewers

This change should be completely backwards-compatible, including with user-provided custom metric function. The code paths here are well-covered by tests (as I found out from many failed tests while developing this 😅 ).


