### PR TITLE
WIP: [c++] default to C++17 for most builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,13 +36,7 @@ endif()
 
 project(lightgbm LANGUAGES C CXX)
 
-if(USE_CUDA)
-  set(CMAKE_CXX_STANDARD 17)
-elseif(BUILD_CPP_TEST)
-  set(CMAKE_CXX_STANDARD 14)
-else()
-  set(CMAKE_CXX_STANDARD 11)
-endif()
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")


### PR DESCRIPTION
Follow-up to #7013

@h-vetinari made a good point there that we probably could safely default to C++17 in most builds here: https://github.com/microsoft/LightGBM/pull/7013#discussion_r2312241486

See the notes on that PR... C++17 has been supported for 6+ years in most compilers by now, so I don't think we lose much portability by doing this. And this should make things easier for upgrading dependencies (for example, linking to newer CUDA Toolkit, Boost, etc.).

## Notes for Reviewers

### There will still be one use of C++11 left

For as long as the R package supports R 3.x, the core source code (excluding anything to do with GPUs or MPI) still needs to be compilable with C++11:

https://github.com/microsoft/LightGBM/blob/de4c88f92c619fed7d4d61056b6c2b8b41107691/R-package/configure.win#L10-L20

Moving the minimum R version to R 4.x would eliminate that. R 4.0 was released 5.5 years ago ([April 2020](https://cran.r-project.org/bin/windows/base/old/)) so it's probably been long enough... but let's not make that a part of this PR. I'll open a separate RFC issue.

* 