### PR TITLE
[ci] fix recent conda and mamba matching error

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -153,7 +153,7 @@ if [[ "${TASK}" != "cpp-tests" ]] && [[ "${TASK}" != "r-package" ]]; then
         sh miniforge.sh -b -p "${CONDA}"
     fi
     conda config --set always_yes yes --set changeps1 no
-    conda update -q -y conda
+    conda update -q -y conda conda-libmamba-solver
 
     # print output of 'conda info', to help in submitting bug reports
     echo "conda info:"

--- a/.ci/test-windows.ps1
+++ b/.ci/test-windows.ps1
@@ -66,7 +66,7 @@ if ($env:TASK -eq "swig") {
 conda init powershell
 conda activate
 conda config --set always_yes yes --set changeps1 no
-conda update -q -y conda "python=$env:PYTHON_VERSION[build=*_cp*]"
+conda update -q -y conda conda-libmamba-solver "python=$env:PYTHON_VERSION[build=*_cp*]"
 
 # print output of 'conda info', to help in submitting bug reports
 Write-Output "conda info:"

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -14,7 +14,7 @@ curl \
 /bin/bash "${HOME}/miniforge.sh" -b -p "${CONDA}"
 
 conda config --set always_yes yes --set changeps1 no
-conda update -q -y conda
+conda update -q -y conda conda-libmamba-solver
 
 conda env create \
     --name docs-env \


### PR DESCRIPTION
Just faced this issue in #7027.

```
Error while loading conda entry point: conda-libmamba-solver (cannot import name 'Spinner' from 'conda.common.io' (/Users/runner/miniforge/lib/python3.12/site-packages/conda/common/io.py))

CondaValueError: You have chosen a non-default solver backend (libmamba) but it was not recognized. Choose one of: classic
```

Refer to https://github.com/ilastik/ilastik/pull/3077.