### PR TITLE
[docs] add a note about DART in early_stopping docstring

### DIFF
--- a/R-package/R/lightgbm.R
+++ b/R-package/R/lightgbm.R
@@ -69,6 +69,9 @@
 #'          in \code{params}, that metric will be considered the "first" one. If you omit \code{metric},
 #'          a default metric will be used based on your choice for the parameter \code{obj} (keyword argument)
 #'          or \code{objective} (passed into \code{params}).
+#'
+#'          \bold{NOTE:} if using \code{boosting_type="dart"}, any early stopping configuration will be ignored
+#'          and early stopping will not be performed.
 #' @section Model serialization:
 #'
 #'          LightGBM model objects can be serialized and de-serialized through functions such as \code{save}

--- a/R-package/man/lgb.cv.Rd
+++ b/R-package/man/lgb.cv.Rd
@@ -134,6 +134,9 @@ Cross validation logic used by LightGBM
          in \code{params}, that metric will be considered the "first" one. If you omit \code{metric},
          a default metric will be used based on your choice for the parameter \code{obj} (keyword argument)
          or \code{objective} (passed into \code{params}).
+
+         \bold{NOTE:} if using \code{boosting_type="dart"}, any early stopping configuration will be ignored
+         and early stopping will not be performed.
 }
 
 \examples{

--- a/R-package/man/lgb.train.Rd
+++ b/R-package/man/lgb.train.Rd
@@ -118,6 +118,9 @@ Low-level R interface to train a LightGBM model. Unlike \code{\link{lightgbm}},
          in \code{params}, that metric will be considered the "first" one. If you omit \code{metric},
          a default metric will be used based on your choice for the parameter \code{obj} (keyword argument)
          or \code{objective} (passed into \code{params}).
+
+         \bold{NOTE:} if using \code{boosting_type="dart"}, any early stopping configuration will be ignored
+         and early stopping will not be performed.
 }
 
 \examples{

--- a/R-package/man/lgb_shared_params.Rd
+++ b/R-package/man/lgb_shared_params.Rd
@@ -87,6 +87,9 @@ Parameter docs shared by \code{lgb.train}, \code{lgb.cv}, and \code{lightgbm}
          in \code{params}, that metric will be considered the "first" one. If you omit \code{metric},
          a default metric will be used based on your choice for the parameter \code{obj} (keyword argument)
          or \code{objective} (passed into \code{params}).
+
+         \bold{NOTE:} if using \code{boosting_type="dart"}, any early stopping configuration will be ignored
+         and early stopping will not be performed.
 }
 
 \section{Model serialization}{

--- a/R-package/man/lightgbm.Rd
+++ b/R-package/man/lightgbm.Rd
@@ -143,5 +143,8 @@ High-level R interface to train a LightGBM model. Unlike \code{\link{lgb.train}}
          in \code{params}, that metric will be considered the "first" one. If you omit \code{metric},
          a default metric will be used based on your choice for the parameter \code{obj} (keyword argument)
          or \code{objective} (passed into \code{params}).
+
+         \bold{NOTE:} if using \code{boosting_type="dart"}, any early stopping configuration will be ignored
+         and early stopping will not be performed.
 }
 

--- a/python-package/lightgbm/callback.py
+++ b/python-package/lightgbm/callback.py
@@ -468,6 +468,11 @@ def early_stopping(
     To check only the first metric set ``first_metric_only`` to True.
     The index of iteration that has the best performance will be saved in the ``best_iteration`` attribute of a model.
 
+    .. note::
+
+        If using ``boosting_type="dart"``, this callback has no effect and early stopping
+        will not be performed.
+
     Parameters
     ----------
     stopping_rounds : int


### PR DESCRIPTION
fixes #6244

Adds a note about DART boosting disabling early stopping in the `callback.early_stopping()` docstring, to make that a bit more visible (especially for people running Python with warnings filtered out).

## Notes for Reviewers

I activated this branch on readthedocs so we can see how this renders.

build link: https://readthedocs.org/projects/lightgbm/builds/27344381/