### PR TITLE
[ci] pin more dependencies in Python 3.8 environment

### DIFF
--- a/.ci/conda-envs/ci-core-py38.txt
+++ b/.ci/conda-envs/ci-core-py38.txt
@@ -39,6 +39,9 @@ pytest=8.2.*
 # pinned here to help speed up solves
 bokeh=3.1.*
 fsspec=2024.5.*
+# TODO(jameslamb): add issue link
+libabseil=20240722.0=*_1
+libre2-11=2024.07.02=*_1
 msgpack-python=1.0.*
 pluggy=1.5.*
 pyparsing=3.1.4

--- a/.ci/conda-envs/ci-core-py38.txt
+++ b/.ci/conda-envs/ci-core-py38.txt
@@ -39,7 +39,8 @@ pytest=8.2.*
 # pinned here to help speed up solves
 bokeh=3.1.*
 fsspec=2024.5.*
-# TODO(jameslamb): add issue link
+# pinning 'libabseil' and 'libre2' to specific build numbers for pyarrow compatibility:
+# ref: https://github.com/microsoft/LightGBM/issues/6772
 libabseil=20240722.0=*_1
 libre2-11=2024.07.02=*_1
 msgpack-python=1.0.*


### PR DESCRIPTION
Fixes #6772

See that issue for details. In short: pins even more things in the Python 3.8 conda environment.

## Notes for Reviewers

As a reminder... `conda-forge` does not support Python 3.8 builds any more ([Python 3.8 is past its end-of-life](https://devguide.python.org/versions/)), so here in CI we use tight pins to get a known-working Python 3.8 environment.