### PR TITLE
[ci] update actions/checkout calls

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -74,6 +74,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: true
       - name: Setup and run tests
         run: |

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: false
       - name: Setup and run tests
         run: |

--- a/.github/workflows/optional_checks.yml
+++ b/.github/workflows/optional_checks.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: false
       - name: Check that all tests succeeded
         shell: bash

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: true
       - name: Setup and run tests
         shell: bash
@@ -106,6 +107,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: true
       - name: Setup and run tests
         shell: bash
@@ -140,6 +142,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: true
       - name: Create wheel
         run: |
@@ -174,6 +177,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: true
       - name: Create wheel
         run: |

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -181,6 +181,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: true
       - name: Install pandoc
         uses: r-lib/actions/setup-pandoc@v2
@@ -240,6 +241,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: true
       - name: Install packages
         shell: bash
@@ -280,6 +282,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: true
       - name: Install pandoc
         uses: r-lib/actions/setup-pandoc@v2

--- a/.github/workflows/r_valgrind.yml
+++ b/.github/workflows/r_valgrind.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           fetch-depth: 5
           submodules: true
+          persist-credentials: false
           repository: microsoft/LightGBM
           ref: "refs/pull/${{ github.event.client_payload.pr_number }}/merge"
       - name: Send init status

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: false
       - name: Setup and run tests
         shell: bash
@@ -48,6 +49,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: false
       - name: Setup and run tests
         shell: bash
@@ -70,6 +72,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: true
       - name: Install packages
         shell: bash

--- a/.github/workflows/triggering_comments.yml
+++ b/.github/workflows/triggering_comments.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 5
+          persist-credentials: false
           submodules: false
 
       - name: Trigger R valgrind tests


### PR DESCRIPTION
From https://github.com/actions/checkout

> _The auth token is persisted in the local git config. This enables your scripts to run authenticated git commands. The token is removed during post-job cleanup. Set `persist-credentials: false` to opt-out._

In almost all cases where LightGBM's CI uses that action, we don't need to do any other authenticated `git` options after the initial call. This sets `persist-credentials: false` in those uses, to reduce the risk of unintended pushes, deletes, etc.