### PR TITLE
[R-package] [ci] drop support for R 3.x (fixes #7023)

### DIFF
--- a/.ci/test-r-package-windows.ps1
+++ b/.ci/test-r-package-windows.ps1
@@ -61,6 +61,8 @@ Remove-From-Path ".*R Client.*"
 Remove-From-Path ".*rtools40.*"
 Remove-From-Path ".*rtools42.*"
 Remove-From-Path ".*rtools43.*"
+Remove-From-Path ".*rtools44.*"
+Remove-From-Path ".*rtools45.*"
 Remove-From-Path ".*shells.*"
 Remove-From-Path ".*Strawberry.*"
 Remove-From-Path ".*tools.*"
@@ -68,21 +70,15 @@ Remove-From-Path ".*tools.*"
 Remove-Item C:\rtools40 -Force -Recurse -ErrorAction Ignore
 Remove-Item C:\rtools42 -Force -Recurse -ErrorAction Ignore
 Remove-Item C:\rtools43 -Force -Recurse -ErrorAction Ignore
+Remove-Item C:\rtools44 -Force -Recurse -ErrorAction Ignore
+Remove-Item C:\rtools45 -Force -Recurse -ErrorAction Ignore
 
 # Get details needed for installing R components
 #
 # NOTES:
 #    * some paths and file names are different on R4.0
 $env:R_MAJOR_VERSION = $env:R_VERSION.split('.')[0]
-if ($env:R_MAJOR_VERSION -eq "3") {
-    # Rtools 3.x has to be installed at C:\Rtools\
-    #     * https://stackoverflow.com/a/46619260/3986677
-    $RTOOLS_INSTALL_PATH = "C:\Rtools"
-    $env:RTOOLS_BIN = "$RTOOLS_INSTALL_PATH\bin"
-    $env:RTOOLS_MINGW_BIN = "$RTOOLS_INSTALL_PATH\mingw_64\bin"
-    $env:RTOOLS_EXE_FILE = "rtools35-x86_64.exe"
-    $env:R_WINDOWS_VERSION = "3.6.3"
-} elseif ($env:R_MAJOR_VERSION -eq "4") {
+if ($env:R_MAJOR_VERSION -eq "4") {
     $RTOOLS_INSTALL_PATH = "C:\rtools43"
     $env:RTOOLS_BIN = "$RTOOLS_INSTALL_PATH\usr\bin"
     $env:RTOOLS_MINGW_BIN = "$RTOOLS_INSTALL_PATH\x86_64-w64-mingw32.static.posix\bin"
@@ -104,11 +100,7 @@ $env:PATH = @(
     "$env:CMAKE_PATH/cmake-$env:CMAKE_VERSION-windows-x86_64/bin",
     "$env:PATH"
 ) -join ";"
-if ([version]$env:R_VERSION -lt [version]"4.0") {
-    $env:CRAN_MIRROR = "https://cran-archive.r-project.org"
-} else {
-    $env:CRAN_MIRROR = "https://cran.rstudio.com"
-}
+$env:CRAN_MIRROR = "https://cran.rstudio.com"
 $env:MIKTEX_EXCEPTION_PATH = "$env:TEMP\miktex"
 
 # don't fail builds for long-running examples unless they're very long.
@@ -202,13 +194,6 @@ if ($env:COMPILER -ne "MSVC") {
         Invoke-R-Code-Redirect-Stderr "commandArgs <- function(...){$env:BUILD_R_FLAGS}; source('build_r.R')"
         Assert-Output $?
     } elseif ($env:R_BUILD_TYPE -eq "cran") {
-        # NOTE: gzip and tar are needed to create a CRAN package on Windows, but
-        # some flavors of tar.exe can fail in some settings on Windows.
-        # Putting the msys64 utilities at the beginning of PATH temporarily to be
-        # sure they're used for that purpose.
-        if ($env:R_MAJOR_VERSION -eq "3") {
-            $env:PATH = @("C:\msys64\usr\bin", "$env:PATH") -join ";"
-        }
         $params = -join @(
             "result <- processx::run(command = 'sh', args = 'build-cran-package.sh', ",
             "echo = TRUE, windows_verbatim_args = FALSE, error_on_status = TRUE)"

--- a/.github/workflows/r_package.yml
+++ b/.github/workflows/r_package.yml
@@ -86,25 +86,11 @@ jobs:
           - os: windows-latest
             task: r-package
             compiler: MINGW
-            toolchain: MINGW
-            r_version: 3.6
-            build_type: cmake
-            container: null
-          - os: windows-latest
-            task: r-package
-            compiler: MINGW
             toolchain: MSYS
             r_version: 4.3
             build_type: cmake
             container: null
           # Visual Studio 2022
-          - os: windows-2022
-            task: r-package
-            compiler: MSVC
-            toolchain: MSVC
-            r_version: 3.6
-            build_type: cmake
-            container: null
           - os: windows-2022
             task: r-package
             compiler: MSVC
@@ -115,13 +101,6 @@ jobs:
           ###############
           # CRAN builds #
           ###############
-          - os: windows-latest
-            task: r-package
-            compiler: MINGW
-            toolchain: MINGW
-            r_version: 3.6
-            build_type: cran
-            container: null
           - os: windows-latest
             task: r-package
             compiler: MINGW

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -51,7 +51,7 @@ Suggests:
     RhpcBLASctl,
     testthat
 Depends:
-    R (>= 3.5)
+    R (>= 4.0)
 Imports:
     R6 (>= 2.4.0),
     data.table (>= 1.9.6),
@@ -62,5 +62,5 @@ Imports:
     parallel,
     utils
 SystemRequirements:
-    ~~CXXSTD~~
+    C++17
 RoxygenNote: 7.3.2

--- a/R-package/R/lgb.Dataset.R
+++ b/R-package/R/lgb.Dataset.R
@@ -266,7 +266,7 @@ Dataset <- R6::R6Class(
         handle <- .Call(
           LGBM_DatasetGetSubset_R
           , ref_handle
-          , c(private$used_indices) # Adding c() fixes issue in R v3.5
+          , c(private$used_indices)
           , length(private$used_indices)
           , params_str
         )

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -92,8 +92,6 @@ Installing a 64-bit version of [Rtools](https://cran.r-project.org/bin/windows/R
 After installing `Rtools` and `CMake`, be sure the following paths are added to the environment variable `PATH`. These may have been automatically added when installing other software.
 
 * `Rtools`
-    - If you have `Rtools` 3.x, example:
-        - `C:\Rtools\mingw_64\bin`
     - If you have `Rtools` 4.0, example:
         - `C:\rtools40\mingw64\bin`
         - `C:\rtools40\usr\bin`
@@ -104,7 +102,7 @@ After installing `Rtools` and `CMake`, be sure the following paths are added to 
 * `CMake`
     - example: `C:\Program Files\CMake\bin`
 * `R`
-    - example: `C:\Program Files\R\R-3.6.1\bin`
+    - example: `C:\Program Files\R\R-4.5.1\bin`
 
 NOTE: Two `Rtools` paths are required from `Rtools` 4.0 onwards because paths and the list of included software was changed in `Rtools` 4.0.
 
@@ -119,16 +117,6 @@ A "toolchain" refers to the collection of software used to build the library. Th
 **Visual Studio (default)**
 
 By default, the package will be built with [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/).
-
-**MinGW (R 3.x)**
-
-If you are using R 3.x and installation fails with Visual Studio, `LightGBM` will fall back to using [MinGW](https://www.mingw-w64.org/) bundled with `Rtools`.
-
-If you want to force `LightGBM` to use MinGW (for any R version), pass `--use-mingw` to the installation script.
-
-```shell
-Rscript build_r.R --use-mingw
-```
 
 **MSYS2 (R 4.x)**
 

--- a/R-package/configure.win
+++ b/R-package/configure.win
@@ -7,30 +7,11 @@
 
 R_EXE="${R_HOME}/bin${R_ARCH_BIN}/R"
 
-# As described in "Using C++ code" in "Writing R Extensions",
-# Rtools35 shipped with g++ 4.9, which didn't support C++17.
-#
-# Testing here for C++17 support, to account for that possibility
-# and to continue supporting R 3.6.
-#
 CXX17=`"${R_EXE}" CMD config CXX17`
 CXX17STD=`"${R_EXE}" CMD config CXX17STD`
 CXX="${CXX17} ${CXX17STD}"
 CXXFLAGS=`"${R_EXE}" CMD config CXX17FLAGS`
 CXX_STD="CXX17"
-
-cpp17_supported="yes"
-if test "${CXX17}" = "";
-then
-    cpp17_supported="no"
-    CXX11=`"${R_EXE}" CMD config CXX11`
-    CXX11STD=`"${R_EXE}" CMD config CXX11STD`
-    CXX="${CXX11} ${CXX11STD}"
-    CXXFLAGS=`"${R_EXE}" CMD config CXX11FLAGS`
-    CXX_STD="CXX11"
-fi
-echo "checking whether C++17 is supported...${cpp17_supported}"
-
 CPPFLAGS=`"${R_EXE}" CMD config CPPFLAGS`
 
 # LightGBM-specific flags

--- a/R-package/tests/testthat/helper.R
+++ b/R-package/tests/testthat/helper.R
@@ -35,11 +35,12 @@ data.table::setDTthreads(1L)
   Sys.getenv("LIGHTGBM_TEST_VERBOSITY", "-1")
 )
 
+
 # [description]
 #    test that every element of 'x' is in 'y'
 #
-#    testthat::expect_in() is not available in version of {testthat}
-#    built for R 3.6, this is here to support a similar interface on R 3.6
+#    testthat::expect_in() was added in {testthat} v3.1.19
+#    This is here to support a similar interface on older {testthat} versions.
 .expect_in <- function(x, y) {
   if (exists("expect_in")) {
     expect_in(x, y)

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -127,17 +127,6 @@ cd "${TEMP_R_DIR}"
     sed -i.bak -e "s/~~VERSION~~/${LGB_VERSION}/" DESCRIPTION
     sed -i.bak -e "s/~~DATE~~/${CURRENT_DATE}/" DESCRIPTION
 
-    # Rtools35 (used with R 3.6 on Windows) doesn't support C++17
-    LGB_CXX_STD="C++17"
-    using_windows_and_r3=$(
-        # shellcheck disable=SC2016
-        Rscript -e 'cat(.Platform$OS.type == "windows" && R.version[["major"]] < 4)'
-    )
-    if test "${using_windows_and_r3}" = "TRUE"; then
-        LGB_CXX_STD="C++11"
-    fi
-    sed -i.bak -e "s/~~CXXSTD~~/${LGB_CXX_STD}/" DESCRIPTION
-
     # Remove 'region', 'endregion', and 'warning' pragmas.
     # This won't change the correctness of the code. CRAN does
     # not allow you to use compiler flag '-Wno-unknown-pragmas' or

--- a/build_r.R
+++ b/build_r.R
@@ -390,12 +390,6 @@ description_contents <- gsub(
   , x = description_contents
   , fixed = TRUE
 )
-description_contents <- gsub(
-  pattern = "~~CXXSTD~~"
-  , replacement = "C++11"
-  , x = description_contents
-  , fixed = TRUE
-)
 writeLines(description_contents, DESCRIPTION_FILE)
 
 # NOTE: --keep-empty-dirs is necessary to keep the deep paths expected

--- a/docker/README.md
+++ b/docker/README.md
@@ -185,12 +185,12 @@ Then navigate to `localhost:8787` in your local web browser, and log in with use
 
 To target a different R version, pass any [valid rocker/verse tag](https://hub.docker.com/r/rocker/verse/tags) to `docker build`.
 
-For example, to test LightGBM with R 3.5:
+For example, to test LightGBM with R 4.5:
 
 ```shell
 docker build \
-    -t lightgbm-r-35 \
+    -t lightgbm-r-45 \
     -f dockerfile-r \
-    --build-arg R_VERSION=3.5 \
+    --build-arg R_VERSION=4.5 \
     .
 ```


### PR DESCRIPTION
Fixes #7023

Proposes the following:

* moving floor for the R package to `R (>= 4.0)`
* using C++17 unconditionally in the R package
  - *this change only affects build from source on Windows*
  - *all other builds (and all CRAN builds) have been using C++17 since January 2023 (#5690)*

## Notes for Reviewers

In an earlier attempt (#7025), I also tried to update to testing on both R 4.0 and R 4.5.
Ran into some issues there on Windows... I think that Rtools have changed in significant ways between R minor versions.

So proposing this PR to get the easier-to-implement "just drop R 3.x" changes merged, to help unblock #7016