### PR TITLE
[python-package] Separately check whether `pyarrow` and `cffi` are installed

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2126,6 +2126,8 @@ class Dataset:
                 categorical_feature=categorical_feature,
                 pandas_categorical=self.pandas_categorical,
             )
+        elif _is_pyarrow_table(data) and feature_name == "auto":
+            feature_name = data.column_names
 
         # process for args
         params = {} if params is None else params
@@ -2185,7 +2187,6 @@ class Dataset:
             self.__init_from_np2d(data, params_str, ref_dataset)
         elif _is_pyarrow_table(data):
             self.__init_from_pyarrow_table(data, params_str, ref_dataset)
-            feature_name = data.column_names
         elif isinstance(data, list) and len(data) > 0:
             if _is_list_of_numpy_arrays(data):
                 self.__init_from_list_np2d(data, params_str, ref_dataset)

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -1708,7 +1708,7 @@ class _InnerPredictor:
     ) -> Tuple[np.ndarray, int]:
         """Predict for a PyArrow table."""
         if not (PYARROW_INSTALLED and CFFI_INSTALLED):
-            raise LightGBMError("Cannot predict from Arrow without `pyarrow` and `cffi` installed.")
+            raise LightGBMError("Cannot predict from Arrow without 'pyarrow' and 'cffi' installed.")
 
         # Check that the input is valid: we only handle numbers (for now)
         if not all(arrow_is_integer(t) or arrow_is_floating(t) or arrow_is_boolean(t) for t in table.schema.types):
@@ -2460,7 +2460,7 @@ class Dataset:
     ) -> "Dataset":
         """Initialize data from a PyArrow table."""
         if not (PYARROW_INSTALLED and CFFI_INSTALLED):
-            raise LightGBMError("Cannot init dataframe from Arrow without `pyarrow` and `cffi` installed.")
+            raise LightGBMError("Cannot init Dataset from Arrow without 'pyarrow' and 'cffi' installed.")
 
         # Check that the input is valid: we only handle numbers (for now)
         if not all(arrow_is_integer(t) or arrow_is_floating(t) or arrow_is_boolean(t) for t in table.schema.types):

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -27,6 +27,7 @@ import numpy as np
 import scipy.sparse
 
 from .compat import (
+    CFFI_INSTALLED,
     PANDAS_INSTALLED,
     PYARROW_INSTALLED,
     arrow_cffi,
@@ -1706,8 +1707,8 @@ class _InnerPredictor:
         predict_type: int,
     ) -> Tuple[np.ndarray, int]:
         """Predict for a PyArrow table."""
-        if not PYARROW_INSTALLED:
-            raise LightGBMError("Cannot predict from Arrow without `pyarrow` installed.")
+        if not (PYARROW_INSTALLED and CFFI_INSTALLED):
+            raise LightGBMError("Cannot predict from Arrow without `pyarrow` and `cffi` installed.")
 
         # Check that the input is valid: we only handle numbers (for now)
         if not all(arrow_is_integer(t) or arrow_is_floating(t) or arrow_is_boolean(t) for t in table.schema.types):
@@ -2186,6 +2187,8 @@ class Dataset:
         elif isinstance(data, np.ndarray):
             self.__init_from_np2d(data, params_str, ref_dataset)
         elif _is_pyarrow_table(data):
+            if not CFFI_INSTALLED:
+                raise LightGBMError("Cannot init dataframe from Arrow without `pyarrow` and `cffi` installed.")
             self.__init_from_pyarrow_table(data, params_str, ref_dataset)
         elif isinstance(data, list) and len(data) > 0:
             if _is_list_of_numpy_arrays(data):
@@ -2459,8 +2462,8 @@ class Dataset:
         ref_dataset: Optional[_DatasetHandle],
     ) -> "Dataset":
         """Initialize data from a PyArrow table."""
-        if not PYARROW_INSTALLED:
-            raise LightGBMError("Cannot init dataframe from Arrow without `pyarrow` installed.")
+        if not (PYARROW_INSTALLED and CFFI_INSTALLED):
+            raise LightGBMError("Cannot init dataframe from Arrow without `pyarrow` and `cffi` installed.")
 
         # Check that the input is valid: we only handle numbers (for now)
         if not all(arrow_is_integer(t) or arrow_is_floating(t) or arrow_is_boolean(t) for t in table.schema.types):

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -2187,8 +2187,6 @@ class Dataset:
         elif isinstance(data, np.ndarray):
             self.__init_from_np2d(data, params_str, ref_dataset)
         elif _is_pyarrow_table(data):
-            if not CFFI_INSTALLED:
-                raise LightGBMError("Cannot init dataframe from Arrow without `pyarrow` and `cffi` installed.")
             self.__init_from_pyarrow_table(data, params_str, ref_dataset)
         elif isinstance(data, list) and len(data) > 0:
             if _is_list_of_numpy_arrays(data):

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -289,7 +289,6 @@ try:
     from pyarrow import ChunkedArray as pa_ChunkedArray
     from pyarrow import Table as pa_Table
     from pyarrow import chunked_array as pa_chunked_array
-    from pyarrow.cffi import ffi as arrow_cffi
     from pyarrow.types import is_boolean as arrow_is_boolean
     from pyarrow.types import is_floating as arrow_is_floating
     from pyarrow.types import is_integer as arrow_is_integer
@@ -316,17 +315,6 @@ except ImportError:
         def __init__(self, *args: Any, **kwargs: Any):
             pass
 
-    class arrow_cffi:  # type: ignore
-        """Dummy class for pyarrow.cffi.ffi."""
-
-        CData = None
-        addressof = None
-        cast = None
-        new = None
-
-        def __init__(self, *args: Any, **kwargs: Any):
-            pass
-
     class pa_compute:  # type: ignore
         """Dummy class for pyarrow.compute."""
 
@@ -337,6 +325,27 @@ except ImportError:
     arrow_is_boolean = None
     arrow_is_integer = None
     arrow_is_floating = None
+
+
+"""cffi"""
+try:
+    from pyarrow.cffi import ffi as arrow_cffi
+
+    CFFI_INSTALLED = True
+except ImportError:
+    CFFI_INSTALLED = False
+
+    class arrow_cffi:  # type: ignore
+        """Dummy class for pyarrow.cffi.ffi."""
+
+        CData = None
+        addressof = None
+        cast = None
+        new = None
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        pass
+
 
 """cpu_count()"""
 try:

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -343,8 +343,8 @@ except ImportError:
         cast = None
         new = None
 
-    def __init__(self, *args: Any, **kwargs: Any):
-        pass
+        def __init__(self, *args: Any, **kwargs: Any):
+            pass
 
 
 """cpu_count()"""

--- a/python-package/lightgbm/compat.py
+++ b/python-package/lightgbm/compat.py
@@ -316,7 +316,7 @@ except ImportError:
             pass
 
     class pa_compute:  # type: ignore
-        """Dummy class for pyarrow.compute."""
+        """Dummy class for pyarrow.compute module."""
 
         all = None
         equal = None
@@ -339,9 +339,6 @@ except ImportError:
         """Dummy class for pyarrow.cffi.ffi."""
 
         CData = None
-        addressof = None
-        cast = None
-        new = None
 
         def __init__(self, *args: Any, **kwargs: Any):
             pass

--- a/tests/python_package_test/conftest.py
+++ b/tests/python_package_test/conftest.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+import lightgbm
+
 
 @pytest.fixture(scope="function")
 def rng():
@@ -10,3 +12,10 @@ def rng():
 @pytest.fixture(scope="function")
 def rng_fixed_seed():
     return np.random.default_rng(seed=42)
+
+
+@pytest.fixture(scope="function")
+def missing_module_cffi(monkeypatch):
+    """Mock 'cffi' not being importable"""
+    monkeypatch.setattr(lightgbm.compat, "CFFI_INSTALLED", False)
+    monkeypatch.setattr(lightgbm.basic, "CFFI_INSTALLED", False)

--- a/tests/python_package_test/conftest.py
+++ b/tests/python_package_test/conftest.py
@@ -5,6 +5,13 @@ import lightgbm
 
 
 @pytest.fixture(scope="function")
+def missing_module_cffi(monkeypatch):
+    """Mock 'cffi' not being importable"""
+    monkeypatch.setattr(lightgbm.compat, "CFFI_INSTALLED", False)
+    monkeypatch.setattr(lightgbm.basic, "CFFI_INSTALLED", False)
+
+
+@pytest.fixture(scope="function")
 def rng():
     return np.random.default_rng()
 
@@ -12,10 +19,3 @@ def rng():
 @pytest.fixture(scope="function")
 def rng_fixed_seed():
     return np.random.default_rng(seed=42)
-
-
-@pytest.fixture(scope="function")
-def missing_module_cffi(monkeypatch):
-    """Mock 'cffi' not being importable"""
-    monkeypatch.setattr(lightgbm.compat, "CFFI_INSTALLED", False)
-    monkeypatch.setattr(lightgbm.basic, "CFFI_INSTALLED", False)

--- a/tests/python_package_test/test_arrow.py
+++ b/tests/python_package_test/test_arrow.py
@@ -432,3 +432,25 @@ def test_predict_ranking():
         num_boost_round=5,
     )
     assert_equal_predict_arrow_pandas(booster, data)
+
+
+def test_arrow_feature_name_auto():
+    data = generate_dummy_arrow_table()
+    dataset = lgb.Dataset(
+        data, label=pa.array([0, 1, 0, 0, 1]), params=dummy_dataset_params(), categorical_feature=["a"]
+    )
+    booster = lgb.train({"num_leaves": 7}, dataset, num_boost_round=5)
+    assert booster.feature_name() == ["a", "b"]
+
+
+def test_arrow_feature_name_manual():
+    data = generate_dummy_arrow_table()
+    dataset = lgb.Dataset(
+        data,
+        label=pa.array([0, 1, 0, 0, 1]),
+        params=dummy_dataset_params(),
+        feature_name=["c", "d"],
+        categorical_feature=["c"],
+    )
+    booster = lgb.train({"num_leaves": 7}, dataset, num_boost_round=5)
+    assert booster.feature_name() == ["c", "d"]

--- a/tests/python_package_test/test_arrow.py
+++ b/tests/python_package_test/test_arrow.py
@@ -460,8 +460,9 @@ def test_arrow_feature_name_manual():
 
 def test_training_and_predicting_from_pa_table_without_cffi_raises():
     data = generate_dummy_arrow_table()
-    with mock.patch.dict(sys.modules, {"cffi": None}):
+    with mock.patch.dict(sys.modules, {"pyarrow.cffi": None}):
         assert lgb.compat.PYARROW_INSTALLED is True
+        assert lgb.compat.CFFI_INSTALLED is False
 
         with pytest.raises(
             lgb.basic.LightGBMError, match="Cannot init dataframe from Arrow without `pyarrow` and `cffi` installed."

--- a/tests/python_package_test/test_arrow.py
+++ b/tests/python_package_test/test_arrow.py
@@ -470,17 +470,16 @@ def test_dataset_construction_from_pa_table_without_cffi_raises_informative_erro
 def test_predicting_from_pa_table_without_cffi_raises_informative_error(missing_module_cffi):
     data = generate_random_arrow_table(num_columns=3, num_datapoints=1_000, seed=42)
     labels = generate_random_arrow_array(num_datapoints=data.shape[0], seed=42)
-    dataset = lgb.Dataset(
-        data.to_pandas(),
-        label=labels.to_pandas(),
+    bst = lgb.train(
+        params={"num_leaves": 7, "verbose": -1},
+        train_set=lgb.Dataset(
+            data.to_pandas(),
+            label=labels.to_pandas(),
+        ),
+        num_boost_round=2,
     )
 
     with pytest.raises(
         lgb.basic.LightGBMError, match="Cannot predict from Arrow without 'pyarrow' and 'cffi' installed."
     ):
-        bst = lgb.train(
-            params={"num_leaves": 7, "verbose": -1},
-            train_set=dataset,
-            num_boost_round=2,
-        )
         bst.predict(data)


### PR DESCRIPTION
The only tests I can think of would require a runner with `pyarrow` but not `cffi` installed.

Note that the `LightGBMErrors` will only raise when `pyarrow` is installed, but `cffi` is not. If `pyarrow` is not installed, `pa_Table` is a dummy class and `isinstance(data, pa_Table)` returns `False`.

This is a breaking change for users who didn't install `lightgbm[arrow]`, but rather just installed `lightgbm` and `pyarrow` separately. Even if not intended, they could previously train a model on a `pyarrow.Table`, as this was converted via to a `scipy.sparse.csr_matrix(data)`. The fix is simply to install `cffi` or to transform manually with `scipy.sparse.csr_matrix`. 

Still, it is good to inform people that they are not "natively" training from a `pyarrow.Table`, incurring an unnecessary copy.

As already suggested in #6782, an alternative would be to raise a warning.
