### PR TITLE
[ci] [C++] drop support for Visual Studio 2015 (fixes #6803)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 version: 4.6.0.99.{build}
 
-image: Visual Studio 2015
+image: Visual Studio 2017
 platform: x64
 configuration:
   - '3.9'

--- a/R-package/src/install.libs.R
+++ b/R-package/src/install.libs.R
@@ -67,7 +67,6 @@ inst_dir <- file.path(R_PACKAGE_SOURCE, "inst", fsep = "/")
     "Visual Studio 17 2022"
     , "Visual Studio 16 2019"
     , "Visual Studio 15 2017"
-    , "Visual Studio 14 2015"
   )
   working_vs_version <- NULL
   for (vs_version in vs_versions) {

--- a/docs/Installation-Guide.rst
+++ b/docs/Installation-Guide.rst
@@ -597,8 +597,6 @@ Following procedure is for the **MSVC** (Microsoft Visual C++) build.
 
    **Note**: Match your Visual C++ version:
 
-   Visual Studio 2015 -> ``msvc-14.0-64.exe``,
-
    Visual Studio 2017 -> ``msvc-14.1-64.exe``,
 
    Visual Studio 2019 -> ``msvc-14.2-64.exe``,
@@ -611,12 +609,12 @@ Following procedure is for the **MSVC** (Microsoft Visual C++) build.
 
      git clone --recursive https://github.com/microsoft/LightGBM
      cd LightGBM
-     cmake -B build -S . -A x64 -DUSE_GPU=ON -DBOOST_ROOT=C:/local/boost_1_63_0 -DBOOST_LIBRARYDIR=C:/local/boost_1_63_0/lib64-msvc-14.0
+     cmake -B build -S . -A x64 -DUSE_GPU=ON -DBOOST_ROOT=C:/local/boost_1_63_0 -DBOOST_LIBRARYDIR=C:/local/boost_1_63_0/lib64-msvc-14.3
      # if you have installed NVIDIA CUDA to a customized location, you should specify paths to OpenCL headers and library like the following:
-     # cmake -B build -S . -A x64 -DUSE_GPU=ON -DBOOST_ROOT=C:/local/boost_1_63_0 -DBOOST_LIBRARYDIR=C:/local/boost_1_63_0/lib64-msvc-14.0 -DOpenCL_LIBRARY="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.0/lib/x64/OpenCL.lib" -DOpenCL_INCLUDE_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.0/include"
+     # cmake -B build -S . -A x64 -DUSE_GPU=ON -DBOOST_ROOT=C:/local/boost_1_63_0 -DBOOST_LIBRARYDIR=C:/local/boost_1_63_0/lib64-msvc-14.3 -DOpenCL_LIBRARY="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.0/lib/x64/OpenCL.lib" -DOpenCL_INCLUDE_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.0/include"
      cmake --build build --target ALL_BUILD --config Release
 
-   **Note**: ``C:/local/boost_1_63_0`` and ``C:/local/boost_1_63_0/lib64-msvc-14.0`` are locations of your **Boost** binaries (assuming you've downloaded 1.63.0 version for Visual Studio 2015).
+   **Note**: ``C:/local/boost_1_63_0`` and ``C:/local/boost_1_63_0/lib64-msvc-14.3`` are locations of your **Boost** binaries (assuming you've downloaded 1.63.0 version for Visual Studio 2022).
 
 The ``.exe`` and ``.dll`` files will be in ``LightGBM/Release`` folder.
 


### PR DESCRIPTION
Fixes #6803 

Drops support for Visual Studio 2015. That issue mentions several benefits of this, but I'm particularly interested in doing it now to help with adding C++17 support in LightGBM (#7016).