### PR TITLE
[c++] Add CPU version of standard R-squared metric

### DIFF
--- a/R-package/R/metrics.R
+++ b/R-package/R/metrics.R
@@ -24,6 +24,7 @@
             , "map" = TRUE
             , "auc" = TRUE
             , "average_precision" = TRUE
+            , "r2" = TRUE
             , "binary_logloss" = FALSE
             , "binary_error" = FALSE
             , "auc_mu" = TRUE

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -1261,6 +1261,8 @@ Metric Parameters
 
       -  ``average_precision``, `average precision score <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.average_precision_score.html>`__
 
+      -  ``r2``, `R-squared <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.r2_score.html>`__
+
       -  ``binary_logloss``, `log loss <https://en.wikipedia.org/wiki/Cross_entropy>`__, aliases: ``binary``
 
       -  ``binary_error``, for one sample: ``0`` for correct classification, ``1`` for error classification

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -1028,6 +1028,7 @@ struct Config {
   // descl2 = ``map``, `MAP <https://makarandtapaswi.wordpress.com/2012/07/02/intuition-behind-average-precision-and-map/>`__, aliases: ``mean_average_precision``
   // descl2 = ``auc``, `AUC <https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_the_curve>`__
   // descl2 = ``average_precision``, `average precision score <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.average_precision_score.html>`__
+  // descl2 = ``r2``, `R-squared <https://https://scikit-learn.org/stable/modules/generated/sklearn.metrics.r2_score.html>`__
   // descl2 = ``binary_logloss``, `log loss <https://en.wikipedia.org/wiki/Cross_entropy>`__, aliases: ``binary``
   // descl2 = ``binary_error``, for one sample: ``0`` for correct classification, ``1`` for error classification
   // descl2 = ``auc_mu``, `AUC-mu <http://proceedings.mlr.press/v97/kleiman19a/kleiman19a.pdf>`__

--- a/src/metric/metric.cpp
+++ b/src/metric/metric.cpp
@@ -76,6 +76,9 @@ Metric* Metric::CreateMetric(const std::string& type, const Config& config) {
       return new CUDAGammaDevianceMetric(config);
     } else if (type == std::string("tweedie")) {
       return new CUDATweedieMetric(config);
+    } else if (type == std::string("r2")) {
+      Log::Warning("Metric R-squared is not implemented in cuda version. Fall back to evaluation on CPU.");
+      return new R2Metric(config);
     }
   } else {
   #endif  // USE_CUDA
@@ -125,6 +128,8 @@ Metric* Metric::CreateMetric(const std::string& type, const Config& config) {
       return new GammaDevianceMetric(config);
     } else if (type == std::string("tweedie")) {
       return new TweedieMetric(config);
+    } else if (type == std::string("r2")) {
+      return new R2Metric(config);
     }
   #ifdef USE_CUDA
   }

--- a/src/metric/regression_metric.hpp
+++ b/src/metric/regression_metric.hpp
@@ -318,5 +318,113 @@ class TweedieMetric : public RegressionMetric<TweedieMetric> {
 };
 
 
+class R2Metric: public Metric {
+  public:
+   explicit R2Metric(const Config& config) :config_(config) {}
+
+   const std::vector<std::string>& GetName() const override {
+     return name_;
+   }
+
+   double factor_to_bigger_better() const override {
+     return 1.0f;
+   }
+
+   void Init(const Metadata& metadata, data_size_t num_data) override {
+     name_.emplace_back("r2");
+     num_data_ = num_data;
+     label_ = metadata.label();
+     weights_ = metadata.weights();
+
+     double sum_label = 0.0f;
+     if (weights_ == nullptr) {
+       sum_weights_ = static_cast<double>(num_data_);
+       #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static) reduction(+:sum_label)
+       for (data_size_t i = 0; i < num_data_; ++i) {
+         sum_label += label_[i];
+       }
+     } else {
+       sum_weights_ = 0.0f;
+       #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static) reduction(+:sum_weights_, sum_label)
+       for (data_size_t i = 0; i < num_data_; ++i) {
+         sum_weights_ += weights_[i];
+         sum_label += label_[i] * weights_[i];
+       }
+     }
+     label_mean_ = sum_label / sum_weights_;
+
+     total_sum_squares_ = 0.0f;
+     if (weights_ == nullptr) {
+       #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static) reduction(+:total_sum_squares_)
+       for (data_size_t i = 0; i < num_data_; ++i) {
+         double diff = label_[i] - label_mean_;
+         total_sum_squares_ += diff * diff;
+       }
+     } else {
+       #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static) reduction(+:total_sum_squares_)
+       for (data_size_t i = 0; i < num_data_; ++i) {
+         double diff = label_[i] - label_mean_;
+         total_sum_squares_ += diff * diff * weights_[i];
+       }
+     }
+   }
+
+   std::vector<double> Eval(const double* score, const ObjectiveFunction* objective) const override {
+     double residual_sum_squares = 0.0f;
+     if (objective == nullptr) {
+       if (weights_ == nullptr) {
+         #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static) reduction(+:residual_sum_squares)
+         for (data_size_t i = 0; i < num_data_; ++i) {
+           double diff = label_[i] - score[i];
+           residual_sum_squares += diff * diff;
+         }
+       } else {
+         #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static) reduction(+:residual_sum_squares)
+         for (data_size_t i = 0; i < num_data_; ++i) {
+           double diff = label_[i] - score[i];
+           residual_sum_squares += diff * diff * weights_[i];
+         }
+       }
+     } else {
+         if (weights_ == nullptr) {
+         #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static) reduction(+:residual_sum_squares)
+         for (data_size_t i = 0; i < num_data_; ++i) {
+           double t = 0;
+           objective->ConvertOutput(&score[i], &t);
+           double diff = label_[i] - t;
+           residual_sum_squares += diff * diff;
+         }
+       } else {
+         #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static) reduction(+:residual_sum_squares)
+         for (data_size_t i = 0; i < num_data_; ++i) {
+           double t = 0;
+           objective->ConvertOutput(&score[i], &t);
+           double diff = label_[i] - t;
+           residual_sum_squares += diff * diff * weights_[i];
+         }
+       }
+     }
+
+     double r2 = 1.0 - (residual_sum_squares / total_sum_squares_);
+     if (std::fabs(total_sum_squares_) < kZeroThreshold) {
+       return std::vector<double>(1, std::fabs(residual_sum_squares) < kZeroThreshold ? 1.0 : 0.0);
+     }
+     return std::vector<double>(1, r2);
+   }
+
+  protected:
+   data_size_t num_data_;
+   const label_t* label_;
+   const label_t* weights_;
+   double sum_weights_;
+   Config config_;
+   std::vector<std::string> name_;
+
+   // Custom members for R2 calculation
+   double label_mean_;
+   double total_sum_squares_;
+ };
+
+
 }  // namespace LightGBM
 #endif   // LightGBM_METRIC_REGRESSION_METRIC_HPP_

--- a/tests/python_package_test/test_engine.py
+++ b/tests/python_package_test/test_engine.py
@@ -16,7 +16,14 @@ import psutil
 import pytest
 from scipy.sparse import csr_matrix, isspmatrix_csc, isspmatrix_csr
 from sklearn.datasets import load_svmlight_file, make_blobs, make_classification, make_multilabel_classification
-from sklearn.metrics import average_precision_score, log_loss, mean_absolute_error, mean_squared_error, roc_auc_score
+from sklearn.metrics import (
+    average_precision_score,
+    log_loss,
+    mean_absolute_error,
+    mean_squared_error,
+    r2_score,
+    roc_auc_score,
+)
 from sklearn.model_selection import GroupKFold, TimeSeriesSplit, train_test_split
 
 import lightgbm as lgb
@@ -4047,6 +4054,27 @@ def test_average_precision_metric():
     lgb_X = lgb.Dataset(X, label=y)
     lgb.train(params, lgb_X, num_boost_round=1, valid_sets=[lgb_X], callbacks=[lgb.record_evaluation(res)])
     assert res["training"]["average_precision"][-1] == pytest.approx(1)
+
+
+def test_r2_metric():
+    # test against sklearn R2 metric
+    X, y = make_synthetic_regression()
+    params = {"objective": "regression", "metric": "r2", "verbose": -1}
+    res = {}
+    train_data = lgb.Dataset(X, label=y)
+    est = lgb.train(
+        params, train_data, num_boost_round=1, valid_sets=[train_data], callbacks=[lgb.record_evaluation(res)]
+    )
+    r2 = res["training"]["r2"][-1]
+    pred = est.predict(X)
+    sklearn_r2 = r2_score(y, pred)
+    assert r2 == pytest.approx(sklearn_r2)
+    # test that R2 is 1 when y has no variance and the model predicts perfectly
+    y = y.copy()
+    y[:] = 1
+    lgb_X = lgb.Dataset(X, label=y)
+    lgb.train(params, lgb_X, num_boost_round=1, valid_sets=[lgb_X], callbacks=[lgb.record_evaluation(res)])
+    assert res["training"]["r2"][-1] == pytest.approx(1)
 
 
 def test_reset_params_works_with_metric_num_class_and_boosting():


### PR DESCRIPTION
Contributes to: #6983

- Adds R-squared to regression metrics as `R2Metric`
   - Since this metric measures goodness of fit i.e. higher is better, I made it a subclass of [`Metric`](https://github.com/microsoft/LightGBM/blob/8d7b6f9286d0e6f8f0b6075e08da030e65f8a2cc/include/LightGBM/metric.h#L24-L63) instead of a subclass of [`RegressionMetric`](https://github.com/microsoft/LightGBM/blob/8d7b6f9286d0e6f8f0b6075e08da030e65f8a2cc/src/metric/regression_metric.hpp#L22-L116) (like the other regression metrics, which measure loss/error) and used a very similar approach to how `AveragePrecisionMetric` is defined in `binary_metric.hpp`:
https://github.com/microsoft/LightGBM/blob/8d7b6f9286d0e6f8f0b6075e08da030e65f8a2cc/src/metric/binary_metric.hpp#L270-L385
- For this PR I decided to skip the CUDA implementation, but planned to follow-up with that after this gets merged as part of #6983