### PR TITLE
[python-package] do not copy column-major numpy arrays when creating Dataset from list of arrays

### DIFF
--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -422,7 +422,7 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromMat(const void* data,
  * \param data_type Type of ``data`` pointer, can be ``C_API_DTYPE_FLOAT32`` or ``C_API_DTYPE_FLOAT64``
  * \param nrow Number of rows
  * \param ncol Number of columns
- * \param is_row_major 1 for row-major, 0 for column-major
+ * \param is_row_major Pointer to the data layouts. 1 for row-major, 0 for column-major
  * \param parameters Additional parameters
  * \param reference Used to align bin mapper with other dataset, nullptr means isn't used
  * \param[out] out Created dataset
@@ -433,7 +433,7 @@ LIGHTGBM_C_EXPORT int LGBM_DatasetCreateFromMats(int32_t nmat,
                                                  int data_type,
                                                  int32_t* nrow,
                                                  int32_t ncol,
-                                                 int is_row_major,
+                                                 int* is_row_major,
                                                  const char* parameters,
                                                  const DatasetHandle reference,
                                                  DatasetHandle* out);

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1309,7 +1309,7 @@ int LGBM_DatasetCreateFromMat(const void* data,
                                     data_type,
                                     &nrow,
                                     ncol,
-                                    is_row_major,
+                                    &is_row_major,
                                     parameters,
                                     reference,
                                     out);
@@ -1320,7 +1320,7 @@ int LGBM_DatasetCreateFromMats(int32_t nmat,
                                int data_type,
                                int32_t* nrow,
                                int32_t ncol,
-                               int is_row_major,
+                               int* is_row_major,
                                const char* parameters,
                                const DatasetHandle reference,
                                DatasetHandle* out) {
@@ -1337,7 +1337,7 @@ int LGBM_DatasetCreateFromMats(int32_t nmat,
 
   std::vector<std::function<std::vector<double>(int row_idx)>> get_row_fun;
   for (int j = 0; j < nmat; ++j) {
-    get_row_fun.push_back(RowFunctionFromDenseMatric(data[j], nrow[j], ncol, data_type, is_row_major));
+    get_row_fun.push_back(RowFunctionFromDenseMatric(data[j], nrow[j], ncol, data_type, is_row_major[j]));
   }
 
   if (reference == nullptr) {

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -985,7 +985,7 @@ def test_equal_datasets_from_row_major_and_col_major_data(tmp_path):
     assert filecmp.cmp(ds_row_path, ds_col_path)
 
 
-def test_equal_datasets_from_one_and_several_matrices(rng, tmp_path):
+def test_equal_datasets_from_one_and_several_matrices_w_different_layouts(rng, tmp_path):
     # several matrices
     mats = [np.require(rng.random(size=(100, 2)), requirements=order) for order in ("C", "F", "F", "C")]
     several_path = tmp_path / "several.txt"

--- a/tests/python_package_test/test_basic.py
+++ b/tests/python_package_test/test_basic.py
@@ -983,3 +983,17 @@ def test_equal_datasets_from_row_major_and_col_major_data(tmp_path):
 
     # check datasets are equal
     assert filecmp.cmp(ds_row_path, ds_col_path)
+
+
+def test_equal_datasets_from_one_and_several_matrices(rng, tmp_path):
+    # several matrices
+    mats = [np.require(rng.random(size=(100, 2)), requirements=order) for order in ("C", "F", "F", "C")]
+    several_path = tmp_path / "several.txt"
+    lgb.Dataset(mats)._dump_text(several_path)
+
+    # one matrix
+    mat = np.vstack(mats)
+    one_path = tmp_path / "one.txt"
+    lgb.Dataset(mat)._dump_text(one_path)
+
+    assert filecmp.cmp(one_path, several_path)


### PR DESCRIPTION
Following the suggestion in https://github.com/microsoft/LightGBM/pull/6751#issuecomment-2543153272 this changes the signature of the C API `LGBM_DatasetCreateFromMats` function to take an array of integers as `is_row_major`, indicating the layout of each matrix. Also updates the `lightgbm.Dataset.__init_from_list_np2d` method to provide this setting and avoid copying the arrays in the list.