### PR TITLE
[ci] stop skipping Arrow test at Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,7 @@ configuration:
 branches:
   only:
     - master
+    - ci/arrow
 
 environment:
   matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,6 @@ install:
   - set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH%
   - set PYTHON_VERSION=%CONFIGURATION%
   - ps: |
-      $env:ALLOW_SKIP_ARROW_TESTS = "1"
       $env:APPVEYOR = "true"
       $env:CMAKE_BUILD_PARALLEL_LEVEL = 4
       $env:MINICONDA = "C:\Miniconda3-x64"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,6 @@ configuration:
 branches:
   only:
     - master
-    - ci/arrow
 
 environment:
   matrix:

--- a/tests/python_package_test/test_arrow.py
+++ b/tests/python_package_test/test_arrow.py
@@ -11,18 +11,10 @@ import lightgbm as lgb
 
 from .utils import np_assert_array_equal
 
-# NOTE: In the AppVeyor CI, importing pyarrow fails due to an old Visual Studio version. Hence,
-#  we conditionally import pyarrow here (and skip tests if it cannot be imported). However, we
-#  don't want these tests to silently be skipped, hence, we only conditionally import when a
-#  specific env var is set.
-if os.getenv("ALLOW_SKIP_ARROW_TESTS") == "1":
-    pa = pytest.importorskip("pyarrow")
-else:
-    import pyarrow as pa  # type: ignore
+if not lgb.compat.PYARROW_INSTALLED:
+    pytest.skip("pyarrow is not installed", allow_module_level=True)
 
-    assert lgb.compat.PYARROW_INSTALLED is True, (
-        "'pyarrow' and its dependencies must be installed to run the arrow tests"
-    )
+import pyarrow as pa  # type: ignore
 
 # ----------------------------------------------------------------------------------------------- #
 #                                            UTILITIES                                            #

--- a/tests/python_package_test/test_arrow.py
+++ b/tests/python_package_test/test_arrow.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 import filecmp
-import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 

--- a/tests/python_package_test/test_arrow.py
+++ b/tests/python_package_test/test_arrow.py
@@ -14,7 +14,7 @@ from .utils import np_assert_array_equal
 if not lgb.compat.PYARROW_INSTALLED:
     pytest.skip("pyarrow is not installed", allow_module_level=True)
 
-import pyarrow as pa  # type: ignore
+import pyarrow as pa
 
 # ----------------------------------------------------------------------------------------------- #
 #                                            UTILITIES                                            #


### PR DESCRIPTION
After dropping support for VS2015 in #7022 we can run Arrow tests at Appveyor with VS2017.