### PR TITLE
[python-package] Fix Binding a socket to all network interfaces could lead CVE-2018-1281

### DIFF
--- a/python-package/lightgbm/dask.py
+++ b/python-package/lightgbm/dask.py
@@ -68,7 +68,8 @@ class _RemoteSocket:
     def acquire(self) -> int:
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.socket.bind(("", 0))
+        local_ip = socket.gethostbyname(socket.gethostname())
+        self.socket.bind((local_ip, 0))
         return self.socket.getsockname()[1]
 
     def release(self) -> None:


### PR DESCRIPTION
https://github.com/microsoft/LightGBM/blob/f91dcfee8baf5fe329bfddadf38577f6443fdf18/python-package/lightgbm/dask.py#L71-L71

Fix the issue the socket should be bound to a specific interface instead of all interfaces. This can be achieved by replacing the empty string (`""`) with a specific IP address. If the IP address is not known in advance, it can be dynamically determined using `socket.gethostbyname(socket.gethostname())`, which retrieves the IP address of the current machine. This ensures that the socket is bound only to the local machine's primary interface.

The changes will be made in the `_RemoteSocket.acquire` method, specifically on line 71 where the `bind` call is made.

---
