### PR TITLE
[ci] fix valgrind workflow

### DIFF
--- a/.github/workflows/optional_checks.yml
+++ b/.github/workflows/optional_checks.yml
@@ -16,6 +16,7 @@ jobs:
           fetch-depth: 5
           submodules: false
       - name: Check that all tests succeeded
+        shell: bash
         run: |
             workflows=(
                 "R valgrind tests;r-valgrind"
@@ -23,7 +24,7 @@ jobs:
             for i in "${workflows[@]}"; do
                 workflow_name=${i%;*}
                 comment="The last reported status from workflow \"$workflow_name\" is failure."
-                comment+=" Commit fixes and rerun the workflow."
+                comment="${comment} Commit fixes and rerun the workflow."
                 trigger_phrase=${i#*;}
                 python \
                     "$GITHUB_WORKSPACE/.ci/get-workflow-status.py" \

--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -32,6 +32,7 @@ jobs:
           ref: "refs/pull/${{ github.event.client_payload.pr_number }}/merge"
       - name: Send init status
         if: ${{ always() }}
+        shell: bash
         run: |
           $GITHUB_WORKSPACE/.ci/set-commit-status.sh \
             "${{ github.workflow }}" \

--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -39,7 +39,7 @@ jobs:
             "pending" \
             "${{ github.event.client_payload.pr_sha }}"
           comment="Workflow **${{ github.workflow }}** has been triggered! 🚀\r\n"
-          comment="${comment} ${GITHUB_SERVER_URL}/microsoft/LightGBM/actions/runs/${GITHUB_RUN_ID}"
+          comment="${comment}${GITHUB_SERVER_URL}/microsoft/LightGBM/actions/runs/${GITHUB_RUN_ID}"
           $GITHUB_WORKSPACE/.ci/append-comment.sh \
             "${{ github.event.client_payload.comment_number }}" \
             "${comment}"

--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -39,7 +39,7 @@ jobs:
             "pending" \
             "${{ github.event.client_payload.pr_sha }}"
           comment="Workflow **${{ github.workflow }}** has been triggered! 🚀\r\n"
-          comment+="${GITHUB_SERVER_URL}/microsoft/LightGBM/actions/runs/${GITHUB_RUN_ID}"
+          comment="${comment} ${GITHUB_SERVER_URL}/microsoft/LightGBM/actions/runs/${GITHUB_RUN_ID}"
           $GITHUB_WORKSPACE/.ci/append-comment.sh \
             "${{ github.event.client_payload.comment_number }}" \
             "${comment}"


### PR DESCRIPTION
Replaces #6815

The valgrind CI job is failing like this:

```text
/__w/_temp/a09e15f1-9453-4607-9d54-66e1c2404ea4.sh: 6: comment+=https://github.com/microsoft/LightGBM/actions/runs/13159252384: not found
```

([build link](https://github.com/microsoft/LightGBM/actions/runs/13159252384/job/36723582045))

This attempts to fix that.

## Notes for Reviewers

As described in #6743, `+=` is a non-POSIX behavior.
My guess is that using it in `run:` in GitHub Actions steps is problematic if the shell is not one that recognizes `+=`.

It *should* be the case that GitHub Actions is using `bash` in these jobs, which shouldn't be a problem. Per https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell

> **`shell` unspecified**
>
> _[`bash -e {0}` is] the default shell on non-Windows platforms. Note that this runs a different command to when `bash` is specified explicitly. If `bash` is not found in the path, this is treated as `sh`._

I'm not sure why (or even if) `bash` is not being found. The container image for the valgrind job definitely does have it.

```shell
docker run \
  --rm \
  -it wch1/r-debug \
  bash --version

# GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu)
```

 This PR attempts to fix that job in 2 ways:

* removing uses of `+=` in Github Actions workflow steps
* explicitly setting `shell: bash` in those steps

### How to Test This

I think that we'll have to merge this to test it, because the comment-triggered workflows pull configuration from `master`: https://github.com/microsoft/LightGBM/pull/6815#issuecomment-2641765572