### PR TITLE
[ci] update Ruff version in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,10 +63,10 @@ repos:
           - sphinx_rtd_theme>=3.0.1
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.5
+    rev: v0.14.0
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
         args: ["--config", "python-package/pyproject.toml"]
         types_or: [python, jupyter]
       # Run the formatter.


### PR DESCRIPTION
`ruff` is now legacy id. New one is `ruff-check`.

https://github.com/astral-sh/ruff-pre-commit/blob/f9351c924055bf6c7b4a4670237d3ce141e9f57c/.pre-commit-hooks.yaml#L23-L25

