### PR TITLE
WIP: [ci] fix valgrind workflow

### DIFF
--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -32,6 +32,7 @@ jobs:
           ref: "refs/pull/${{ github.event.client_payload.pr_number }}/merge"
       - name: Send init status
         if: ${{ always() }}
+        shell: bash
         run: |
           $GITHUB_WORKSPACE/.ci/set-commit-status.sh \
             "${{ github.workflow }}" \

--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -39,7 +39,7 @@ jobs:
             "pending" \
             "${{ github.event.client_payload.pr_sha }}"
           comment="Workflow **${{ github.workflow }}** has been triggered! 🚀\r\n"
-          comment+="${GITHUB_SERVER_URL}/microsoft/LightGBM/actions/runs/${GITHUB_RUN_ID}"
+          comment="${comment} ${GITHUB_SERVER_URL}/microsoft/LightGBM/actions/runs/${GITHUB_RUN_ID}"
           $GITHUB_WORKSPACE/.ci/append-comment.sh \
             "${{ github.event.client_payload.comment_number }}" \
             "${comment}"


### PR DESCRIPTION
The valgrind CI job is failing like this:

```text
/__w/_temp/a09e15f1-9453-4607-9d54-66e1c2404ea4.sh: 6: comment+=https://github.com/microsoft/LightGBM/actions/runs/13159252384: not found
```

([build link](https://github.com/microsoft/LightGBM/actions/runs/13159252384/job/36723582045))

This attempts to fix that.

## Notes for Reviewers

I first thought that the root cause was that GitHub Actions falls back to `sh` is `bash` is not found in `PATH`: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell

But `wch1/r-debug` (the container this runs in) has `bash` 🤔 